### PR TITLE
ci: add release security-scan

### DIFF
--- a/.github/scripts/check_approval_drift.py
+++ b/.github/scripts/check_approval_drift.py
@@ -1,0 +1,204 @@
+"""Release security check #1 — approval drift (a TOCTOU guard).
+
+The window we care about: a human reviews a PR (time-of-check), but what is
+actually merged and shipped (time-of-use) is not what they reviewed — because
+commits were pushed after approval, or the PR was merged with no human approval
+at all (e.g. auto-merge, or an agent acting on an injected review comment).
+
+For every PR merged into this line of history since the last release tag, this
+compares the PR's merged head against its last *human* APPROVED review:
+
+  * merged with **no human approval**            -> blocking
+  * commits pushed **after** the last approval    -> blocking (the reviewed
+    diff is not the shipped diff)
+
+Deterministic: reads ``git log`` for the merged-PR list and the read-only
+GitHub REST API for reviews. It never runs the PR's code.
+
+Env:
+  GITHUB_TOKEN       (recommended; raises rate limits, reads private repos)
+  GITHUB_REPOSITORY  (owner/name; falls back to the origin remote)
+  SECURITY_SCAN_BASELINE_TAG  (optional; overrides the auto-detected last tag)
+  SECURITY_SCAN_TRUSTED_BOTS  (optional CSV of bot logins whose merges are
+                               allowed without human approval, e.g. dependabot)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from security_scan_common import (
+    Report,
+    github_request,
+    last_release_tag,
+    resolve_repo,
+    run_git,
+)
+
+
+# Squash-merge subjects on this repo end with "(#1234)"; that is the PR number.
+_PR_NUM_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+# GitHub marks these association values as coming from outside the project.
+_OUTSIDE_ASSOC = {"NONE", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN"}
+
+
+def merged_pr_numbers(baseline: str) -> list[tuple[int, str]]:
+    """(pr_number, subject) for commits in ``baseline..HEAD`` that name a PR."""
+    log = run_git(
+        "log", "--first-parent", "--pretty=format:%H%x1f%s", f"{baseline}..HEAD"
+    )
+    found: list[tuple[int, str]] = []
+    for line in log.splitlines():
+        if "\x1f" not in line:
+            continue
+        _, subject = line.split("\x1f", 1)
+        match = _PR_NUM_RE.search(subject)
+        if match:
+            found.append((int(match.group(1)), subject))
+    return found
+
+
+def _is_bot(user: dict[str, object]) -> bool:
+    return user.get("type") == "Bot" or str(user.get("login", "")).endswith("[bot]")
+
+
+def audit_pr(
+    repo: str, number: int, token: str | None, trusted_bots: set[str]
+) -> tuple[str, str | None]:
+    """Return (status, detail) for one PR.
+
+    status is one of: "ok", "no-human-approval", "changed-after-approval",
+    "trusted-bot", "error".
+    """
+    try:
+        pr = github_request(f"/repos/{repo}/pulls/{number}", token)
+        reviews = github_request(
+            f"/repos/{repo}/pulls/{number}/reviews?per_page=100", token
+        )
+    except Exception as exc:  # noqa: BLE001 - report, do not crash the gate
+        return "error", str(exc)
+
+    merge_sha = pr.get("merge_commit_sha")
+    head_sha = (pr.get("head") or {}).get("sha")
+    author = (pr.get("user") or {}).get("login", "?")
+
+    approvals = [
+        r
+        for r in reviews
+        if r.get("state") == "APPROVED"
+        and not _is_bot(r.get("user") or {})
+        and (r.get("author_association") or "NONE") not in _OUTSIDE_ASSOC
+    ]
+
+    if not approvals:
+        merged_by = (pr.get("merged_by") or {})
+        if _is_bot(merged_by) and merged_by.get("login") in trusted_bots:
+            return "trusted-bot", f"merged by trusted bot {merged_by.get('login')}"
+        return (
+            "no-human-approval",
+            f"author @{author}; merged={_short(merge_sha)}; no human APPROVED review",
+        )
+
+    # The reviewed commit is the head each approval was submitted against.
+    approved_shas = {r.get("commit_id") for r in approvals if r.get("commit_id")}
+    reviewed_head = head_sha in approved_shas
+    if not reviewed_head:
+        latest = approvals[-1]
+        reviewer = (latest.get("user") or {}).get("login", "?")
+        approved_on = _short(latest.get("commit_id"))
+        return (
+            "changed-after-approval",
+            (
+                f"last approval by @{reviewer} was on {approved_on}, but merged "
+                f"head was {_short(head_sha)} — commits landed after review"
+            ),
+        )
+
+    return "ok", None
+
+
+def _short(sha: object) -> str:
+    return str(sha)[:9] if sha else "?"
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    repo = resolve_repo()
+    baseline = os.environ.get("SECURITY_SCAN_BASELINE_TAG") or last_release_tag()
+    trusted_bots = {
+        b.strip()
+        for b in os.environ.get("SECURITY_SCAN_TRUSTED_BOTS", "").split(",")
+        if b.strip()
+    }
+
+    report = Report("🔒 Approval drift (time-of-check vs time-of-use)")
+
+    if not baseline:
+        report.add("No previous `v*` release tag found; nothing to compare against.")
+        print(report.render())
+        return 0
+
+    try:
+        run_git("rev-parse", "--verify", f"{baseline}^{{commit}}")
+    except Exception:  # noqa: BLE001
+        report.warn("baseline unavailable")
+        report.add(
+            f"Baseline tag `{baseline}` is not present locally "
+            "(fetch tags with `fetch-depth: 0`). Skipping."
+        )
+        print(report.render())
+        return 0
+
+    prs = merged_pr_numbers(baseline)
+    report.add(f"Baseline: `{baseline}` — {len(prs)} merged PR(s) in range.")
+    report.add("")
+
+    blocking_rows: list[str] = []
+    ok = 0
+    errors = 0
+    for number, _subject in prs:
+        status, detail = audit_pr(repo, number, token, trusted_bots)
+        if status == "ok":
+            ok += 1
+        elif status == "trusted-bot":
+            ok += 1
+        elif status == "error":
+            errors += 1
+            report.warn(f"could not audit #{number}")
+        else:
+            blocking_rows.append(f"| #{number} | `{status}` | {detail} |")
+            report.block(f"#{number}: {status}")
+
+    if blocking_rows:
+        report.add("| PR | finding | detail |")
+        report.add("| -- | ------- | ------ |")
+        report.lines.extend(blocking_rows)
+        report.add("")
+    report.add(
+        f"Audited {len(prs)} PR(s): {ok} clean, {len(blocking_rows)} flagged, "
+        f"{errors} un-auditable."
+    )
+    if errors:
+        report.add(
+            "\n> Un-auditable PRs are reported as warnings, not blockers, so a "
+            "transient API error does not wedge a release."
+        )
+
+    sys.stdout.write(report.render())
+    _emit_summary_file(report)
+    return 1 if report.blocking else 0
+
+
+def _emit_summary_file(report: Report) -> None:
+    out = os.environ.get("SECURITY_SCAN_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write(report.render())
+            handle.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_approval_drift.py
+++ b/.github/scripts/check_approval_drift.py
@@ -94,7 +94,7 @@ def audit_pr(
     ]
 
     if not approvals:
-        merged_by = (pr.get("merged_by") or {})
+        merged_by = pr.get("merged_by") or {}
         if _is_bot(merged_by) and merged_by.get("login") in trusted_bots:
             return "trusted-bot", f"merged by trusted bot {merged_by.get('login')}"
         return (

--- a/.github/scripts/check_approval_drift.py
+++ b/.github/scripts/check_approval_drift.py
@@ -32,6 +32,7 @@ import sys
 from security_scan_common import (
     Report,
     github_request,
+    github_request_all,
     last_release_tag,
     resolve_repo,
     run_git,
@@ -85,7 +86,11 @@ def audit_pr(
     """
     try:
         pr = github_request(f"/repos/{repo}/pulls/{number}", token)
-        reviews = github_request(
+        # Paginate: the reviews endpoint returns every review (COMMENTED too),
+        # so a heavily-discussed PR can exceed one page. A human APPROVED past
+        # the first page must not be missed, or the PR is misclassified as
+        # unapproved and blocks a clean release.
+        reviews = github_request_all(
             f"/repos/{repo}/pulls/{number}/reviews?per_page=100", token
         )
     except Exception as exc:  # noqa: BLE001 - report, do not crash the gate

--- a/.github/scripts/check_approval_drift.py
+++ b/.github/scripts/check_approval_drift.py
@@ -45,20 +45,30 @@ _PR_NUM_RE = re.compile(r"\(#(\d+)\)\s*$")
 _OUTSIDE_ASSOC = {"NONE", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN"}
 
 
-def merged_pr_numbers(baseline: str) -> list[tuple[int, str]]:
-    """(pr_number, subject) for commits in ``baseline..HEAD`` that name a PR."""
+def merged_pr_numbers(baseline: str) -> tuple[list[tuple[int, str]], list[str]]:
+    """PRs named in ``baseline..HEAD`` plus the subjects that map to none.
+
+    Returns ``(matched, unmapped)`` where ``matched`` is ``(pr_number,
+    subject)`` for first-parent commits whose subject ends in ``(#N)``, and
+    ``unmapped`` is the subjects that do not — so the caller can surface the
+    blind spot (a merge that skipped the squash convention is exactly the one
+    an approval-drift guard must not silently ignore) instead of dropping it.
+    """
     log = run_git(
         "log", "--first-parent", "--pretty=format:%H%x1f%s", f"{baseline}..HEAD"
     )
-    found: list[tuple[int, str]] = []
+    matched: list[tuple[int, str]] = []
+    unmapped: list[str] = []
     for line in log.splitlines():
         if "\x1f" not in line:
             continue
         _, subject = line.split("\x1f", 1)
         match = _PR_NUM_RE.search(subject)
         if match:
-            found.append((int(match.group(1)), subject))
-    return found
+            matched.append((int(match.group(1)), subject))
+        else:
+            unmapped.append(subject)
+    return matched, unmapped
 
 
 def _is_bot(user: dict[str, object]) -> bool:
@@ -152,8 +162,19 @@ def main() -> int:
         print(report.render())
         return 0
 
-    prs = merged_pr_numbers(baseline)
+    prs, unmapped = merged_pr_numbers(baseline)
     report.add(f"Baseline: `{baseline}` — {len(prs)} merged PR(s) in range.")
+    if unmapped:
+        report.warn(f"{len(unmapped)} commit(s) not mapped to a PR")
+        report.add(
+            f"> ⚠️ {len(unmapped)} first-parent commit(s) in range did not match "
+            "the `(#N)` squash convention and were **not** audited (a merge/rebase "
+            "merge, or a lost `(#N)` suffix). These are a blind spot — inspect them:"
+        )
+        for subject in unmapped[:20]:
+            report.add(f">   - {subject}")
+        if len(unmapped) > 20:
+            report.add(f">   - …and {len(unmapped) - 20} more")
     report.add("")
 
     blocking_rows: list[str] = []

--- a/.github/scripts/check_dependency_diff.py
+++ b/.github/scripts/check_dependency_diff.py
@@ -1,0 +1,191 @@
+"""Release security check #2 — supply-chain dependency diff.
+
+Compares the resolved dependency set (``uv.lock``) between the last release tag
+and HEAD, then for everything new or bumped:
+
+  * looks it up in **OSV** for known vulnerabilities (blocking on a hit), and
+  * flags packages resolved from a **non-PyPI source** — git URLs, direct
+    URLs, or alternative indexes — which is the classic supply-chain and
+    dependency-confusion surface (blocking; a release should pin to the
+    trusted registry).
+
+Deterministic: parses the two lockfile revisions from git and queries the
+public OSV API. It never installs or executes any dependency.
+
+Env:
+  SECURITY_SCAN_BASELINE_TAG  (optional; overrides the auto-detected last tag)
+  SECURITY_SCAN_OUTPUT        (optional; append the rendered report here too)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+
+from security_scan_common import (
+    Report,
+    last_release_tag,
+    osv_query_batch,
+    run_git,
+)
+
+
+LOCKFILE = "uv.lock"
+
+
+def _load_lock(ref: str) -> dict[str, dict[str, object]]:
+    """Return {name: {version, source}} for every package in ``ref``'s lock."""
+    try:
+        raw = run_git("show", f"{ref}:{LOCKFILE}")
+    except Exception:  # noqa: BLE001
+        return {}
+    data = tomllib.loads(raw)
+    packages: dict[str, dict[str, object]] = {}
+    for pkg in data.get("package", []):
+        name = pkg.get("name")
+        if not name:
+            continue
+        packages[name] = {
+            "version": pkg.get("version", "?"),
+            "source": pkg.get("source", {}),
+        }
+    return packages
+
+
+def _source_label(source: object) -> str:
+    if not isinstance(source, dict):
+        return str(source)
+    # uv encodes the source as {registry: ...} | {git: ...} | {url: ...} |
+    # {editable: ...} | {virtual: ...} | {path: ...}
+    for key in ("git", "url", "path", "editable", "virtual"):
+        if key in source:
+            return f"{key}:{source[key]}"
+    if "registry" in source:
+        return f"registry:{source['registry']}"
+    return str(source)
+
+
+def _is_trusted_registry(source: object) -> bool:
+    """A first-party workspace member or a plain PyPI registry pin is trusted."""
+    if not isinstance(source, dict):
+        return False
+    if "registry" in source:
+        return "pypi.org" in str(source["registry"])
+    # Workspace members / virtual roots are the SDK's own packages.
+    return "virtual" in source or "editable" in source
+
+
+def main() -> int:
+    baseline = os.environ.get("SECURITY_SCAN_BASELINE_TAG") or last_release_tag()
+    report = Report("📦 Supply-chain dependency diff")
+
+    if not baseline:
+        report.add("No previous `v*` release tag found; nothing to compare against.")
+        print(report.render())
+        return 0
+
+    try:
+        run_git("rev-parse", "--verify", f"{baseline}^{{commit}}")
+    except Exception:  # noqa: BLE001
+        report.warn("baseline unavailable")
+        report.add(
+            f"Baseline tag `{baseline}` is not present locally "
+            "(fetch tags with `fetch-depth: 0`). Skipping."
+        )
+        print(report.render())
+        return 0
+
+    before = _load_lock(baseline)
+    after = _load_lock("HEAD")
+    if not after:
+        report.warn("no lockfile")
+        report.add(f"Could not read `{LOCKFILE}` at HEAD. Skipping.")
+        print(report.render())
+        return 0
+
+    added = {n: after[n] for n in after.keys() - before.keys()}
+    removed = sorted(before.keys() - after.keys())
+    bumped = {
+        n: (before[n]["version"], after[n]["version"])
+        for n in after.keys() & before.keys()
+        if before[n]["version"] != after[n]["version"]
+    }
+
+    report.add(f"Baseline: `{baseline}`")
+    report.add(
+        f"Added: **{len(added)}**, bumped: **{len(bumped)}**, "
+        f"removed: **{len(removed)}**."
+    )
+    report.add("")
+
+    # --- non-registry sources on new/changed packages (supply-chain surface) --
+    suspicious_source = []
+    for name in list(added) + list(bumped):
+        source = after[name]["source"]
+        if not _is_trusted_registry(source):
+            suspicious_source.append((name, _source_label(source)))
+    if suspicious_source:
+        report.add("**Non-PyPI sources on new/changed packages:**")
+        for name, label in sorted(suspicious_source):
+            report.add(f"- `{name}` ← `{label}`")
+            report.block(f"{name} resolved from non-registry source ({label})")
+        report.add("")
+
+    # --- OSV known-vulnerability lookup on new + bumped versions ---------------
+    to_scan = [(n, str(after[n]["version"])) for n in list(added) + list(bumped)]
+    if to_scan:
+        queries = [
+            {"package": {"ecosystem": "PyPI", "name": n}, "version": v}
+            for n, v in to_scan
+        ]
+        results = osv_query_batch(queries)
+        if results is None:
+            report.warn("OSV lookup failed")
+            report.add(
+                "> OSV lookup failed (network); reported as a warning, not a "
+                "blocker. Re-run to retry."
+            )
+        else:
+            vuln_hits = []
+            for (name, version), res in zip(to_scan, results):
+                vulns = res.get("vulns") if isinstance(res, dict) else None
+                if vulns:
+                    ids = ", ".join(v.get("id", "?") for v in vulns)
+                    vuln_hits.append((name, version, ids))
+            if vuln_hits:
+                report.add("**Known vulnerabilities (OSV):**")
+                for name, version, ids in vuln_hits:
+                    report.add(f"- `{name}=={version}` → {ids}")
+                    report.block(f"{name}=={version} has known vuln(s): {ids}")
+                report.add("")
+            else:
+                report.add(
+                    f"OSV: no known vulns across {len(to_scan)} new/bumped dep(s)."
+                )
+                report.add("")
+
+    # --- readable inventory ---------------------------------------------------
+    if added:
+        report.add("<details><summary>Added dependencies</summary>\n")
+        for name in sorted(added):
+            report.add(f"- `{name}=={added[name]['version']}`")
+        report.add("\n</details>")
+    if bumped:
+        report.add("<details><summary>Bumped dependencies</summary>\n")
+        for name in sorted(bumped):
+            old, new = bumped[name]
+            report.add(f"- `{name}`: {old} → {new}")
+        report.add("\n</details>")
+
+    sys.stdout.write(report.render())
+    out = os.environ.get("SECURITY_SCAN_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write(report.render())
+            handle.write("\n")
+    return 1 if report.blocking else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_dependency_diff.py
+++ b/.github/scripts/check_dependency_diff.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import os
 import sys
 import tomllib
+from urllib.parse import urlparse
 
 from security_scan_common import (
     Report,
@@ -32,6 +33,14 @@ from security_scan_common import (
 
 
 LOCKFILE = "uv.lock"
+
+# Exact hosts we accept as the trusted package registry. An exact-host match
+# (not a substring) so a look-alike like ``pypi.org.evil.example`` cannot be
+# mistaken for PyPI. Anything else — a mirror, an alternate index, a git/url
+# source — is *blocked on purpose*: an unexpected source on a release is the
+# supply-chain / dependency-confusion signal we want a human to look at, not
+# something to wave through.
+_TRUSTED_REGISTRY_HOSTS = {"pypi.org", "files.pythonhosted.org"}
 
 
 def _load_lock(ref: str) -> dict[str, dict[str, object]]:
@@ -66,14 +75,31 @@ def _source_label(source: object) -> str:
     return str(source)
 
 
+def _registry_host(source: dict[str, object]) -> str | None:
+    """The host of a ``{registry: url}`` source, or None if not a registry."""
+    registry = source.get("registry")
+    if not isinstance(registry, str):
+        return None
+    return (urlparse(registry).hostname or "").lower()
+
+
 def _is_trusted_registry(source: object) -> bool:
-    """A first-party workspace member or a plain PyPI registry pin is trusted."""
+    """True only for a first-party workspace member or an *exact* PyPI host.
+
+    Deliberately strict: a mirror, alternate index, git/url source, or an
+    unrecognized source shape is NOT trusted, so it is blocked and a human
+    looks at it. That is the point of the check on a release — an unexpected
+    source is the supply-chain signal, and a block just parks it for a
+    maintainer (cheap and rare on a release PR).
+    """
     if not isinstance(source, dict):
         return False
-    if "registry" in source:
-        return "pypi.org" in str(source["registry"])
     # Workspace members / virtual roots are the SDK's own packages.
-    return "virtual" in source or "editable" in source
+    if "virtual" in source or "editable" in source:
+        return True
+    if "registry" in source:
+        return _registry_host(source) in _TRUSTED_REGISTRY_HOSTS
+    return False
 
 
 def main() -> int:
@@ -141,10 +167,12 @@ def main() -> int:
         ]
         results = osv_query_batch(queries)
         if results is None:
-            report.warn("OSV lookup failed")
+            report.block("OSV lookup failed")
             report.add(
-                "> OSV lookup failed (network); reported as a warning, not a "
-                "blocker. Re-run to retry."
+                "> OSV lookup failed (network): could not verify new/bumped "
+                "deps against known vulnerabilities. Blocking on purpose — a "
+                "release that can't be checked shouldn't ship. Often transient; "
+                "re-run to retry, or a maintainer can clear it on the fly."
             )
         else:
             vuln_hits = []

--- a/.github/scripts/security_scan_common.py
+++ b/.github/scripts/security_scan_common.py
@@ -1,0 +1,127 @@
+"""Shared helpers for the release security-scan checks.
+
+Deterministic-first by design: these helpers only read git history and query
+read-only HTTP APIs (GitHub REST, OSV). They never execute the code under
+review. That is the whole point of a security gate — a scanner that runs (or
+asks an LLM to reason over) untrusted PR content is itself an injection target.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+
+
+GITHUB_API = "https://api.github.com"
+
+
+def run_git(*args: str) -> str:
+    """Run a git command and return stripped stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def last_release_tag() -> str | None:
+    """Most recent ``vX.Y.Z`` tag reachable from HEAD, or None if there is none.
+
+    The release scan compares "what ships now" against the last thing that
+    shipped, so the previous release tag is the natural, immutable baseline.
+    """
+    try:
+        # --merged HEAD keeps us on this line of history; sort by version.
+        tags = run_git(
+            "tag", "--list", "v*", "--merged", "HEAD", "--sort=-v:refname"
+        ).splitlines()
+    except subprocess.CalledProcessError:
+        return None
+    return tags[0].strip() if tags and tags[0].strip() else None
+
+
+def github_request(path_or_url: str, token: str | None) -> object:
+    """GET a GitHub REST endpoint and parse JSON. Raises on HTTP error."""
+    url = path_or_url
+    if url.startswith("/"):
+        url = f"{GITHUB_API}{url}"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def osv_query_batch(
+    queries: list[dict[str, object]],
+) -> list[dict[str, object]] | None:
+    """Query the OSV batched vulnerability API. Returns None on network failure.
+
+    OSV is public and needs no auth. Network failure is treated as a warning by
+    callers (do not block a release on a flaky lookup), while an actual
+    known-vulnerable hit is a hard finding.
+    """
+    payload = json.dumps({"queries": queries}).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.osv.dev/v1/querybatch",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError):
+        return None
+    results = data.get("results")
+    return results if isinstance(results, list) else []
+
+
+@dataclass
+class Report:
+    """Accumulates a markdown report plus a blocking/ok verdict."""
+
+    title: str
+    lines: list[str] = field(default_factory=list)
+    blocking: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def add(self, line: str = "") -> None:
+        self.lines.append(line)
+
+    def block(self, reason: str) -> None:
+        self.blocking.append(reason)
+
+    def warn(self, reason: str) -> None:
+        self.warnings.append(reason)
+
+    def render(self) -> str:
+        if self.blocking:
+            status = f"❌ {len(self.blocking)} blocking finding(s)"
+        elif self.warnings:
+            status = f"⚠️ {len(self.warnings)} warning(s), nothing blocking"
+        else:
+            status = "✅ no findings"
+        out = [f"### {self.title}", "", f"**{status}**", ""]
+        out.extend(self.lines)
+        return "\n".join(out).rstrip() + "\n"
+
+
+def resolve_repo() -> str:
+    """`owner/name` from GITHUB_REPOSITORY, falling back to the git remote."""
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    if env_repo:
+        return env_repo
+    url = run_git("config", "--get", "remote.origin.url")
+    slug = url.rsplit("github.com", 1)[-1].lstrip(":/")
+    if slug.endswith(".git"):
+        slug = slug[:-4]
+    return slug

--- a/.github/scripts/security_scan_common.py
+++ b/.github/scripts/security_scan_common.py
@@ -46,18 +46,60 @@ def last_release_tag() -> str | None:
     return tags[0].strip() if tags and tags[0].strip() else None
 
 
-def github_request(path_or_url: str, token: str | None) -> object:
-    """GET a GitHub REST endpoint and parse JSON. Raises on HTTP error."""
-    url = path_or_url
-    if url.startswith("/"):
-        url = f"{GITHUB_API}{url}"
+def _github_get(url: str, token: str | None) -> tuple[object, str | None]:
+    """GET one GitHub REST page; return ``(parsed_json, link_header)``."""
     req = urllib.request.Request(url)
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
     if token:
         req.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return json.loads(resp.read().decode("utf-8")), resp.headers.get("Link")
+
+
+def github_request(path_or_url: str, token: str | None) -> object:
+    """GET a GitHub REST endpoint and parse JSON. Raises on HTTP error."""
+    url = path_or_url
+    if url.startswith("/"):
+        url = f"{GITHUB_API}{url}"
+    body, _ = _github_get(url, token)
+    return body
+
+
+def _next_link(link_header: str | None) -> str | None:
+    """The ``rel="next"`` URL from a REST ``Link`` header, or None."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        segments = part.split(";")
+        if len(segments) < 2:
+            continue
+        url_part = segments[0].strip().lstrip("<").rstrip(">")
+        if any('rel="next"' in seg.strip() for seg in segments[1:]):
+            return url_part
+    return None
+
+
+def github_request_all(path_or_url: str, token: str | None) -> list[object]:
+    """GET a paginated GitHub REST list endpoint, following ``Link: next``.
+
+    Concatenates every page into one list. A security gate must see *all*
+    reviews — if a human APPROVED sits past the first page, truncating to a
+    single page would misclassify the PR as unapproved (a false-positive
+    block). A non-list response is returned wrapped as a single-item list.
+    """
+    url = path_or_url
+    if url.startswith("/"):
+        url = f"{GITHUB_API}{url}"
+    items: list[object] = []
+    while url:
+        page, link = _github_get(url, token)
+        if isinstance(page, list):
+            items.extend(page)
+        else:
+            return [page]
+        url = _next_link(link)
+    return items
 
 
 def osv_query_batch(

--- a/.github/scripts/security_scan_common.py
+++ b/.github/scripts/security_scan_common.py
@@ -65,9 +65,11 @@ def osv_query_batch(
 ) -> list[dict[str, object]] | None:
     """Query the OSV batched vulnerability API. Returns None on network failure.
 
-    OSV is public and needs no auth. Network failure is treated as a warning by
-    callers (do not block a release on a flaky lookup), while an actual
-    known-vulnerable hit is a hard finding.
+    OSV is public and needs no auth. A None return means the release diff could
+    not be verified against known vulnerabilities; the dependency-diff caller
+    treats that as blocking (fail-closed — a release that can't be checked
+    shouldn't ship), and an actual known-vulnerable hit is likewise a hard
+    finding.
     """
     payload = json.dumps({"queries": queries}).encode("utf-8")
     req = urllib.request.Request(

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ on:
     pull_request:
         # `opened/synchronize/reopened` drive behavior A on release/** PRs;
         # `labeled` drives behavior B anywhere.
-        types: [opened, synchronize, reopened, labeled]
+        types: [labeled]
     workflow_dispatch:
         inputs:
             reason:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,117 @@
+---
+name: Release Security Scan
+run-name: >-
+    Release Security Scan ${{ inputs.reason || github.event.label.name || 'manual' }}
+
+# Fourth release-PR check, alongside integration-test / behavior-test /
+# test-examples. It guards the *release* diff (last tag -> this PR) against two
+# supply-chain / integrity risks:
+#   1. approval drift (TOCTOU): code that shipped without the human-approved
+#      state actually being what merged;
+#   2. dependency risk: new/bumped deps with known OSV vulns or non-PyPI
+#      sources.
+#
+# Deterministic by design: the scanners only read git history and query
+# read-only APIs (GitHub REST, OSV). They never install or execute the code
+# under review — a security gate that runs untrusted content is itself an
+# injection target. We therefore use plain `pull_request` (not
+# pull_request_target) and need no secrets beyond the default GITHUB_TOKEN.
+
+on:
+    pull_request:
+        types: [labeled]
+    workflow_dispatch:
+        inputs:
+            reason:
+                description: Reason for manual trigger
+                required: true
+                default: ''
+            baseline_tag:
+                description: >-
+                    Baseline release tag to diff against (default: auto-detect
+                    the latest reachable v* tag).
+                required: false
+                default: ''
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    security-scan:
+        # Only run on the release label, or manual dispatch.
+        if: >-
+            github.event.label.name == 'security-scan' ||
+            github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        steps:
+            - name: Checkout (full history + tags for the baseline diff)
+              uses: actions/checkout@v7
+              with:
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.13'
+
+            - name: Run approval-drift check (TOCTOU)
+              id: approval
+              continue-on-error: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  SECURITY_SCAN_BASELINE_TAG: ${{ inputs.baseline_tag }}
+                  SECURITY_SCAN_OUTPUT: ${{ github.workspace }}/security-report.md
+                  # Dependabot merges are allowed without a human approval; the
+                  # dependency check still audits what they bring in.
+                  SECURITY_SCAN_TRUSTED_BOTS: dependabot[bot]
+              run: python .github/scripts/check_approval_drift.py
+
+            - name: Run supply-chain dependency diff
+              id: deps
+              continue-on-error: true
+              env:
+                  SECURITY_SCAN_BASELINE_TAG: ${{ inputs.baseline_tag }}
+                  SECURITY_SCAN_OUTPUT: ${{ github.workspace }}/security-report.md
+              run: python .github/scripts/check_dependency_diff.py
+
+            - name: Post results to the PR
+              if: github.event_name == 'pull_request'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  BODY_FILE="security-report.md"
+                  {
+                      echo "## 🔒 Release Security Scan"
+                      echo
+                      if [ -f "$BODY_FILE" ]; then
+                          cat "$BODY_FILE"
+                      else
+                          echo "_No report produced._"
+                      fi
+                      echo
+                      echo "<sub>Deterministic scanners: approval-drift + supply-chain dependency diff. Read-only; no PR code executed.</sub>"
+                  } > comment.md
+                  jq -Rs '{body: .}' comment.md > payload.json
+                  curl -sSf -X POST \
+                      -H "Authorization: token ${GITHUB_TOKEN}" \
+                      -H "Accept: application/vnd.github+json" \
+                      "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+                      -d @payload.json > /dev/null
+                  echo "Posted security-scan comment to PR #${PR_NUMBER}."
+
+            - name: Fail if any check found blocking issues
+              run: |
+                  if [ "${{ steps.approval.outcome }}" = "failure" ] || \
+                     [ "${{ steps.deps.outcome }}" = "failure" ]; then
+                      echo "::error::Release security scan found blocking issues. See the PR comment."
+                      exit 1
+                  fi
+                  echo "Release security scan passed."

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,15 +11,26 @@ run-name: >-
 #   2. dependency risk: new/bumped deps with known OSV vulns or non-PyPI
 #      sources.
 #
+# Two behaviors, one job:
+#   A. Always-on for `release/**` PRs — these are internal repo branches (never
+#      forks), so this is the guaranteed gate on the thing that actually ships,
+#      and it cannot be skipped (no label required).
+#   B. Best-effort for any other branch via the `security-scan` label or manual
+#      dispatch — a human opts a feature/fork PR in.
+#
 # Deterministic by design: the scanners only read git history and query
 # read-only APIs (GitHub REST, OSV). They never install or execute the code
 # under review — a security gate that runs untrusted content is itself an
 # injection target. We therefore use plain `pull_request` (not
-# pull_request_target) and need no secrets beyond the default GITHUB_TOKEN.
+# pull_request_target) and need no secrets beyond the default GITHUB_TOKEN. On
+# fork PRs that token is read-only, so results always go to the job summary and
+# the PR comment is posted only when the token can write (non-fork).
 
 on:
     pull_request:
-        types: [labeled]
+        # `opened/synchronize/reopened` drive behavior A on release/** PRs;
+        # `labeled` drives behavior B anywhere.
+        types: [opened, synchronize, reopened, labeled]
     workflow_dispatch:
         inputs:
             reason:
@@ -40,10 +51,13 @@ permissions:
 
 jobs:
     security-scan:
-        # Only run on the release label, or manual dispatch.
+        # Behavior A: always on release/** PRs. Behavior B: the label, or manual
+        # dispatch. Non-release PRs without the label are skipped so this does
+        # not run on every open PR.
         if: >-
+            github.event_name == 'workflow_dispatch' ||
             github.event.label.name == 'security-scan' ||
-            github.event_name == 'workflow_dispatch'
+            startsWith(github.event.pull_request.head.ref, 'release/')
         runs-on: ubuntu-24.04
         timeout-minutes: 15
         steps:
@@ -79,12 +93,8 @@ jobs:
                   SECURITY_SCAN_OUTPUT: ${{ github.workspace }}/security-report.md
               run: python .github/scripts/check_dependency_diff.py
 
-            - name: Post results to the PR
-              if: github.event_name == 'pull_request'
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
-                  REPO: ${{ github.repository }}
+            - name: Assemble report
+              if: always()
               run: |
                   set -euo pipefail
                   BODY_FILE="security-report.md"
@@ -99,13 +109,51 @@ jobs:
                       echo
                       echo "<sub>Deterministic scanners: approval-drift + supply-chain dependency diff. Read-only; no PR code executed.</sub>"
                   } > comment.md
+                  # Always surface the full report in the Actions run summary —
+                  # this is the one place that works even on fork PRs where the
+                  # token cannot comment.
+                  cat comment.md >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Post results comment (non-fork PRs only)
+              # On a fork PR the default token is read-only regardless of the
+              # permissions block, so the POST would 403. Guard on same-repo so
+              # a stray label on a fork PR doesn't produce a confusing red X —
+              # the run summary above still has the full results either way.
+              if: >-
+                  github.event_name == 'pull_request' &&
+                  github.event.pull_request.head.repo.full_name == github.repository
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  # Upsert: reuse our own marker comment instead of spamming a
+                  # fresh one on every labeled/synchronize event.
+                  MARKER="<!-- release-security-scan -->"
+                  printf '%s\n' "$MARKER" >> comment.md
                   jq -Rs '{body: .}' comment.md > payload.json
-                  curl -sSf -X POST \
+                  EXISTING=$(curl -sSf \
                       -H "Authorization: token ${GITHUB_TOKEN}" \
                       -H "Accept: application/vnd.github+json" \
-                      "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
-                      -d @payload.json > /dev/null
-                  echo "Posted security-scan comment to PR #${PR_NUMBER}."
+                      "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+                      | jq -r --arg m "$MARKER" \
+                          'map(select(.body | contains($m))) | .[0].id // empty')
+                  if [ -n "$EXISTING" ]; then
+                      curl -sSf -X PATCH \
+                          -H "Authorization: token ${GITHUB_TOKEN}" \
+                          -H "Accept: application/vnd.github+json" \
+                          "https://api.github.com/repos/${REPO}/issues/comments/${EXISTING}" \
+                          -d @payload.json > /dev/null
+                      echo "Updated existing security-scan comment (${EXISTING})."
+                  else
+                      curl -sSf -X POST \
+                          -H "Authorization: token ${GITHUB_TOKEN}" \
+                          -H "Accept: application/vnd.github+json" \
+                          "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+                          -d @payload.json > /dev/null
+                      echo "Posted security-scan comment to PR #${PR_NUMBER}."
+                  fi
 
             - name: Fail if any check found blocking issues
               run: |

--- a/tests/cross/test_check_approval_drift.py
+++ b/tests/cross/test_check_approval_drift.py
@@ -1,0 +1,95 @@
+"""Tests for the approval-drift (TOCTOU) release check.
+
+Focus on the deterministic, network-free surface: how merged-PR subjects are
+mapped to PR numbers (and, crucially, which ones are *not* mapped and must be
+surfaced as a blind spot), and bot detection. The GitHub REST calls in
+``audit_pr``/``main`` are not exercised here.
+
+``merged_pr_numbers`` shells out to ``git log``; we drive it deterministically
+by monkeypatching the module's ``run_git`` to return a canned log, so no real
+repository history is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script_module(name: str):
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / ".github" / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    script_path = scripts_dir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_drift = _load_script_module("check_approval_drift")
+
+_US = "\x1f"  # the unit-separator used in the git pretty-format
+
+
+def _fake_log(*subjects: str) -> str:
+    """Build a ``%H\\x1f%s`` git log body from subjects (sha is irrelevant)."""
+    return "\n".join(f"deadbeef{i}{_US}{s}" for i, s in enumerate(subjects))
+
+
+def test_matched_and_unmapped_are_split(monkeypatch):
+    log = _fake_log(
+        "feat: add a thing (#4001)",
+        "fix: a merge commit with no PR suffix",
+        "chore: bump deps (#4002)",
+        "Merge branch 'main' into feature",
+    )
+    monkeypatch.setattr(_drift, "run_git", lambda *a, **k: log)
+
+    matched, unmapped = _drift.merged_pr_numbers("v1.0.0")
+
+    assert matched == [
+        (4001, "feat: add a thing (#4001)"),
+        (4002, "chore: bump deps (#4002)"),
+    ]
+    assert unmapped == [
+        "fix: a merge commit with no PR suffix",
+        "Merge branch 'main' into feature",
+    ]
+
+
+def test_all_mapped_leaves_no_blind_spot(monkeypatch):
+    log = _fake_log("a (#1)", "b (#2)", "c (#3)")
+    monkeypatch.setattr(_drift, "run_git", lambda *a, **k: log)
+
+    matched, unmapped = _drift.merged_pr_numbers("v1.0.0")
+
+    assert [n for n, _ in matched] == [1, 2, 3]
+    assert unmapped == []
+
+
+def test_trailing_whitespace_after_pr_number_still_matches(monkeypatch):
+    monkeypatch.setattr(_drift, "run_git", lambda *a, **k: _fake_log("x (#42)  "))
+    matched, unmapped = _drift.merged_pr_numbers("v1.0.0")
+    assert matched == [(42, "x (#42)  ")]
+    assert unmapped == []
+
+
+def test_pr_ref_not_at_end_is_unmapped(monkeypatch):
+    # A "(#N)" that is not the trailing token is not the squash-merge PR id.
+    monkeypatch.setattr(
+        _drift, "run_git", lambda *a, **k: _fake_log("revert of (#7) change")
+    )
+    matched, unmapped = _drift.merged_pr_numbers("v1.0.0")
+    assert matched == []
+    assert unmapped == ["revert of (#7) change"]
+
+
+def test_is_bot_detects_type_and_suffix():
+    assert _drift._is_bot({"type": "Bot"}) is True
+    assert _drift._is_bot({"login": "dependabot[bot]"}) is True
+    assert _drift._is_bot({"login": "octocat", "type": "User"}) is False

--- a/tests/cross/test_check_dependency_diff.py
+++ b/tests/cross/test_check_dependency_diff.py
@@ -1,0 +1,113 @@
+"""Tests for the supply-chain dependency-diff release check.
+
+Exercises the pure source-classification helpers — the part that decides
+whether a resolved dependency is trusted (PyPI / first-party) or must block a
+release (mirror, alternate index, git/url, or an unrecognized shape). No
+network: OSV and GitHub are never touched here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script_module(name: str):
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / ".github" / "scripts"
+    # The check scripts import their sibling ``security_scan_common``; make it
+    # importable by putting the scripts dir on the path before executing.
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    script_path = scripts_dir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_dep = _load_script_module("check_dependency_diff")
+
+_is_trusted_registry = _dep._is_trusted_registry
+_registry_host = _dep._registry_host
+_source_label = _dep._source_label
+
+
+# --- trusted sources ------------------------------------------------------
+
+
+def test_canonical_pypi_registry_is_trusted():
+    assert _is_trusted_registry({"registry": "https://pypi.org/simple"}) is True
+
+
+def test_files_pythonhosted_is_trusted():
+    assert (
+        _is_trusted_registry({"registry": "https://files.pythonhosted.org/x"}) is True
+    )
+
+
+def test_first_party_workspace_members_are_trusted():
+    assert _is_trusted_registry({"editable": "."}) is True
+    assert _is_trusted_registry({"virtual": "."}) is True
+
+
+# --- sources that must block ----------------------------------------------
+
+
+def test_mirror_registry_blocks():
+    # An alternate index / mirror is not the canonical host -> not trusted.
+    assert _is_trusted_registry({"registry": "https://mirror.internal/simple"}) is False
+
+
+def test_lookalike_host_is_not_trusted():
+    # The classic substring-match bypass must not slip through.
+    assert (
+        _is_trusted_registry({"registry": "https://pypi.org.evil.example/simple"})
+        is False
+    )
+
+
+def test_git_source_blocks():
+    assert _is_trusted_registry({"git": "https://github.com/foo/bar"}) is False
+
+
+def test_url_source_blocks():
+    assert _is_trusted_registry({"url": "https://example.com/pkg.whl"}) is False
+
+
+def test_missing_or_empty_source_is_not_trusted():
+    # Deliberate: an unknown/empty source shape fails closed (blocks) rather
+    # than being waved through as a default-registry package.
+    assert _is_trusted_registry({}) is False
+    assert _is_trusted_registry(None) is False
+    assert _is_trusted_registry("weird") is False
+
+
+# --- helper: registry host extraction -------------------------------------
+
+
+def test_registry_host_extracts_and_lowercases():
+    assert _registry_host({"registry": "https://PyPI.org/simple"}) == "pypi.org"
+
+
+def test_registry_host_none_for_non_registry():
+    assert _registry_host({"git": "https://x"}) is None
+    assert _registry_host({}) is None
+
+
+# --- helper: readable source label ----------------------------------------
+
+
+def test_source_label_prefers_specific_keys():
+    assert _source_label({"git": "https://github.com/foo/bar"}).startswith("git:")
+    assert _source_label({"url": "https://x/pkg.whl"}).startswith("url:")
+    assert _source_label({"registry": "https://pypi.org/simple"}).startswith(
+        "registry:"
+    )
+
+
+def test_source_label_handles_non_dict():
+    assert _source_label("plain") == "plain"

--- a/tests/cross/test_security_scan_common.py
+++ b/tests/cross/test_security_scan_common.py
@@ -1,0 +1,93 @@
+"""Tests for shared security-scan helpers — Link-header pagination.
+
+The approval-drift gate must see *every* review of a PR; if a human APPROVED
+sits past the first REST page, truncating would misclassify the PR as
+unapproved and block a clean release. These cover the ``Link: rel="next"``
+follow and the header parser, with no real network (the per-page GET is
+monkeypatched).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script_module(name: str):
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / ".github" / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    script_path = scripts_dir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_common = _load_script_module("security_scan_common")
+
+
+# --- _next_link -----------------------------------------------------------
+
+
+def test_next_link_extracts_next_url():
+    header = (
+        '<https://api.github.com/x?page=2>; rel="next", '
+        '<https://api.github.com/x?page=5>; rel="last"'
+    )
+    assert _common._next_link(header) == "https://api.github.com/x?page=2"
+
+
+def test_next_link_none_when_absent():
+    header = '<https://api.github.com/x?page=1>; rel="prev"'
+    assert _common._next_link(header) is None
+
+
+def test_next_link_none_for_empty_header():
+    assert _common._next_link(None) is None
+    assert _common._next_link("") is None
+
+
+# --- github_request_all ---------------------------------------------------
+
+
+def test_paginates_until_no_next(monkeypatch):
+    pages = {
+        "https://api.github.com/reviews?per_page=100": (
+            [{"id": 1}, {"id": 2}],
+            '<https://api.github.com/reviews?page=2>; rel="next"',
+        ),
+        "https://api.github.com/reviews?page=2": (
+            [{"id": 3}],
+            None,
+        ),
+    }
+
+    def fake_get(url, token):
+        return pages[url]
+
+    monkeypatch.setattr(_common, "_github_get", fake_get)
+
+    items = _common.github_request_all(
+        "https://api.github.com/reviews?per_page=100", token=None
+    )
+    assert [i["id"] for i in items] == [1, 2, 3]
+
+
+def test_single_page_no_link(monkeypatch):
+    monkeypatch.setattr(_common, "_github_get", lambda url, token: ([{"id": 9}], None))
+    items = _common.github_request_all("/reviews", token=None)
+    assert items == [{"id": 9}]
+
+
+def test_non_list_response_wrapped(monkeypatch):
+    # A dict (e.g. an error object) must not be iterated element-wise.
+    monkeypatch.setattr(
+        _common, "_github_get", lambda url, token: ({"message": "x"}, None)
+    )
+    items = _common.github_request_all("/reviews", token=None)
+    assert items == [{"message": "x"}]


### PR DESCRIPTION
HUMAN:

I asked smolpaws to add a fourth release-PR check for security: an approval-drift (TOCTOU) guard and a supply-chain dependency diff. Starting with these two deterministic checks; more to follow.

---

AGENT:

## Why

We run three labeled suites on release PRs today — `integration-test`, `behavior-test`, `test-examples`. This adds a **fourth**, `security-scan`, for a gap those don't cover: the integrity of *what actually ships* versus *what a human reviewed*.

As agents (ours included) get faster and some PRs start merging with lighter or automated review, a real window opens up:

- a PR is approved, then commits land **after** the approval and still get merged;
- a PR is merged with **no human approval** at all;
- a review/QA agent runs while an **injected comment** sits on the PR, and whatever it did ends up on `main`.

This is a classic **TOCTOU** (time-of-check → time-of-use) gap. Cutting a release from that `main` inherits it. The right place to catch it is the release diff — *last release tag → this PR* — audited as one unit.

## Summary

- Adds `.github/workflows/security-scan.yml`: a new opt-in job gated on a `security-scan` label (plus `workflow_dispatch`), mirroring the existing labeled-suite pattern. Posts one PR comment and fails on any blocking finding.
- Adds `check_approval_drift.py` (TOCTOU): for every PR merged since the last `v*` tag, flags those merged with **no human approval**, or where commits landed **after** the last human approval (reviewed sha ≠ merged sha). Trusted bots (e.g. `dependabot[bot]`) are configurable and exempt.
- Adds `check_dependency_diff.py` (supply chain): diffs `uv.lock`, checks new/bumped packages against **OSV** for known vulns, and flags any resolved from a **non-PyPI source** (git/url/alt-index — dependency-confusion surface).
- Adds `security_scan_common.py` shared helpers. **Deterministic by design**: the scanners only read git history and query read-only APIs (GitHub REST, OSV); they never install or execute PR code, so the gate itself is not an injection target — hence plain `pull_request` (not `pull_request_target`) and no secrets beyond the default `GITHUB_TOKEN`. An **OSV lookup failure blocks** (fail-closed: a release diff that can't be verified against known vulns shouldn't ship — a maintainer re-runs or clears it), as does any non-PyPI / mirror / unrecognized source. Un-auditable PRs in the approval-drift check (transient GitHub API errors) remain warnings so a flaky call doesn't wedge a release.

## Issue Number

N/A (follow-up to the OpenHands/release-actions#18 freeze-on-ready discussion).

## How to Test

Run either scanner locally against real history:

```bash
# Supply-chain diff (OSV + non-PyPI source), stdlib only
SECURITY_SCAN_BASELINE_TAG=v1.28.0 python .github/scripts/check_dependency_diff.py

# Approval drift (needs a token to read reviews)
GITHUB_TOKEN=<token> GITHUB_REPOSITORY=OpenHands/software-agent-sdk \
  SECURITY_SCAN_BASELINE_TAG=v1.31.0 python .github/scripts/check_approval_drift.py
```

Or add the `security-scan` label to a PR / trigger via `workflow_dispatch`.

Verified locally against this repo's real history (evidence):
- `check_dependency_diff.py` over `v1.28.0..HEAD` correctly surfaced a known-vulnerable transitive `starlette==1.0.1` with real advisory IDs (`GHSA-82w8-qh3p-5jfq, GHSA-jp82-jpqv-5vv3, GHSA-wqp7-x3pw-xc5r, GHSA-x746-7m8f-x49c, PYSEC-2026-248, PYSEC-2026-249`) and listed 9 added / 11 bumped deps; over `v1.32.0..HEAD` it reports ✅ no findings (only the SDK's own version bumps).
- `check_approval_drift.py` over `v1.31.0..HEAD` flagged a real `changed-after-approval` merge (#4018: last approval by @neubig on `1986d9562`, merged head `780de42de`), exit code 1; over `v1.33.0..HEAD` it reports ✅ no findings across 6 PRs.
- `ruff check` and `ruff format` clean on all three scripts.

## Type

- [x] Feature (CI)

## Notes

- Scoped to the **two** deterministic checks we agreed to start with. Natural follow-ups (separate PRs): a prompt-injection / agent-influence scan of PR content + surrounding comments; a general static "weirdness" pass (egress / dangerous-exec / CI-workflow tampering); and running the scanners from a trusted ref rather than PR head for extra hardening.
- Not yet dogfooded on a live release PR — suggest enabling on the next release cut (or a follow-up integration test) before relying on it as a gate.

*Opened by 🐾 smolpaws on Engel's behalf.*



<!-- review threads resolved: 48e37cc -->
