### PR TITLE
fix(skills): make marketplaces additive to public skills

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -104,8 +104,8 @@ class SkillsRequest(BaseModel):
         default_factory=list,
         description=(
             "Marketplace registrations for plugin-based skill loading. Registrations "
-            "with auto_load=True or a list of plugin names replace legacy public "
-            "skills."
+            "with auto_load=True or a list of plugin names add their skills to the "
+            "public skills."
         ),
     )
 

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -350,7 +350,8 @@ def load_all_skills(
     Skills are loaded from multiple sources and merged with the following
     precedence (later overrides earlier for duplicate names):
     1. Sandbox skills (lowest) - Exposed URLs from sandbox
-    2. Registered marketplace skills or public skills legacy fallback
+    2. Registered marketplace skills - Auto-load plugins from registered
+       marketplaces, layered together with the legacy public skills
     3. User skills - From ~/.openhands/skills/
     4. Organization skills - From {org}/.openhands or equivalent
     5. Project skills (highest) - From {workspace}/.openhands/skills/
@@ -367,7 +368,7 @@ def load_all_skills(
         marketplace_path: Relative marketplace JSON path for public skills.
             Pass None to load all public skills without marketplace filtering.
         registered_marketplaces: Marketplace registrations whose auto-load plugins
-            replace legacy public skills when provided.
+            are loaded in addition to legacy public skills.
 
     Returns:
         SkillLoadResult containing merged skills and source counts.
@@ -397,14 +398,13 @@ def load_all_skills(
     skill_lists.append(marketplace_skills)
 
     # 2-3. Load legacy public + user skills via helper (no project yet — org sits
-    # between). Auto-load registered marketplaces replace legacy public skills,
-    # while user skills keep their existing precedence above the public marketplace
-    # tier.
+    # between). Auto-load registered marketplaces are additive with the legacy
+    # public skills, and user skills keep their existing precedence above both.
     sdk_base = load_available_skills(
         work_dir=None,
         include_user=load_user,
         include_project=False,
-        include_public=load_public and not auto_load_registrations,
+        include_public=load_public,
         marketplace_path=marketplace_path,
     )
     sources["sdk_base"] = len(sdk_base)

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -345,7 +345,7 @@ def load_all_skills(
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
     registered_marketplaces: list[MarketplaceRegistration] | None = None,
 ) -> SkillLoadResult:
-    """Load and merge skills in precedence order."""
+    """Merge skills: sandbox < marketplace < public < user < org < project."""
     sources: dict[str, int] = {}
     skill_lists: list[list[Skill]] = []
 

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -345,34 +345,7 @@ def load_all_skills(
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
     registered_marketplaces: list[MarketplaceRegistration] | None = None,
 ) -> SkillLoadResult:
-    """Load and merge skills from all configured sources.
-
-    Skills are loaded from multiple sources and merged with the following
-    precedence (later overrides earlier for duplicate names):
-    1. Sandbox skills (lowest) - Exposed URLs from sandbox
-    2. Registered marketplace skills - Auto-load plugins from registered
-       marketplaces, layered together with the legacy public skills
-    3. User skills - From ~/.openhands/skills/
-    4. Organization skills - From {org}/.openhands or equivalent
-    5. Project skills (highest) - From {workspace}/.openhands/skills/
-
-    Args:
-        load_public: Whether to load public skills from OpenHands/extensions repo.
-        load_user: Whether to load user skills from ~/.openhands/skills/.
-        load_project: Whether to load project skills from workspace.
-        load_org: Whether to load organization-level skills.
-        project_dir: Workspace directory path for project skills.
-        org_repos: Pre-authenticated (Git URL, org name) pairs for org skills.
-            All repos are loaded and merged into the single org tier.
-        sandbox_exposed_urls: List of exposed URLs from sandbox.
-        marketplace_path: Relative marketplace JSON path for public skills.
-            Pass None to load all public skills without marketplace filtering.
-        registered_marketplaces: Marketplace registrations whose auto-load plugins
-            are loaded in addition to legacy public skills.
-
-    Returns:
-        SkillLoadResult containing merged skills and source counts.
-    """
+    """Load and merge skills in precedence order."""
     sources: dict[str, int] = {}
     skill_lists: list[list[Skill]] = []
 
@@ -397,9 +370,6 @@ def load_all_skills(
     sources["registered_marketplaces"] = len(marketplace_skills)
     skill_lists.append(marketplace_skills)
 
-    # 2-3. Load legacy public + user skills via helper (no project yet — org sits
-    # between). Auto-load registered marketplaces are additive with the legacy
-    # public skills, and user skills keep their existing precedence above both.
     sdk_base = load_available_skills(
         work_dir=None,
         include_user=load_user,

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -231,9 +231,7 @@ class AgentContext(BaseModel):
     @model_validator(mode="after")
     def _load_auto_skills(self):
         """Load user/legacy-public skills if enabled, then apply ``disabled_skills``."""
-        # Any marketplace registration opts the context out of the legacy
-        # public-skills path, even when the registration is resolution-only.
-        include_public = self.load_public_skills and not self.registered_marketplaces
+        include_public = self.load_public_skills
         if self.load_user_skills or include_public:
             auto_skills = load_available_skills(
                 work_dir=None,

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -259,10 +259,10 @@ class TestLoadAllSkills:
 
     _PATCH_TARGET = "openhands.agent_server.skills_service.load_available_skills"
 
-    def test_load_all_skills_registered_marketplaces_replace_legacy_public(
+    def test_load_all_skills_registered_marketplaces_keep_legacy_public(
         self, tmp_path: Path
     ):
-        """Registered marketplaces load public-tier plugin skills."""
+        """Registered marketplaces load public-tier plugin skills additively."""
         marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
         user_skill = Skill(name="user-skill", content="user", trigger=None)
 
@@ -288,7 +288,7 @@ class TestLoadAllSkills:
         assert "manual-skill" in skill_names
         assert "user-skill" in skill_names
         assert result.sources["registered_marketplaces"] == 2
-        assert mock_avail.call_args_list[0].kwargs["include_public"] is False
+        assert mock_avail.call_args_list[0].kwargs["include_public"] is True
 
     def test_load_all_skills_non_auto_registered_marketplaces_keep_legacy_public(
         self, tmp_path: Path

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -263,10 +263,15 @@ class TestLoadAllSkills:
         self, tmp_path: Path
     ):
         marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
+        public_skill = Skill(name="public-skill", content="public", trigger=None)
         user_skill = Skill(name="user-skill", content="user", trigger=None)
 
         with patch(
-            self._PATCH_TARGET, side_effect=[{"user-skill": user_skill}, {}]
+            self._PATCH_TARGET,
+            side_effect=[
+                {"public-skill": public_skill, "user-skill": user_skill},
+                {},
+            ],
         ) as mock_avail:
             result = load_all_skills(
                 load_public=True,
@@ -285,8 +290,10 @@ class TestLoadAllSkills:
         skill_names = {skill.name for skill in result.skills}
         assert "auto-skill" in skill_names
         assert "manual-skill" in skill_names
+        assert "public-skill" in skill_names
         assert "user-skill" in skill_names
         assert result.sources["registered_marketplaces"] == 2
+        assert result.sources["sdk_base"] == 2
         assert mock_avail.call_args_list[0].kwargs["include_public"] is True
 
     def test_load_all_skills_non_auto_registered_marketplaces_keep_legacy_public(

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -262,7 +262,6 @@ class TestLoadAllSkills:
     def test_load_all_skills_registered_marketplaces_keep_legacy_public(
         self, tmp_path: Path
     ):
-        """Registered marketplaces load public-tier plugin skills additively."""
         marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
         user_skill = Skill(name="user-skill", content="user", trigger=None)
 

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -23,6 +23,8 @@ from openhands.sdk.plugin import (
     install_plugin,
     installed,
 )
+from openhands.sdk.skills import Skill
+from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
 from openhands.sdk.tool.builtins import ThinkTool
 
 
@@ -153,7 +155,6 @@ class TestLocalConversationPlugins:
     """
 
     def test_auto_load_marketplace_plugins(self, tmp_path: Path, mock_llm):
-        """Test marketplace registrations auto-load plugins at startup."""
         marketplace_dir = create_test_marketplace(
             tmp_path / "marketplace",
             plugins=[
@@ -165,18 +166,32 @@ class TestLocalConversationPlugins:
         )
         workspace = tmp_path / "workspace"
         workspace.mkdir()
-        agent = Agent(
-            llm=mock_llm,
-            tools=[],
-            agent_context=AgentContext(
-                registered_marketplaces=[
-                    MarketplaceRegistration(
-                        name="auto",
-                        source=str(marketplace_dir),
-                        auto_load=True,
-                    )
-                ]
-            ),
+        public_skill = Skill(name="public-skill", content="Public", trigger=None)
+        with patch(
+            "openhands.sdk.context.agent_context.load_available_skills",
+            return_value={"public-skill": public_skill},
+        ) as load_available_skills:
+            agent = Agent(
+                llm=mock_llm,
+                tools=[],
+                agent_context=AgentContext(
+                    load_public_skills=True,
+                    registered_marketplaces=[
+                        MarketplaceRegistration(
+                            name="auto",
+                            source=str(marketplace_dir),
+                            auto_load=True,
+                        )
+                    ],
+                ),
+            )
+
+        load_available_skills.assert_called_with(
+            work_dir=None,
+            include_user=False,
+            include_project=False,
+            include_public=True,
+            marketplace_path=DEFAULT_MARKETPLACE_PATH,
         )
 
         conversation = LocalConversation(
@@ -189,6 +204,7 @@ class TestLocalConversationPlugins:
         assert conversation.agent.agent_context is not None
         skill_names = [s.name for s in conversation.agent.agent_context.skills]
         assert "auto-skill" in skill_names
+        assert "public-skill" in skill_names
         assert conversation.resolved_plugins is not None
         assert len(conversation.resolved_plugins) == 1
 
@@ -476,12 +492,10 @@ class TestLocalConversationPlugins:
 
         conversation.close()
 
-    def test_registered_marketplaces_skip_legacy_public_skill_loading(
-        self, tmp_path: Path
-    ):
-        """Test registered marketplaces suppress legacy public skill loading."""
+    def test_registered_marketplaces_keep_public_skill_loading(self, tmp_path: Path):
         with patch(
-            "openhands.sdk.context.agent_context.load_available_skills"
+            "openhands.sdk.context.agent_context.load_available_skills",
+            return_value={},
         ) as mock_load_available_skills:
             AgentContext(
                 load_public_skills=True,
@@ -494,7 +508,13 @@ class TestLocalConversationPlugins:
                 ],
             )
 
-        mock_load_available_skills.assert_not_called()
+        mock_load_available_skills.assert_called_with(
+            work_dir=None,
+            include_user=False,
+            include_project=False,
+            include_public=True,
+            marketplace_path=DEFAULT_MARKETPLACE_PATH,
+        )
 
     def test_create_conversation_with_plugins(self, tmp_path: Path, basic_agent):
         """Test creating LocalConversation with plugins parameter."""


### PR DESCRIPTION
HUMAN:

Picked this up from the open issue tracker, fix verified locally.

---

AGENT:

## Why

Marketplace registration currently overrides explicit public-skill settings in two paths:

- `load_all_skills()` disables its legacy public loader whenever an auto-load marketplace exists.
- `AgentContext` disables public-skill loading whenever any marketplace is registered, including resolution-only registrations.

This PR changes that behavior so marketplace registration adds skills without implicitly removing the public catalog.

## Behavior Change

Consumers that register auto-load marketplaces while public loading is enabled will now receive both public and marketplace skills.

In the agent-server API, `load_public=False` disables both legacy public loading and registered marketplace auto-load. The API does not currently expose a separate marketplace-only switch, so this PR removes the previous implicit marketplace-only behavior.

For direct SDK conversations, `load_public_skills=False` still disables public skills while `LocalConversation` resolves registered marketplace plugins independently.

## Summary

- Keep legacy public skills enabled in `load_all_skills()` when auto-load marketplaces are present.
- Honor `AgentContext.load_public_skills` independently of marketplace registrations.
- Keep resolution-only marketplace registrations from suppressing public skills.
- Update the `SkillsRequest` OpenAPI description to document additive loading.
- Add server and conversation regressions that assert public and marketplace skills coexist.

## Issue Number

OpenHands/OpenHands#15237

## How to Test

- 916 relevant agent-server, Agent Profile, SDK context, skills, and conversation tests passed; 2 skipped.
- Ruff format/lint and all pre-commit gates passed, including pycodestyle, pyright, import rules, and tool registration.
- Real `POST /api/skills` QA with a local registered marketplace returned 56 skills: 55 public skills plus one marketplace skill.
- `/openapi.json` reports that marketplace registrations add skills to the public catalog.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
