### PR TITLE
Push browser_use logging workaround cleanup deadline to v2.0.0

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/logging_fix.py
+++ b/openhands-tools/openhands/tools/browser_use/logging_fix.py
@@ -15,7 +15,7 @@ from openhands.sdk.utils.deprecation import warn_cleanup
 
 warn_cleanup(
     "Monkey patching to prevent browser_use logging interference",
-    cleanup_by="1.35.0",
+    cleanup_by="2.0.0",
     details=(
         "This workaround should be removed once browser_use fixes the "
         "problematic logging configuration code. The upstream PR #3717 "


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Change deprecation warn version.

---

AGENT:

## Why

The `browser_use` server reconfigures logging for **all** loggers on import,
clobbering the agent server's own logging configuration. We work around it with a
monkey-patch in `openhands-tools/openhands/tools/browser_use/logging_fix.py`,
guarded by `warn_cleanup(cleanup_by="1.35.0")`.

The `Verify deprecation removals` check (`.github/scripts/check_deprecations.py`)
fails once the project version reaches that deadline — so `cleanup_by="1.35.0"` is
**blocking the v1.35.0 release** (#4070).

The workaround cannot simply be removed: the upstream fix
(browser-use#3717) was **closed without merge**, and as of `browser_use` 0.13.3
the server still calls `logging.basicConfig()`, `logging.disable()` and
`_ensure_all_loggers_use_stderr()` on import with no opt-out. So we push the
deadline out instead.

## Summary

- Bump the `warn_cleanup` cleanup deadline for the `browser_use` logging
  monkey-patch from `1.35.0` to `2.0.0` in
  `openhands-tools/openhands/tools/browser_use/logging_fix.py`.

```diff
-    cleanup_by="1.35.0",
+    cleanup_by="2.0.0",
```

## Issue Number

#4072

## How to Test

No runtime behavior changes (only the deadline string moves). Evidence that the CI
gate this PR targets now passes:

**1. Run the exact check CI runs** (exits `0`):

```
uv run --with packaging python .github/scripts/check_deprecations.py
```
```
openhands-sdk: checked 1 deprecation metadata entries against version 1.34.0.
openhands-tools: checked 1 deprecation metadata entries against version 1.34.0.
openhands-workspace: checked 0 deprecation metadata entries against version 1.34.0.
openhands-agent-server: checked 0 deprecation metadata entries against version 1.34.0.
Checked 2 deprecation metadata entries across 4 package(s).
```

**2. Prove the new `2.0.0` deadline clears the `1.35.0` release** (the local
pyproject is still `1.34.0`, so this exercises the check's own `_should_fail`
logic against the release version directly):

```
uv run --with packaging python -c "
import sys; sys.path.insert(0, '.github/scripts')
import check_deprecations as c
from pathlib import Path
rec = c.DeprecationRecord(identifier='browser_use logging', removed_in='2.0.0',
    deprecated_in=None, path=Path('x'), line=1, kind='cleanup_call', package='openhands-tools')
print('blocks release at 1.35.0 ? ->', c._should_fail('1.35.0', rec))
print('blocks release at 1.99.0 ? ->', c._should_fail('1.99.0', rec))
print('blocks release at 2.0.0  ? ->', c._should_fail('2.0.0', rec))
"
```
```
blocks release at 1.35.0 ? -> False
blocks release at 1.99.0 ? -> False
blocks release at 2.0.0  ? -> True
```

**3. Lint / type checks pass:**

```
uv run --with pre-commit pre-commit run --files openhands-tools/openhands/tools/browser_use/logging_fix.py
```
```
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

## Video/Screenshots

N/A — no user-facing or GUI change. This edits only a deprecation-deadline marker
consumed by the CI check; the command output above is the evidence.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Runtime behavior is unchanged; only the `cleanup_by` marker moves from `1.35.0`
  to `2.0.0`.
- This PR targets `main`, so it does not by itself unblock the v1.35.0 release PR
  (#4070, branch `rel-1.35.0`); the change also needs to reach that branch (merge
  `main` in, or cherry-pick the commit).
- Cleanup is tracked by #4072, and the `warn_cleanup` marker will fail CI again at
  `2.0.0` as a backstop.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bc8ee98-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bc8ee98-python \
  ghcr.io/openhands/agent-server:bc8ee98-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bc8ee98-golang-amd64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-golang-amd64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-golang-amd64
ghcr.io/openhands/agent-server:bc8ee98-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bc8ee98-golang-arm64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-golang-arm64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-golang-arm64
ghcr.io/openhands/agent-server:bc8ee98-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bc8ee98-java-amd64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-java-amd64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-java-amd64
ghcr.io/openhands/agent-server:bc8ee98-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bc8ee98-java-arm64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-java-arm64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-java-arm64
ghcr.io/openhands/agent-server:bc8ee98-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bc8ee98-python-amd64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-python-amd64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-python-amd64
ghcr.io/openhands/agent-server:bc8ee98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bc8ee98-python-arm64
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-python-arm64
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-python-arm64
ghcr.io/openhands/agent-server:bc8ee98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bc8ee98-golang
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-golang
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-golang
ghcr.io/openhands/agent-server:bc8ee98-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bc8ee98-java
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-java
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-java
ghcr.io/openhands/agent-server:bc8ee98-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bc8ee98-python
ghcr.io/openhands/agent-server:bc8ee98905c2560daca27acecdbc723ed342f8b3-python
ghcr.io/openhands/agent-server:push-browser-use-cleanup-deadline-v2-python
ghcr.io/openhands/agent-server:bc8ee98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bc8ee98-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bc8ee98-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->