### PR TITLE
test(agent-server): deflake conversation tree fork/navigate tests

### DIFF
--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2933,6 +2933,22 @@ class TestACPActivityHeartbeatWiring:
         assert not hasattr(agent, "_on_activity")
 
 
+def _branch_events(conversation) -> list:
+    """Log events excluding async ``ConversationStateUpdateEvent`` artifacts.
+
+    Those state-sync artifacts are appended to the log asynchronously
+    (``EventService._emit_event_from_thread``), so their position in
+    ``_state.events`` relative to the synchronous message appends is racy.
+    Filtering them keeps positional indexing and length invariants deterministic
+    for the fork/navigate assertions below.
+    """
+    return [
+        e
+        for e in conversation._state.events
+        if not isinstance(e, ConversationStateUpdateEvent)
+    ]
+
+
 class TestConversationTreeForkAndNavigate:
     """Service-level coverage for fork-from-event lineage and navigation."""
 
@@ -2962,7 +2978,7 @@ class TestConversationTreeForkAndNavigate:
                 Message(role="user", content=[TextContent(text=text)]),
                 run=False,
             )
-        events = list(event_service.get_conversation()._state.events)
+        events = _branch_events(event_service.get_conversation())
         return info, event_service, events
 
     @pytest.mark.asyncio
@@ -2999,12 +3015,14 @@ class TestConversationTreeForkAndNavigate:
 
             fork_service = await svc.get_event_service(fork_info.id)
             assert fork_service is not None
-            fork_events = list(fork_service.get_conversation()._state.events)
+            fork_events = _branch_events(fork_service.get_conversation())
+            # Only path_to_root(branch_point) was copied — the active branch up
+            # to and including the branch point, not the whole log.
             assert [e.id for e in fork_events] == expected_branch_ids
             assert len(fork_events) < len(events)
 
             # Source is untouched by the fork.
-            src_events = list(source_service.get_conversation()._state.events)
+            src_events = _branch_events(source_service.get_conversation())
             assert len(src_events) == len(events)
 
     @pytest.mark.asyncio
@@ -3026,7 +3044,7 @@ class TestConversationTreeForkAndNavigate:
             assert fork_info.forked_from_event_id is None
             fork_service = await svc.get_event_service(fork_info.id)
             assert fork_service is not None
-            fork_events = list(fork_service.get_conversation()._state.events)
+            fork_events = _branch_events(fork_service.get_conversation())
             assert len(fork_events) == len(events)
 
     @pytest.mark.asyncio
@@ -3064,9 +3082,7 @@ class TestConversationTreeForkAndNavigate:
             assert nav_info is not None
             assert nav_info.leaf_event_id == target
             # All branches stay on disk — nothing is pruned.
-            assert len(list(event_service.get_conversation()._state.events)) == len(
-                events
-            )
+            assert len(_branch_events(event_service.get_conversation())) == len(events)
 
     @pytest.mark.asyncio
     async def test_navigate_unknown_event_raises(self, tmp_path):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small fix to deflake tests.

---

AGENT:

## Why

`TestConversationTreeForkAndNavigate::test_fork_from_event_slices_branch_and_records_lineage`
is flaky and failed CI on the v1.35.0 release PR (#4070), which only bumps
version strings — so the failure is unrelated to that diff.

Root cause: the test class snapshots the raw event log via
`list(conversation._state.events)` and indexes it positionally (`events[0]`,
`events[1]`) and by length. That log also contains `ConversationStateUpdateEvent`
state-sync artifacts, which are appended **asynchronously** by
`EventService._emit_event_from_thread` (`main_loop.run_in_executor(None, locked_on_event)`),
so their position relative to the synchronous `send_message(run=False)` appends is
racy. When one lands at index 0, `branch_point = events[1]` is actually the first
*real* user message — itself a tree root (`parent_id == ROOT_PARENT_ID`) — so
fork-from-event correctly slices a single-event branch while the test expected two.
This is a test bug; the tree/fork product behavior is correct.

## Summary

- Add a `_branch_events(conversation)` helper that returns the log excluding async `ConversationStateUpdateEvent` artifacts.
- Use it at every `_state.events` read in `TestConversationTreeForkAndNavigate`, so positional indexing and length invariants are deterministic. No product code is touched.

## Issue Number

N/A — flaky test surfaced by CI on #4070.

## How to Test

From the repo root:

```bash
uv sync --frozen --group dev

# Target test (fails 30/30 on the pre-fix code, passes with this change):
for i in $(seq 1 30); do \
  CI=true uv run python -m pytest -q \
    "tests/agent_server/test_conversation_service.py::TestConversationTreeForkAndNavigate::test_fork_from_event_slices_branch_and_records_lineage"; \
done

# Whole class under xdist, as CI runs it:
CI=true uv run python -m pytest -n auto \
  "tests/agent_server/test_conversation_service.py::TestConversationTreeForkAndNavigate"
```

Evidence gathered on this branch:

- **Pre-fix (change stashed):** the target test failed **30/30** locally with the same assertion diff seen in CI (`['<id>'] == ['<id>', '<id>']`).
- **Post-fix:** the target test passed **20/20**; the full 8-test class passed **3/3** under `-n auto`.
- `pre-commit run --files tests/agent_server/test_conversation_service.py` → all hooks pass (ruff-format, ruff-check, pycodestyle, pyright, import rules, tool registration).

## Video/Screenshots

N/A — test-only change; verification is the pytest runs above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Test-only change; no runtime/product code modified.
- Targets `main`; the v1.35.0 release branch (#4070) can pick it up via merge/rebase to clear its red CI.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ff7a1a7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ff7a1a7-python \
  ghcr.io/openhands/agent-server:ff7a1a7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ff7a1a7-golang-amd64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-golang-amd64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-golang-amd64
ghcr.io/openhands/agent-server:ff7a1a7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ff7a1a7-golang-arm64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-golang-arm64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-golang-arm64
ghcr.io/openhands/agent-server:ff7a1a7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ff7a1a7-java-amd64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-java-amd64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-java-amd64
ghcr.io/openhands/agent-server:ff7a1a7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ff7a1a7-java-arm64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-java-arm64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-java-arm64
ghcr.io/openhands/agent-server:ff7a1a7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ff7a1a7-python-amd64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-python-amd64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-python-amd64
ghcr.io/openhands/agent-server:ff7a1a7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ff7a1a7-python-arm64
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-python-arm64
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-python-arm64
ghcr.io/openhands/agent-server:ff7a1a7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ff7a1a7-golang
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-golang
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-golang
ghcr.io/openhands/agent-server:ff7a1a7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ff7a1a7-java
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-java
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-java
ghcr.io/openhands/agent-server:ff7a1a7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ff7a1a7-python
ghcr.io/openhands/agent-server:ff7a1a7a9865a38419991d7aa6384acd421c3dd7-python
ghcr.io/openhands/agent-server:fix-deflake-conversation-tree-fork-tests-python
ghcr.io/openhands/agent-server:ff7a1a7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ff7a1a7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ff7a1a7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->