### PR TITLE
Add claude-sonnet-5 to PROMPT_CACHE_MODELS

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -149,6 +149,10 @@ PROMPT_CACHE_MODELS: list[str] = [
     "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
+    # Claude Sonnet 5 supports prompt caching but is not covered by any
+    # "claude-sonnet-4*" entry above; without this, every input token bills
+    # uncached, which cancels the tier's price advantage on agent workloads.
+    "claude-sonnet-5",
     # https://www.anthropic.com/news/claude-fable-5
     # Listed explicitly until LiteLLM metadata recognizes it.
     "claude-fable-5",

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -139,6 +139,10 @@ PROMPT_CACHE_MODELS: list[str] = [
     "claude-opus-4-8",
     # https://platform.claude.com/docs/en/build-with-claude/prompt-caching
     "claude-opus-5",
+    # Claude Sonnet 5 supports prompt caching but is not covered by any
+    # "claude-sonnet-4*" entry above; without this, every input token bills
+    # uncached, which cancels the tier's price advantage on agent workloads.
+    "claude-sonnet-5",
     # https://www.anthropic.com/news/claude-fable-5
     "claude-fable-5",
     # Do NOT add Gemini: explicit cache_control markers freeze its cache at the

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -142,6 +142,11 @@ def test_extended_thinking_support(model, expected_extended_thinking):
         ("claude-fable-5", True),
         ("anthropic/claude-fable-5", True),
         ("litellm_proxy/anthropic/claude-fable-5", True),
+        # claude-sonnet-5 is not matched by any claude-sonnet-4* entry and must
+        # be listed explicitly, same as claude-fable-5.
+        ("claude-sonnet-5", True),
+        ("anthropic/claude-sonnet-5", True),
+        ("litellm_proxy/anthropic/claude-sonnet-5", True),
         # User-facing model names (no provider prefix)
         ("anthropic.claude-3-5-sonnet-20241022", True),
         ("anthropic.claude-3-haiku-20240307", True),

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -148,6 +148,11 @@ def test_extended_thinking_support(model, expected_extended_thinking):
         ("claude-opus-5", True),
         ("anthropic/claude-opus-5", True),
         ("litellm_proxy/anthropic/claude-opus-5", True),
+        # claude-sonnet-5 is not matched by any claude-sonnet-4* entry and must
+        # be listed explicitly, same as claude-fable-5.
+        ("claude-sonnet-5", True),
+        ("anthropic/claude-sonnet-5", True),
+        ("litellm_proxy/anthropic/claude-sonnet-5", True),
         # User-facing model names (no provider prefix)
         ("anthropic.claude-3-5-sonnet-20241022", True),
         ("anthropic.claude-3-haiku-20240307", True),


### PR DESCRIPTION
HUMAN:

We hit this running Claude Sonnet 5 agents: cache_read stayed at 0 and Sonnet runs cost the same as Opus until we traced it to this missing allowlist entry. Fix mirrors the existing claude-fable-5 precedent; happy to share more of our telemetry if useful.

---

AGENT:

## Why

`claude-sonnet-5` supports Anthropic prompt caching, but `PROMPT_CACHE_MODELS` has no entry matching it: the `"claude-sonnet-4"` substring doesn't match `claude-sonnet-5`, and unlike `claude-opus-4-8` / `claude-fable-5` it was never listed explicitly. Nothing fails — requests succeed — but no `cache_control` markers are emitted, so every input token bills uncached.

Measured on a production-like agentic workload (`anthropic/claude-sonnet-5` via LiteLLM, observed in Laminar telemetry): across 10 LLM calls totalling ~257k input tokens, `cache_read_input_tokens` and `cache_creation_input_tokens` stayed **0**. The identical workload on `anthropic/claude-opus-4-8` served 203k of 255k input tokens from cache. Net effect: Sonnet 5 runs cost the same as Opus 4.8 runs ($0.29/run in our eval), cancelling the tier's price advantage.

## Summary

- Add `"claude-sonnet-5"` to `PROMPT_CACHE_MODELS` in `openhands-sdk/openhands/sdk/llm/utils/model_features.py`, with a comment explaining why it needs an explicit entry (mirrors the existing `claude-fable-5` precedent).
- Add three test cases to `tests/sdk/llm/test_model_features.py` covering the raw, provider-prefixed, and `litellm_proxy`-prefixed forms.

## Evidence

- Root cause verified against the published wheels: `PROMPT_CACHE_MODELS` in 1.21.0 and 1.33.0 both lack any pattern matching `claude-sonnet-5` (1.33.0 added `claude-opus-4-8` and `claude-fable-5` explicitly).
- Matcher semantics verified standalone with the same case-insensitive substring logic as `model_matches`: `claude-sonnet-5`, `anthropic/claude-sonnet-5`, and `litellm_proxy/anthropic/claude-sonnet-5` now match; `gemini-3.1-pro` / `unknown-model` remain unmatched; existing entries (`claude-sonnet-4-6`, `anthropic/claude-opus-4-8`) are unaffected.
- End-to-end telemetry evidence (cache token counts per model, cost comparison) is from Laminar traces of our deployed agent, summarized in "Why" above; happy to share more detail if useful.
- Unit tests added mirror the existing `claude-fable-5` cases; the full suite was not run locally (patch prepared outside a dev checkout) — relying on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
