### PR TITLE
ci(version-bump-prs): make PR-creation steps independent

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -52,7 +52,6 @@ jobs:
                   enable-cache: false
 
             - name: Wait for packages to be available on PyPI
-              id: wait_for_packages
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -99,9 +98,12 @@ jobs:
                   echo "✅ All packages are resolvable on PyPI!"
 
             - name: Create PR for OpenHands repo
-              # Runs independently of the other "Create PR" steps below: each
-              # bumps an unrelated repo, so one failing shouldn't skip the rest.
-              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
+              id: openhands_pr
+              # continue-on-error keeps the sibling "Create PR" steps below
+              # independent: each bumps an unrelated repo, so one failing must
+              # not skip the rest. Failures are surfaced in the Summary step via
+              # steps.<id>.outcome.
+              continue-on-error: true
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -304,7 +306,8 @@ jobs:
                   fi
 
             - name: Create PR for OpenHands-CLI repo
-              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
+              id: cli_pr
+              continue-on-error: true
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -381,7 +384,8 @@ jobs:
                   fi
 
             - name: Create PR for automation repo
-              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
+              id: automation_pr
+              continue-on-error: true
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -472,20 +476,38 @@ jobs:
                   fi
 
             - name: Summary
-              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
+                  OPENHANDS_OUTCOME: ${{ steps.openhands_pr.outcome }}
+                  CLI_OUTCOME: ${{ steps.cli_pr.outcome }}
+                  AUTOMATION_OUTCOME: ${{ steps.automation_pr.outcome }}
               run: |
-                  echo "## ✅ Version Bump PRs Created" >> $GITHUB_STEP_SUMMARY
+                  echo "## Version Bump PRs" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "PRs have been created to bump SDK packages to version **$VERSION**:" >> $GITHUB_STEP_SUMMARY
+                  echo "Results of bumping SDK packages to version **$VERSION**:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "- [OpenHands](https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
-                  echo "- [OpenHands-CLI](https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
-                  echo "- [automation](https://github.com/OpenHands/automation/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+
+                  # The "Create PR" steps use continue-on-error, so surface any
+                  # failure here instead of silently linking to a PR that was
+                  # never created.
+                  if [ "$OPENHANDS_OUTCOME" = "failure" ]; then
+                    echo "- ⚠️ **OpenHands PR creation FAILED** — see the \"Create PR for OpenHands repo\" step logs" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "- [OpenHands](https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  fi
+                  if [ "$CLI_OUTCOME" = "failure" ]; then
+                    echo "- ⚠️ **OpenHands-CLI PR creation FAILED** — see the \"Create PR for OpenHands-CLI repo\" step logs" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "- [OpenHands-CLI](https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  fi
+                  if [ "$AUTOMATION_OUTCOME" = "failure" ]; then
+                    echo "- ⚠️ **automation PR creation FAILED** — see the \"Create PR for automation repo\" step logs" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "- [automation](https://github.com/OpenHands/automation/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  fi
 
             - name: Notify Slack
-              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' && env.SLACK_BOT_TOKEN != '' }}
+              if: env.SLACK_BOT_TOKEN != ''
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                   method: chat.postMessage

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -52,6 +52,7 @@ jobs:
                   enable-cache: false
 
             - name: Wait for packages to be available on PyPI
+              id: wait_for_packages
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -98,6 +99,9 @@ jobs:
                   echo "✅ All packages are resolvable on PyPI!"
 
             - name: Create PR for OpenHands repo
+              # Runs independently of the other "Create PR" steps below: each
+              # bumps an unrelated repo, so one failing shouldn't skip the rest.
+              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -300,6 +304,7 @@ jobs:
                   fi
 
             - name: Create PR for OpenHands-CLI repo
+              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -376,6 +381,7 @@ jobs:
                   fi
 
             - name: Create PR for automation repo
+              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -466,6 +472,7 @@ jobs:
                   fi
 
             - name: Summary
+              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -478,7 +485,7 @@ jobs:
                   echo "- [automation](https://github.com/OpenHands/automation/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
 
             - name: Notify Slack
-              if: env.SLACK_BOT_TOKEN != ''
+              if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' && env.SLACK_BOT_TOKEN != '' }}
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                   method: chat.postMessage


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

If one step is failing, the other are still running.

---

AGENT:

## Why

In the `create-version-bump-prs` job, a step with no `if:` condition implicitly
requires all prior steps to have succeeded. In [run 29010691311](https://github.com/OpenHands/software-agent-sdk/actions/runs/29010691311/job/86093299051),
the "Create PR for OpenHands-CLI repo" step failed, which caused the
independent "Create PR for automation repo", "Summary", and "Notify Slack"
steps to be skipped — even though they bump unrelated repos and don't depend
on that step's outcome.

## Summary
- Give the "Wait for packages to be available on PyPI" step an `id: wait_for_packages`.
- Change the three "Create PR for..." steps, "Summary", and "Notify Slack" to
  `if: ${{ !cancelled() && steps.wait_for_packages.outcome == 'success' }}`
  (Notify Slack keeps its existing `SLACK_BOT_TOKEN` check too), so each only
  depends on the shared setup steps, not on its sibling steps.

## Issue Number

N/A

## How to Test

- Validated the YAML with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/version-bump-prs.yml'))"` — parses cleanly.
- Printed each step's resolved `if:` condition via PyYAML to confirm the three
  "Create PR" steps, "Summary", and "Notify Slack" now depend on
  `wait_for_packages` rather than each other, while "Checkout", "Get version",
  "Validate version", and "Install uv" keep their default (all-must-succeed)
  behavior.
- Did not trigger a real `workflow_dispatch` run, since this workflow creates
  live PRs against `OpenHands/OpenHands`, `OpenHands/openhands-cli`, and
  `OpenHands/automation` — not safe to exercise end-to-end outside of an
  actual release.

## Video/Screenshots

N/A — CI workflow change, no UI.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Only the `create-version-bump-prs` job is touched; `bump-typescript-client`
  is a separate job with genuinely sequential steps and is unaffected.
- The job's overall conclusion is still `failure` if any step fails (no
  `continue-on-error` is used) — this only stops one failing step from
  skipping its independent siblings.
