### PR TITLE
refactor(skills): report touched paths on observations for path-rule injection

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -5,7 +5,7 @@ import copy
 import json
 import uuid
 from collections.abc import Mapping, Sequence
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Any, Final, TypeGuard, cast
 
 from openhands.sdk.agent.acp_agent import ACPAgent
@@ -72,6 +72,7 @@ from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
 from openhands.sdk.skills import load_available_skills, merge_skills_by_name
+from openhands.sdk.skills.skill import normalize_rule_path
 from openhands.sdk.skills.utils import (
     expand_mcp_variables,
     expand_variable_references,
@@ -495,8 +496,9 @@ class LocalConversation(BaseConversation):
             return event
 
         contents: list[TextContent] = []
+        working_dir = self.workspace.working_dir
         for raw_path in event.observation.affected_paths:
-            if (file_path := self._normalize_rule_path(raw_path)) is None:
+            if (file_path := normalize_rule_path(raw_path, working_dir)) is None:
                 continue
             result = agent_context.get_tool_use_suffix(
                 file_path=file_path,
@@ -513,32 +515,6 @@ class LocalConversation(BaseConversation):
         return event.model_copy(
             update={"extended_content": list(event.extended_content) + contents}
         )
-
-    def _normalize_rule_path(self, raw_path: str) -> str | None:
-        """Return the workspace-relative POSIX form of ``raw_path``.
-
-        Returns None when the path is empty or resolves outside the workspace
-        (rules are repo-scoped).
-        """
-        if not raw_path:
-            return None
-
-        # Use the native path flavour so Windows drive paths (e.g. ``D:\\...``) are
-        # recognized as absolute; emit a POSIX string for glob matching.
-        raw = PurePath(raw_path)
-        if not raw.is_absolute():
-            return raw.as_posix()
-        root = PurePath(self.workspace.working_dir)
-        with contextlib.suppress(ValueError):
-            return raw.relative_to(root).as_posix()
-        # Fall back to filesystem resolution so a symlinked workspace root (e.g.
-        # macOS /tmp -> /private/tmp) still matches; strict=False keeps a
-        # not-yet-created leaf.
-        with contextlib.suppress(ValueError, OSError):
-            resolved = Path(raw_path).resolve()
-            resolved_root = Path(self.workspace.working_dir).resolve()
-            return resolved.relative_to(resolved_root).as_posix()
-        return None  # touched a file outside the workspace; rules are repo-scoped
 
     def _recover_persisted_client_tools(
         self,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -484,8 +484,8 @@ class LocalConversation(BaseConversation):
     def _maybe_inject_path_rules(self, event: Event) -> Event:
         """Return ``event`` with matching path-rule content, or unchanged.
 
-        Only ``ObservationEvent``s carrying a file path are considered. Matching
-        rules already injected in this conversation are skipped via
+        Only ``ObservationEvent``s that report ``affected_paths`` are considered.
+        Matching rules already injected in this conversation are skipped via
         ``state.activated_path_rules``.
         """
         if not isinstance(event, ObservationEvent):
@@ -494,40 +494,33 @@ class LocalConversation(BaseConversation):
         if (agent_context := self.agent.agent_context) is None:
             return event
 
-        if (file_path := self._touched_rule_path(event)) is None:
-            return event
+        contents: list[TextContent] = []
+        for raw_path in event.observation.affected_paths:
+            if (file_path := self._normalize_rule_path(raw_path)) is None:
+                continue
+            result = agent_context.get_tool_use_suffix(
+                file_path=file_path,
+                skip_skill_names=self._state.activated_path_rules,
+            )
+            if result is None:
+                continue
+            content, activated_rule_names = result
+            self._state.activated_path_rules.extend(activated_rule_names)
+            contents.append(content)
 
-        result = agent_context.get_tool_use_suffix(
-            file_path=file_path,
-            skip_skill_names=self._state.activated_path_rules,
-        )
-        if result is None:
+        if not contents:
             return event
-
-        content, activated_rule_names = result
-        self._state.activated_path_rules.extend(activated_rule_names)
         return event.model_copy(
-            update={"extended_content": list(event.extended_content) + [content]}
+            update={"extended_content": list(event.extended_content) + contents}
         )
 
-    def _touched_rule_path(self, event: ObservationEvent) -> str | None:
-        """Return the workspace-relative POSIX path a tool observation touched.
+    def _normalize_rule_path(self, raw_path: str) -> str | None:
+        """Return the workspace-relative POSIX form of ``raw_path``.
 
-        Correlates the observation to its ``ActionEvent`` and reads the action's
-        ``path`` field generically (no dependency on the tools package). Returns
-        None when the action has no file ``path`` or the path is outside the
-        workspace.
+        Returns None when the path is empty or resolves outside the workspace
+        (rules are repo-scoped).
         """
-        action_event: Event | None = None
-        with contextlib.suppress(KeyError):
-            idx = self._state.events.get_index(event.action_id)
-            action_event = self._state.events[idx]
-        if not isinstance(action_event, ActionEvent) or action_event.action is None:
-            return None
-        # Read the field directly rather than model_dump(): avoids copying large
-        # edit payloads (file_text/old_str/new_str) just to read the path.
-        raw_path = getattr(action_event.action, "path", None)
-        if not isinstance(raw_path, str) or not raw_path:
+        if not raw_path:
             return None
 
         # Use the native path flavour so Windows drive paths (e.g. ``D:\\...``) are

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import json
 import os
@@ -6,7 +7,7 @@ import threading
 import time
 from collections.abc import Iterable, Mapping
 from functools import lru_cache
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Annotated, Any, ClassVar, Final, Literal, Union
 from xml.sax.saxutils import escape as xml_escape
 
@@ -92,6 +93,37 @@ def path_matches_glob(file_path: str, pattern: str) -> bool:
     if not pattern:
         return False
     return _compile_path_glob(pattern).fullmatch(file_path) is not None
+
+
+def normalize_rule_path(
+    raw_path: str, working_dir: str | os.PathLike[str]
+) -> str | None:
+    """Return the ``working_dir``-relative POSIX form of ``raw_path``.
+
+    Path rules are repo-scoped, so a touched path is normalized to this form
+    before matching it against :class:`PathTrigger` globs with
+    :func:`path_matches_glob`. Returns None when ``raw_path`` is empty or
+    resolves outside ``working_dir``.
+    """
+    if not raw_path:
+        return None
+
+    # Use the native path flavour so Windows drive paths (e.g. ``D:\\...``) are
+    # recognized as absolute; emit a POSIX string for glob matching.
+    raw = PurePath(raw_path)
+    if not raw.is_absolute():
+        return raw.as_posix()
+    root = PurePath(working_dir)
+    with contextlib.suppress(ValueError):
+        return raw.relative_to(root).as_posix()
+    # Fall back to filesystem resolution so a symlinked workspace root (e.g.
+    # macOS /tmp -> /private/tmp) still matches; strict=False keeps a
+    # not-yet-created leaf.
+    with contextlib.suppress(ValueError, OSError):
+        resolved = Path(raw_path).resolve()
+        resolved_root = Path(working_dir).resolve()
+        return resolved.relative_to(resolved_root).as_posix()
+    return None  # touched a file outside the workspace; rules are repo-scoped
 
 
 class SkillInfo(BaseModel):

--- a/openhands-sdk/openhands/sdk/tool/schema.py
+++ b/openhands-sdk/openhands/sdk/tool/schema.py
@@ -363,6 +363,16 @@ class Observation(Schema, ABC):
         default=False, description="Whether the observation indicates an error"
     )
 
+    @property
+    def affected_paths(self) -> list[str]:
+        """Filesystem paths this tool created, modified, or moved.
+
+        Empty by default; file-touching observations override it so consumers
+        (e.g. path-rule injection) read typed data instead of guessing a
+        ``path`` field on the action.
+        """
+        return []
+
     @classmethod
     def from_text(
         cls,

--- a/openhands-tools/openhands/tools/apply_patch/definition.py
+++ b/openhands-tools/openhands/tools/apply_patch/definition.py
@@ -53,6 +53,18 @@ class ApplyPatchObservation(Observation):
     fuzz: int = 0
     commit: Commit | None = None
 
+    @property
+    def affected_paths(self) -> list[str]:
+        if self.is_error or self.commit is None:
+            return []
+        paths = list(self.commit.changes.keys())
+        paths.extend(
+            change.move_path
+            for change in self.commit.changes.values()
+            if change.move_path
+        )
+        return paths
+
 
 class ApplyPatchExecutor(ToolExecutor[ApplyPatchAction, ApplyPatchObservation]):
     """Executor that applies unified text patches within the workspace.

--- a/openhands-tools/openhands/tools/file_editor/definition.py
+++ b/openhands-tools/openhands/tools/file_editor/definition.py
@@ -91,6 +91,10 @@ class FileEditorObservation(Observation):
     _diff_cache: Text | None = PrivateAttr(default=None)
 
     @property
+    def affected_paths(self) -> list[str]:
+        return [self.path] if self.path and not self.is_error else []
+
+    @property
     def visualize(self) -> Text:
         """Return Rich Text representation of this observation.
 

--- a/openhands-tools/openhands/tools/gemini/edit/definition.py
+++ b/openhands-tools/openhands/tools/gemini/edit/definition.py
@@ -65,6 +65,10 @@ class EditObservation(Observation):
     _diff_cache: Text | None = PrivateAttr(default=None)
 
     @property
+    def affected_paths(self) -> list[str]:
+        return [self.file_path] if self.file_path and not self.is_error else []
+
+    @property
     def visualize(self) -> Text:
         """Return Rich Text representation of this observation."""
         text = Text()

--- a/openhands-tools/openhands/tools/gemini/read_file/definition.py
+++ b/openhands-tools/openhands/tools/gemini/read_file/definition.py
@@ -63,6 +63,10 @@ class ReadFileObservation(Observation):
     )
 
     @property
+    def affected_paths(self) -> list[str]:
+        return [self.file_path] if self.file_path and not self.is_error else []
+
+    @property
     def visualize(self) -> Text:
         """Return Rich Text representation of this observation."""
         text = Text()

--- a/openhands-tools/openhands/tools/gemini/write_file/definition.py
+++ b/openhands-tools/openhands/tools/gemini/write_file/definition.py
@@ -47,6 +47,10 @@ class WriteFileObservation(Observation):
     _diff_cache: Text | None = PrivateAttr(default=None)
 
     @property
+    def affected_paths(self) -> list[str]:
+        return [self.file_path] if self.file_path and not self.is_error else []
+
+    @property
     def visualize(self) -> Text:
         """Return Rich Text representation of this observation."""
         text = Text()

--- a/tests/sdk/conversation/test_path_rules_injection.py
+++ b/tests/sdk/conversation/test_path_rules_injection.py
@@ -1,11 +1,14 @@
 """Tests for the path-rule injection seam in LocalConversation.
 
-When the agent touches a file whose path matches a PathTrigger skill ("rule"),
-the rule content is appended to the resulting ObservationEvent's
-``extended_content`` and deduped via ``state.activated_path_rules``.
+When a tool observation reports an ``affected_paths`` entry matching a
+PathTrigger skill ("rule"), the rule content is appended to the
+ObservationEvent's ``extended_content`` and deduped via
+``state.activated_path_rules``.
 """
 
 from pathlib import Path
+
+from pydantic import Field
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.context.agent_context import AgentContext
@@ -19,7 +22,7 @@ from openhands.sdk.tool.builtins.invoke_skill import (
     InvokeSkillAction,
     InvokeSkillExecutor,
 )
-from openhands.sdk.tool.schema import Action
+from openhands.sdk.tool.schema import Action, Observation
 
 
 class _FileAction(Action):
@@ -35,7 +38,21 @@ class _NoPathAction(Action):
     command: str = "ls"
 
 
-def _conversation(tmp_path: Path, rule: Skill) -> LocalConversation:
+class _FileObservation(Observation):
+    """Minimal path-bearing observation (stands in for a file-tool result).
+
+    The injection seam reads ``observation.affected_paths``; this stand-in lets
+    the SDK tests exercise it without importing openhands-tools.
+    """
+
+    paths: list[str] = Field(default_factory=list)
+
+    @property
+    def affected_paths(self) -> list[str]:
+        return list(self.paths)
+
+
+def _conversation(tmp_path: Path, *rules: Skill) -> LocalConversation:
     agent = Agent(
         llm=TestLLM.from_messages(
             [Message(role="assistant", content=[TextContent(text="ok")])],
@@ -43,7 +60,7 @@ def _conversation(tmp_path: Path, rule: Skill) -> LocalConversation:
         ),
         tools=[],
         include_default_tools=[],
-        agent_context=AgentContext(skills=[rule]),
+        agent_context=AgentContext(skills=list(rules)),
     )
     return LocalConversation(
         agent=agent,
@@ -71,8 +88,14 @@ def _append_file_action(conv: LocalConversation, abs_path: str) -> ActionEvent:
 
 
 def _observation_for(action_event: ActionEvent) -> ObservationEvent:
+    # Mirror the action's touched path onto the observation, which is where the
+    # injection seam reads it from (``observation.affected_paths``).
+    touched = getattr(action_event.action, "path", None)
     return ObservationEvent(
-        observation=FinishObservation(content=[TextContent(text="tool-result")]),
+        observation=_FileObservation(
+            paths=[touched] if touched else [],
+            content=[TextContent(text="tool-result")],
+        ),
         action_id=action_event.id,
         tool_name=action_event.tool_name,
         tool_call_id=action_event.tool_call_id,
@@ -193,7 +216,7 @@ def test_file_outside_workspace_is_not_matched(tmp_path: Path) -> None:
 def test_symlinked_workspace_root_still_matches(tmp_path: Path) -> None:
     """A rule fires even when the action path and the workspace root differ only
     by a symlink (e.g. macOS /tmp -> /private/tmp); the resolve() fallback in
-    ``_touched_rule_path`` recovers the workspace-relative path."""
+    ``_normalize_rule_path`` recovers the workspace-relative path."""
     real = tmp_path / "real_ws"
     real.mkdir()
     link = tmp_path / "link_ws"
@@ -331,19 +354,53 @@ def test_no_injection_when_agent_has_no_context(tmp_path: Path) -> None:
         conv.close()
 
 
-def test_no_injection_when_action_not_correlated(tmp_path: Path) -> None:
-    """An observation whose action_id isn't in the event log yields no path."""
+def test_no_injection_when_observation_reports_no_paths(tmp_path: Path) -> None:
+    """An observation that reports no ``affected_paths`` never injects a rule."""
     rule = Skill(name="any", content="rule", trigger=PathTrigger(paths=["**/*"]))
     conv = _conversation(tmp_path, rule)
     try:
-        orphan = ObservationEvent(
+        obs = ObservationEvent(
             observation=FinishObservation(content=[TextContent(text="x")]),
-            action_id="nonexistent-action-id",
-            tool_name="file_editor",
+            action_id="unrelated-action-id",
+            tool_name="finish",
             tool_call_id="tc9",
         )
-        injected = _inject(conv, orphan)
+        injected = _inject(conv, obs)
         assert injected.extended_content == []
         assert conv._state.activated_path_rules == []
+    finally:
+        conv.close()
+
+
+def test_multiple_affected_paths_inject_matching_rules(tmp_path: Path) -> None:
+    """An observation touching several files fires each matching rule (e.g. an
+    apply_patch that edits and renames across directories)."""
+    api = Skill(
+        name="api", content="Use zod.", trigger=PathTrigger(paths=["src/api/**/*.ts"])
+    )
+    ui = Skill(
+        name="ui",
+        content="Use tailwind.",
+        trigger=PathTrigger(paths=["src/ui/**/*.ts"]),
+    )
+    conv = _conversation(tmp_path, api, ui)
+    try:
+        obs = ObservationEvent(
+            observation=_FileObservation(
+                paths=[
+                    str(tmp_path / "src" / "api" / "a.ts"),
+                    str(tmp_path / "src" / "ui" / "b.ts"),
+                ],
+                content=[TextContent(text="tool-result")],
+            ),
+            action_id="a1",
+            tool_name="apply_patch",
+            tool_call_id="tc1",
+        )
+        injected = _inject(conv, obs)
+        texts = " ".join(c.text for c in injected.extended_content)
+        assert "Use zod." in texts
+        assert "Use tailwind." in texts
+        assert sorted(conv._state.activated_path_rules) == ["api", "ui"]
     finally:
         conv.close()

--- a/tests/sdk/conversation/test_path_rules_injection.py
+++ b/tests/sdk/conversation/test_path_rules_injection.py
@@ -216,7 +216,7 @@ def test_file_outside_workspace_is_not_matched(tmp_path: Path) -> None:
 def test_symlinked_workspace_root_still_matches(tmp_path: Path) -> None:
     """A rule fires even when the action path and the workspace root differ only
     by a symlink (e.g. macOS /tmp -> /private/tmp); the resolve() fallback in
-    ``_normalize_rule_path`` recovers the workspace-relative path."""
+    ``normalize_rule_path`` recovers the workspace-relative path."""
     real = tmp_path / "real_ws"
     real.mkdir()
     link = tmp_path / "link_ws"

--- a/tests/sdk/skills/test_path_trigger.py
+++ b/tests/sdk/skills/test_path_trigger.py
@@ -16,7 +16,7 @@ from openhands.sdk.skills import (
     utils as skills_utils,
 )
 from openhands.sdk.skills.exceptions import SkillValidationError
-from openhands.sdk.skills.skill import path_matches_glob
+from openhands.sdk.skills.skill import normalize_rule_path, path_matches_glob
 
 
 _HAS_GIT = shutil.which("git") is not None
@@ -68,6 +68,45 @@ def test_path_matches_glob(file_path: str, pattern: str, expected: bool) -> None
 
 def test_empty_pattern_never_matches() -> None:
     assert path_matches_glob("anything.ts", "") is False
+
+
+def test_normalize_rule_path_relative_is_passed_through() -> None:
+    # A relative path is already workspace-relative; only the flavour is
+    # normalized to POSIX (matters on Windows).
+    assert normalize_rule_path("src/api/x.ts", "/ws") == "src/api/x.ts"
+
+
+def test_normalize_rule_path_absolute_inside_workspace() -> None:
+    assert normalize_rule_path("/ws/src/api/x.ts", "/ws") == "src/api/x.ts"
+
+
+def test_normalize_rule_path_empty_is_none() -> None:
+    assert normalize_rule_path("", "/ws") is None
+
+
+def test_normalize_rule_path_absolute_outside_workspace_is_none(
+    tmp_path: Path,
+) -> None:
+    # Outside the workspace on the filesystem too, so the resolve() fallback
+    # cannot rescue it -> rules are repo-scoped, so None.
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    outside = tmp_path / "outside" / "x.ts"
+    assert normalize_rule_path(str(outside), str(workspace)) is None
+
+
+def test_normalize_rule_path_symlinked_root_resolved(tmp_path: Path) -> None:
+    """A path under the resolved root still normalizes when the workspace is
+    given by its symlinked form (e.g. macOS /tmp -> /private/tmp)."""
+    real = tmp_path / "real_ws"
+    real.mkdir()
+    link = tmp_path / "link_ws"
+    try:
+        link.symlink_to(real)
+    except OSError:
+        pytest.skip("symlinks not supported on this platform")
+    # workspace passed as the symlink; touched path is the resolved (real) form.
+    assert normalize_rule_path(str(real / "src" / "x.ts"), str(link)) == "src/x.ts"
 
 
 def _write_rule(directory: Path, name: str, frontmatter: str, body: str) -> Path:

--- a/tests/tools/test_affected_paths.py
+++ b/tests/tools/test_affected_paths.py
@@ -1,0 +1,61 @@
+"""``affected_paths`` on tool observations drives path-rule injection.
+
+Each file-touching observation reports the path(s) it modified so
+``LocalConversation`` can fire path rules without guessing a ``path`` field on
+the action. Search/listing observations touch no files and report nothing,
+which keeps rules from firing spuriously on a directory that was only searched.
+"""
+
+from openhands.tools.apply_patch.core import ActionType, Commit, FileChange
+from openhands.tools.apply_patch.definition import ApplyPatchObservation
+from openhands.tools.file_editor import FileEditorObservation
+from openhands.tools.gemini import (
+    EditObservation,
+    ReadFileObservation,
+    WriteFileObservation,
+)
+from openhands.tools.glob import GlobObservation
+from openhands.tools.grep import GrepObservation
+
+
+def test_file_editor_reports_edited_path() -> None:
+    obs = FileEditorObservation(command="str_replace", path="/w/a.py")
+    assert obs.affected_paths == ["/w/a.py"]
+
+
+def test_file_editor_reports_nothing_on_error() -> None:
+    obs = FileEditorObservation(command="str_replace", path="/w/a.py", is_error=True)
+    assert obs.affected_paths == []
+
+
+def test_gemini_write_edit_read_report_file_path() -> None:
+    assert WriteFileObservation(file_path="/w/a.py").affected_paths == ["/w/a.py"]
+    assert EditObservation(file_path="/w/b.py").affected_paths == ["/w/b.py"]
+    assert ReadFileObservation(file_path="/w/c.py").affected_paths == ["/w/c.py"]
+
+
+def test_apply_patch_reports_all_changed_and_moved_paths() -> None:
+    commit = Commit(
+        changes={
+            "src/api/a.ts": FileChange(type=ActionType.UPDATE),
+            "src/api/b.ts": FileChange(type=ActionType.ADD),
+            "old.ts": FileChange(type=ActionType.UPDATE, move_path="src/api/new.ts"),
+        }
+    )
+    obs = ApplyPatchObservation(commit=commit)
+    # Both the changed files and the rename destination are reported.
+    assert obs.affected_paths == [
+        "src/api/a.ts",
+        "src/api/b.ts",
+        "old.ts",
+        "src/api/new.ts",
+    ]
+
+
+def test_search_observations_report_no_paths() -> None:
+    # grep/glob only search a directory; they modify nothing, so path rules
+    # must not fire even though the observations carry file lists.
+    assert (
+        GrepObservation(matches=[], pattern="x", search_path="/w").affected_paths == []
+    )
+    assert GlobObservation(files=[], pattern="*", search_path="/w").affected_paths == []

--- a/tests/tools/test_path_rules_file_editor.py
+++ b/tests/tools/test_path_rules_file_editor.py
@@ -1,9 +1,10 @@
-"""End-to-end check that path rules fire on the REAL file-editor action.
+"""End-to-end check that path rules fire on the REAL file-editor tool.
 
-The injection seam reads the touched path from the action's ``path`` field
-(``local_conversation._touched_rule_path``). These tests use the actual
+The injection seam reads the touched path from the observation's
+``affected_paths`` (``FileEditorObservation``). These tests use the actual
 ``FileEditorAction`` / ``FileEditorObservation`` from openhands-tools so a
-rename of that field (which would silently no-op the whole feature) is caught.
+rename of the underlying ``path`` field (which would silently no-op the whole
+feature) is caught.
 """
 
 from pathlib import Path
@@ -66,7 +67,9 @@ def test_real_file_editor_action_triggers_path_rule(tmp_path: Path) -> None:
 
         obs = ObservationEvent(
             observation=FileEditorObservation(
-                command="view", content=[TextContent(text="<file contents>")]
+                command="view",
+                path=str(tmp_path / "src" / "api" / "users.ts"),
+                content=[TextContent(text="<file contents>")],
             ),
             action_id=action_event.id,
             tool_name="str_replace_editor",
@@ -97,7 +100,9 @@ def test_real_file_editor_action_nonmatching_path(tmp_path: Path) -> None:
         with conv._state:
             conv._on_event(action_event)
         obs = ObservationEvent(
-            observation=FileEditorObservation(command="view"),
+            observation=FileEditorObservation(
+                command="view", path=str(tmp_path / "README.md")
+            ),
             action_id=action_event.id,
             tool_name="str_replace_editor",
             tool_call_id="tc1",
@@ -126,7 +131,11 @@ def test_real_file_editor_create_command_triggers_rule(tmp_path: Path) -> None:
         with conv._state:
             conv._on_event(action_event)
         obs = ObservationEvent(
-            observation=FileEditorObservation(command="create", prev_exist=False),
+            observation=FileEditorObservation(
+                command="create",
+                path=str(tmp_path / "src" / "api" / "new.ts"),
+                prev_exist=False,
+            ),
             action_id=action_event.id,
             tool_name="str_replace_editor",
             tool_call_id="tc1",

--- a/tests/tools/test_path_rules_missed_tools.py
+++ b/tests/tools/test_path_rules_missed_tools.py
@@ -1,0 +1,124 @@
+"""End-to-end: path rules fire for the tools the old ``getattr(action, "path")``
+seam silently missed (Gemini file tools, apply_patch), and do NOT fire for a
+directory that was only searched (grep).
+
+These drive the REAL observations from openhands-tools through the actual
+injection seam (``LocalConversation._maybe_inject_path_rules``).
+"""
+
+from pathlib import Path
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.context.agent_context import AgentContext
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.event import ObservationEvent
+from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.skills import PathTrigger, Skill
+from openhands.sdk.testing import TestLLM
+from openhands.tools.apply_patch.core import ActionType, Commit, FileChange
+from openhands.tools.apply_patch.definition import ApplyPatchObservation
+from openhands.tools.gemini import WriteFileObservation
+from openhands.tools.grep import GrepObservation
+
+
+def _conversation(tmp_path: Path, *rules: Skill) -> LocalConversation:
+    agent = Agent(
+        llm=TestLLM.from_messages(
+            [Message(role="assistant", content=[TextContent(text="ok")])],
+            model="test-model",
+        ),
+        tools=[],
+        include_default_tools=[],
+        agent_context=AgentContext(skills=list(rules)),
+    )
+    return LocalConversation(
+        agent=agent,
+        workspace=tmp_path,
+        persistence_dir=tmp_path / "conversation",
+        delete_on_close=True,
+    )
+
+
+def _obs_event(observation, tool_name: str) -> ObservationEvent:
+    return ObservationEvent(
+        observation=observation,
+        action_id="a1",
+        tool_name=tool_name,
+        tool_call_id="tc1",
+    )
+
+
+def _api_rule() -> Skill:
+    return Skill(
+        name="api",
+        content="Use zod for API validation.",
+        trigger=PathTrigger(paths=["src/api/**/*.ts"]),
+    )
+
+
+def test_gemini_write_file_triggers_path_rule(tmp_path: Path) -> None:
+    """A real Gemini WriteFileObservation (field ``file_path``) fires the rule
+    the old ``getattr(action, "path")`` seam missed."""
+    conv = _conversation(tmp_path, _api_rule())
+    try:
+        obs = _obs_event(
+            WriteFileObservation(
+                file_path=str(tmp_path / "src" / "api" / "users.ts"), is_new_file=True
+            ),
+            tool_name="write_file",
+        )
+        injected = conv._maybe_inject_path_rules(obs)
+        assert isinstance(injected, ObservationEvent)
+        assert any("Use zod" in c.text for c in injected.extended_content)
+        assert conv._state.activated_path_rules == ["api"]
+    finally:
+        conv.close()
+
+
+def test_apply_patch_triggers_rules_for_every_changed_file(tmp_path: Path) -> None:
+    """A real ApplyPatchObservation touching files in two rule directories fires
+    both rules from a single observation (multi-path)."""
+    api = _api_rule()
+    ui = Skill(
+        name="ui",
+        content="Use tailwind.",
+        trigger=PathTrigger(paths=["src/ui/**/*.ts"]),
+    )
+    conv = _conversation(tmp_path, api, ui)
+    try:
+        commit = Commit(
+            changes={
+                "src/api/a.ts": FileChange(type=ActionType.UPDATE),
+                "src/ui/b.ts": FileChange(type=ActionType.ADD),
+            }
+        )
+        injected = conv._maybe_inject_path_rules(
+            _obs_event(ApplyPatchObservation(commit=commit), tool_name="apply_patch")
+        )
+        assert isinstance(injected, ObservationEvent)
+        texts = " ".join(c.text for c in injected.extended_content)
+        assert "Use zod" in texts and "Use tailwind" in texts
+        assert sorted(conv._state.activated_path_rules) == ["api", "ui"]
+    finally:
+        conv.close()
+
+
+def test_grep_over_a_matching_directory_does_not_trigger(tmp_path: Path) -> None:
+    """grep searches a directory but modifies nothing, so the rule must not
+    fire even though the searched directory matches the rule's tree."""
+    conv = _conversation(tmp_path, _api_rule())
+    try:
+        obs = _obs_event(
+            GrepObservation(
+                matches=[str(tmp_path / "src" / "api" / "users.ts")],
+                pattern="zod",
+                search_path=str(tmp_path / "src" / "api"),
+            ),
+            tool_name="grep",
+        )
+        injected = conv._maybe_inject_path_rules(obs)
+        assert isinstance(injected, ObservationEvent)
+        assert injected.extended_content == []
+        assert conv._state.activated_path_rules == []
+    finally:
+        conv.close()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Refactor path-rule injection.

---

AGENT:

## Why

Path-rule injection discovered the touched file via
`getattr(action_event.action, "path", None)` in
`LocalConversation._touched_rule_path` — an implicit, untyped contract flagged
while reviewing #3994. It fails in two directions with tools that ship today:

- **Misses tools.** The Gemini file tools name the field `file_path`, and
  `apply_patch` carries only a patch string — so `getattr(action, "path")`
  returns `None` and rules silently never fire.
- **Fires spuriously.** `grep` / `glob` / `list_directory` carry a `path` that
  is a *search directory*, not a modified file, so a directory a tool merely
  searched can trigger `{dir}/**` or `**` rules.

It also can't express an operation that touches several files (a rename touches
source **and** destination; a patch can touch many).

## Summary

- Add an `affected_paths` property to the `Observation` base (empty by default);
  file-touching observations override it to declare the paths they modified.
- The injection seam now reads `observation.affected_paths` directly — dropping
  the action-correlation lookup and the `getattr` string-name guess, and
  supporting multiple paths.
- Producers populate it: `file_editor`, Gemini `read`/`write`/`edit`, and
  `apply_patch` (changed files + rename destinations). `grep`/`glob`/`list`
  report nothing, so rules no longer fire on a directory that was only searched.

This follows **Option C** from the issue, adapted: the value is a *derived*
property, not a stored/serialized field, so it needs no event-schema migration
and recomputes correctly after deserialization (the base is frozen with
`extra="forbid"`, so a serialized computed field would break round-trip
validation).

## Issue Number

Closes #4038

## How to Test

Unit + producer coverage:

```
uv run pytest tests/sdk/conversation/test_path_rules_injection.py \
              tests/tools/test_path_rules_file_editor.py \
              tests/tools/test_affected_paths.py -q
# 22 passed
```

Broader regression sweep (base-schema + producer changes):

```
uv run pytest tests/sdk/tool tests/tools/{file_editor,apply_patch,gemini,grep,glob} \
              tests/sdk/conversation -q
# 1226 passed
```

End-to-end (the previously-missed case) — drive a **real Gemini `write_file`**
observation through a live `LocalConversation` and confirm the rule fires:

```
getattr(action, 'path'): None            <- what the old seam saw (missed it)
observation.affected_paths: ['/.../src/api/users.ts']
...
RESULT: rule fired for a Gemini write_file. activated_path_rules = ['api']
```

`pre-commit run --all-files` scoped to the changed files passes (ruff, pyright,
import-dependency rules, tool-registration).

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Producer + consumer land together (by design).** Once the seam reads
  `affected_paths`, any file-mutating observation that doesn't override the
  property reports nothing — so all producers are updated in this PR. Third-party
  tools that want path rules should override `affected_paths` on their
  observation.
- **Reads count as touches.** `read_file` / file-editor `view` report their path
  (consistent with the pre-existing file-editor behaviour). Erroring ops report
  nothing. Happy to gate reads out if reviewers prefer writes-only.
- The core `openhands-sdk` → `openhands-tools` layering is preserved (no new
  cross-package imports; verified by the import-rules hook).
