### PR TITLE
fix(tools): scope client tool resolution to conversations

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -50,7 +50,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
-from openhands.sdk.tool.client_tool import register_client_tools
+from openhands.sdk.tool.client_tool import merge_client_tools
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -775,18 +775,13 @@ class ConversationService:
 
         # Validate and inject self-contained client tool specs.
         if request.client_tools:
-            client_tool_specs = register_client_tools(
-                request.client_tools, agent_tools=request.agent.tools
+            request.agent = request.agent.model_copy(
+                update={
+                    "tools": merge_client_tools(
+                        request.client_tools, request.agent.tools
+                    )
+                }
             )
-            # Inject Tool specs into the agent so _initialize() resolves them
-            existing_names = {t.name for t in request.agent.tools}
-            new_tools = [
-                ts for ts in client_tool_specs if ts.name not in existing_names
-            ]
-            if new_tools:
-                request.agent = request.agent.model_copy(
-                    update={"tools": [*request.agent.tools, *new_tools]}
-                )
 
         # Register subagent definitions forwarded from the client
         if request.agent_definitions:
@@ -1200,8 +1195,14 @@ class ConversationService:
                         )
                 # Restore dynamic client action types from persisted specs.
                 if stored.client_tools:
-                    register_client_tools(
-                        stored.client_tools, agent_tools=stored.agent.tools
+                    stored.agent = stored.agent.model_copy(
+                        update={
+                            "tools": merge_client_tools(
+                                stored.client_tools,
+                                stored.agent.tools,
+                                migrate_legacy=True,
+                            )
+                        }
                     )
                 # Register agent definitions when resuming
                 if stored.agent_definitions:

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1200,7 +1200,9 @@ class ConversationService:
                             "tools": merge_client_tools(
                                 stored.client_tools,
                                 stored.agent.tools,
-                                migrate_legacy=True,
+                                legacy_tool_names={
+                                    spec.name for spec in stored.client_tools
+                                },
                             )
                         }
                     )

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -773,12 +773,11 @@ class ConversationService:
                     conversation_id,
                 )
 
-        # Register client-defined tools (JSON specs, no Python code). The
-        # ClientTool *class* is registered statelessly; each tool's schema
-        # travels with the conversation via the returned Tool.params, so
-        # concurrent conversations never clobber each other's schemas.
+        # Validate and inject self-contained client tool specs.
         if request.client_tools:
-            client_tool_specs = register_client_tools(request.client_tools)
+            client_tool_specs = register_client_tools(
+                request.client_tools, agent_tools=request.agent.tools
+            )
             # Inject Tool specs into the agent so _initialize() resolves them
             existing_names = {t.name for t in request.agent.tools}
             new_tools = [
@@ -1199,11 +1198,11 @@ class ConversationService:
                             f"resuming conversation {stored.id}: "
                             f"{list(stored.tool_module_qualnames.keys())}"
                         )
-                # Re-register client-defined tools when resuming. The agent's
-                # persisted tool specs already carry each schema via params, so
-                # we only need to (re-)register the ClientTool class per name.
+                # Restore dynamic client action types from persisted specs.
                 if stored.client_tools:
-                    register_client_tools(stored.client_tools)
+                    register_client_tools(
+                        stored.client_tools, agent_tools=stored.agent.tools
+                    )
                 # Register agent definitions when resuming
                 if stored.agent_definitions:
                     _register_agent_definitions(

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -286,22 +286,24 @@ class LocalConversation(BaseConversation):
 
         # Recover persisted client specs before resolving the agent's tools.
         resolved_client_tools = list(client_tools or [])
+        migrate_legacy_client_tools = False
         if not resolved_client_tools and persistence_dir is not None:
             resolved_client_tools = self._recover_persisted_client_tools(
                 persistence_dir, desired_id
             )
+            migrate_legacy_client_tools = bool(resolved_client_tools)
         if resolved_client_tools:
-            from openhands.sdk.tool.client_tool import register_client_tools
+            from openhands.sdk.tool.client_tool import merge_client_tools
 
-            client_tool_specs = register_client_tools(
-                resolved_client_tools, agent_tools=agent.tools
+            agent = agent.model_copy(
+                update={
+                    "tools": merge_client_tools(
+                        resolved_client_tools,
+                        agent.tools,
+                        migrate_legacy=migrate_legacy_client_tools,
+                    )
+                }
             )
-            existing_names = {t.name for t in agent.tools}
-            new_tools = [
-                ts for ts in client_tool_specs if ts.name not in existing_names
-            ]
-            if new_tools:
-                agent = agent.model_copy(update={"tools": [*agent.tools, *new_tools]})
 
         self.agent = agent
         if isinstance(workspace, (str, Path)):
@@ -579,7 +581,7 @@ class LocalConversation(BaseConversation):
                 tools.append(Tool.model_validate(raw_tool))
             except ValidationError:
                 continue
-        return extract_client_tool_specs(tools)
+        return extract_client_tool_specs(tools, allow_legacy=True)
 
     @property
     def id(self) -> ConversationID:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -284,13 +284,7 @@ class LocalConversation(BaseConversation):
         # Create-or-resume: factory inspects BASE_STATE to decide
         desired_id = conversation_id or uuid.uuid4()
 
-        # Resolve client-defined tools, then register them and inject the matching
-        # Tool specs into the agent so the agent can call them. Execution is
-        # deferred to a consumer of the emitted ActionEvent (e.g. a frontend); the
-        # executor only acks. Specs come either from the caller (`client_tools`)
-        # or, when resuming a persisted conversation without re-supplying them,
-        # from the persisted agent's tool specs — mirroring the server resume
-        # path so a fresh process can re-register the dynamic tools.
+        # Recover persisted client specs before resolving the agent's tools.
         resolved_client_tools = list(client_tools or [])
         if not resolved_client_tools and persistence_dir is not None:
             resolved_client_tools = self._recover_persisted_client_tools(
@@ -299,7 +293,9 @@ class LocalConversation(BaseConversation):
         if resolved_client_tools:
             from openhands.sdk.tool.client_tool import register_client_tools
 
-            client_tool_specs = register_client_tools(resolved_client_tools)
+            client_tool_specs = register_client_tools(
+                resolved_client_tools, agent_tools=agent.tools
+            )
             existing_names = {t.name for t in agent.tools}
             new_tools = [
                 ts for ts in client_tool_specs if ts.name not in existing_names

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePath
 from typing import Any, Final, TypeGuard, cast
 
+from pydantic import ValidationError
+
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context.condenser import CondenserBase, LLMSummarizingCondenser
@@ -16,6 +18,7 @@ from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.cancellation import CancellationToken
 from openhands.sdk.conversation.event_store import EventLog
 from openhands.sdk.conversation.exceptions import ConversationRunError
+from openhands.sdk.conversation.persistence_const import BASE_STATE
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
@@ -83,8 +86,13 @@ from openhands.sdk.subagent import (
 )
 from openhands.sdk.tool import ToolDefinition
 from openhands.sdk.tool.builtins import InvokeSkillTool
-from openhands.sdk.tool.client_tool import ClientToolSpec
+from openhands.sdk.tool.client_tool import (
+    ClientToolSpec,
+    extract_client_tool_specs,
+    merge_client_tools,
+)
 from openhands.sdk.tool.schema import Action, Observation
+from openhands.sdk.tool.spec import Tool
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -286,21 +294,26 @@ class LocalConversation(BaseConversation):
 
         # Recover persisted client specs before resolving the agent's tools.
         resolved_client_tools = list(client_tools or [])
-        migrate_legacy_client_tools = False
-        if not resolved_client_tools and persistence_dir is not None:
-            resolved_client_tools = self._recover_persisted_client_tools(
-                persistence_dir, desired_id
+        legacy_client_tool_names: set[str] = set()
+        if not resolved_client_tools and (
+            persistence_dir is not None or file_store is not None
+        ):
+            (
+                resolved_client_tools,
+                legacy_client_tool_names,
+            ) = self._recover_persisted_client_tools(
+                persistence_dir,
+                desired_id,
+                agent.tools,
+                file_store=file_store,
             )
-            migrate_legacy_client_tools = bool(resolved_client_tools)
         if resolved_client_tools:
-            from openhands.sdk.tool.client_tool import merge_client_tools
-
             agent = agent.model_copy(
                 update={
                     "tools": merge_client_tools(
                         resolved_client_tools,
                         agent.tools,
-                        migrate_legacy=migrate_legacy_client_tools,
+                        legacy_tool_names=legacy_client_tool_names,
                     )
                 }
             )
@@ -547,33 +560,23 @@ class LocalConversation(BaseConversation):
 
     def _recover_persisted_client_tools(
         self,
-        persistence_base_dir: str | Path,
+        persistence_base_dir: str | Path | None,
         conversation_id: ConversationID,
-    ) -> list[ClientToolSpec]:
-        """Recover client tool specs from a persisted conversation's base state.
-
-        When a persisted conversation is resumed in a fresh process, the dynamic
-        client tools are absent from the global registry and the caller may not
-        re-supply ``client_tools``. Without recovery, the persisted agent's
-        client tools would appear "removed" and resume would fail. We read the
-        persisted agent tool specs and pull out the embedded ``ClientToolSpec``s
-        so they can be re-registered and re-injected. Returns an empty list when
-        there is no persisted state yet (fresh conversation).
-        """
-        from pydantic import ValidationError
-
-        from openhands.sdk.conversation.persistence_const import BASE_STATE
-        from openhands.sdk.tool.client_tool import extract_client_tool_specs
-        from openhands.sdk.tool.spec import Tool
-
-        base_path = (
-            Path(self.get_persistence_dir(persistence_base_dir, conversation_id))
-            / BASE_STATE
-        )
+        runtime_tools: Sequence[Tool] = (),
+        *,
+        file_store: FileStore | None = None,
+    ) -> tuple[list[ClientToolSpec], set[str]]:
+        """Recover persisted client tool specs."""
+        if file_store is None:
+            if persistence_base_dir is None:
+                return [], set()
+            file_store = LocalFileStore(
+                self.get_persistence_dir(persistence_base_dir, conversation_id)
+            )
         try:
-            data = json.loads(base_path.read_text())
+            data = json.loads(file_store.read(BASE_STATE))
         except (FileNotFoundError, json.JSONDecodeError):
-            return []
+            return [], set()
         raw_tools = (data.get("agent") or {}).get("tools") or []
         tools: list[Tool] = []
         for raw_tool in raw_tools:
@@ -581,7 +584,20 @@ class LocalConversation(BaseConversation):
                 tools.append(Tool.model_validate(raw_tool))
             except ValidationError:
                 continue
-        return extract_client_tool_specs(tools, allow_legacy=True)
+
+        specs = extract_client_tool_specs(tools)
+        marked_names = {spec.name for spec in specs}
+        runtime_names = {tool.name for tool in runtime_tools}
+        legacy_tools = [
+            tool
+            for tool in tools
+            if tool.name not in marked_names and tool.name not in runtime_names
+        ]
+        legacy_specs = extract_client_tool_specs(legacy_tools, allow_legacy=True)
+        return [
+            *specs,
+            *legacy_specs,
+        ], {spec.name for spec in legacy_specs}
 
     @property
     def id(self) -> ConversationID:

--- a/openhands-sdk/openhands/sdk/tool/client_tool.py
+++ b/openhands-sdk/openhands/sdk/tool/client_tool.py
@@ -14,7 +14,7 @@ import threading
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.schema import Action, Observation, Schema
@@ -49,6 +49,7 @@ logger = get_logger(__name__)
 _client_action_types: dict[str, type[Action]] = {}
 _client_action_schemas: dict[str, dict[str, Any]] = {}
 _client_action_lock = threading.RLock()
+_CLIENT_TOOL_MARKER = "_openhands_client_tool"
 
 
 class ClientToolRegistrationError(ValueError):
@@ -323,45 +324,48 @@ class ClientTool(ToolDefinition[Action, ClientToolObservation]):
         )
 
 
-def extract_client_tool_specs(tools: "Sequence[Tool]") -> list[ClientToolSpec]:
-    """Recover :class:`ClientToolSpec`s embedded in persisted ``Tool`` specs.
+def _extract_client_tool_spec(
+    tool: "Tool", *, allow_legacy: bool = False
+) -> ClientToolSpec | None:
+    if not allow_legacy and tool.params.get(_CLIENT_TOOL_MARKER) is not True:
+        return None
+    raw = tool.params.get("spec")
+    if not isinstance(raw, dict):
+        return None
+    try:
+        spec = ClientToolSpec.model_validate(raw)
+    except ValidationError:
+        return None
+    return spec if spec.name == tool.name else None
 
-    Client tools carry their full spec under ``Tool.params['spec']`` (see
-    :func:`register_client_tools`). When a conversation is resumed in a fresh
-    process, that spec is the only place the schema survives, so we use it to
-    re-register the dynamic tools. A persisted ``Tool`` is treated as a client
-    tool only when its ``params['spec']`` validates as a ``ClientToolSpec`` whose
-    ``name`` matches the tool name, which avoids misclassifying ordinary tools
-    that happen to use a ``spec`` param.
-    """
-    from pydantic import ValidationError
 
-    specs: list[ClientToolSpec] = []
-    for tool in tools:
-        raw = (tool.params or {}).get("spec")
-        if not isinstance(raw, dict):
-            continue
-        try:
-            spec = ClientToolSpec.model_validate(raw)
-        except ValidationError:
-            continue
-        if spec.name == tool.name:
-            specs.append(spec)
-    return specs
+def _client_tool_spec(spec: ClientToolSpec) -> "Tool":
+    from openhands.sdk.tool.spec import Tool
+
+    return Tool(
+        name=spec.name,
+        params={"spec": spec.model_dump(), _CLIENT_TOOL_MARKER: True},
+    )
+
+
+def extract_client_tool_specs(
+    tools: "Sequence[Tool]", *, allow_legacy: bool = False
+) -> list[ClientToolSpec]:
+    """Extract embedded client tool specs."""
+    return [
+        spec
+        for tool in tools
+        if (spec := _extract_client_tool_spec(tool, allow_legacy=allow_legacy))
+        is not None
+    ]
 
 
 def resolve_client_tool(
     tool: "Tool", conv_state: "ConversationState"
 ) -> Sequence[ToolDefinition] | None:
     """Resolve a registered client tool from its embedded spec."""
-    raw = (tool.params or {}).get("spec")
-    if not isinstance(raw, dict):
-        return None
-    try:
-        spec = ClientToolSpec.model_validate(raw)
-    except ValueError:
-        return None
-    if spec.name != tool.name:
+    spec = _extract_client_tool_spec(tool)
+    if spec is None:
         return None
     with _client_action_lock:
         if spec.name not in _client_action_types:
@@ -427,5 +431,27 @@ def register_client_tools(
             if spec.name not in already_registered:
                 register_tool(spec.name, ClientTool)
                 already_registered.add(spec.name)
-            tool_specs.append(Tool(name=spec.name, params={"spec": spec.model_dump()}))
+            tool_specs.append(_client_tool_spec(spec))
         return tool_specs
+
+
+def merge_client_tools(
+    specs: Sequence[ClientToolSpec],
+    agent_tools: Sequence["Tool"],
+    *,
+    migrate_legacy: bool = False,
+) -> list["Tool"]:
+    """Register and merge client tools into an agent tool list."""
+    specs_by_name = {spec.name: spec for spec in specs}
+    tools: list[Tool] = []
+    for tool in agent_tools:
+        spec = specs_by_name.get(tool.name)
+        embedded = _extract_client_tool_spec(tool, allow_legacy=migrate_legacy)
+        tools.append(
+            _client_tool_spec(spec) if spec is not None and spec == embedded else tool
+        )
+
+    client_tools = register_client_tools(specs, agent_tools=tools)
+    existing_names = {tool.name for tool in tools}
+    tools.extend(tool for tool in client_tools if tool.name not in existing_names)
+    return tools

--- a/openhands-sdk/openhands/sdk/tool/client_tool.py
+++ b/openhands-sdk/openhands/sdk/tool/client_tool.py
@@ -11,7 +11,7 @@ This eliminates the need for Python tool code in JavaScript repos and the comple
 
 import copy
 import threading
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
@@ -439,14 +439,16 @@ def merge_client_tools(
     specs: Sequence[ClientToolSpec],
     agent_tools: Sequence["Tool"],
     *,
-    migrate_legacy: bool = False,
+    legacy_tool_names: Collection[str] = (),
 ) -> list["Tool"]:
     """Register and merge client tools into an agent tool list."""
     specs_by_name = {spec.name: spec for spec in specs}
     tools: list[Tool] = []
     for tool in agent_tools:
         spec = specs_by_name.get(tool.name)
-        embedded = _extract_client_tool_spec(tool, allow_legacy=migrate_legacy)
+        embedded = _extract_client_tool_spec(
+            tool, allow_legacy=tool.name in legacy_tool_names
+        )
         tools.append(
             _client_tool_spec(spec) if spec is not None and spec == embedded else tool
         )

--- a/openhands-sdk/openhands/sdk/tool/client_tool.py
+++ b/openhands-sdk/openhands/sdk/tool/client_tool.py
@@ -48,7 +48,6 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 _client_action_types: dict[str, type[Action]] = {}
 _client_action_schemas: dict[str, dict[str, Any]] = {}
-_client_tool_names: set[str] = set()
 _client_action_lock = threading.RLock()
 
 
@@ -351,25 +350,36 @@ def extract_client_tool_specs(tools: "Sequence[Tool]") -> list[ClientToolSpec]:
     return specs
 
 
-def register_client_tools(specs: Sequence[ClientToolSpec]) -> list["Tool"]:
-    """Register client-defined tools and return per-conversation tool specs.
+def resolve_client_tool(
+    tool: "Tool", conv_state: "ConversationState"
+) -> Sequence[ToolDefinition] | None:
+    """Resolve a registered client tool from its embedded spec."""
+    raw = (tool.params or {}).get("spec")
+    if not isinstance(raw, dict):
+        return None
+    try:
+        spec = ClientToolSpec.model_validate(raw)
+    except ValueError:
+        return None
+    if spec.name != tool.name:
+        return None
+    with _client_action_lock:
+        if spec.name not in _client_action_types:
+            return None
+    return ClientTool.create(conv_state=conv_state, spec=spec)
 
-    The :class:`ClientTool` *class* (a stateless resolver) is registered once
-    per tool name in the global tool registry, while each tool's schema travels
-    with the conversation through ``Tool.params`` rather than living in the
-    process-global registry. This keeps the resolver stateless so two
-    conversations that define the same tool name with the same schema don't
-    clobber each other.
 
-    Args:
-        specs: The client tool specs to register.
-
-    Returns:
-        A list of :class:`~openhands.sdk.tool.spec.Tool` specs (one per input
-        spec) to inject into an agent's ``tools`` so ``_initialize()`` can
-        resolve them.
-    """
-    from openhands.sdk.tool.registry import list_registered_tools, register_tool
+def register_client_tools(
+    specs: Sequence[ClientToolSpec],
+    *,
+    agent_tools: Sequence["Tool"] | None = None,
+) -> list["Tool"]:
+    """Validate client tools and return per-conversation tool specs."""
+    from openhands.sdk.tool.registry import (
+        is_tool_registered_as,
+        list_registered_tools,
+        register_tool,
+    )
     from openhands.sdk.tool.spec import Tool
 
     seen_names: set[str] = set()
@@ -384,21 +394,38 @@ def register_client_tools(specs: Sequence[ClientToolSpec]) -> list["Tool"]:
     with _client_action_lock:
         tool_specs: list[Tool] = []
         already_registered = set(list_registered_tools())
-        for spec in specs:
-            collides_with_non_client_tool = (
-                spec.name in already_registered and spec.name not in _client_tool_names
+        if agent_tools is None:
+            collisions = [
+                spec.name
+                for spec in specs
+                if spec.name in already_registered
+                and not is_tool_registered_as(spec.name, ClientTool)
+            ]
+        else:
+            collisions = []
+            for spec in specs:
+                existing = [tool for tool in agent_tools if tool.name == spec.name]
+                if not existing:
+                    continue
+                existing_specs = extract_client_tool_specs(existing)
+                if len(existing_specs) != len(existing):
+                    collisions.append(spec.name)
+                elif any(existing_spec != spec for existing_spec in existing_specs):
+                    raise ClientToolRegistrationError(
+                        f"Client tool '{spec.name}' conflicts with the existing "
+                        "client tool spec in this agent."
+                    )
+
+        for name in collisions:
+            raise ClientToolRegistrationError(
+                f"Client tool name '{name}' collides with an existing "
+                "non-client tool. Choose a unique client tool name."
             )
-            if collides_with_non_client_tool:
-                raise ClientToolRegistrationError(
-                    f"Client tool name '{spec.name}' collides with an existing "
-                    "non-client tool. Choose a unique client tool name."
-                )
 
         for spec in specs:
             _get_client_action_type(spec.name, spec.parameters)
             if spec.name not in already_registered:
                 register_tool(spec.name, ClientTool)
                 already_registered.add(spec.name)
-            _client_tool_names.add(spec.name)
             tool_specs.append(Tool(name=spec.name, params={"spec": spec.model_dump()}))
         return tool_specs

--- a/openhands-sdk/openhands/sdk/tool/client_tool.py
+++ b/openhands-sdk/openhands/sdk/tool/client_tool.py
@@ -428,7 +428,7 @@ def register_client_tools(
 
         for spec in specs:
             _get_client_action_type(spec.name, spec.parameters)
-            if spec.name not in already_registered:
+            if agent_tools is None and spec.name not in already_registered:
                 register_tool(spec.name, ClientTool)
                 already_registered.add(spec.name)
             tool_specs.append(_client_tool_spec(spec))

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -128,6 +128,7 @@ def register_tool(
             "register_tool(...) only accepts: (1) a ToolDefinition instance with "
             ".executor, or (2) a ToolDefinition subclass with .create(**params)"
         )
+    setattr(resolver, "__openhands_tool_factory__", factory)
 
     # Track the module qualname for this tool
     module_qualname = None
@@ -149,6 +150,12 @@ def register_tool(
 def resolve_tool(
     tool_spec: Tool, conv_state: "ConversationState"
 ) -> Sequence[ToolDefinition]:
+    from openhands.sdk.tool.client_tool import resolve_client_tool
+
+    client_tool = resolve_client_tool(tool_spec, conv_state)
+    if client_tool is not None:
+        return client_tool
+
     with _LOCK:
         resolver = _REG.get(tool_spec.name)
 
@@ -161,6 +168,15 @@ def resolve_tool(
 def list_registered_tools() -> list[str]:
     with _LOCK:
         return list(_REG.keys())
+
+
+def is_tool_registered_as(
+    name: str, factory: ToolDefinition | type[ToolDefinition]
+) -> bool:
+    """Return whether ``factory`` currently owns ``name``."""
+    with _LOCK:
+        resolver = _REG.get(name)
+    return getattr(resolver, "__openhands_tool_factory__", None) is factory
 
 
 def is_tool_usable(name: str) -> bool:

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -18,17 +18,6 @@ logger = get_logger(__name__)
 Resolver = Callable[[dict[str, Any], "ConversationState"], Sequence[ToolDefinition]]
 UsabilityChecker = Callable[[], bool]
 ToolFactory = ToolDefinition | type[ToolDefinition]
-"""A resolver produces ToolDefinition instances for given params.
-
-Args:
-    params: Arbitrary parameters passed to the resolver. These are typically
-        used to configure the ToolDefinition instances that are created.
-    conversation: Optional conversation state to get directories from.
-Returns: A sequence of ToolDefinition instances. Most of the time this will be a
-    single-item
-    sequence, but in some cases a ToolDefinition.create may produce multiple tools
-    (e.g., BrowserToolSet).
-"""
 
 _LOCK = RLock()
 

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -1,5 +1,6 @@
 import inspect
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from threading import RLock
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +17,7 @@ logger = get_logger(__name__)
 # A resolver produces ToolDefinition instances for given params.
 Resolver = Callable[[dict[str, Any], "ConversationState"], Sequence[ToolDefinition]]
 UsabilityChecker = Callable[[], bool]
+ToolFactory = ToolDefinition | type[ToolDefinition]
 """A resolver produces ToolDefinition instances for given params.
 
 Args:
@@ -29,7 +31,15 @@ Returns: A sequence of ToolDefinition instances. Most of the time this will be a
 """
 
 _LOCK = RLock()
-_REG: dict[str, Resolver] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolRegistration:
+    resolver: Resolver
+    factory: ToolFactory
+
+
+_REG: dict[str, _ToolRegistration] = {}
 _USABILITY_REG: dict[str, UsabilityChecker] = {}
 _MODULE_QUALNAMES: dict[str, str] = {}  # Maps tool name to module qualname
 
@@ -112,7 +122,7 @@ def _check_tool_usable(name: str, checker: UsabilityChecker) -> bool:
 
 def register_tool(
     name: str,
-    factory: ToolDefinition | type[ToolDefinition],
+    factory: ToolFactory,
 ) -> None:
     if not isinstance(name, str) or not name.strip():
         raise ValueError("ToolDefinition name must be a non-empty string")
@@ -128,8 +138,6 @@ def register_tool(
             "register_tool(...) only accepts: (1) a ToolDefinition instance with "
             ".executor, or (2) a ToolDefinition subclass with .create(**params)"
         )
-    setattr(resolver, "__openhands_tool_factory__", factory)
-
     # Track the module qualname for this tool
     module_qualname = None
     if isinstance(factory, type):
@@ -141,7 +149,7 @@ def register_tool(
         # TODO: throw exception when registering duplicate name tools
         if name in _REG:
             logger.warning(f"Duplicate tool name registerd {name}")
-        _REG[name] = resolver
+        _REG[name] = _ToolRegistration(resolver=resolver, factory=factory)
         _USABILITY_REG[name] = usability_checker
         if module_qualname:
             _MODULE_QUALNAMES[name] = module_qualname
@@ -157,12 +165,12 @@ def resolve_tool(
         return client_tool
 
     with _LOCK:
-        resolver = _REG.get(tool_spec.name)
+        registration = _REG.get(tool_spec.name)
 
-    if resolver is None:
+    if registration is None:
         raise KeyError(f"ToolDefinition '{tool_spec.name}' is not registered")
 
-    return resolver(tool_spec.params, conv_state)
+    return registration.resolver(tool_spec.params, conv_state)
 
 
 def list_registered_tools() -> list[str]:
@@ -170,13 +178,11 @@ def list_registered_tools() -> list[str]:
         return list(_REG.keys())
 
 
-def is_tool_registered_as(
-    name: str, factory: ToolDefinition | type[ToolDefinition]
-) -> bool:
+def is_tool_registered_as(name: str, factory: ToolFactory) -> bool:
     """Return whether ``factory`` currently owns ``name``."""
     with _LOCK:
-        resolver = _REG.get(name)
-    return getattr(resolver, "__openhands_tool_factory__", None) is factory
+        registration = _REG.get(name)
+    return registration is not None and registration.factory is factory
 
 
 def is_tool_usable(name: str) -> bool:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -6,7 +6,6 @@ import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -50,8 +49,20 @@ from openhands.sdk.mcp.config import dump_mcp_config
 from openhands.sdk.secret import SecretSource, StaticSecret
 from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.tool import Tool
+from openhands.sdk.tool.client_tool import (
+    ClientTool,
+    ClientToolSpec,
+    extract_client_tool_specs,
+)
+from openhands.sdk.tool.registry import (
+    is_tool_registered_as,
+    register_tool,
+    resolve_tool,
+)
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
+from openhands.tools.terminal import TerminalTool
 from openhands.tools.terminal.definition import TerminalAction, TerminalObservation
 
 
@@ -144,18 +155,6 @@ async def test_start_conversation_registers_and_injects_client_tools(
     conversation_service, tmp_path
 ):
     """Persist and resolve a client tool beside another agent's server tool."""
-    from openhands.sdk.tool.client_tool import (
-        ClientTool,
-        ClientToolSpec,
-        extract_client_tool_specs,
-    )
-    from openhands.sdk.tool.registry import (
-        is_tool_registered_as,
-        register_tool,
-        resolve_tool,
-    )
-    from openhands.tools.terminal import TerminalTool
-
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     register_tool("srv_show_dialog", TerminalTool)
@@ -205,7 +204,53 @@ async def test_start_conversation_registers_and_injects_client_tools(
     assert extract_client_tool_specs(stored.agent.tools) == stored.client_tools
     assert is_tool_registered_as("srv_show_dialog", TerminalTool)
     tool_spec = next(t for t in stored.agent.tools if t.name == "srv_show_dialog")
-    resolved = resolve_tool(tool_spec, cast(ConversationState, None))
+    resolved = resolve_tool(tool_spec, MagicMock(spec=ConversationState))
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], ClientTool)
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_legacy_client_tool_provenance(tmp_path):
+    spec = ClientToolSpec(name="legacy_resumed_client", description="client")
+    legacy_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
+    register_tool(spec.name, TerminalTool)
+
+    conversations_dir = tmp_path / "conversations"
+    stored = StoredConversation(
+        id=uuid4(),
+        agent=Agent(
+            llm=LLM(model="gpt-4o", usage_id="test-llm"),
+            tools=[legacy_tool],
+        ),
+        workspace=LocalWorkspace(working_dir=str(tmp_path / "workspace")),
+        confirmation_policy=NeverConfirm(),
+        client_tools=[spec],
+    )
+    conversation_dir = conversations_dir / stored.id.hex
+    conversation_dir.mkdir(parents=True)
+    (conversation_dir / "meta.json").write_text(stored.model_dump_json())
+
+    captured: dict[str, StoredConversation] = {}
+    service = ConversationService(conversations_dir=conversations_dir)
+
+    async def fake_start_event_service(stored: StoredConversation):
+        captured["stored"] = stored
+        event_service = AsyncMock(spec=EventService)
+        event_service.stored = stored
+        return event_service
+
+    with patch.object(
+        service,
+        "_start_event_service",
+        side_effect=fake_start_event_service,
+    ):
+        async with service:
+            pass
+
+    resumed = captured["stored"]
+    assert extract_client_tool_specs(resumed.agent.tools) == [spec]
+    assert is_tool_registered_as(spec.name, TerminalTool)
+    resolved = resolve_tool(resumed.agent.tools[0], MagicMock(spec=ConversationState))
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)
 

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -142,15 +142,18 @@ def conversation_service():
 async def test_start_conversation_registers_and_injects_client_tools(
     conversation_service, tmp_path
 ):
-    """client_tools specs are registered, injected into the agent, and persisted.
-
-    Persistence on ``StoredConversation`` is what allows forks and server
-    restarts to re-register the dynamic client tools.
-    """
-    from openhands.sdk.tool.client_tool import ClientToolSpec
+    """Persist and resolve a client tool beside another agent's server tool."""
+    from openhands.sdk.tool.client_tool import ClientTool, ClientToolSpec
+    from openhands.sdk.tool.registry import (
+        is_tool_registered_as,
+        register_tool,
+        resolve_tool,
+    )
+    from openhands.tools.terminal import TerminalTool
 
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
+    register_tool("srv_show_dialog", TerminalTool)
 
     request = StartConversationRequest(
         agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
@@ -192,14 +195,13 @@ async def test_start_conversation_registers_and_injects_client_tools(
         await conversation_service.start_conversation(request)
 
     stored = captured["stored"]
-    # Injected into the agent's tool specs so _initialize() can resolve it
     assert "srv_show_dialog" in {t.name for t in stored.agent.tools}
-    # Persisted so forks / restarts can re-register the dynamic action type
     assert [s.name for s in stored.client_tools] == ["srv_show_dialog"]
-    # The class is registered in the global tool registry
-    from openhands.sdk.tool.registry import list_registered_tools
-
-    assert "srv_show_dialog" in list_registered_tools()
+    assert is_tool_registered_as("srv_show_dialog", TerminalTool)
+    tool_spec = next(t for t in stored.agent.tools if t.name == "srv_show_dialog")
+    resolved = resolve_tool(tool_spec, None)  # type: ignore[arg-type]
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], ClientTool)
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -6,6 +6,7 @@ import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -143,7 +144,11 @@ async def test_start_conversation_registers_and_injects_client_tools(
     conversation_service, tmp_path
 ):
     """Persist and resolve a client tool beside another agent's server tool."""
-    from openhands.sdk.tool.client_tool import ClientTool, ClientToolSpec
+    from openhands.sdk.tool.client_tool import (
+        ClientTool,
+        ClientToolSpec,
+        extract_client_tool_specs,
+    )
     from openhands.sdk.tool.registry import (
         is_tool_registered_as,
         register_tool,
@@ -197,9 +202,10 @@ async def test_start_conversation_registers_and_injects_client_tools(
     stored = captured["stored"]
     assert "srv_show_dialog" in {t.name for t in stored.agent.tools}
     assert [s.name for s in stored.client_tools] == ["srv_show_dialog"]
+    assert extract_client_tool_specs(stored.agent.tools) == stored.client_tools
     assert is_tool_registered_as("srv_show_dialog", TerminalTool)
     tool_spec = next(t for t in stored.agent.tools if t.name == "srv_show_dialog")
-    resolved = resolve_tool(tool_spec, None)  # type: ignore[arg-type]
+    resolved = resolve_tool(tool_spec, cast(ConversationState, None))
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)
 

--- a/tests/cross/test_client_tool_registration.py
+++ b/tests/cross/test_client_tool_registration.py
@@ -10,7 +10,11 @@ from openhands.sdk.tool.client_tool import (
     register_client_tools,
     resolve_client_tool,
 )
-from openhands.sdk.tool.registry import register_tool, resolve_tool
+from openhands.sdk.tool.registry import (
+    list_registered_tools,
+    register_tool,
+    resolve_tool,
+)
 from openhands.sdk.tool.spec import Tool
 from openhands.tools.terminal import TerminalTool
 
@@ -36,6 +40,20 @@ def test_client_tool_can_share_a_registry_name_across_agents() -> None:
 
     tool_specs = register_client_tools([spec], agent_tools=[])
 
+    resolved = resolve_tool(tool_specs[0], MagicMock(spec=ConversationState))
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], ClientTool)
+
+
+def test_scoped_client_tool_does_not_claim_a_registry_name() -> None:
+    spec = ClientToolSpec(
+        name="scoped_client_only_tool",
+        description="Client-only tool",
+    )
+
+    tool_specs = register_client_tools([spec], agent_tools=[])
+
+    assert spec.name not in list_registered_tools()
     resolved = resolve_tool(tool_specs[0], MagicMock(spec=ConversationState))
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)

--- a/tests/cross/test_client_tool_registration.py
+++ b/tests/cross/test_client_tool_registration.py
@@ -1,7 +1,8 @@
-from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
+from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.tool.client_tool import (
     ClientTool,
     ClientToolRegistrationError,
@@ -35,7 +36,7 @@ def test_client_tool_can_share_a_registry_name_across_agents() -> None:
 
     tool_specs = register_client_tools([spec], agent_tools=[])
 
-    resolved = resolve_tool(tool_specs[0], cast(Any, None))
+    resolved = resolve_tool(tool_specs[0], MagicMock(spec=ConversationState))
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)
 
@@ -69,7 +70,7 @@ def test_server_tool_spec_params_are_not_resolved_as_a_client_tool() -> None:
     register_client_tools([spec], agent_tools=[])
     server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
 
-    assert resolve_client_tool(server_tool, cast(Any, None)) is None
+    assert resolve_client_tool(server_tool, MagicMock(spec=ConversationState)) is None
 
 
 def test_client_tool_resolution_survives_a_registry_overwrite() -> None:
@@ -81,7 +82,7 @@ def test_client_tool_resolution_survives_a_registry_overwrite() -> None:
     register_tool(spec.name, TerminalTool)
 
     restored_tools = register_client_tools([spec], agent_tools=stored_tools)
-    resolved = resolve_tool(restored_tools[0], cast(Any, None))
+    resolved = resolve_tool(restored_tools[0], MagicMock(spec=ConversationState))
 
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)

--- a/tests/cross/test_client_tool_registration.py
+++ b/tests/cross/test_client_tool_registration.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 
 from openhands.sdk.tool.client_tool import (
@@ -5,6 +7,7 @@ from openhands.sdk.tool.client_tool import (
     ClientToolRegistrationError,
     ClientToolSpec,
     register_client_tools,
+    resolve_client_tool,
 )
 from openhands.sdk.tool.registry import register_tool, resolve_tool
 from openhands.sdk.tool.spec import Tool
@@ -32,7 +35,7 @@ def test_client_tool_can_share_a_registry_name_across_agents() -> None:
 
     tool_specs = register_client_tools([spec], agent_tools=[])
 
-    resolved = resolve_tool(tool_specs[0], None)  # type: ignore[arg-type]
+    resolved = resolve_tool(tool_specs[0], cast(Any, None))
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)
 
@@ -49,8 +52,24 @@ def test_client_tool_rejects_a_same_agent_name_collision() -> None:
     ):
         register_client_tools(
             [spec],
-            agent_tools=[Tool(name=TerminalTool.name, params={})],
+            agent_tools=[
+                Tool(
+                    name=TerminalTool.name,
+                    params={"spec": spec.model_dump()},
+                )
+            ],
         )
+
+
+def test_server_tool_spec_params_are_not_resolved_as_a_client_tool() -> None:
+    spec = ClientToolSpec(
+        name="server_tool_with_spec_params",
+        description="Server-owned tool",
+    )
+    register_client_tools([spec], agent_tools=[])
+    server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
+
+    assert resolve_client_tool(server_tool, cast(Any, None)) is None
 
 
 def test_client_tool_resolution_survives_a_registry_overwrite() -> None:
@@ -62,7 +81,7 @@ def test_client_tool_resolution_survives_a_registry_overwrite() -> None:
     register_tool(spec.name, TerminalTool)
 
     restored_tools = register_client_tools([spec], agent_tools=stored_tools)
-    resolved = resolve_tool(restored_tools[0], None)  # type: ignore[arg-type]
+    resolved = resolve_tool(restored_tools[0], cast(Any, None))
 
     assert len(resolved) == 1
     assert isinstance(resolved[0], ClientTool)

--- a/tests/cross/test_client_tool_registration.py
+++ b/tests/cross/test_client_tool_registration.py
@@ -1,10 +1,13 @@
 import pytest
 
 from openhands.sdk.tool.client_tool import (
+    ClientTool,
     ClientToolRegistrationError,
     ClientToolSpec,
     register_client_tools,
 )
+from openhands.sdk.tool.registry import register_tool, resolve_tool
+from openhands.sdk.tool.spec import Tool
 from openhands.tools.terminal import TerminalTool
 
 
@@ -19,3 +22,47 @@ def test_register_client_tools_rejects_builtin_tool_name_collision() -> None:
         match="collides with an existing non-client tool",
     ):
         register_client_tools([spec])
+
+
+def test_client_tool_can_share_a_registry_name_across_agents() -> None:
+    spec = ClientToolSpec(
+        name=TerminalTool.name,
+        description="Client terminal",
+    )
+
+    tool_specs = register_client_tools([spec], agent_tools=[])
+
+    resolved = resolve_tool(tool_specs[0], None)  # type: ignore[arg-type]
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], ClientTool)
+
+
+def test_client_tool_rejects_a_same_agent_name_collision() -> None:
+    spec = ClientToolSpec(
+        name=TerminalTool.name,
+        description="Client terminal",
+    )
+
+    with pytest.raises(
+        ClientToolRegistrationError,
+        match="collides with an existing non-client tool",
+    ):
+        register_client_tools(
+            [spec],
+            agent_tools=[Tool(name=TerminalTool.name, params={})],
+        )
+
+
+def test_client_tool_resolution_survives_a_registry_overwrite() -> None:
+    spec = ClientToolSpec(
+        name="mixed_canvas_tool",
+        description="Client canvas tool",
+    )
+    stored_tools = register_client_tools([spec])
+    register_tool(spec.name, TerminalTool)
+
+    restored_tools = register_client_tools([spec], agent_tools=stored_tools)
+    resolved = resolve_tool(restored_tools[0], None)  # type: ignore[arg-type]
+
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], ClientTool)

--- a/tests/sdk/conversation/local/test_client_tools_persistence.py
+++ b/tests/sdk/conversation/local/test_client_tools_persistence.py
@@ -4,19 +4,25 @@ import json
 import uuid
 from pathlib import Path
 
+import pytest
+
 from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.persistence_const import BASE_STATE
+from openhands.sdk.io import InMemoryFileStore
 from openhands.sdk.tool import Tool, client_tool as ct, registry as reg
 from openhands.sdk.tool.client_tool import (
+    ClientToolRegistrationError,
     ClientToolSpec,
     extract_client_tool_specs,
 )
+from openhands.tools.terminal import TerminalTool
 
 
-def _make_agent() -> Agent:
+def _make_agent(tools: list[Tool] | None = None) -> Agent:
     return Agent(
         llm=LLM(model="gpt-4o", usage_id="test-llm"),
-        tools=[Tool(name="terminal")],
+        tools=tools if tools is not None else [Tool(name="terminal")],
     )
 
 
@@ -105,6 +111,93 @@ def test_recover_persisted_client_tools_no_state(tmp_path: Path) -> None:
         recovered = convo._recover_persisted_client_tools(
             str(tmp_path / "nonexistent"), uuid.uuid4()
         )
-        assert recovered == []
+        assert recovered == ([], set())
     finally:
         convo.close()
+
+
+def test_client_tools_resume_from_file_store(tmp_path: Path) -> None:
+    spec = ClientToolSpec(name="file_store_client", description="client")
+    store = InMemoryFileStore()
+    cid = uuid.uuid4()
+
+    created = LocalConversation(
+        agent=_make_agent(),
+        workspace=str(tmp_path / "ws"),
+        conversation_id=cid,
+        client_tools=[spec],
+        file_store=store,
+        delete_on_close=False,
+    )
+    created.close()
+    _wipe_client_tool_globals([spec.name])
+
+    resumed = LocalConversation(
+        agent=_make_agent(),
+        workspace=str(tmp_path / "ws"),
+        conversation_id=cid,
+        file_store=store,
+        delete_on_close=False,
+    )
+    try:
+        assert extract_client_tool_specs(resumed.agent.tools) == [spec]
+    finally:
+        resumed.close()
+
+
+def test_server_spec_param_is_not_migrated_as_client(tmp_path: Path) -> None:
+    spec = ClientToolSpec(name="persisted_server_spec", description="server")
+    server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
+    reg.register_tool(spec.name, TerminalTool)
+    cid = uuid.uuid4()
+    persist_dir = tmp_path / "persist"
+
+    created = Conversation(
+        agent=_make_agent([server_tool]),
+        workspace=str(tmp_path / "ws"),
+        persistence_dir=str(persist_dir),
+        conversation_id=cid,
+        delete_on_close=False,
+    )
+    created.close()
+
+    resumed = Conversation(
+        agent=_make_agent([server_tool]),
+        workspace=str(tmp_path / "ws"),
+        persistence_dir=str(persist_dir),
+        conversation_id=cid,
+        delete_on_close=False,
+    )
+    try:
+        assert extract_client_tool_specs(resumed.agent.tools) == []
+        assert resumed.agent.tools == [server_tool]
+        assert reg.is_tool_registered_as(spec.name, TerminalTool)
+    finally:
+        resumed.close()
+
+
+def test_marked_client_rejects_runtime_server_collision(tmp_path: Path) -> None:
+    spec = ClientToolSpec(name="persisted_client_collision", description="client")
+    cid = uuid.uuid4()
+    persist_dir = tmp_path / "persist"
+
+    created = Conversation(
+        agent=_make_agent([]),
+        workspace=str(tmp_path / "ws"),
+        persistence_dir=str(persist_dir),
+        conversation_id=cid,
+        client_tools=[spec],
+        delete_on_close=False,
+    )
+    created.close()
+
+    server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
+    reg.register_tool(spec.name, TerminalTool)
+    with pytest.raises(ClientToolRegistrationError, match="collides"):
+        Conversation(
+            agent=_make_agent([server_tool]),
+            workspace=str(tmp_path / "ws"),
+            persistence_dir=str(persist_dir),
+            conversation_id=cid,
+            delete_on_close=False,
+        )

--- a/tests/sdk/conversation/local/test_client_tools_persistence.py
+++ b/tests/sdk/conversation/local/test_client_tools_persistence.py
@@ -92,8 +92,7 @@ def test_persisted_client_tools_resume_without_respecifying(tmp_path: Path) -> N
     try:
         assert set(names) <= {t.name for t in resumed.agent.tools}
         assert extract_client_tool_specs(resumed.agent.tools) == specs
-        for n in names:
-            assert n in reg.list_registered_tools()
+        assert set(names).isdisjoint(reg.list_registered_tools())
     finally:
         resumed.close()
 

--- a/tests/sdk/conversation/local/test_client_tools_persistence.py
+++ b/tests/sdk/conversation/local/test_client_tools_persistence.py
@@ -1,11 +1,16 @@
 """Persistence/resume behavior for client-defined tools on LocalConversation."""
 
+import json
 import uuid
 from pathlib import Path
 
 from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.conversation.persistence_const import BASE_STATE
 from openhands.sdk.tool import Tool, client_tool as ct, registry as reg
-from openhands.sdk.tool.client_tool import ClientToolSpec
+from openhands.sdk.tool.client_tool import (
+    ClientToolSpec,
+    extract_client_tool_specs,
+)
 
 
 def _make_agent() -> Agent:
@@ -26,12 +31,7 @@ def _wipe_client_tool_globals(names: list[str]) -> None:
 
 
 def test_persisted_client_tools_resume_without_respecifying(tmp_path: Path) -> None:
-    """A persisted conversation re-registers/injects client tools on resume.
-
-    The caller does not pass ``client_tools`` on resume; the specs must be
-    recovered from persisted state so the agent keeps the tools and resume does
-    not fail with "tools were removed mid-conversation".
-    """
+    """Resume and migrate legacy persisted client tool specs."""
     specs = [
         ClientToolSpec(
             name="persist_show_notification",
@@ -66,11 +66,16 @@ def test_persisted_client_tools_resume_without_respecifying(tmp_path: Path) -> N
     assert set(names) <= {t.name for t in created.agent.tools}
     created.close()
 
-    # Fresh-process simulation: drop the global registrations.
+    base_state_path = persist_dir / cid.hex / BASE_STATE
+    base_state = json.loads(base_state_path.read_text())
+    for tool in base_state["agent"]["tools"]:
+        if tool["name"] in names:
+            tool["params"].pop("_openhands_client_tool")
+    base_state_path.write_text(json.dumps(base_state))
+
     _wipe_client_tool_globals(names)
     assert not any(n in reg.list_registered_tools() for n in names)
 
-    # Resume WITHOUT re-supplying client_tools.
     resumed = Conversation(
         agent=_make_agent(),
         workspace=str(ws_dir),
@@ -80,8 +85,7 @@ def test_persisted_client_tools_resume_without_respecifying(tmp_path: Path) -> N
     )
     try:
         assert set(names) <= {t.name for t in resumed.agent.tools}
-        # The dynamic action types are registered again so persisted
-        # ClientAction_* events could be deserialized.
+        assert extract_client_tool_specs(resumed.agent.tools) == specs
         for n in names:
             assert n in reg.list_registered_tools()
     finally:

--- a/tests/sdk/conversation/local/test_client_tools_persistence.py
+++ b/tests/sdk/conversation/local/test_client_tools_persistence.py
@@ -11,12 +11,12 @@ from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.persistence_const import BASE_STATE
 from openhands.sdk.io import InMemoryFileStore
 from openhands.sdk.tool import Tool, client_tool as ct, registry as reg
+from openhands.sdk.tool.builtins import FinishTool
 from openhands.sdk.tool.client_tool import (
     ClientToolRegistrationError,
     ClientToolSpec,
     extract_client_tool_specs,
 )
-from openhands.tools.terminal import TerminalTool
 
 
 def _make_agent(tools: list[Tool] | None = None) -> Agent:
@@ -148,7 +148,7 @@ def test_client_tools_resume_from_file_store(tmp_path: Path) -> None:
 def test_server_spec_param_is_not_migrated_as_client(tmp_path: Path) -> None:
     spec = ClientToolSpec(name="persisted_server_spec", description="server")
     server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
-    reg.register_tool(spec.name, TerminalTool)
+    reg.register_tool(spec.name, FinishTool)
     cid = uuid.uuid4()
     persist_dir = tmp_path / "persist"
 
@@ -171,7 +171,7 @@ def test_server_spec_param_is_not_migrated_as_client(tmp_path: Path) -> None:
     try:
         assert extract_client_tool_specs(resumed.agent.tools) == []
         assert resumed.agent.tools == [server_tool]
-        assert reg.is_tool_registered_as(spec.name, TerminalTool)
+        assert reg.is_tool_registered_as(spec.name, FinishTool)
     finally:
         resumed.close()
 
@@ -192,7 +192,7 @@ def test_marked_client_rejects_runtime_server_collision(tmp_path: Path) -> None:
     created.close()
 
     server_tool = Tool(name=spec.name, params={"spec": spec.model_dump()})
-    reg.register_tool(spec.name, TerminalTool)
+    reg.register_tool(spec.name, FinishTool)
     with pytest.raises(ClientToolRegistrationError, match="collides"):
         Conversation(
             agent=_make_agent([server_tool]),

--- a/tests/sdk/tool/test_client_tool.py
+++ b/tests/sdk/tool/test_client_tool.py
@@ -14,6 +14,7 @@ from openhands.sdk.tool.client_tool import (
     ClientToolObservation,
     ClientToolRegistrationError,
     ClientToolSpec,
+    extract_client_tool_specs,
     register_client_tools,
 )
 from openhands.sdk.tool.registry import list_registered_tools, resolve_tool
@@ -433,6 +434,7 @@ def test_register_client_tools_returns_tool_specs():
     assert ts.name == "reg_tool"
     assert ts.params["spec"]["name"] == "reg_tool"
     assert ts.params["spec"]["parameters"]["properties"]["q"]["type"] == "string"
+    assert extract_client_tool_specs([ts]) == [spec]
     # The ClientTool class is registered under the tool name
     assert "reg_tool" in list_registered_tools()
 

--- a/tests/sdk/tool/test_client_tool.py
+++ b/tests/sdk/tool/test_client_tool.py
@@ -1,10 +1,12 @@
 """Tests for client-defined tools (ClientToolSpec / ClientTool)."""
 
-from typing import Any, cast
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from pydantic import ValidationError
 
+from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.llm import TextContent
 from openhands.sdk.llm.message import MessageToolCall
@@ -464,7 +466,9 @@ def test_register_client_tools_allows_existing_client_tool_same_schema():
 
     assert [tool_spec.name for tool_spec in first_tool_specs] == [spec.name]
     assert [tool_spec.name for tool_spec in second_tool_specs] == [spec.name]
-    resolved_tools = resolve_tool(second_tool_specs[0], cast(Any, None))
+    resolved_tools = resolve_tool(
+        second_tool_specs[0], MagicMock(spec=ConversationState)
+    )
     assert len(resolved_tools) == 1
     assert isinstance(resolved_tools[0], ClientTool)
     assert resolved_tools[0].name == spec.name

--- a/tests/sdk/tool/test_defaults.py
+++ b/tests/sdk/tool/test_defaults.py
@@ -9,6 +9,7 @@ from openhands.sdk.tool.defaults import (
     SUB_AGENT_TOOL_NAME,
     default_tool_specs,
 )
+from openhands.sdk.tool.tool import ToolDefinition
 
 
 def _names(**kwargs) -> list[str]:
@@ -39,7 +40,13 @@ def test_explicit_browser_appends_before_sub_agents() -> None:
 
 def test_is_tool_usable_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     assert registry.is_tool_usable("definitely-not-registered") is False
-    monkeypatch.setitem(registry._REG, "probe", lambda params, conv: [])
+    monkeypatch.setitem(
+        registry._REG,
+        "probe",
+        registry._ToolRegistration(
+            resolver=lambda params, conv: [], factory=ToolDefinition
+        ),
+    )
     monkeypatch.setitem(registry._USABILITY_REG, "probe", lambda: True)
     assert registry.is_tool_usable("probe") is True
 

--- a/tests/sdk/tool/test_registry.py
+++ b/tests/sdk/tool/test_registry.py
@@ -7,7 +7,11 @@ from openhands.sdk import register_tool
 from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.llm.message import ImageContent, TextContent
 from openhands.sdk.tool import ToolDefinition
-from openhands.sdk.tool.registry import list_usable_tools, resolve_tool
+from openhands.sdk.tool.registry import (
+    is_tool_registered_as,
+    list_usable_tools,
+    resolve_tool,
+)
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.tool.spec import Tool
 from openhands.sdk.tool.tool import ToolExecutor
@@ -105,6 +109,15 @@ def test_register_tool_type_respects_is_usable():
     register_tool("say_hello_unusable", _UnavailableHelloTool)
 
     assert "say_hello_unusable" not in list_usable_tools()
+
+
+def test_registered_tool_retains_factory_identity():
+    register_tool("say_hello_factory_identity", _SimpleHelloTool)
+
+    assert is_tool_registered_as("say_hello_factory_identity", _SimpleHelloTool)
+    assert not is_tool_registered_as(
+        "say_hello_factory_identity", _UnavailableHelloTool
+    )
 
 
 def test_register_tool_instance_rejects_params():


### PR DESCRIPTION
HUMAN:

Allow separate conversations to use the same external tool name with different implementations

AGENT:

## Why

Client tool schemas are persisted inside each conversation's `Tool.params`, but resolution still depended on a process-global name registry. If another conversation registered a server tool under the same external name, it could overwrite the client resolver. A later cold resume could then resolve the wrong implementation or fail depending on conversation startup order.

This was exposed while validating mixed Agent Canvas profile and legacy launches, but the bug is generic to SDK consumers using `client_tools`.

## Summary

- Persist explicit `_openhands_client_tool` provenance alongside each embedded, validated client-tool spec.
- Resolve marked client tools from their conversation-owned spec before consulting the global server-tool registry.
- Keep conversation-scoped client tools out of the global registry, eliminating cross-conversation overwrite and concurrent-startup races.
- Represent registry entries with a typed, immutable resolver/factory record; no callable mutation or untyped ownership metadata.
- Validate collisions against tools in the same agent while allowing unrelated conversations to reuse the same external name.
- Recover current client tools through either `persistence_dir` or a custom `FileStore`.
- Migrate legacy unmarked client specs only from authoritative persisted names, while preserving explicitly supplied server-tool ownership.
- Restore persisted client action types before local and agent-server resume.

Same-agent client/server collisions and incompatible client/client schemas remain rejected. No Canvas-specific types or behavior are introduced.

## How to Test

```bash
uv run pytest -q \
  tests/sdk/tool/test_client_tool.py \
  tests/sdk/conversation/local/test_client_tools_persistence.py \
  tests/cross/test_client_tool_registration.py \
  tests/agent_server/test_conversation_service.py
```

Result: `122 passed`.

Additional validation on `0515fc029`:

- Broader SDK/local/cross/server regression suite: `481 passed`.
- OpenHands consumer tests: `197 passed`.
- Agent Canvas payload and launch tests: `94 passed`.
- Live `profile → legacy → profile → cold restart`: all three conversations resumed `finished`, retained the correct client/server ownership, and produced zero `ConversationErrorEvent` entries.
- OpenHands QA: PASS on active resolution, legacy cold resume, collision rejection, and a real agent-server HTTP creation flow.
- GitHub CI: `34 passed`, with no failures or unresolved review threads.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs / chore

## Related

- OpenHands/software-agent-sdk#4030 adds the independent launch-augmentation API that exposed this existing lifecycle bug.
- OpenHands/agent-canvas#1650 consumes both fixes.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0515fc0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0515fc0-python \
  ghcr.io/openhands/agent-server:0515fc0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0515fc0-golang-amd64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-golang-amd64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-golang-amd64
ghcr.io/openhands/agent-server:0515fc0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0515fc0-golang-arm64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-golang-arm64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-golang-arm64
ghcr.io/openhands/agent-server:0515fc0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0515fc0-java-amd64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-java-amd64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-java-amd64
ghcr.io/openhands/agent-server:0515fc0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0515fc0-java-arm64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-java-arm64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-java-arm64
ghcr.io/openhands/agent-server:0515fc0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0515fc0-python-amd64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-python-amd64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-python-amd64
ghcr.io/openhands/agent-server:0515fc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0515fc0-python-arm64
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-python-arm64
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-python-arm64
ghcr.io/openhands/agent-server:0515fc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0515fc0-golang
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-golang
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-golang
ghcr.io/openhands/agent-server:0515fc0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0515fc0-java
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-java
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-java
ghcr.io/openhands/agent-server:0515fc0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0515fc0-python
ghcr.io/openhands/agent-server:0515fc029b55c34c669d1eac7bbe02f09ed6d9db-python
ghcr.io/openhands/agent-server:fix-conversation-scoped-client-tools-python
ghcr.io/openhands/agent-server:0515fc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0515fc0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0515fc0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->