### PR TITLE
feat(sdk): support conversation-scoped LLM headers

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -834,6 +834,7 @@ class EventService:
             secrets=self.stored.secrets,
             cipher=self.cipher,
             hook_config=self.stored.hook_config,
+            llm_extra_headers=self.stored.llm_extra_headers,
             tags=self.stored.tags,
             user_id=self.stored.user_id,
             observability_metadata=self.stored.observability_metadata,

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -84,6 +84,11 @@ class StoredConversation(StartConversationRequest):
     # agent_profile_id is resolved into launched_agent_profile at creation; exclude from
     # the persistence payload so it does not re-appear in meta.json.
     agent_profile_id: UUID | None = Field(default=None, exclude=True)
+    llm_extra_headers: dict[str, str] | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+    )
 
     id: OpenHandsUUID
     title: str | None = Field(

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -72,6 +72,7 @@ class Conversation:
         callbacks: list[ConversationCallbackType] | None = None,
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         max_iteration_per_run: int = 500,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
@@ -101,6 +102,7 @@ class Conversation:
         callbacks: list[ConversationCallbackType] | None = None,
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         max_iteration_per_run: int = 500,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
@@ -130,6 +132,7 @@ class Conversation:
         callbacks: list[ConversationCallbackType] | None = None,
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         max_iteration_per_run: int = 500,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
@@ -196,6 +199,7 @@ class Conversation:
                 callbacks=callbacks,
                 token_callbacks=token_callbacks,
                 hook_config=hook_config,
+                llm_extra_headers=llm_extra_headers,
                 max_iteration_per_run=max_iteration_per_run,
                 stuck_detection=stuck_detection,
                 stuck_detection_thresholds=stuck_detection_thresholds,
@@ -218,6 +222,7 @@ class Conversation:
             callbacks=callbacks,
             token_callbacks=token_callbacks,
             hook_config=hook_config,
+            llm_extra_headers=llm_extra_headers,
             max_iteration_per_run=max_iteration_per_run,
             stuck_detection=stuck_detection,
             stuck_detection_thresholds=stuck_detection_thresholds,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePath
+from types import MappingProxyType
 from typing import Any, Final, TypeGuard, cast
 
 from openhands.sdk.agent.acp_agent import ACPAgent
@@ -169,6 +170,7 @@ class LocalConversation(BaseConversation):
     _pending_hook_config: HookConfig | None  # Hook config to combine with plugin hooks
     _subscription_disabled_condenser: Any | None
     _mcp_tool_provider: MCPToolProvider
+    _llm_extra_headers: Mapping[str, str]
 
     def __init__(
         self,
@@ -203,6 +205,7 @@ class LocalConversation(BaseConversation):
         prompt_cache_key: str | None = None,
         file_store: FileStore | None = None,
         mcp_tool_provider: MCPToolProvider | None = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         **_: object,
     ):
         """Initialize the conversation.
@@ -261,6 +264,8 @@ class LocalConversation(BaseConversation):
             file_store: Optional FileStore to use for conversation state and EventLog
                 persistence. If provided, this takes precedence over persistence_dir
                 for state and EventLog storage.
+            llm_extra_headers: Headers applied to every LLM request made by this
+                conversation.
         """
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially
@@ -269,6 +274,7 @@ class LocalConversation(BaseConversation):
         self._arun_task = None
         self._cancel_token = None
         self._prompt_cache_key = prompt_cache_key
+        self._llm_extra_headers = MappingProxyType(dict(llm_extra_headers or {}))
         self._step_holds_state_lock = False
 
         # Store plugin specs for lazy loading (no IO in constructor)
@@ -1104,6 +1110,7 @@ class LocalConversation(BaseConversation):
                 # Resolve lazily: switch_llm()/switch_profile() rebind self.agent,
                 # so agent hooks must read the current LLM at execution time.
                 llm_getter=lambda: self.agent.llm,
+                llm_extra_headers=self._llm_extra_headers,
                 persistence_dir=hook_persistence_dir,
                 visualizer=self._visualizer,
                 conversation_stats=self._state.stats,
@@ -1177,6 +1184,7 @@ class LocalConversation(BaseConversation):
             session_id=str(self._state.id),
             original_callback=self._base_callback,
             llm_getter=lambda: self.agent.llm,
+            llm_extra_headers=self._llm_extra_headers,
             persistence_dir=hook_persistence_dir,
             visualizer=self._visualizer,
             conversation_stats=self._state.stats,
@@ -1411,6 +1419,7 @@ class LocalConversation(BaseConversation):
         return LLMCallContext(
             prompt_cache_key=self._prompt_cache_key or conv_id,
             session_id=conv_id,
+            extra_headers=self._llm_extra_headers,
         )
 
     def _bind_conversation_context(self, llm: LLM) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -725,6 +725,7 @@ class RemoteConversation(BaseConversation):
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        llm_extra_headers: Mapping[str, str] | None = None,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -762,6 +763,8 @@ class RemoteConversation(BaseConversation):
             observability_tags: Optional root span tags for observability backends.
             observability_span_name: Optional child span name for observability
                       backends. The root span remains named "conversation".
+            llm_extra_headers: Headers applied to every LLM request made by this
+                      conversation. Used only when creating a conversation.
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
@@ -859,6 +862,8 @@ class RemoteConversation(BaseConversation):
             }
             if user_id:
                 payload["user_id"] = user_id
+            if llm_extra_headers is not None:
+                payload["llm_extra_headers"] = dict(llm_extra_headers)
             if stuck_detection_thresholds is not None:
                 # Convert to StuckDetectionThresholds if dict, then serialize
                 if isinstance(stuck_detection_thresholds, Mapping):

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -210,6 +210,11 @@ class StartConversationRequest(BaseModel):
             "hooks."
         ),
     )
+    llm_extra_headers: dict[str, str] | None = Field(
+        default=None,
+        repr=False,
+        description="Headers applied to every LLM request made by this conversation.",
+    )
     tags: ConversationTags = Field(
         default_factory=dict,
         description=(

--- a/openhands-sdk/openhands/sdk/hooks/conversation_hooks.py
+++ b/openhands-sdk/openhands/sdk/hooks/conversation_hooks.py
@@ -1,6 +1,6 @@
 """Hook integration for conversations."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.conversation.visualizer import ConversationVisualizerBase
@@ -394,6 +394,7 @@ def create_hook_callback(
     emit_hook_events: bool = True,
     llm: "LLM | None" = None,
     llm_getter: "Callable[[], LLM | None] | None" = None,
+    llm_extra_headers: Mapping[str, str] | None = None,
     persistence_dir: str | None = None,
     visualizer: type[ConversationVisualizerBase]
     | ConversationVisualizerBase
@@ -412,6 +413,7 @@ def create_hook_callback(
         llm: LLM instance inherited from the parent conversation, used by agent hooks.
         llm_getter: Callable returning the conversation's current LLM. Preferred
             over ``llm`` so agent hooks follow switch_llm()/switch_profile().
+        llm_extra_headers: Headers inherited by agent hook sub-conversations.
         persistence_dir: Directory used to persist agent hook sub-conversation events.
         visualizer: Visualizer instance passed to agent hook sub-conversations.
         conversation_stats: Parent conversation stats that should include hook spend.
@@ -425,6 +427,7 @@ def create_hook_callback(
         session_id=session_id,
         llm=llm,
         llm_getter=llm_getter,
+        llm_extra_headers=llm_extra_headers,
         persistence_dir=persistence_dir,
         visualizer=visualizer,
         conversation_stats=conversation_stats,

--- a/openhands-sdk/openhands/sdk/hooks/executor.py
+++ b/openhands-sdk/openhands/sdk/hooks/executor.py
@@ -7,7 +7,7 @@ import os
 import signal
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -164,6 +164,7 @@ class HookExecutor:
         async_process_manager: AsyncProcessManager | None = None,
         llm: "LLM | None" = None,
         llm_getter: "Callable[[], LLM | None] | None" = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         persistence_dir: str | None = None,
         visualizer: type[ConversationVisualizerBase]
         | ConversationVisualizerBase
@@ -177,6 +178,7 @@ class HookExecutor:
         # LLM: switch_llm()/switch_profile() replace agent.llm after the executor
         # is built, and a captured instance would go stale.
         self._llm_getter = llm_getter
+        self.llm_extra_headers = dict(llm_extra_headers or {})
         self.persistence_dir = persistence_dir
         self.visualizer = visualizer
         self.conversation_stats = conversation_stats
@@ -270,6 +272,7 @@ class HookExecutor:
                 persistence_dir=self.persistence_dir,
                 visualizer=hook_visualizer,
                 max_iteration_per_run=hook.max_iterations,
+                llm_extra_headers=self.llm_extra_headers,
             )
             conversation.send_message(
                 f"Evaluate this {event_type} hook event and make your decision.\n\n"

--- a/openhands-sdk/openhands/sdk/hooks/manager.py
+++ b/openhands-sdk/openhands/sdk/hooks/manager.py
@@ -1,7 +1,7 @@
 """Hook manager - orchestrates hook execution within conversations."""
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.conversation.visualizer import ConversationVisualizerBase
@@ -28,6 +28,7 @@ class HookManager:
         session_id: str | None = None,
         llm: "LLM | None" = None,
         llm_getter: "Callable[[], LLM | None] | None" = None,
+        llm_extra_headers: Mapping[str, str] | None = None,
         persistence_dir: str | None = None,
         visualizer: type[ConversationVisualizerBase]
         | ConversationVisualizerBase
@@ -39,6 +40,7 @@ class HookManager:
             working_dir=working_dir,
             llm=llm,
             llm_getter=llm_getter,
+            llm_extra_headers=llm_extra_headers,
             persistence_dir=persistence_dir,
             visualizer=visualizer,
             conversation_stats=conversation_stats,

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -7,10 +7,11 @@ import json
 import os
 import threading
 import warnings
-from collections.abc import AsyncIterable, Callable, Iterable, Sequence
+from collections.abc import AsyncIterable, Callable, Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args, get_origin
 
 from pydantic import (
@@ -185,21 +186,26 @@ LLM_PROFILE_SCHEMA_VERSION: Final[int] = 1
 class LLMCallContext:
     """Per-conversation state threaded through the completion call chain.
 
-    The primary path threads this explicitly:
-    ``Agent.step()`` → ``make_llm_completion()`` → ``llm.completion(call_context=...)``
-    → ``select_chat_options(call_context=...)``.
-
-    A fallback copy is also stored as a ``PrivateAttr`` on :class:`LLM`
-    (via ``_bind_conversation_context``) for callers that don't thread
-    context explicitly (e.g. the condenser's dedicated LLM).  The
-    PrivateAttr is:
-    * dropped on ``model_dump()`` / ``model_validate()`` round-trips,
-    * shallow-copied by ``model_copy()`` (sub-agent),
-    * never serialised into user-visible config.
+    The primary path threads this explicitly from the agent step into the LLM
+    call. A fallback copy is stored as a private attribute on :class:`LLM` for
+    callers that do not thread context explicitly, such as a dedicated
+    condenser LLM. The context is immutable and never serialized into LLM or
+    conversation configuration.
     """
 
     prompt_cache_key: str | None = None
     session_id: str | None = None
+    extra_headers: Mapping[str, str] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "extra_headers",
+            MappingProxyType(dict(self.extra_headers)),
+        )
+
+    def __deepcopy__(self, _memo: dict[int, object]) -> LLMCallContext:
+        return self
 
 
 class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -109,6 +109,12 @@ def select_chat_options(
     ctx = call_context or llm._call_context
     if ctx.prompt_cache_key:
         out["prompt_cache_key"] = ctx.prompt_cache_key
+    if ctx.extra_headers:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {
+            **existing,
+            **ctx.extra_headers,
+        }
     if ctx.session_id:
         existing = out.get("extra_headers") or {}
         out["extra_headers"] = {

--- a/openhands-sdk/openhands/sdk/llm/options/responses_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/responses_options.py
@@ -96,6 +96,12 @@ def select_responses_options(
     ctx = call_context or llm._call_context
     if ctx.prompt_cache_key:
         out["prompt_cache_key"] = ctx.prompt_cache_key
+    if ctx.extra_headers:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {
+            **existing,
+            **ctx.extra_headers,
+        }
     if ctx.session_id:
         existing = out.get("extra_headers") or {}
         out["extra_headers"] = {

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -975,6 +975,12 @@ class ConversationSettings(BaseModel):
         exclude=True,
         description="Hook configuration for lifecycle events.",
     )
+    llm_extra_headers: dict[str, str] | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description="Headers applied to every LLM request made by this conversation.",
+    )
     selected_repository: str | None = Field(
         default=None,
         exclude=True,
@@ -1115,6 +1121,8 @@ class ConversationSettings(BaseModel):
             payload.setdefault("plugins", self.plugins)
         if self.hook_config is not None:
             payload.setdefault("hook_config", self.hook_config)
+        if self.llm_extra_headers is not None:
+            payload.setdefault("llm_extra_headers", self.llm_extra_headers)
         if self.observability_metadata is not None:
             payload.setdefault("observability_metadata", self.observability_metadata)
         if self.observability_tags is not None:

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -220,6 +220,9 @@ class DelegateExecutor(ToolExecutor):
                     "visualizer": sub_visualizer,
                     "hook_config": factory.definition.hooks,
                     "persistence_dir": subagents_persistence_dir,
+                    "llm_extra_headers": (
+                        parent_conversation.get_llm_call_context().extra_headers
+                    ),
                 }
 
                 if factory.definition.max_iteration_per_run is not None:

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -216,6 +216,9 @@ class TaskManager:
                 persistence_dir=self._persistence_dir,
                 conversation_id=conversation_id,
                 hook_config=factory.definition.hooks,
+                llm_extra_headers=(
+                    self.parent_conversation.get_llm_call_context().extra_headers
+                ),
                 delete_on_close=True,
             )
 
@@ -311,6 +314,7 @@ class TaskManager:
             max_iteration_per_run=max_iteration_per_run,
             max_budget_per_run=max_budget_per_run,
             hook_config=hook_config,
+            llm_extra_headers=parent.get_llm_call_context().extra_headers,
             delete_on_close=True,
             prompt_cache_key=str(parent.state.id),
         )

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1780,6 +1780,21 @@ class TestEventServiceSaveMeta:
         assert loaded.updated_at == original_updated_at
 
     @pytest.mark.asyncio
+    async def test_save_meta_excludes_llm_extra_headers(self, event_service, tmp_path):
+        event_service.stored.llm_extra_headers = {
+            "Authorization": "Bearer sensitive-value"
+        }
+        event_service.conversations_dir = tmp_path
+        conversation_dir = tmp_path / event_service.stored.id.hex
+        conversation_dir.mkdir(parents=True, exist_ok=True)
+
+        await event_service.save_meta()
+
+        payload = (conversation_dir / "meta.json").read_text()
+        assert "llm_extra_headers" not in payload
+        assert "sensitive-value" not in payload
+
+    @pytest.mark.asyncio
     async def test_save_meta_round_trips_agent_definition_mcp_secrets(
         self, sample_stored_conversation, tmp_path
     ):

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -1064,6 +1064,68 @@ def test_conversation_stats_with_live_server(
     conv.close()
 
 
+def test_remote_conversation_llm_headers_reach_every_run(
+    server_env, monkeypatch: pytest.MonkeyPatch
+):
+    from openhands.sdk.llm.llm_response import LLMResponse
+    from openhands.sdk.llm.message import Message
+    from openhands.sdk.llm.utils.metrics import MetricsSnapshot
+
+    seen_headers: list[dict[str, str]] = []
+
+    def response() -> LLMResponse:
+        litellm_msg = LiteLLMMessage.model_validate(
+            {"role": "assistant", "content": "Done"}
+        )
+        return LLMResponse(
+            message=Message.from_llm_chat_message(litellm_msg),
+            metrics=MetricsSnapshot(
+                model_name="test-model",
+                accumulated_cost=0.0,
+                max_budget_per_task=None,
+                accumulated_token_usage=None,
+            ),
+            raw_response=ModelResponse(
+                id="test-response",
+                created=int(time.time()),
+                model="test-model",
+                choices=[Choices(index=0, finish_reason="stop", message=litellm_msg)],
+            ),
+        )
+
+    async def fake_acompletion(self, messages, tools=None, call_context=None, **kwargs):  # type: ignore[no-untyped-def]
+        assert call_context is not None
+        seen_headers.append(dict(call_context.extra_headers))
+        return response()
+
+    monkeypatch.setattr(LLM, "acompletion", fake_acompletion, raising=True)
+
+    agent = Agent(
+        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")),
+        tools=[],
+    )
+    workspace = RemoteWorkspace(
+        host=server_env["host"],
+        working_dir="/tmp/workspace/project",
+    )
+    conversation: RemoteConversation = Conversation(
+        agent=agent,
+        workspace=workspace,
+        llm_extra_headers={"X-Request-ID": "request-1"},
+    )
+
+    conversation.send_message("first")
+    conversation.run()
+    conversation.send_message("second")
+    conversation.run()
+
+    assert seen_headers == [
+        {"X-Request-ID": "request-1"},
+        {"X-Request-ID": "request-1"},
+    ]
+    conversation.close()
+
+
 def test_events_not_lost_during_client_disconnection(
     server_env, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/sdk/conversation/local/test_call_context_isolation.py
+++ b/tests/sdk/conversation/local/test_call_context_isolation.py
@@ -6,11 +6,14 @@ x-litellm-session-id).
 """
 
 import tempfile
+from collections.abc import Mapping
 
+import pytest
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm import LLMCallContext
 from openhands.sdk.llm.options.chat_options import select_chat_options
@@ -38,6 +41,16 @@ def test_call_context_defaults_to_empty():
     ctx = llm._call_context
     assert ctx.prompt_cache_key is None
     assert ctx.session_id is None
+    assert ctx.extra_headers == {}
+
+
+def test_call_context_copies_extra_headers():
+    headers = {"X-Request-ID": "first"}
+    ctx = LLMCallContext(extra_headers=headers)
+
+    headers["X-Request-ID"] = "changed"
+
+    assert ctx.extra_headers == {"X-Request-ID": "first"}
 
 
 def test_call_context_is_assignable():
@@ -65,6 +78,19 @@ def test_call_context_shallow_copied_by_model_copy():
     child = llm.model_copy(update={"usage_id": "child"})
     assert child._call_context.prompt_cache_key == "parent"
     assert child._call_context.session_id == "parent-sess"
+
+
+def test_call_context_supports_deep_model_copy():
+    llm = _llm()
+    llm._call_context = LLMCallContext(
+        prompt_cache_key="parent",
+        session_id="parent-sess",
+        extra_headers={"X-Request-ID": "request-1"},
+    )
+
+    child = llm.model_copy(deep=True)
+
+    assert child._call_context.extra_headers == {"X-Request-ID": "request-1"}
 
 
 # ── select_chat_options injection tests ────────────────────────────────
@@ -107,6 +133,26 @@ def test_chat_options_context_wins_over_user_session_id():
     assert out["extra_headers"]["x-litellm-session-id"] == "conv-99"
 
 
+def test_chat_options_merge_conversation_headers():
+    llm = _llm(extra_headers={"X-Static": "static", "X-Shared": "static"})
+    ctx = LLMCallContext(
+        session_id="conv-99",
+        extra_headers={"X-Conversation": "conversation", "X-Shared": "conversation"},
+    )
+
+    out = select_chat_options(
+        llm,
+        user_kwargs={},
+        has_tools=False,
+        call_context=ctx,
+    )
+
+    assert out["extra_headers"]["X-Static"] == "static"
+    assert out["extra_headers"]["X-Shared"] == "conversation"
+    assert out["extra_headers"]["X-Conversation"] == "conversation"
+    assert out["extra_headers"]["x-litellm-session-id"] == "conv-99"
+
+
 def test_responses_options_context_wins_over_user_session_id():
     """Context session_id must override a stale user-supplied value."""
     llm = _llm()
@@ -117,6 +163,27 @@ def test_responses_options_context_wins_over_user_session_id():
         include=None,
         store=None,
     )
+    assert out["extra_headers"]["x-litellm-session-id"] == "conv-99"
+
+
+def test_responses_options_merge_conversation_headers():
+    llm = _llm(extra_headers={"X-Static": "static", "X-Shared": "static"})
+    ctx = LLMCallContext(
+        session_id="conv-99",
+        extra_headers={"X-Conversation": "conversation", "X-Shared": "conversation"},
+    )
+
+    out = select_responses_options(
+        llm,
+        user_kwargs={},
+        include=None,
+        store=None,
+        call_context=ctx,
+    )
+
+    assert out["extra_headers"]["X-Static"] == "static"
+    assert out["extra_headers"]["X-Shared"] == "conversation"
+    assert out["extra_headers"]["X-Conversation"] == "conversation"
     assert out["extra_headers"]["x-litellm-session-id"] == "conv-99"
 
 
@@ -200,6 +267,68 @@ def test_extra_headers_not_polluted_by_session_id():
 
     # session ID should be in context
     assert conv.agent.llm._call_context.session_id == str(conv.id)
+
+
+def test_conversation_headers_apply_to_every_sync_run(monkeypatch):
+    seen_headers: list[Mapping[str, str]] = []
+
+    def step(self, conversation, on_event, on_token=None):
+        options = select_chat_options(self.llm, user_kwargs={}, has_tools=False)
+        seen_headers.append(options["extra_headers"])
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+    monkeypatch.setattr(Agent, "step", step)
+    headers = {"X-Request-ID": "request-1"}
+    conversation = Conversation(
+        agent=_agent(_llm(extra_headers={"X-Static": "static"})),
+        llm_extra_headers=headers,
+    )
+    headers["X-Request-ID"] = "changed"
+
+    conversation.send_message("first")
+    conversation.run()
+    conversation.send_message("second")
+    conversation.run()
+
+    assert [headers["X-Request-ID"] for headers in seen_headers] == [
+        "request-1",
+        "request-1",
+    ]
+    assert [headers["X-Static"] for headers in seen_headers] == [
+        "static",
+        "static",
+    ]
+    assert conversation.agent.llm.extra_headers == {"X-Static": "static"}
+
+
+@pytest.mark.asyncio
+async def test_conversation_headers_apply_to_every_async_run(monkeypatch):
+    seen_headers: list[Mapping[str, str]] = []
+
+    async def astep(self, conversation, on_event, on_token=None):
+        options = select_chat_options(self.llm, user_kwargs={}, has_tools=False)
+        seen_headers.append(options["extra_headers"])
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+    monkeypatch.setattr(Agent, "astep", astep)
+    conversation = Conversation(
+        agent=_agent(_llm(extra_headers={"X-Static": "static"})),
+        llm_extra_headers={"X-Request-ID": "request-1"},
+    )
+
+    conversation.send_message("first")
+    await conversation.arun()
+    conversation.send_message("second")
+    await conversation.arun()
+
+    assert [headers["X-Request-ID"] for headers in seen_headers] == [
+        "request-1",
+        "request-1",
+    ]
+    assert [headers["X-Static"] for headers in seen_headers] == [
+        "static",
+        "static",
+    ]
 
 
 def test_fork_gets_fresh_context():

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -921,6 +921,8 @@ class TestRemoteConversation:
         ]
         assert len(request_calls) == 1, "Should have made exactly one POST call"
 
+        assert "json" not in request_calls[0].kwargs
+
         # Verify NO polling GET calls were made (only the initial events fetch)
         get_conversation_calls = [
             call
@@ -928,10 +930,33 @@ class TestRemoteConversation:
             if call[0][0] == "GET"
             and call[0][1] == f"/api/conversations/{conversation_id}"
         ]
-        # Should be 0 because blocking=False skips polling
         assert len(get_conversation_calls) == 0, (
             "Should not poll for status when blocking=False"
         )
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
+    def test_remote_conversation_creation_forwards_llm_extra_headers(
+        self, mock_ws_client
+    ):
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+        mock_ws_client.return_value = Mock()
+        RemoteConversation(
+            agent=self.agent,
+            workspace=self.workspace,
+            llm_extra_headers={"X-Request-ID": "request-1"},
+        )
+
+        create_call = next(
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call.args[:2] == ("POST", "/api/conversations")
+        )
+        assert create_call.kwargs["json"]["llm_extra_headers"] == {
+            "X-Request-ID": "request-1"
+        }
 
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"

--- a/tests/sdk/hooks/test_executor.py
+++ b/tests/sdk/hooks/test_executor.py
@@ -694,6 +694,27 @@ class TestAgentHookExecution:
         assert hook_llm.timeout == 7
         assert executor.llm.timeout == parent_timeout
 
+    def test_agent_hook_inherits_conversation_llm_headers(
+        self, tmp_path, mock_llm, sample_event
+    ):
+        executor = HookExecutor(
+            working_dir=str(tmp_path),
+            llm=mock_llm,
+            llm_extra_headers={"X-Request-ID": "request-1"},
+        )
+
+        with (
+            patch(self._AGENT_PATH),
+            patch(self._CONV_PATH, side_effect=RuntimeError("stop early")) as mock_conv,
+        ):
+            executor._execute_agent_hook(
+                HookDefinition(type=HookType.AGENT), sample_event
+            )
+
+        assert mock_conv.call_args.kwargs["llm_extra_headers"] == {
+            "X-Request-ID": "request-1"
+        }
+
     def test_hook_metrics_under_usage_id(self, executor, sample_event):
         """Hook LLM uses per-hook usage_id and an isolated Metrics object."""
         parent_metrics = executor.llm.metrics

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -242,6 +242,7 @@ def test_conversation_settings_create_request() -> None:
         max_iterations=77,
         confirmation_mode=True,
         security_analyzer="llm",
+        llm_extra_headers={"X-Request-ID": "request-1"},
     )
     workspace = LocalWorkspace(working_dir="/tmp")
     agent = OpenHandsAgentSettings(llm=LLM(model="test-model")).create_agent()
@@ -255,8 +256,10 @@ def test_conversation_settings_create_request() -> None:
     assert isinstance(request, StartConversationRequest)
     assert request.workspace == workspace
     assert request.max_iterations == 77
+    assert request.llm_extra_headers == {"X-Request-ID": "request-1"}
     assert isinstance(request.confirmation_policy, ConfirmRisky)
     assert isinstance(request.security_analyzer, LLMSecurityAnalyzer)
+    assert "llm_extra_headers" not in settings.model_dump(mode="json")
 
     overridden_request = settings.create_request(
         StartConversationRequest,

--- a/tests/tools/delegate/test_delegation.py
+++ b/tests/tools/delegate/test_delegation.py
@@ -12,6 +12,7 @@ from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
 from openhands.sdk.llm import LLM, TextContent
+from openhands.sdk.llm.llm import LLMCallContext
 from openhands.sdk.subagent.registry import (
     _reset_registry_for_tests,
     register_agent,
@@ -178,6 +179,22 @@ def test_delegation_manager_init():
 
     # Test that sub-agents dict is empty initially
     assert len(manager._sub_agents) == 0
+
+
+def test_delegate_sub_agents_inherit_parent_llm_extra_headers():
+    register_builtins_agents()
+    executor, parent_conversation = create_test_executor_and_parent()
+    parent_conversation.get_llm_call_context.return_value = LLMCallContext(
+        extra_headers={"X-Request-ID": "request-1"}
+    )
+    parent_conversation._visualizer = None
+
+    executor(DelegateAction(command="spawn", ids=["agent1"]), parent_conversation)
+
+    sub_conversation = executor._sub_agents["agent1"]
+    assert sub_conversation.get_llm_call_context().extra_headers == {
+        "X-Request-ID": "request-1"
+    }
 
 
 def test_close_closes_spawned_sub_agents():

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -34,6 +35,7 @@ def _make_llm() -> LLM:
 def _make_parent_conversation(
     tmp_path: Path,
     persistence_dir: str | Path | None = None,
+    llm_extra_headers: Mapping[str, str] | None = None,
 ) -> LocalConversation:
     """Create a real (minimal) parent conversation for the manager."""
     llm = _make_llm()
@@ -44,16 +46,22 @@ def _make_parent_conversation(
         visualizer=None,
         delete_on_close=False,
         persistence_dir=persistence_dir,
+        llm_extra_headers=llm_extra_headers,
     )
 
 
 def _manager_with_parent(
     tmp_path: Path,
     persistence_dir: str | Path | None = None,
+    llm_extra_headers: Mapping[str, str] | None = None,
 ) -> tuple[TaskManager, LocalConversation]:
     """Return a TaskManager whose parent conversation is already set."""
     manager = TaskManager()
-    parent = _make_parent_conversation(tmp_path, persistence_dir=persistence_dir)
+    parent = _make_parent_conversation(
+        tmp_path,
+        persistence_dir=persistence_dir,
+        llm_extra_headers=llm_extra_headers,
+    )
     manager._ensure_parent(parent)
     return manager, parent
 
@@ -393,6 +401,27 @@ class TestTaskManager:
             sub_keys.append(conv.get_llm_call_context().prompt_cache_key)
 
         assert sub_keys == [parent_key, parent_key]
+
+    def test_sub_agents_inherit_parent_llm_extra_headers(self, tmp_path):
+        manager, _ = _manager_with_parent(
+            tmp_path,
+            llm_extra_headers={"X-Request-ID": "request-1"},
+        )
+        register_builtins_agents()
+        task_id, conversation_id = manager._generate_ids()
+        agent = manager._get_sub_agent("general-purpose")
+
+        conversation = manager._get_conversation(
+            description=None,
+            max_iteration_per_run=500,
+            task_id=task_id,
+            conversation_id=conversation_id,
+            worker_agent=agent,
+        )
+
+        assert conversation.get_llm_call_context().extra_headers == {
+            "X-Request-ID": "request-1"
+        }
 
 
 def _make_task_with_mock_conv(task_id: str, **conv_kwargs) -> Task:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I requested this change so one application request ID follows every LLM call made throughout an agent conversation without mutating shared LLM configuration.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Applications embedding the SDK need to attach correlation, tracing, or routing headers to every LLM request made by one agent conversation. `LLM.extra_headers` is static configuration, so mutating it for a task risks leaking state when an LLM or agent is reused. Conversation-scoped headers let one request ID follow every LLM call across repeated runs of the same live conversation.

## Summary

- Add nullable, runtime-only `llm_extra_headers` to `ConversationSettings`, conversation creation, and the Agent Server start request.
- Carry a copied, immutable header map through the existing `LLMCallContext` to chat and Responses API calls, including retries, condensers, sub-agents, and agent hooks.
- Send remote headers with `POST /api/conversations`; the existing `/run` contract remains unchanged.
- Exclude the headers from persisted conversation metadata and user-visible configuration.
- Document the behavior in OpenHands/docs#617: https://github.com/OpenHands/docs/pull/617

## Issue Number

Closes #4064.

The implementation follows review feedback by using the existing `ConversationSettings` architecture and making the headers conversation-scoped.

## How to Test

- `make lint`
- `uv run pyright` — 0 errors
- Targeted SDK, Agent Server, hooks, task, and delegate tests — 584 passed
- `NO_PROXY=127.0.0.1,localhost uv run pytest -q tests/cross/test_remote_conversation_live_server.py -k remote_conversation_llm_headers_reach_every_run` — 1 passed against a real FastAPI/HTTP/WebSocket Agent Server
- `make test-server-schema` — generated OpenAPI schema is valid
- Full `uv run pytest -q -n auto` — 8259 passed. Four environment/parallel-run failures passed when rerun in isolation; the remaining two local failures are unrelated terminal backslash timeout checks.

The live-server test runs the same remote conversation twice and verifies that both LLM calls receive the same `X-Request-ID`.

## Video/Screenshots

Not applicable; this is an SDK and REST API change covered by an end-to-end live-server test.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The API is generic and does not contain application-specific header names. Conversation-scoped headers override same-named static LLM headers, while SDK-owned headers such as `x-litellm-session-id` remain authoritative. Header values are not persisted or logged by this implementation. A server restart requires the caller to supply them again when creating a new live conversation.
