### PR TITLE
fix(sdk): keep legacy history on resume when the stored tail is a non-tree artifact

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -265,18 +265,32 @@ class ConversationState(OpenHandsModel):
 
         A set leaf is returned as-is. ``head_is_empty`` marks a deliberate empty
         HEAD (``navigate_to(None)``) -> no active branch. Otherwise a ``None`` leaf
-        falls back to the last event only for pre-feature conversations (last
-        event has no ``parent_id``), so legacy history loads unbranched.
+        (pre-feature conversation) falls back to the last *real* event, so legacy
+        history loads unbranched.
+
+        Trailing non-tree artifacts -- a ``ConversationStateUpdateEvent`` or
+        ``ConversationErrorEvent`` a newer server may have written onto a legacy
+        tail during an interrupted startup -- are skipped: they are not tree
+        nodes (see ``append_event``), so treating one as the leaf would both make
+        it the parent of the next event and, because it carries a ``parent_id``,
+        cut the legacy linear fallback and strand all prior history (#4057).
         """
         if self.leaf_event_id is not None:
             return self.leaf_event_id
         if self.head_is_empty:
             return None
-        if (n := len(self._events)) == 0:
+        if len(self._events) == 0:
             return None
-        if self._events[n - 1].parent_id is not None:
-            return None
-        return self._events.get_id(n - 1)
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.event.conversation_state import (
+            ConversationStateUpdateEvent,
+        )
+
+        artifacts = (ConversationStateUpdateEvent, ConversationErrorEvent)
+        for i in range(len(self._events) - 1, -1, -1):
+            if not isinstance(self._events[i], artifacts):
+                return self._events.get_id(i)
+        return None
 
     def active_branch(self, limit: int | None = None) -> list[Event]:
         """Raw events on the active branch (``path_to_root(leaf)``), root-first.

--- a/tests/cross/test_conversation_restore_behavior.py
+++ b/tests/cross/test_conversation_restore_behavior.py
@@ -35,6 +35,8 @@ from openhands.sdk.context.condenser.llm_summarizing_condenser import (
 )
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.event import ActionEvent, MessageEvent
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.sdk.event.types import ROOT_PARENT_ID
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.openhands_provider import (
     LITELLM_PROXY_PREFIX,
@@ -829,5 +831,94 @@ def test_restore_reasoning_effort_none_strips_temperature(mock_completion):
             assert last_call["reasoning_effort"] == "none"
             assert "temperature" not in last_call
             assert "top_p" not in last_call
+        finally:
+            restored.close()
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_restore_pre_event_tree_conversation_with_artifact_tail_keeps_history(
+    mock_completion,
+):
+    """Resuming a pre-event-tree conversation whose tail is a startup artifact
+    must keep the full history (#4057).
+
+    Older agent-servers (pre event-tree) wrote events without ``parent_id`` and
+    never persisted ``leaf_event_id``. We reproduce that shape from a *real* run:
+    strip ``parent_id`` off every event and drop the tree HEAD markers from
+    ``base_state``, then append the kind of non-tree artifact a newer server
+    writes onto the tail during an interrupted startup (a
+    ``ConversationStateUpdateEvent`` carrying a ``parent_id``). On resume the
+    agent must load the whole prior history and chain onto its real tail, rather
+    than stamping the next event a false ``__root__`` that orphans everything.
+    """
+    mock_completion.return_value = create_mock_litellm_response(
+        content="Acknowledged.", finish_reason="stop"
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        lifecycle = RestoreLifecycle(
+            workspace_dir=base / "workspace",
+            persistence_base_dir=base / "persist",
+        )
+        lifecycle.workspace_dir.mkdir(parents=True, exist_ok=True)
+        lifecycle.persistence_base_dir.mkdir(parents=True, exist_ok=True)
+
+        tools = [Tool(name="TerminalTool"), Tool(name="FileEditorTool")]
+        agent = _agent(
+            llm_model="gpt-4o-mini",
+            tools=tools,
+            condenser_max_size=80,
+            skill_name="skill-v1",
+            skill_keyword="alpha",
+        )
+
+        # 1) Produce a realistic event log by actually running a session.
+        lifecycle.run_initial_session(agent)
+        assert lifecycle.conversation_id is not None
+        events_dir = (
+            lifecycle.persistence_base_dir / lifecycle.conversation_id.hex / "events"
+        )
+        event_files = sorted(
+            events_dir.glob("event-*.json"),
+            key=lambda p: int(p.name.split("-")[1]),
+        )
+        assert len(event_files) >= 3
+        original_ids = [json.loads(p.read_text())["id"] for p in event_files]
+
+        # 2) Downgrade to the pre-event-tree shape: strip parent_id off every
+        #    event and drop the tree HEAD markers older servers never wrote.
+        for p in event_files:
+            data = json.loads(p.read_text())
+            data.pop("parent_id", None)
+            p.write_text(json.dumps(data))
+        base_state = lifecycle.read_base_state()
+        base_state.pop("leaf_event_id", None)
+        base_state.pop("head_is_empty", None)
+        lifecycle.write_base_state(base_state)
+
+        # 3) Append the interrupted-startup artifact: a non-tree event a newer
+        #    server chained onto the legacy tail (it carries a parent_id).
+        artifact = ConversationStateUpdateEvent(
+            parent_id=original_ids[-1], key="execution_status", value="idle"
+        )
+        artifact_path = events_dir / f"event-{len(event_files):05d}-{artifact.id}.json"
+        artifact_path.write_text(artifact.model_dump_json(exclude_none=True))
+
+        # 4) Resume under the current (tree-aware) code.
+        restored = lifecycle.restore(agent)
+        try:
+            # The whole prior history is the active branch (nothing orphaned);
+            # the non-tree artifact is not on it.
+            active_ids = [e.id for e in restored.state.active_branch()]
+            assert active_ids == original_ids
+
+            # Continuing chains onto the real legacy tail, not a false __root__.
+            restored.send_message("Third message")
+            new_event = restored.state.events[-1]
+            assert new_event.parent_id == original_ids[-1]
+            assert new_event.parent_id != ROOT_PARENT_ID
+            reachable = {e.id for e in restored.state.events.path_to_root(new_event.id)}
+            assert set(original_ids).issubset(reachable)
         finally:
             restored.close()

--- a/tests/cross/test_conversation_restore_behavior.py
+++ b/tests/cross/test_conversation_restore_behavior.py
@@ -922,3 +922,73 @@ def test_restore_pre_event_tree_conversation_with_artifact_tail_keeps_history(
             assert set(original_ids).issubset(reachable)
         finally:
             restored.close()
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_restore_event_tree_conversation_keeps_history(mock_completion):
+    """Control for the pre-event-tree case: a normal 1.33.0+ restore is unaffected.
+
+    A conversation persisted by an event-tree server (events carry ``parent_id``,
+    ``base_state`` persists ``leaf_event_id``) is restored *without* any downgrade
+    and must keep its full history and chain onto the real tail. Because
+    ``leaf_event_id`` is set, ``_resolve_active_leaf`` returns it directly and the
+    legacy-resume path the #4057 fix touches is never entered — this guards that
+    normal restore stays intact.
+    """
+    mock_completion.return_value = create_mock_litellm_response(
+        content="Acknowledged.", finish_reason="stop"
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        lifecycle = RestoreLifecycle(
+            workspace_dir=base / "workspace",
+            persistence_base_dir=base / "persist",
+        )
+        lifecycle.workspace_dir.mkdir(parents=True, exist_ok=True)
+        lifecycle.persistence_base_dir.mkdir(parents=True, exist_ok=True)
+
+        tools = [Tool(name="TerminalTool"), Tool(name="FileEditorTool")]
+        agent = _agent(
+            llm_model="gpt-4o-mini",
+            tools=tools,
+            condenser_max_size=80,
+            skill_name="skill-v1",
+            skill_keyword="alpha",
+        )
+
+        lifecycle.run_initial_session(agent)
+        assert lifecycle.conversation_id is not None
+        events_dir = (
+            lifecycle.persistence_base_dir / lifecycle.conversation_id.hex / "events"
+        )
+        event_files = sorted(
+            events_dir.glob("event-*.json"),
+            key=lambda p: int(p.name.split("-")[1]),
+        )
+        assert len(event_files) >= 3
+        original_ids = [json.loads(p.read_text())["id"] for p in event_files]
+
+        # This IS the modern (event-tree) on-disk shape — leaf persisted and
+        # events carry parent_id (contrast the pre-event-tree test above). No
+        # downgrade, no injected artifact.
+        assert "leaf_event_id" in lifecycle.read_base_state()
+        assert json.loads(event_files[0].read_text()).get("parent_id") is None
+        assert json.loads(event_files[-1].read_text()).get("parent_id") is not None
+
+        restored = lifecycle.restore(agent)
+        try:
+            # HEAD is the persisted leaf; the whole history is the active branch.
+            assert restored.state.leaf_event_id == original_ids[-1]
+            active_ids = [e.id for e in restored.state.active_branch()]
+            assert active_ids == original_ids
+
+            # Continuing chains onto the real tail, exactly as before the fix.
+            restored.send_message("Third message")
+            new_event = restored.state.events[-1]
+            assert new_event.parent_id == original_ids[-1]
+            assert new_event.parent_id != ROOT_PARENT_ID
+            reachable = {e.id for e in restored.state.events.path_to_root(new_event.id)}
+            assert set(original_ids).issubset(reachable)
+        finally:
+            restored.close()

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -18,6 +18,8 @@ from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.event.types import ROOT_PARENT_ID, SourceType
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
@@ -309,6 +311,65 @@ def test_legacy_conversation_resumes_and_continues():
         assert _ground_truth_view_ids(resumed) == [e.id for e in legacy]
 
         # A new event seamlessly continues the chain off the last legacy event.
+        new = _emit(resumed, _msg("after-resume"))
+        assert _by_id(resumed.state.events, new.id).parent_id == legacy[-1].id
+        assert resumed.state.leaf_event_id == new.id
+        assert [e.id for e in resumed.state.events.path_to_root(new.id)] == [
+            *(e.id for e in legacy),
+            new.id,
+        ]
+
+
+@pytest.mark.parametrize(
+    "make_tail",
+    [
+        pytest.param(
+            lambda parent_id: ConversationErrorEvent(
+                source="environment",
+                parent_id=parent_id,
+                code="RuntimeError",
+                detail="interrupted startup",
+            ),
+            id="conversation-error-tail",
+        ),
+        pytest.param(
+            lambda parent_id: ConversationStateUpdateEvent(
+                parent_id=parent_id,
+                key="execution_status",
+                value="idle",
+            ),
+            id="state-update-tail",
+        ),
+    ],
+)
+def test_legacy_resume_with_non_tree_artifact_tail_keeps_history(make_tail):
+    """A legacy log whose stored tail is a non-tree artifact still resumes whole.
+
+    A newer agent-server can write a ``ConversationStateUpdateEvent`` or
+    ``ConversationErrorEvent`` onto a legacy tail during an interrupted startup.
+    That artifact carries a ``parent_id``, but it is not a real HEAD: the first
+    post-resume event must chain onto the last real legacy event, not be stamped
+    a false ``__root__`` that strands all prior history (#4057).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        # Legacy flat log (no parent_id, leaf never advances) — pre-tree shape.
+        legacy = [_msg(f"legacy-{i}") for i in range(3)]
+        for ev in legacy:
+            conv.state.events.append(ev)
+        # Trailing artifact chained onto the legacy tail, as a newer server writes
+        # it: carries a parent_id but is not a tree node.
+        conv.state.events.append(make_tail(legacy[-1].id))
+        conv_id = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        assert resumed.state.leaf_event_id is None
+        # The artifact is skipped; the active branch is the full legacy history.
+        assert _view_ids(resumed) == [e.id for e in legacy]
+        assert _ground_truth_view_ids(resumed) == [e.id for e in legacy]
+
+        # The first new event chains onto the last legacy event, NOT a false root.
         new = _emit(resumed, _msg("after-resume"))
         assert _by_id(resumed.state.events, new.id).parent_id == legacy[-1].id
         assert resumed.state.leaf_event_id == new.id

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -22,6 +22,7 @@ from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.event.types import ROOT_PARENT_ID, SourceType
+from openhands.sdk.event.user_action import PauseEvent
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
 from openhands.sdk.tool.schema import Action
 
@@ -377,6 +378,56 @@ def test_legacy_resume_with_non_tree_artifact_tail_keeps_history(make_tail):
             *(e.id for e in legacy),
             new.id,
         ]
+
+
+@pytest.mark.parametrize(
+    "make_tail",
+    [
+        pytest.param(
+            lambda pid: [
+                ConversationStateUpdateEvent(parent_id=pid, key="k", value="v"),
+                ConversationErrorEvent(
+                    source="environment", parent_id=pid, code="E", detail="d"
+                ),
+                ConversationStateUpdateEvent(parent_id=pid, key="k2", value="v2"),
+            ],
+            id="multiple-stacked-artifacts",
+        ),
+        pytest.param(
+            lambda pid: [PauseEvent(parent_id=pid)],
+            id="tail-type-not-special-cased",
+        ),
+    ],
+)
+def test_legacy_resume_never_orphans_history_regardless_of_tail(make_tail):
+    """No trailing non-tree noise on a legacy log can orphan prior history.
+
+    Whatever a newer server appended onto the legacy tail during an interrupted
+    startup — several stacked artifacts, or an event type ``_resolve_active_leaf``
+    does not special-case — the first post-resume event must not be stamped a
+    false ``__root__``: every legacy event stays reachable from the new leaf
+    (#4057).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        legacy = [_msg(f"legacy-{i}") for i in range(3)]
+        for ev in legacy:
+            conv.state.events.append(ev)
+        for ev in make_tail(legacy[-1].id):
+            conv.state.events.append(ev)
+        conv_id = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        new = _emit(resumed, _msg("after-resume"))
+        stored = _by_id(resumed.state.events, new.id)
+        reachable = [e.id for e in resumed.state.events.path_to_root(new.id)]
+
+        legacy_ids = [e.id for e in legacy]
+        assert stored.parent_id != ROOT_PARENT_ID  # not a false root
+        # Every legacy event is still reachable, in order (nothing orphaned).
+        assert [i for i in reachable if i in set(legacy_ids)] == legacy_ids
+        assert reachable[-1] == new.id
 
 
 def test_parent_id_round_trips_on_disk_and_root_omits_it():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fixing resume of convo.

---

AGENT:

## Why

Resuming a conversation created by an older agent-server (pre event-tree, e.g. `1.29.3`) under `1.33.0+` can make the agent lose all prior history: it rebuilds context only from events written after resume and behaves as if the conversation is brand-new. No data is lost on disk — every event file is intact — but the agent's `path_to_root(leaf)` walk stops early, orphaning the older events from the LLM's view.

Root cause: on a legacy resume `leaf_event_id` is unset (older servers didn't persist it), so `ConversationState._resolve_active_leaf` falls back to the last stored event. It treated *"the last stored event has a `parent_id`"* as grounds for a brand-new root. When the stored tail is a **non-tree artifact** — a `ConversationStateUpdateEvent` or `ConversationErrorEvent` a newer server writes onto the legacy tail during a failed/interrupted startup — that check is true, so `_resolve_active_leaf` returns `None` and `_stamp_parent_id` stamps the first post-resume event with `parent_id="__root__"`. `_effective_parent_id` then halts at that false root and never reaches (or falls back into) the older events.

## Summary

- `_resolve_active_leaf`: on a legacy resume (unset `leaf_event_id`), skip trailing non-tree artifacts (`ConversationStateUpdateEvent` / `ConversationErrorEvent`) and resolve to the last **real** event, so the first new event chains onto the legacy tail instead of a false `__root__`. Keeps the existing legacy linear fallback; no disk rewrite.
- Added parametrized unit regression tests: the two named artifact-tail types, plus multiple stacked artifacts and a trailing event type `_resolve_active_leaf` does not special-case (e.g. `PauseEvent`) — all fail on the pre-fix code.
- Added a **realistic** restore test in `tests/cross/` (per review): a conversation persisted in the pre-event-tree shape *derived from a real run* (strip `parent_id` off every event, drop `leaf_event_id`/`head_is_empty` from `base_state`) with an artifact tail, resumed and continued.

## Issue Number

Fixes #4057

## How to Test

**End-to-end reproduction through a real `LocalConversation` resume** (not a unit test). Save as `repro.py` and run `uv run python repro.py`:

```python
import tempfile

from openhands.sdk.agent import Agent
from openhands.sdk.conversation import Conversation
from openhands.sdk.event.conversation_error import ConversationErrorEvent
from openhands.sdk.event.llm_convertible import MessageEvent
from openhands.sdk.llm import LLM, Message, TextContent
from pydantic import SecretStr


def msg(t):
    return MessageEvent(
        source="user",
        llm_message=Message(role="user", content=[TextContent(text=t)]),
    )


with tempfile.TemporaryDirectory() as tmp:
    agent = Agent(
        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("x"), usage_id="t"), tools=[]
    )
    conv = Conversation(
        agent=agent, persistence_dir=tmp, workspace=tmp,
        visualizer=None, delete_on_close=False,
    )
    legacy = [msg(f"legacy-{i}") for i in range(12)]
    for e in legacy:
        conv.state.events.append(e)  # pre-tree flat log (no parent_id)
    conv.state.events.append(  # artifact tail from an interrupted startup
        ConversationErrorEvent(
            source="environment", parent_id=legacy[-1].id,
            code="RuntimeError", detail="boom",
        )
    )
    cid = conv.id
    conv.close()

    resumed = Conversation(
        agent=agent, persistence_dir=tmp, workspace=tmp,
        conversation_id=cid, visualizer=None, delete_on_close=False,
    )
    with resumed._state:
        resumed._on_event(msg("first message after resume"))
    leaf = resumed.state.leaf_event_id
    reachable = len(resumed.state.events.path_to_root(leaf))
    print(f"reachable from agent's view = {reachable} / {len(resumed.state.events)} on disk")
```

- On `main` (pre-fix): `reachable from agent's view = 1 / 14 on disk` — the 12 legacy events + artifact are orphaned; the agent sees only the new message.
- On this branch (fixed): `reachable from agent's view = 13 / 14 on disk` — the full legacy history is back on the active branch. (The non-tree artifact is intentionally kept off the LLM branch — it is not an LLM event — so nothing is lost on disk.)

**Regression tests** (fail on `main`, pass here):

```
uv run pytest tests/sdk/conversation/local/test_conversation_tree.py -k legacy_resume -q
```

- With the fix: `4 passed` — two named artifact-tail types, multiple stacked artifacts, and a non-special-cased `PauseEvent` tail.
- Reverting only `_resolve_active_leaf`: those `4 failed` (the tail carries a `parent_id`, so the pre-fix code stamps a false `__root__`).

**Realistic restore test** in `tests/cross/` (per review — real run downgraded to the pre-event-tree on-disk shape, then resumed):

```
uv run pytest tests/cross/test_conversation_restore_behavior.py::test_restore_pre_event_tree_conversation_with_artifact_tail_keeps_history -q
```

- With the fix: `1 passed`. Reverting `_resolve_active_leaf`: `1 failed` (resumes with an empty active branch — the orphaning).

**Broader suite + lint**, all green:

```
uv run pytest tests/sdk/conversation/local/test_conversation_tree.py tests/sdk/conversation/test_event_tree.py tests/cross/test_conversation_restore_behavior.py -q
# 53 passed

uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/state.py tests/sdk/conversation/local/test_conversation_tree.py
# Ruff format / Ruff lint / pycodestyle / pyright / import rules — all Passed
```

## Video/Screenshots

N/A — SDK library change; terminal logs are inline under **How to Test**.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Scope: preventive fix.** It stops new orphaning for any legacy conversation resumed from now on. A conversation that was **already** corrupted by an earlier resume has `leaf_event_id` persisted pointing at the false `__root__`, so `_resolve_active_leaf` returns early and it stays orphaned until repaired. Recovery for those: re-link the offending event's `parent_id` from `"__root__"` to the id of the last pre-resume event; the legacy fallback then chains the rest. A conservative load-time auto-heal for already-affected conversations is feasible as a follow-up (keyed on the corruption fingerprint: the false `__root__` sits immediately after a non-tree artifact over a legacy prefix).
- **The hardcoded artifact set is not load-bearing for data safety.** `_resolve_active_leaf` skips `ConversationStateUpdateEvent` / `ConversationErrorEvent` to keep known non-tree artifacts *off* the active lineage, but preventing orphaning does not depend on that list being exhaustive: returning *any* trailing event as the leaf lets `path_to_root` walk back through the full legacy history. Verified that a `PauseEvent` / `InterruptEvent` tail (not in the list) and several stacked artifacts all keep history intact — orphaning is only reachable in the degenerate case where the log contains no real event at all (nothing to lose).
- Detailed walkthrough of the bug: https://enyst.github.io/arch/eventlog-resume-orphaned-history.html
