### PR TITLE
Keep public skills when marketplace autoload is enabled

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -104,8 +104,8 @@ class SkillsRequest(BaseModel):
         default_factory=list,
         description=(
             "Marketplace registrations for plugin-based skill loading. Registrations "
-            "with auto_load=True or a list of plugin names replace legacy public "
-            "skills."
+            "with auto_load=True or a list of plugin names are loaded alongside "
+            "legacy public skills."
         ),
     )
 

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -397,14 +397,14 @@ def load_all_skills(
     skill_lists.append(marketplace_skills)
 
     # 2-3. Load legacy public + user skills via helper (no project yet — org sits
-    # between). Auto-load registered marketplaces replace legacy public skills,
-    # while user skills keep their existing precedence above the public marketplace
+    # between). Auto-load registered marketplaces extend public skills, while
+    # user skills keep their existing precedence above the public marketplace
     # tier.
     sdk_base = load_available_skills(
         work_dir=None,
         include_user=load_user,
         include_project=False,
-        include_public=load_public and not auto_load_registrations,
+        include_public=load_public,
         marketplace_path=marketplace_path,
     )
     sources["sdk_base"] = len(sdk_base)

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -261,6 +261,48 @@ class TestGetSkillsEndpoint:
         assert data["sources"]["sdk_base"] == 1
         assert mock_load_available.call_args_list[0].kwargs["include_public"] is True
 
+    def test_get_skills_auto_load_marketplace_keeps_public_skills(self, client):
+        public_skill = Skill(name="public-skill", content="public", trigger=None)
+        marketplace_skill = Skill(
+            name="marketplace-skill", content="marketplace", trigger=None
+        )
+
+        with (
+            patch(
+                "openhands.agent_server.skills_service.load_registered_marketplace_skills",
+                return_value=[marketplace_skill],
+            ),
+            patch(
+                "openhands.agent_server.skills_service.load_available_skills",
+                side_effect=[{"public-skill": public_skill}, {}],
+            ) as mock_load_available,
+        ):
+            response = client.post(
+                "/api/skills",
+                json={
+                    "load_user": False,
+                    "load_project": False,
+                    "load_org": False,
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/marketplace",
+                            "auto_load": True,
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [skill["name"] for skill in data["skills"]] == [
+            "marketplace-skill",
+            "public-skill",
+        ]
+        assert data["sources"]["registered_marketplaces"] == 1
+        assert data["sources"]["sdk_base"] == 1
+        assert mock_load_available.call_args_list[0].kwargs["include_public"] is True
+
     def test_get_skills_request_marketplace_overrides_server_default(self):
         """Request registrations override same-named server defaults."""
         config = Config(


### PR DESCRIPTION
HUMAN:

---

AGENT:
The code path in `load_all_skills()` currently skips default public skills whenever an auto-load marketplace is present. I changed that so marketplace skills extend the public tier instead of replacing it, then added a regression test for the request-marketplace case.

## Why

Fixes OpenHands/OpenHands#15237.

Users who enable a repository marketplace still need default public skills such as `openhands-automation`. The current agent-server behavior loads marketplace skills but disables the default public tier, so new conversations can lose the built-in skills they depend on.

## Summary

- Keep `include_public=True` when auto-load marketplace registrations are present.
- Update the request model/service comments to describe marketplace skills as additive.
- Add a router regression test proving an auto-load marketplace request keeps default public skills.

## Issue Number

OpenHands/OpenHands#15237

## How to Test

Ran:

```bash
uv run pytest tests/agent_server/test_skills_router.py -q
uv run ruff format --check openhands-agent-server/openhands/agent_server/skills_router.py openhands-agent-server/openhands/agent_server/skills_service.py tests/agent_server/test_skills_router.py
uv run ruff check openhands-agent-server/openhands/agent_server/skills_router.py openhands-agent-server/openhands/agent_server/skills_service.py tests/agent_server/test_skills_router.py
git diff --check
```

Results:

- `42 passed, 6 warnings` for `test_skills_router.py`.
- Ruff format check passed.
- Ruff lint passed.
- Whitespace check passed.

## Video/Screenshots

Not applicable; this is an agent-server skill loading change covered by API-level tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `HUMAN` section is intentionally left blank because the repository template says agents should not edit it. This PR should stay draft until a human author adds that note.
