### PR TITLE
fix: pick a display base ref that keeps committed work visible

### DIFF
--- a/openhands-sdk/openhands/sdk/git/git_changes.py
+++ b/openhands-sdk/openhands/sdk/git/git_changes.py
@@ -60,7 +60,10 @@ def get_changes_in_repo(
     # Validate the repository first
     validated_repo = validate_git_repository(repo_dir)
 
-    ref = get_valid_ref(validated_repo, override=ref)
+    # These changes are rendered to the user (e.g. the GUI's Diff view), so
+    # auto-detect the base with the display policy: committed and even
+    # pushed work stays visible instead of vanishing behind a vacuous base.
+    ref = get_valid_ref(validated_repo, override=ref, purpose="display")
     if not ref:
         logger.warning(f"No valid git reference found for {validated_repo}")
         return []

--- a/openhands-sdk/openhands/sdk/git/git_diff.py
+++ b/openhands-sdk/openhands/sdk/git/git_diff.py
@@ -93,7 +93,9 @@ def get_git_diff(relative_file_path: str | Path, ref: str | None = None) -> GitD
     # Validate the git repository
     validated_repo = validate_git_repository(closest_git_repo)
 
-    current_rev = get_valid_ref(validated_repo, override=ref)
+    # Must match get_changes_in_repo's base selection (purpose="display"),
+    # so the per-file diff lines up with the change list it was opened from.
+    current_rev = get_valid_ref(validated_repo, override=ref, purpose="display")
     if not current_rev:
         logger.warning(f"No valid git reference found for {validated_repo}")
         return GitDiff(modified="", original="")

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -3,6 +3,7 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
+from typing import Literal
 
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.utils.redact import (
@@ -110,7 +111,178 @@ def _repo_has_commits(repo_dir: str | Path) -> bool:
         return False
 
 
-def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | None:
+def _rev_parse(repo_dir: str | Path, ref: str) -> str | None:
+    """Resolve ``ref`` to a commit SHA, or None if it doesn't resolve."""
+    try:
+        result = run_git_command(
+            ["git", "--no-pager", "rev-parse", "--verify", ref], repo_dir
+        )
+        return result or None
+    except GitCommandError:
+        return None
+
+
+def _merge_base(repo_dir: str | Path, ref_a: str, ref_b: str) -> str | None:
+    """Return the merge base of two refs, or None if it can't be computed
+    (e.g. unrelated histories, shallow clone)."""
+    try:
+        result = run_git_command(
+            ["git", "--no-pager", "merge-base", ref_a, ref_b], repo_dir
+        )
+        return result or None
+    except GitCommandError:
+        return None
+
+
+def _get_current_branch(repo_dir: str | Path) -> str | None:
+    """Return the current branch name, or None when detached/unborn."""
+    try:
+        branch = run_git_command(
+            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"], repo_dir
+        )
+        if branch and branch != "HEAD":
+            return branch
+    except GitCommandError:
+        logger.debug("Could not get current branch name")
+    return None
+
+
+def _get_remote_default_branch(repo_dir: str | Path) -> str | None:
+    """Find origin's default branch name (e.g. ``main``).
+
+    Prefers the local ``origin/HEAD`` symref (recorded on clone — no
+    network); falls back to ``git remote show origin`` (a network call)
+    for remotes that were added without recording ``origin/HEAD``.
+    """
+    try:
+        symref = run_git_command(
+            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "origin/HEAD"],
+            repo_dir,
+        )
+        prefix = "origin/"
+        if symref.startswith(prefix) and len(symref) > len(prefix):
+            return symref[len(prefix) :]
+    except GitCommandError:
+        logger.debug("origin/HEAD not set; falling back to `git remote show`")
+
+    try:
+        remote_info = run_git_command(
+            ["git", "--no-pager", "remote", "show", "origin"], repo_dir
+        )
+        for line in remote_info.splitlines():
+            if "HEAD branch:" in line:
+                default_branch = line.split(":")[-1].strip()
+                if default_branch and default_branch != "(unknown)":
+                    return default_branch
+                break
+    except GitCommandError:
+        logger.debug("Could not get remote information")
+    return None
+
+
+def _has_tracked_changes(repo_dir: str | Path) -> bool:
+    """True when the working tree or index differs from HEAD.
+
+    Untracked files are deliberately excluded: they never appear in
+    ``git diff <ref>`` output (they're reported separately via
+    ``ls-files --others``), so they must not influence base selection —
+    a stray scratch file must not re-hide a fully-pushed branch's diff.
+    """
+    try:
+        status = run_git_command(
+            ["git", "--no-pager", "status", "--porcelain", "--untracked-files=no"],
+            repo_dir,
+        )
+        return bool(status.strip())
+    except GitCommandError:
+        # Fail-safe: treat as dirty so the branch keeps comparing against
+        # its own upstream instead of surfacing unrelated history.
+        return True
+
+
+def _get_display_base_ref(repo_dir: str | Path) -> str:
+    """Auto-detect the base ref for *displaying* what a conversation changed.
+
+    Unlike the export algorithm (which must only pick bases that are
+    reconstructable from a fresh clone, because workspace-export patches
+    are replayed elsewhere), this picks the base that best answers "what
+    has been changed here" — including work that is already committed and
+    even pushed. Candidates, in order:
+
+    1. ``origin/<current-branch>`` — but *skipped* when it points at HEAD
+       while the tracked working tree is clean: comparing a fully-pushed
+       branch against its own upstream renders an empty diff and would
+       hide the branch's (PR's) work. A dirty tree keeps this candidate,
+       so a pre-existing attached branch shows only the new edits rather
+       than the whole branch history.
+    2. ``merge-base(HEAD, origin/<default>)`` — the fork point. Preferred
+       over the default tip so commits that landed on the default branch
+       after the fork don't render as reverse-noise.
+    3. ``origin/<default>`` — when the merge base is unavailable (e.g.
+       shallow clone).
+    4. Without a usable origin: ``merge-base(HEAD, local main|master)``,
+       only when that branch is not the current one and is an ancestor of
+       HEAD — exactly the no-remote worktree shape (``openhands/<uuid>``
+       forked off local ``main``), keeping committed work visible.
+    5. ``HEAD`` — git-status-style. In particular this keeps no-remote
+       repos from falling through to the empty tree, which would list
+       every tracked file as an addition.
+
+    The caller has already handled repos without commits, so this only
+    falls back to the empty tree for an unborn/orphan HEAD (matching the
+    explicit-``HEAD``-override behavior: untracked files render as
+    additions).
+    """
+    head_sha = _rev_parse(repo_dir, "HEAD")
+    current_branch = _get_current_branch(repo_dir)
+
+    if current_branch is not None:
+        upstream_ref = f"origin/{current_branch}"
+        upstream_sha = _rev_parse(repo_dir, upstream_ref)
+        if upstream_sha is not None:
+            if upstream_sha == head_sha and not _has_tracked_changes(repo_dir):
+                logger.debug(
+                    f"{upstream_ref} points at HEAD with a clean tree; "
+                    "skipping it so committed work stays visible"
+                )
+            else:
+                logger.debug(f"Using upstream of current branch: {upstream_ref}")
+                return upstream_sha
+
+    default_branch = _get_remote_default_branch(repo_dir)
+    if default_branch is not None:
+        merge_base = _merge_base(repo_dir, "HEAD", f"origin/{default_branch}")
+        if merge_base is not None:
+            logger.debug(f"Using merge base with origin/{default_branch}")
+            return merge_base
+        default_sha = _rev_parse(repo_dir, f"origin/{default_branch}")
+        if default_sha is not None:
+            logger.debug(f"Using default branch tip: origin/{default_branch}")
+            return default_sha
+    else:
+        for local_default in ("main", "master"):
+            local_default_sha = _rev_parse(repo_dir, local_default)
+            if local_default_sha is not None:
+                if local_default != current_branch:
+                    merge_base = _merge_base(repo_dir, "HEAD", local_default)
+                    if merge_base is not None and merge_base == local_default_sha:
+                        logger.debug(f"Using local default branch: {local_default}")
+                        return merge_base
+                break
+
+    if head_sha is not None:
+        logger.debug("Using HEAD as display base (git status-style diff)")
+        return head_sha
+    logger.debug(f"Using empty tree reference: {GIT_EMPTY_TREE_HASH}")
+    return GIT_EMPTY_TREE_HASH
+
+
+def get_valid_ref(
+    repo_dir: str | Path,
+    override: str | None = None,
+    *,
+    purpose: Literal["export", "display"] = "export",
+) -> str | None:
     """Get a valid git reference to compare against.
 
     If ``override`` is provided, it is resolved via ``git rev-parse --verify``
@@ -126,7 +298,8 @@ def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | No
     overrides that do not resolve still raise ``GitCommandError`` so a
     typo'd branch/SHA is not silently swallowed.
 
-    Otherwise, tries multiple strategies to find a valid reference:
+    Otherwise, auto-detects a reference according to ``purpose``. For
+    ``purpose="export"`` (the default), tries multiple strategies:
     1. Current branch's origin (e.g., origin/main)
     2. Default branch (e.g., origin/main, origin/master)
     3. Merge base with default branch
@@ -136,6 +309,14 @@ def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | No
         repo_dir: Path to the git repository
         override: Optional explicit ref (e.g. ``"HEAD"`` or a commit hash) to
             use instead of the auto-detected comparison ref.
+        purpose: What the ref is used for. ``"export"`` (default) only picks
+            bases that are reconstructable from a fresh clone — required by
+            workspace export/restore, whose patches are replayed elsewhere.
+            ``"display"`` optimizes for showing a conversation's work (see
+            :func:`_get_display_base_ref`): it skips a fully-pushed branch's
+            own upstream, prefers the fork point over the default-branch
+            tip, and degrades to ``HEAD`` (git status-style) instead of the
+            empty tree for repos without a usable origin.
 
     Returns:
         Valid git reference hash, or None if no valid reference found
@@ -179,13 +360,16 @@ def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | No
                 return GIT_EMPTY_TREE_HASH
             raise
 
-    refs_to_try = []
-
     # Check if repo has any commits first. Empty repos (created with git init)
     # won't have commits or remotes, so we can skip directly to the empty tree fallback.
     if not _repo_has_commits(repo_dir):
         logger.debug("Repository has no commits yet, using empty tree reference")
         return GIT_EMPTY_TREE_HASH
+
+    if purpose == "display":
+        return _get_display_base_ref(repo_dir)
+
+    refs_to_try = []
 
     # Try current branch's origin
     try:

--- a/tests/sdk/git/test_git_changes.py
+++ b/tests/sdk/git/test_git_changes.py
@@ -81,18 +81,19 @@ def test_get_changes_in_repo_modified_files():
 
         changes = get_changes_in_repo(temp_dir)
 
-        # The function compares against empty tree for new repos without remote
-        # So modified files appear as ADDED since there's no remote origin
+        # Repos without a remote (sitting on their default branch) compare
+        # against HEAD, so modified files appear as UPDATED — not as a
+        # whole-repo ADDED list against the empty tree.
         assert len(changes) == 2
 
         # Sort by path for consistent testing
         changes.sort(key=lambda x: str(x.path))
 
         assert changes[0].path == Path("file1.txt")
-        assert changes[0].status == GitChangeStatus.ADDED
+        assert changes[0].status == GitChangeStatus.UPDATED
 
         assert changes[1].path == Path("file2.py")
-        assert changes[1].status == GitChangeStatus.ADDED
+        assert changes[1].status == GitChangeStatus.UPDATED
 
 
 def test_get_changes_in_repo_deleted_files():
@@ -113,9 +114,17 @@ def test_get_changes_in_repo_deleted_files():
 
         changes = get_changes_in_repo(temp_dir)
 
-        # For repos without remote, deleted files don't show up in diff against empty tree  # noqa: E501
-        # This is expected behavior - the function compares against empty tree
-        assert len(changes) == 0
+        # Repos without a remote compare against HEAD, so deletions of
+        # committed files are visible.
+        assert len(changes) == 2
+
+        changes.sort(key=lambda x: str(x.path))
+
+        assert changes[0].path == Path("file1.txt")
+        assert changes[0].status == GitChangeStatus.DELETED
+
+        assert changes[1].path == Path("file2.py")
+        assert changes[1].status == GitChangeStatus.DELETED
 
 
 def test_get_changes_in_repo_mixed_changes():
@@ -138,16 +147,17 @@ def test_get_changes_in_repo_mixed_changes():
 
         changes = get_changes_in_repo(temp_dir)
 
-        # For repos without remote, all files (existing, new, modified) show up as ADDED
-        # when comparing against empty tree. Deleted files don't appear.
+        # Repos without a remote compare against HEAD: untouched committed
+        # files (existing.txt) are not listed, and each kind of change gets
+        # its real status.
         assert len(changes) == 3
 
         # Convert to dict for easier testing
         changes_dict = {str(change.path): change.status for change in changes}
 
-        assert changes_dict["existing.txt"] == GitChangeStatus.ADDED
         assert changes_dict["new_file.txt"] == GitChangeStatus.ADDED
-        assert changes_dict["to_modify.py"] == GitChangeStatus.ADDED
+        assert changes_dict["to_modify.py"] == GitChangeStatus.UPDATED
+        assert changes_dict["to_delete.md"] == GitChangeStatus.DELETED
 
 
 def test_get_changes_in_repo_nested_directories():
@@ -204,8 +214,9 @@ def test_get_changes_in_repo_staged_and_unstaged():
         # Convert to dict for easier testing
         changes_dict = {str(change.path): change.status for change in changes}
 
-        # All files appear as ADDED when comparing against empty tree
-        assert changes_dict["file.txt"] == GitChangeStatus.ADDED
+        # Comparing against HEAD: the committed-then-modified file is
+        # UPDATED; the staged and untracked new files are ADDED.
+        assert changes_dict["file.txt"] == GitChangeStatus.UPDATED
         assert changes_dict["staged.txt"] == GitChangeStatus.ADDED
         assert changes_dict["unstaged.txt"] == GitChangeStatus.ADDED
 
@@ -564,3 +575,146 @@ def test_get_git_changes_propagates_ref():
         changes = get_git_changes(temp_dir, ref="HEAD")
         paths = {str(c.path) for c in changes}
         assert paths == {"b.txt"}
+
+
+def setup_cloned_repo(root: str) -> Path:
+    """Bare origin (default branch ``main``) with one committed README, plus
+    a configured clone of it — mirroring a real conversation workspace where
+    tracking refs and ``origin/HEAD`` exist."""
+    origin = Path(root) / "origin.git"
+    run_bash_command(f"git init --bare -b main {origin}", root)
+
+    seed = Path(root) / "seed"
+    seed.mkdir()
+    run_bash_command("git init -b main", str(seed))
+    run_bash_command("git config user.name 'Test User'", str(seed))
+    run_bash_command("git config user.email 'test@example.com'", str(seed))
+    (seed / "README.md").write_text("base")
+    run_bash_command("git add .", str(seed))
+    run_bash_command("git commit -m 'base'", str(seed))
+    run_bash_command(f"git remote add origin {origin}", str(seed))
+    run_bash_command("git push -u origin main", str(seed))
+
+    clone = Path(root) / "clone"
+    run_bash_command(f"git clone {origin} {clone}", root)
+    run_bash_command("git config user.name 'Test User'", str(clone))
+    run_bash_command("git config user.email 'test@example.com'", str(clone))
+    return clone
+
+
+def push_agent_branch(repo: Path) -> None:
+    """Create ``openhands/pr-branch`` with one committed file and push it,
+    leaving the branch in sync with its upstream (the post-PR state)."""
+    run_bash_command("git checkout -b openhands/pr-branch", str(repo))
+    (repo / "new.txt").write_text("pr change")
+    run_bash_command("git add .", str(repo))
+    run_bash_command("git commit -m 'agent pr work'", str(repo))
+    run_bash_command("git push -u origin openhands/pr-branch", str(repo))
+
+
+def test_get_changes_in_repo_committed_changes_stay_visible():
+    """Committed-but-unpushed work must stay visible — the Diff view used to
+    go blank the moment the agent ran ``git commit`` (APP-2205)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange
+        repo = setup_cloned_repo(temp_dir)
+        (repo / "README.md").write_text("changed by agent")
+        run_bash_command("git commit -am 'agent work'", str(repo))
+
+        # Act
+        changes = get_changes_in_repo(repo)
+
+        # Assert
+        assert changes == [
+            GitChange(status=GitChangeStatus.UPDATED, path=Path("README.md"))
+        ]
+
+
+def test_get_changes_in_repo_pushed_branch_shows_pr_diff():
+    """A branch fully pushed to its upstream (the PR flow) must diff against
+    the fork point — comparing it against its own upstream would render the
+    whole PR as "no changes"."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange
+        repo = setup_cloned_repo(temp_dir)
+        push_agent_branch(repo)
+
+        # Act
+        changes = get_changes_in_repo(repo)
+
+        # Assert
+        assert changes == [
+            GitChange(status=GitChangeStatus.ADDED, path=Path("new.txt"))
+        ]
+
+
+def test_get_changes_in_repo_pushed_branch_with_tracked_edit_shows_only_edit():
+    """A tracked working-tree edit keeps the branch comparing against its own
+    upstream, so a pre-existing attached branch shows only the new edit
+    rather than its whole history."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange
+        repo = setup_cloned_repo(temp_dir)
+        push_agent_branch(repo)
+        (repo / "README.md").write_text("post-push edit")
+
+        # Act
+        changes = get_changes_in_repo(repo)
+
+        # Assert — new.txt is already in the upstream, so only the edit shows.
+        assert changes == [
+            GitChange(status=GitChangeStatus.UPDATED, path=Path("README.md"))
+        ]
+
+
+def test_get_changes_in_repo_untracked_file_does_not_hide_pushed_branch_diff():
+    """Untracked files never appear in ``git diff <ref>``, so they must not
+    count as "dirty" for base selection — a stray scratch file must not
+    re-hide a fully-pushed branch's work."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange
+        repo = setup_cloned_repo(temp_dir)
+        push_agent_branch(repo)
+        (repo / "scratch.log").write_text("junk")
+
+        # Act
+        changes = get_changes_in_repo(repo)
+
+        # Assert — the branch's committed work is still diffed against the
+        # fork point; the untracked file itself surfaces as an addition.
+        changes_dict = {str(change.path): change.status for change in changes}
+        assert changes_dict == {
+            "new.txt": GitChangeStatus.ADDED,
+            "scratch.log": GitChangeStatus.ADDED,
+        }
+
+
+def test_get_changes_in_repo_no_remote_worktree_shows_committed_changes():
+    """The GUI's default local flow: a worktree branch forked off local
+    ``main`` in a repo without a remote. Committed work must stay visible
+    instead of degrading to a whole-repo empty-tree comparison."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange
+        repo = Path(temp_dir) / "repo"
+        repo.mkdir()
+        run_bash_command("git init -b main", str(repo))
+        run_bash_command("git config user.name 'Test User'", str(repo))
+        run_bash_command("git config user.email 'test@example.com'", str(repo))
+        (repo / "app.txt").write_text("base")
+        run_bash_command("git add .", str(repo))
+        run_bash_command("git commit -m 'base'", str(repo))
+
+        worktree = Path(temp_dir) / "worktree"
+        run_bash_command(
+            f"git worktree add -b openhands/conv1 {worktree} main", str(repo)
+        )
+        (worktree / "app.txt").write_text("changed by agent")
+        run_bash_command("git commit -am 'agent work'", str(worktree))
+
+        # Act
+        changes = get_changes_in_repo(worktree)
+
+        # Assert
+        assert changes == [
+            GitChange(status=GitChangeStatus.UPDATED, path=Path("app.txt"))
+        ]

--- a/tests/sdk/git/test_git_diff.py
+++ b/tests/sdk/git/test_git_diff.py
@@ -78,8 +78,9 @@ def test_get_git_diff_modified_file():
 
         assert isinstance(diff, GitDiff)
         assert diff.modified == modified_content
-        # For repos without remote, original is empty when comparing against empty tree
-        assert diff.original == ""
+        # Repos without a remote compare against HEAD, so the committed
+        # content is the original side of the diff.
+        assert diff.original == original_content
 
 
 def test_get_git_diff_deleted_file():
@@ -132,8 +133,9 @@ def test_get_git_diff_nested_path():
 
         assert isinstance(diff, GitDiff)
         assert diff.modified == modified_content
-        # For repos without remote, original is empty when comparing against empty tree
-        assert diff.original == ""
+        # Repos without a remote compare against HEAD, so the committed
+        # content is the original side of the diff.
+        assert diff.original == original_content
 
 
 def test_get_git_diff_no_repository():
@@ -206,15 +208,16 @@ def test_git_diff_model_properties():
         assert isinstance(diff.modified, str)
         assert isinstance(diff.original, str)
         assert diff.modified == modified_content
-        # For repos without remote, original is empty when comparing against empty tree
-        assert diff.original == ""
+        # Repos without a remote compare against HEAD, so the committed
+        # content is the original side of the diff.
+        assert diff.original == original_content
 
         # Test serialization
         diff_dict = diff.model_dump()
         assert "modified" in diff_dict
         assert "original" in diff_dict
         assert diff_dict["modified"] == modified_content
-        assert diff_dict["original"] == ""
+        assert diff_dict["original"] == original_content
 
 
 def test_git_diff_with_empty_file():
@@ -266,8 +269,9 @@ def test_git_diff_with_special_characters():
 
         assert isinstance(diff, GitDiff)
         assert diff.modified == modified_content
-        # For repos without remote, original is empty when comparing against empty tree
-        assert diff.original == ""
+        # Repos without a remote compare against HEAD, so the committed
+        # content is the original side of the diff.
+        assert diff.original == original_content
 
 
 def test_git_diff_large_file_error():
@@ -327,3 +331,28 @@ def test_get_git_diff_invalid_ref_raises():
 
         with pytest.raises(GitCommandError):
             run_in_directory(temp_dir, get_git_diff, "f.txt", ref="not-a-real-ref")
+
+
+def test_get_git_diff_committed_branch_change_diffs_against_fork_point():
+    """A change committed on a branch must diff against the branch's fork
+    point — matching the change list. Diffing against HEAD instead would
+    render the committed content as an empty diff (APP-2205)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange — repo on `main`, then a branch with a committed change.
+        run_bash_command("git init -b main", temp_dir)
+        run_bash_command("git config user.name 'Test User'", temp_dir)
+        run_bash_command("git config user.email 'test@example.com'", temp_dir)
+        target = Path(temp_dir) / "file.txt"
+        target.write_text("base")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'base'", temp_dir)
+        run_bash_command("git checkout -b openhands/conv1", temp_dir)
+        target.write_text("changed by agent")
+        run_bash_command("git commit -am 'agent work'", temp_dir)
+
+        # Act
+        diff = run_in_directory(temp_dir, get_git_diff, "file.txt")
+
+        # Assert — original is the fork-point (main) content.
+        assert diff.original == "base"
+        assert diff.modified == "changed by agent"

--- a/tests/sdk/git/test_git_utils.py
+++ b/tests/sdk/git/test_git_utils.py
@@ -1,0 +1,44 @@
+"""Tests for git utils base-ref resolution (``get_valid_ref``)."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from openhands.sdk.git.utils import GIT_EMPTY_TREE_HASH, get_valid_ref
+
+
+def run_bash_command(command: str, cwd: str) -> subprocess.CompletedProcess:
+    """Run a bash command in the specified directory."""
+    return subprocess.run(
+        command,
+        shell=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_get_valid_ref_purposes_diverge_for_committed_no_remote_repo():
+    """The display purpose resolves HEAD for a committed repo without a
+    remote (so the Diff view gets git-status semantics), while the default
+    export purpose keeps resolving the empty tree — workspace-export patches
+    must stay reconstructable from a fresh clone, so the display policy must
+    not leak into it."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Arrange — a repo with a commit and no remote.
+        run_bash_command("git init -b main", temp_dir)
+        run_bash_command("git config user.name 'Test User'", temp_dir)
+        run_bash_command("git config user.email 'test@example.com'", temp_dir)
+        (Path(temp_dir) / "a.txt").write_text("a")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'base'", temp_dir)
+        head_sha = run_bash_command("git rev-parse HEAD", temp_dir).stdout.strip()
+
+        # Act
+        export_ref = get_valid_ref(temp_dir)
+        display_ref = get_valid_ref(temp_dir, purpose="display")
+
+        # Assert
+        assert export_ref == GIT_EMPTY_TREE_HASH
+        assert display_ref == head_sha


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

Implemented and verified end-to-end by an AI agent; evidence (commands + logs) in "How to Test" below.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

The agent-canvas Files tab renders a blank diff whenever a conversation's work is committed and pushed (OpenHands/agent-canvas#2079). `get_valid_ref` auto-detection tries `origin/<current-branch>` first, so once the branch is pushed that base equals HEAD and `/api/git/changes` returns `[]` — an entire PR renders as "no changes". Separately, a repo with commits but no `origin` falls through to the empty-tree hash and reports _every tracked file_ as an addition, which is why the GUI historically pinned `ref=HEAD` (trading noise for the blank-after-commit bug).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add keyword-only `purpose: Literal["export", "display"] = "export"` to `get_valid_ref`. The default export path is byte-for-byte unchanged — `file_router`'s git-delta archives must only use bases reconstructable from a fresh clone (`X-Archive-Base-Commit` replay contract).
- New `"display"` auto-detect policy (used only by `get_git_changes` / `get_git_diff`): skip `origin/<current-branch>` when it equals HEAD with a clean tracked tree (fall through to the fork point so pushed PR work stays visible; untracked files don't count as dirty); prefer `merge-base(HEAD, origin/<default>)` over the default tip; for repos without a usable origin use `merge-base(HEAD, local main|master)` (the no-remote worktree shape); fall back to `HEAD` instead of the empty tree.
- Default-branch detection prefers the local `origin/HEAD` symref before the network `git remote show origin` call on the display path.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/2079

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

`uv run agent-server --port 8010`, then exercise the four repo shapes:

```
# 1) clone with origin, committed unpushed change
curl ".../api/git/changes?path=<repo>&ref=HEAD"  → []            (explicit HEAD: unchanged behavior)
curl ".../api/git/changes?path=<repo>"           → [{"status":"UPDATED","path":"README.md"}]

# 2) branch committed AND pushed in sync (the PR case) — was [] before this PR
curl ".../api/git/changes?path=<repo>"           → [{"status":"ADDED","path":"new.txt"}]

# 3) no-remote repo, worktree branch off main, committed — was [] before
curl ".../api/git/changes?path=<worktree>"       → [{"status":"UPDATED","path":"app.txt"}]

# 4) no-remote repo on main, committed — was "every tracked file ADDED" noise before
curl ".../api/git/changes?path=<repo>"           → []

```

Also verified with a 16-scenario matrix script (uncommitted / committed / pushed / dirty-after-push / untracked-after-push / in-sync-clean / empty repo / explicit-ref override / export-vs-display purpose divergence) — all pass.

Test suites: `uv run pytest tests/sdk/git tests/agent_server/test_git_router.py tests/agent_server/test_file_router.py` → 202 passed. Includes new regression tests for the pushed-branch fork-point diff, the clean-tree skip rule, the untracked-files exemption, the no-remote worktree, and export-purpose invariance. `ruff` and `pyright` clean.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="797" alt="app-2205" src="https://github.com/user-attachments/assets/64a23869-91bb-4e9c-b558-bb80df062352" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:02526e9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-02526e9-python \
  ghcr.io/openhands/agent-server:02526e9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:02526e9-golang-amd64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-2205-golang-amd64
ghcr.io/openhands/agent-server:02526e9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:02526e9-golang-arm64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-2205-golang-arm64
ghcr.io/openhands/agent-server:02526e9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:02526e9-java-amd64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-2205-java-amd64
ghcr.io/openhands/agent-server:02526e9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:02526e9-java-arm64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-2205-java-arm64
ghcr.io/openhands/agent-server:02526e9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:02526e9-python-amd64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-2205-python-amd64
ghcr.io/openhands/agent-server:02526e9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:02526e9-python-arm64
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-2205-python-arm64
ghcr.io/openhands/agent-server:02526e9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:02526e9-golang
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-golang
ghcr.io/openhands/agent-server:hieptl-app-2205-golang
ghcr.io/openhands/agent-server:02526e9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:02526e9-java
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-java
ghcr.io/openhands/agent-server:hieptl-app-2205-java
ghcr.io/openhands/agent-server:02526e9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:02526e9-python
ghcr.io/openhands/agent-server:02526e9dafe6aecacaf23664c0bb97d39656f61b-python
ghcr.io/openhands/agent-server:hieptl-app-2205-python
ghcr.io/openhands/agent-server:02526e9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `02526e9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `02526e9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->