### PR TITLE
test(sdk): make filestore cache checks deterministic

### DIFF
--- a/.pr/live_filestore_cache_stress.py
+++ b/.pr/live_filestore_cache_stress.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from openhands.sdk.io.local import LocalFileStore
+
+
+TIMING_ITERATIONS = 3000
+MULTIFILE_ITERATIONS = 300
+DIRECT_ITERATIONS = 3000
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int((len(ordered) - 1) * fraction))
+    return ordered[index]
+
+
+def distribution(values: list[float]) -> dict[str, float]:
+    return {
+        "min": min(values),
+        "p50": statistics.median(values),
+        "p95": percentile(values, 0.95),
+        "p99": percentile(values, 0.99),
+        "max": max(values),
+    }
+
+
+def start_load(load_file: Path) -> list[subprocess.Popen[bytes]]:
+    load_file.write_bytes(b"f" * (16 * 1024 * 1024))
+    processes = [
+        subprocess.Popen(
+            ["sha256sum", "/dev/zero"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        for _ in range(2)
+    ]
+    reader = (
+        "import sys\n"
+        "path=sys.argv[1]\n"
+        "while True:\n"
+        "  with open(path, 'rb', buffering=0) as stream:\n"
+        "    while stream.read(1024 * 1024):\n"
+        "      pass\n"
+    )
+    processes.append(
+        subprocess.Popen(
+            [sys.executable, "-c", reader, str(load_file)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    )
+    return processes
+
+
+def stop_load(processes: list[subprocess.Popen[bytes]]) -> None:
+    for process in processes:
+        process.terminate()
+    for process in processes:
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def timing_cache_hit(store: LocalFileStore) -> dict[str, Any]:
+    ratios: list[float] = []
+    mismatches = 0
+    expected = "x" * 100000
+    for _ in range(TIMING_ITERATIONS):
+        store.cache.clear()
+        start = time.perf_counter()
+        for _ in range(10):
+            assert store.read("large_file.txt") == expected
+        first = time.perf_counter() - start
+
+        start = time.perf_counter()
+        for _ in range(10):
+            assert store.read("large_file.txt") == expected
+        second = time.perf_counter() - start
+        ratio = second / first
+        ratios.append(ratio)
+        mismatches += ratio >= 2.0
+
+    return {
+        "iterations": TIMING_ITERATIONS,
+        "assertion": "second_pass_time < first_pass_time * 2",
+        "mismatches": mismatches,
+        "second_over_first": distribution(ratios),
+    }
+
+
+def timing_multifile(store: LocalFileStore) -> dict[str, Any]:
+    speedups: list[float] = []
+    mismatches = 0
+    for _ in range(MULTIFILE_ITERATIONS):
+        store.cache.clear()
+        start = time.perf_counter()
+        for index in range(50):
+            store.read(f"file_{index}.txt")
+        first = time.perf_counter() - start
+
+        start = time.perf_counter()
+        for index in range(50):
+            store.read(f"file_{index}.txt")
+        second = time.perf_counter() - start
+        speedup = first / second
+        speedups.append(speedup)
+        mismatches += speedup <= 0.8
+
+    return {
+        "iterations": MULTIFILE_ITERATIONS,
+        "assertion": "first_pass_time / second_pass_time > 0.8",
+        "mismatches": mismatches,
+        "first_over_second": distribution(speedups),
+    }
+
+
+def direct_read_assertions(root: Path) -> dict[str, Any]:
+    store = LocalFileStore(str(root / "direct"), cache_limit_size=100)
+    store.write("tracked.txt", "original")
+    full_path = store.get_full_path("tracked.txt")
+    real_open = builtins.open
+    opens: list[str] = []
+
+    def tracked_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        opened = os.path.abspath(os.fsdecode(os.fspath(file)))
+        if opened == full_path:
+            opens.append(opened)
+        return real_open(file, *args, **kwargs)
+
+    builtins.open = tracked_open
+    try:
+        for iteration in range(DIRECT_ITERATIONS):
+            before = len(opens)
+            store.cache.clear()
+            assert store.read("tracked.txt") == "original"
+            assert len(opens) == before + 1
+            for _ in range(10):
+                assert store.read("tracked.txt") == "original"
+            assert len(opens) == before + 1
+
+        stale_before = len(opens)
+        with real_open(full_path, "w") as stream:
+            stream.write("changed-on-disk")
+        cached = store.read("tracked.txt")
+        stale_open_count = len(opens)
+        store.cache.clear()
+        refreshed = store.read("tracked.txt")
+        refreshed_open_count = len(opens)
+    finally:
+        builtins.open = real_open
+
+    return {
+        "iterations": DIRECT_ITERATIONS,
+        "expected_disk_opens": DIRECT_ITERATIONS,
+        "observed_disk_opens_before_stale_probe": stale_before,
+        "cached_after_external_change": cached,
+        "opens_while_returning_cached_value": stale_open_count - stale_before,
+        "refreshed_after_cache_clear": refreshed,
+        "opens_for_refresh": refreshed_open_count - stale_open_count,
+    }
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="pr4088-stress-") as temp:
+        root = Path(temp)
+        store = LocalFileStore(str(root / "timing"), cache_limit_size=100)
+        store.write("large_file.txt", "x" * 100000)
+        for index in range(50):
+            store.write(f"file_{index}.txt", f"Test content {index}\n" * 500)
+
+        test_source = Path("tests/sdk/io/test_filestore_cache.py").read_text()
+        filesystem = subprocess.run(
+            ["findmnt", "-n", "-o", "FSTYPE", "--target", temp],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        processes = start_load(root / "filesystem-load.bin")
+        try:
+            result = {
+                "test_style": (
+                    "direct-open-counts"
+                    if "_track_open_calls" in test_source
+                    else "perf-counter-thresholds"
+                ),
+                "filesystem": filesystem,
+                "cpu_count": os.cpu_count(),
+                "load_processes": ["sha256sum /dev/zero"] * 2
+                + ["continuous 16MiB filesystem reads"],
+                "timing_cache_hit": timing_cache_hit(store),
+                "timing_multifile": timing_multifile(store),
+                "direct_read_assertions": direct_read_assertions(root),
+            }
+        finally:
+            stop_load(processes)
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk/io/test_filestore_cache.py
+++ b/tests/sdk/io/test_filestore_cache.py
@@ -7,13 +7,31 @@ This module tests:
 4. Handling of large numbers of events without OOM
 """
 
+import builtins
+import os
 import tempfile
-import time
+from typing import Any
 
 import pytest
 
 from openhands.sdk.io.cache import MemoryLRUCache
 from openhands.sdk.io.local import LocalFileStore
+
+
+def _track_open_calls(
+    monkeypatch: pytest.MonkeyPatch, tracked_paths: set[str]
+) -> list[str]:
+    real_open = builtins.open
+    open_calls: list[str] = []
+
+    def tracked_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        opened_path = os.path.abspath(os.fsdecode(os.fspath(file)))
+        if opened_path in tracked_paths:
+            open_calls.append(opened_path)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", tracked_open)
+    return open_calls
 
 
 def test_cache_basic_functionality():
@@ -31,45 +49,24 @@ def test_cache_basic_functionality():
         assert full_path in store.cache
 
 
-def test_cache_hit_performance():
-    """Test that cache hits are significantly faster than disk reads."""
+def test_cache_hit_performance(monkeypatch: pytest.MonkeyPatch):
+    """Test that cache hits avoid reading from disk again."""
     with tempfile.TemporaryDirectory() as temp_dir:
         store = LocalFileStore(temp_dir, cache_limit_size=100)
 
-        # Create a larger test file to make timing more measurable
-        test_content = "x" * 100000  # 100KB
+        test_content = "x" * 100000
         store.write("large_file.txt", test_content)
+        full_path = store.get_full_path("large_file.txt")
+        open_calls = _track_open_calls(monkeypatch, {full_path})
 
-        # Warm up and do multiple reads to get more stable timing
-        num_reads = 10
-
-        # First pass - from disk (cache miss + subsequent cache hits)
-        # Clear cache first
         store.cache.clear()
-        content1 = ""
-        start = time.perf_counter()
-        for _ in range(num_reads):
-            content1 = store.read("large_file.txt")
-        first_pass_time = time.perf_counter() - start
+        assert store.read("large_file.txt") == test_content
+        assert open_calls == [full_path]
 
-        # Second pass - all from cache (all cache hits)
-        content2 = ""
-        start = time.perf_counter()
-        for _ in range(num_reads):
-            content2 = store.read("large_file.txt")
-        second_pass_time = time.perf_counter() - start
+        for _ in range(10):
+            assert store.read("large_file.txt") == test_content
 
-        # Verify correctness
-        assert content1 == test_content
-        assert content2 == test_content
-
-        # The first pass includes one disk read, so should be noticeably slower
-        # This is a more lenient check since timing can vary on different systems
-        print(
-            f"First pass: {first_pass_time:.6f}s, Second pass: {second_pass_time:.6f}s"
-        )
-        # Just verify cache is working - second pass should not be much slower
-        assert second_pass_time < first_pass_time * 2
+        assert open_calls == [full_path]
 
 
 def test_cache_lru_eviction():
@@ -237,37 +234,30 @@ def test_cache_correctness_under_concurrent_operations():
                     store.read(f"file_{i}.txt")
 
 
-def test_cache_performance_repeated_reads():
-    """Test that repeated reads show performance improvement."""
+def test_cache_performance_repeated_reads(monkeypatch: pytest.MonkeyPatch):
+    """Test that repeated reads use the cache after one read per file."""
     with tempfile.TemporaryDirectory() as temp_dir:
         store = LocalFileStore(temp_dir, cache_limit_size=100)
 
-        # Create test files with more content to make disk I/O more noticeable
         num_files = 50
         for i in range(num_files):
-            content = f"Test content {i}\n" * 500  # ~10KB per file
+            content = f"Test content {i}\n" * 500
             store.write(f"file_{i}.txt", content)
 
-        # Clear cache to ensure fresh start
+        full_paths = {store.get_full_path(f"file_{i}.txt") for i in range(num_files)}
+        open_calls = _track_open_calls(monkeypatch, full_paths)
+
         store.cache.clear()
 
-        # First pass - cache misses
-        start = time.perf_counter()
         for i in range(num_files):
             store.read(f"file_{i}.txt")
-        first_pass_time = time.perf_counter() - start
 
-        # Second pass - cache hits
-        start = time.perf_counter()
+        assert sorted(open_calls) == sorted(full_paths)
+
         for i in range(num_files):
             store.read(f"file_{i}.txt")
-        second_pass_time = time.perf_counter() - start
 
-        # Second pass should be faster or at least not significantly slower
-        speedup = first_pass_time / second_pass_time
-        print(f"Cache speedup: {speedup:.2f}x")
-        # Use a more lenient check - cache should help or at least not hurt
-        assert speedup > 0.8  # Cache doesn't slow things down significantly
+        assert sorted(open_calls) == sorted(full_paths)
 
 
 def test_cache_zero_size():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The existing cache tests infer correctness from timing thresholds, which are inherently flaky across machines and load conditions.

## Summary

- Replace elapsed-time assertions with direct tracking of reads of cache-backed files.
- Assert that each file is opened once on a cache miss and not reopened on subsequent cache hits.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `9028562e2d5e` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -2010,2 +2010,2 @@
-schema SecurityAnalyzerBase-Input oneOf=[PatternSecurityAnalyzer-Input,PolicyRailSecurityAnalyzer-Input,EnsembleSecurityAnalyzer-Input,GraySwanAnalyzer-Input,LLMSecurityAnalyzer-Input]
-schema SecurityAnalyzerBase-Output oneOf=[PatternSecurityAnalyzer-Output,PolicyRailSecurityAnalyzer-Output,EnsembleSecurityAnalyzer-Output,GraySwanAnalyzer-Output,LLMSecurityAnalyzer-Output]
+schema SecurityAnalyzerBase-Input oneOf=[PatternSecurityAnalyzer-Input,PolicyRailSecurityAnalyzer-Input,EnsembleSecurityAnalyzer-Input,GraySwanAnalyzer-Input,LLMSecurityAnalyzer-Input,ToolShieldLLMSecurityAnalyzer-Input]
+schema SecurityAnalyzerBase-Output oneOf=[PatternSecurityAnalyzer-Output,PolicyRailSecurityAnalyzer-Output,EnsembleSecurityAnalyzer-Output,GraySwanAnalyzer-Output,LLMSecurityAnalyzer-Output,ToolShieldLLMSecurityAnalyzer-Output]
@@ -2385,0 +2386,10 @@
+schema ToolShieldLLMSecurityAnalyzer-Input property history_window optional schema=type="integer" default=20
+schema ToolShieldLLMSecurityAnalyzer-Input property kind optional schema=type="string" const="ToolShieldLLMSecurityAnalyzer"
+schema ToolShieldLLMSecurityAnalyzer-Input property llm required schema=LLM-Input
+schema ToolShieldLLMSecurityAnalyzer-Input property safety_experiences optional schema=type="string" default=""
+schema ToolShieldLLMSecurityAnalyzer-Input type="object"
+schema ToolShieldLLMSecurityAnalyzer-Output property history_window optional schema=type="integer" default=20
+schema ToolShieldLLMSecurityAnalyzer-Output property kind required schema=type="string" const="ToolShieldLLMSecurityAnalyzer"
+schema ToolShieldLLMSecurityAnalyzer-Output property llm required schema=LLM-Output
+schema ToolShieldLLMSecurityAnalyzer-Output property safety_experiences optional schema=type="string" default=""
+schema ToolShieldLLMSecurityAnalyzer-Output type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

None; split from #3996 because it is unrelated to the ACP prompt argument-order fix.

## How to Test

`uv run pytest tests/sdk/io/test_filestore_cache.py -q`

Result: 13 passed. The tests exercise `LocalFileStore` through real temporary files and monkeypatch only `builtins.open` to record accesses, verifying cache misses read from disk once and cache hits avoid additional disk opens.

## Video/Screenshots

Not applicable: test-only change with no UI.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Kept as a draft pending review.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4ece2f0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4ece2f0-python \
  ghcr.io/openhands/agent-server:4ece2f0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4ece2f0-golang-amd64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-golang-amd64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-golang-amd64
ghcr.io/openhands/agent-server:4ece2f0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4ece2f0-golang-arm64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-golang-arm64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-golang-arm64
ghcr.io/openhands/agent-server:4ece2f0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4ece2f0-java-amd64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-java-amd64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-java-amd64
ghcr.io/openhands/agent-server:4ece2f0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4ece2f0-java-arm64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-java-arm64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-java-arm64
ghcr.io/openhands/agent-server:4ece2f0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4ece2f0-python-amd64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-python-amd64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-python-amd64
ghcr.io/openhands/agent-server:4ece2f0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4ece2f0-python-arm64
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-python-arm64
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-python-arm64
ghcr.io/openhands/agent-server:4ece2f0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4ece2f0-golang
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-golang
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-golang
ghcr.io/openhands/agent-server:4ece2f0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4ece2f0-java
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-java
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-java
ghcr.io/openhands/agent-server:4ece2f0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4ece2f0-python
ghcr.io/openhands/agent-server:4ece2f02b67a0ced88f794e9fbe627cf2bd53350-python
ghcr.io/openhands/agent-server:codex-filestore-cache-deterministic-python
ghcr.io/openhands/agent-server:4ece2f0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4ece2f0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4ece2f0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Live evidence

Run on 2026-07-13 UTC on Linux 6.8.0-134-generic x86_64, Python 3.13.13, uv 0.11.8, four visible CPUs, and an ext4 filesystem. The exact reusable stress harness is committed as `.pr/live_filestore_cache_stress.py`.

Both checkouts used the identical command and load: two concurrent `sha256sum /dev/zero` CPU burners plus a separate process continuously reading a 16 MiB file.

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run python .pr/live_filestore_cache_stress.py
```

The harness runs the 10-read timing comparison 3,000 times, the 50-file timing comparison 300 times, and the direct filesystem-open cache assertion 3,000 times. For current main, the committed harness was invoked by its PR-worktree path while `uv run` supplied current-main packages.

### Current `main`: timing thresholds mismatch under load

Commit: `777671766f4196da318b5b1e6179a6dc897cad36`

The checked-in test style was `perf-counter-thresholds`. The exact stress result was:

```json
{
  "timing_cache_hit": {
    "iterations": 3000,
    "mismatches": 155,
    "second_over_first": {
      "p50": 0.5252995333969792,
      "p95": 6.077143726964858,
      "p99": 16.676834610462734,
      "max": 50.784200017986485
    }
  },
  "timing_multifile": {
    "iterations": 300,
    "mismatches": 11,
    "first_over_second": {
      "min": 0.48085813873587946,
      "p50": 12.105222548853295,
      "p99": 25.63879727922124
    }
  }
}
```

The original assertions fail when `second/first >= 2.0` or `first/second <= 0.8`; both conditions occurred repeatedly even though all returned content remained correct. This records the timing-dependent flake window directly.

### PR head: direct assertions remain deterministic

Commit: `4ece2f02b67a0ced88f794e9fbe627cf2bd53350`

The checked-in test style was `direct-open-counts`. Under the identical load, the timing measurements remained noisy (169/3,000 and 10/300 threshold mismatches), demonstrating why they are no longer suitable assertions. The replacement direct check was exact for every iteration:

```json
{
  "iterations": 3000,
  "expected_disk_opens": 3000,
  "observed_disk_opens_before_stale_probe": 3000,
  "cached_after_external_change": "original",
  "opens_while_returning_cached_value": 0,
  "refreshed_after_cache_clear": "changed-on-disk",
  "opens_for_refresh": 1
}
```

Each cache miss caused exactly one real filesystem open and each group of ten cache hits caused no additional open. The stale-content probe changed the file outside `LocalFileStore`: the cache correctly returned the old value without reopening, then `cache.clear()` caused exactly one new open and returned the changed disk content. Thus the direct assertions are deterministic while still distinguishing cached stale content from a real refresh.

### Complete focused test output under the same load

Current main:

```text
collected 13 items
tests/sdk/io/test_filestore_cache.py ............. [100%]
13 passed in 1.15s
```

PR head:

```text
collected 13 items
tests/sdk/io/test_filestore_cache.py ............. [100%]
13 passed in 1.18s
```

The one-shot main test pass does not contradict the stress result: the old assertions are probabilistic, while the thousands-of-iterations run captured their failure window. `uv run pre-commit run --files .pr/live_filestore_cache_stress.py` also passed all hooks.


Closes #4094
