### PR TITLE
feat(agent-server): accept final snapshot trace metadata

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -38,6 +38,7 @@ from openhands.agent_server.models import (
     StartGoalRequest,
     Success,
     UpdateConversationRequest,
+    UpdateObservabilityMetadataRequest,
     UpdateSecretsRequest,
     trim_conversation_response_skills,
 )
@@ -271,6 +272,26 @@ async def delete_conversation(
     deleted = await conversation_service.delete_conversation(conversation_id)
     if not deleted:
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
+    return Success()
+
+
+@conversation_router.post(
+    "/{conversation_id}/observability/metadata",
+    responses={404: {"description": "Item not found"}},
+)
+async def update_observability_metadata(
+    conversation_id: UUID,
+    request: UpdateObservabilityMetadataRequest,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Augment trace metadata for an active conversation."""
+    event_service = await conversation_service.get_event_service(conversation_id)
+    if event_service is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    try:
+        await event_service.update_observability_metadata(request.metadata)
+    except ValueError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     return Success()
 
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -45,6 +45,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.conversation.types import TraceMetadataValue
 from openhands.sdk.event import (
     AgentErrorEvent,
     ObservationBaseEvent,
@@ -1361,6 +1362,13 @@ class EventService:
             raise ValueError("inactive_service")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.update_secrets, secrets)
+
+    async def update_observability_metadata(
+        self, metadata: dict[str, TraceMetadataValue]
+    ) -> None:
+        """Augment the active conversation trace metadata."""
+        conversation = self.get_conversation()
+        conversation.update_observability_metadata(metadata)
 
     async def set_confirmation_policy(self, policy: ConfirmationPolicyBase):
         """Set the confirmation policy for the conversation."""

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -20,7 +20,10 @@ from openhands.sdk.conversation.request import (  # re-export for backward compa
 )
 from openhands.sdk.conversation.secret_registry import SecretRegistry
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.conversation.types import ConversationTags
+from openhands.sdk.conversation.types import (
+    ConversationObservabilityMetadata,
+    ConversationTags,
+)
 from openhands.sdk.event.base import Event
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm.message import (  # re-export
@@ -480,6 +483,12 @@ class UpdateConversationRequest(BaseModel):
             "Replaces all existing tags when provided."
         ),
     )
+
+
+class UpdateObservabilityMetadataRequest(BaseModel):
+    """Payload to augment conversation trace metadata."""
+
+    metadata: ConversationObservabilityMetadata
 
 
 class ForkConversationRequest(BaseModel):

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -197,6 +197,12 @@ class BaseConversation(ABC):
             return
         update_root_span_metadata(self._observability_root_span, metadata)
 
+    def update_observability_metadata(
+        self, metadata: dict[str, TraceMetadataValue]
+    ) -> None:
+        """Augment the conversation trace metadata."""
+        self._update_observability_metadata(metadata)
+
     @property
     @abstractmethod
     def id(self) -> ConversationID: ...

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1042,6 +1042,65 @@ def test_delete_conversation_failure(
         client.app.dependency_overrides.clear()
 
 
+def test_update_observability_metadata(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/observability/metadata",
+            json={"metadata": {"final_snapshot_captured": True, "byte_count": 42}},
+        )
+
+        assert response.status_code == 200
+        mock_event_service.update_observability_metadata.assert_awaited_once_with(
+            {"final_snapshot_captured": True, "byte_count": 42}
+        )
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_update_observability_metadata_not_found(
+    client, mock_conversation_service, sample_conversation_id
+):
+    mock_conversation_service.get_event_service.return_value = None
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/observability/metadata",
+            json={"metadata": {"final_snapshot_captured": True}},
+        )
+
+        assert response.status_code == 404
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_update_observability_metadata_rejects_nested_values(
+    client, mock_conversation_service, sample_conversation_id
+):
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/observability/metadata",
+            json={"metadata": {"packages": {"pytest": "9.0.0"}}},
+        )
+
+        assert response.status_code == 422
+    finally:
+        client.app.dependency_overrides.clear()
+
+
 def test_run_conversation_success(
     client, mock_conversation_service, mock_event_service, sample_conversation_id
 ):

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -81,6 +81,17 @@ def event_service(sample_stored_conversation):
     return service
 
 
+@pytest.mark.asyncio
+async def test_update_observability_metadata(event_service):
+    conversation = MagicMock(spec=LocalConversation)
+    event_service._conversation = conversation
+    metadata = {"final_snapshot_captured": True, "byte_count": 42}
+
+    await event_service.update_observability_metadata(metadata)
+
+    conversation.update_observability_metadata.assert_called_once_with(metadata)
+
+
 @pytest.fixture
 def mock_conversation_with_events():
     """Create a mock conversation with sample events."""


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Final snapshot manifests are produced after the conversation starts, but the agent server had no authenticated path for runtime services to add that late-discovered data to the active Laminar trace.

## Summary

- expose a public conversation method for augmenting root trace metadata
- add an authenticated agent-server endpoint that validates and forwards scalar trace metadata
- cover forwarding, missing conversations, and invalid nested values

## Issue Number

N/A

## How to Test

- `PATH="$HOME/.local/bin:$PATH" uv run pytest tests/agent_server/test_conversation_router.py tests/agent_server/test_event_service.py -q`
- Result: 202 passed.
- `PATH="$HOME/.local/bin:$PATH" uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/base.py openhands-agent-server/openhands/agent_server/models.py openhands-agent-server/openhands/agent_server/event_service.py openhands-agent-server/openhands/agent_server/conversation_router.py tests/agent_server/test_conversation_router.py tests/agent_server/test_event_service.py`
- Result: formatting, lint, pycodestyle, pyright, import rules, and tool registration checks passed.
- Full GCS-to-Laminar validation requires the coordinated runtime-api and OpenHands changes plus promoted agent-server images, so it is deferred to rollout validation.

## Video/Screenshots

Not applicable; this is an internal API.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Stacked on #4054. Merge and release #4054 first, then this PR, before deploying the callers.