### PR TITLE
ci: use eval LLM proxy for QA changes

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -39,10 +39,10 @@ jobs:
               uses: OpenHands/extensions/plugins/qa-changes@main
               with:
                   llm-model: litellm_proxy/openai/gpt-5.5
-                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  llm-base-url: https://llm-proxy.eval.all-hands.dev
                   max-budget: '10.0'
                   timeout-minutes: '30'
                   max-iterations: '500'
-                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  llm-api-key: ${{ secrets.LLM_API_KEY_EVAL }}
                   github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary
- switch QA Changes workflow to the eval LiteLLM proxy
- use the eval LLM GitHub Actions secret, matching integration-runner.yml

## Why
QA Changes has been using the app proxy/key and hit the LiteLLM team budget limit. integration-runner.yml already uses `LLM_API_KEY_EVAL` with `https://llm-proxy.eval.all-hands.dev`, so this aligns QA with the eval path.

## Validation
- Parsed `.github/workflows/qa-changes-by-openhands.yml` and `.github/workflows/integration-runner.yml` with Ruby YAML parser.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c685b09-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c685b09-python \
  ghcr.io/openhands/agent-server:c685b09-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c685b09-golang-amd64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-golang-amd64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-golang-amd64
ghcr.io/openhands/agent-server:c685b09-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c685b09-golang-arm64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-golang-arm64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-golang-arm64
ghcr.io/openhands/agent-server:c685b09-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c685b09-java-amd64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-java-amd64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-java-amd64
ghcr.io/openhands/agent-server:c685b09-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c685b09-java-arm64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-java-arm64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-java-arm64
ghcr.io/openhands/agent-server:c685b09-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c685b09-python-amd64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-python-amd64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-python-amd64
ghcr.io/openhands/agent-server:c685b09-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c685b09-python-arm64
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-python-arm64
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-python-arm64
ghcr.io/openhands/agent-server:c685b09-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c685b09-golang
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-golang
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-golang
ghcr.io/openhands/agent-server:c685b09-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c685b09-java
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-java
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-java
ghcr.io/openhands/agent-server:c685b09-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c685b09-python
ghcr.io/openhands/agent-server:c685b093f6cb4471864a8b7ac4f85f64256bd2fc-python
ghcr.io/openhands/agent-server:qa-changes-use-eval-proxy-python
ghcr.io/openhands/agent-server:c685b09-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c685b09-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c685b09-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->