### PR TITLE
fix: heal history orphaned by pre-#4068 legacy-resume __root__ bug

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -222,6 +222,34 @@ class EventLog(EventsListBase):
             )
             raise
 
+    def rewrite_event(self, idx: int, event: Event) -> None:
+        """Overwrite the already-persisted event at ``idx`` in place.
+
+        The event keeps its index and id (the filename is unchanged); only its
+        stored payload is replaced. Used by one-time on-disk migrations that
+        repair a single event's fields (e.g. re-linking a wrongly-rooted
+        ``parent_id``) without appending or reordering the log.
+
+        Raises:
+            IndexError: If ``idx`` is out of range.
+            ValueError: If ``event.id`` does not match the event stored at ``idx``.
+        """
+        if idx < 0 or idx >= self._length:
+            raise IndexError(f"Event index out of range: {idx}")
+        existing_id = self._idx_to_id[idx]
+        if event.id != existing_id:
+            raise ValueError(
+                f"rewrite_event id mismatch at idx {idx}: stored '{existing_id}', "
+                f"got '{event.id}'"
+            )
+        payload = event.model_dump_json(exclude_none=True)
+        write_guard = (
+            nullcontext() if self._write_guard is None else self._write_guard()
+        )
+        with write_guard:
+            self._fs.write(self._path(idx, event_id=existing_id), payload)
+        self._event_cache[idx] = event
+
     def _count_events_on_disk(self) -> int:
         """Count event files on disk."""
         try:

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -260,6 +260,80 @@ class ConversationState(OpenHandsModel):
     def events(self) -> EventLog:
         return self._events
 
+    def _migrate_orphaned_root_tail(self) -> None:
+        """One-time on-disk repair for history orphaned by the pre-#4068 bug.
+
+        Before #4068, resuming a pre-event-tree conversation whose stored tail was
+        a non-tree artifact (a ``ConversationStateUpdateEvent`` / ``Conversation
+        ErrorEvent`` written during an interrupted startup) could stamp the first
+        post-resume event with ``parent_id == "__root__"``. ``_effective_parent_id``
+        treats that as a hard root, so ``path_to_root`` stops there and every older
+        event is orphaned from the LLM's view — even though all event files are
+        intact on disk. #4068 stops *new* resumes from doing this, but conversations
+        already written with the bad ``__root__`` stay broken until repaired.
+
+        This heals exactly the bug's on-disk fingerprint and nothing else. To be
+        repaired, an event at ``idx > 0`` with ``parent_id == "__root__"`` must:
+
+        1. sit immediately after a **non-tree artifact** (a
+           ``ConversationStateUpdateEvent`` / ``ConversationErrorEvent``) — the
+           stale tail that tricked ``_resolve_active_leaf`` into returning ``None``.
+           The bug cannot occur without such a tail, and a deliberate feature root
+           (``navigate_to(None)`` then emit) sits after a *real* event, so this
+           condition alone excludes it; and
+        2. sit on top of an otherwise-legacy log: every real (non-artifact) event
+           before it carries no ``parent_id``.
+
+        When both hold, the event is re-linked to the nearest preceding real event
+        (the legacy tail), reconnecting the history. Anything else — genuine tree
+        roots, deliberate ``navigate_to(None)`` roots, real branch points — is left
+        untouched.
+        """
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.event.conversation_state import (
+            ConversationStateUpdateEvent,
+        )
+
+        events = self._events
+        n = len(events)
+        if n < 2:
+            return
+
+        artifacts = (ConversationStateUpdateEvent, ConversationErrorEvent)
+        repaired = 0
+        for idx in range(1, n):
+            event = events[idx]
+            if event.parent_id != ROOT_PARENT_ID:
+                continue
+            # (1) The bug's fingerprint: the wrongly-rooted event sits directly on
+            # a non-tree artifact tail. A deliberate navigate_to(None) root follows
+            # a real event, so it fails this and is left alone.
+            if not isinstance(events[idx - 1], artifacts):
+                continue
+            # (2) Everything real below must be pre-tree (no parent_id), i.e. a
+            # genuine legacy log rather than a real tree with branches.
+            preceding_real = [
+                events[j] for j in range(idx) if not isinstance(events[j], artifacts)
+            ]
+            if not preceding_real:
+                continue
+            if any(e.parent_id is not None for e in preceding_real):
+                continue
+            new_parent = preceding_real[-1].id
+            self._events.rewrite_event(
+                idx, event.model_copy(update={"parent_id": new_parent})
+            )
+            repaired += 1
+
+        if repaired:
+            logger.info(
+                "Migrated %d orphaned-root event(s) in conversation %s: re-linked "
+                "post-resume event(s) that were wrongly stamped '__root__' to the "
+                "legacy tail, restoring prior history.",
+                repaired,
+                self.id,
+            )
+
     def _resolve_active_leaf(self) -> EventID | None:
         """The effective HEAD, resolving a ``None`` ``leaf_event_id`` by lineage.
 
@@ -531,6 +605,10 @@ class ConversationState(OpenHandsModel):
             state._fs = file_store
             state._events = EventLog(file_store, dir_path=EVENTS_DIR)
             state._cipher = cipher
+
+            # One-time repair for conversations orphaned by the pre-#4068
+            # legacy-resume bug (see _migrate_orphaned_root_tail).
+            state._migrate_orphaned_root_tail()
 
             # Cold-load: rebuild the cached view with full property
             # enforcement — persisted events may come from an older code

--- a/tests/cross/test_conversation_restore_behavior.py
+++ b/tests/cross/test_conversation_restore_behavior.py
@@ -33,11 +33,13 @@ from openhands.sdk.context import AgentContext, KeywordTrigger, Skill
 from openhands.sdk.context.condenser.llm_summarizing_condenser import (
     LLMSummarizingCondenser,
 )
+from openhands.sdk.conversation.event_store import EventLog
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.event import ActionEvent, MessageEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.types import ROOT_PARENT_ID
-from openhands.sdk.llm import LLM
+from openhands.sdk.io import LocalFileStore
+from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.utils.openhands_provider import (
     LITELLM_PROXY_PREFIX,
     OPENHANDS_LLM_PROXY_BASE_URL,
@@ -992,3 +994,113 @@ def test_restore_event_tree_conversation_keeps_history(mock_completion):
             assert set(original_ids).issubset(reachable)
         finally:
             restored.close()
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_restore_migrates_orphaned_root_and_restores_history(mock_completion):
+    """A conversation damaged by the pre-#4068 bug is healed on the next resume.
+
+    #4068 stops *new* legacy resumes from stamping a false ``__root__``, but
+    conversations already written that way stay broken until repaired. Here we
+    reproduce the exact on-disk damage from a *real* session, then assert that
+    resuming under the current code re-links the orphaned event to the legacy tail
+    (the one-time migration), so the full history is reachable again and the fix
+    persists to disk.
+    """
+    mock_completion.return_value = create_mock_litellm_response(
+        content="Acknowledged.", finish_reason="stop"
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        lifecycle = RestoreLifecycle(
+            workspace_dir=base / "workspace",
+            persistence_base_dir=base / "persist",
+        )
+        lifecycle.workspace_dir.mkdir(parents=True, exist_ok=True)
+        lifecycle.persistence_base_dir.mkdir(parents=True, exist_ok=True)
+
+        tools = [Tool(name="TerminalTool"), Tool(name="FileEditorTool")]
+        agent = _agent(
+            llm_model="gpt-4o-mini",
+            tools=tools,
+            condenser_max_size=80,
+            skill_name="skill-v1",
+            skill_keyword="alpha",
+        )
+
+        # 1) Real session to get a realistic event log.
+        lifecycle.run_initial_session(agent)
+        assert lifecycle.conversation_id is not None
+        events_dir = (
+            lifecycle.persistence_base_dir / lifecycle.conversation_id.hex / "events"
+        )
+        event_files = sorted(
+            events_dir.glob("event-*.json"),
+            key=lambda p: int(p.name.split("-")[1]),
+        )
+        assert len(event_files) >= 3
+        legacy_ids = [json.loads(p.read_text())["id"] for p in event_files]
+
+        # 2) Downgrade to the pre-event-tree shape (strip parent_id, drop HEAD).
+        for p in event_files:
+            data = json.loads(p.read_text())
+            data.pop("parent_id", None)
+            p.write_text(json.dumps(data))
+        base_state = lifecycle.read_base_state()
+        base_state.pop("leaf_event_id", None)
+        base_state.pop("head_is_empty", None)
+        lifecycle.write_base_state(base_state)
+
+        # 3) Append the interrupted-startup artifact (non-tree, carries parent_id)
+        #    that a newer server chained onto the legacy tail...
+        artifact = ConversationStateUpdateEvent(
+            parent_id=legacy_ids[-1], key="execution_status", value="idle"
+        )
+        artifact_idx = len(event_files)
+        (events_dir / f"event-{artifact_idx:05d}-{artifact.id}.json").write_text(
+            artifact.model_dump_json(exclude_none=True)
+        )
+
+        # 4) ...then the post-resume user event WRONGLY stamped __root__ (the bug).
+        orphan = MessageEvent(
+            source="user",
+            llm_message=Message(role="user", content=[TextContent(text="after")]),
+            parent_id=ROOT_PARENT_ID,
+        )
+        orphan_idx = artifact_idx + 1
+        (events_dir / f"event-{orphan_idx:05d}-{orphan.id}.json").write_text(
+            orphan.model_dump_json(exclude_none=True)
+        )
+
+        # Sanity: the damage really orphans history before the migration runs.
+        conversation_dir = (
+            lifecycle.persistence_base_dir / lifecycle.conversation_id.hex
+        )
+        pre = EventLog(LocalFileStore(str(conversation_dir)))
+        assert [e.id for e in pre.path_to_root(orphan.id)] == [orphan.id]
+
+        # 5) Resume under current code → migration runs.
+        restored = lifecycle.restore(agent)
+        try:
+            healed = next(e for e in restored.state.events if e.id == orphan.id)
+            assert healed.parent_id == legacy_ids[-1]
+            assert healed.parent_id != ROOT_PARENT_ID
+
+            reachable = [e.id for e in restored.state.events.path_to_root(orphan.id)]
+            # Every legacy event is reachable again, in order.
+            assert [i for i in reachable if i in set(legacy_ids)] == legacy_ids
+            assert reachable[-1] == orphan.id
+
+            # Continuing chains onto the healed tail, not a false root.
+            restored.send_message("Third message")
+            new_event = restored.state.events[-1]
+            assert new_event.parent_id != ROOT_PARENT_ID
+            after = {e.id for e in restored.state.events.path_to_root(new_event.id)}
+            assert set(legacy_ids).issubset(after)
+        finally:
+            restored.close()
+
+        # 6) The repair is durable on disk.
+        reopened = EventLog(LocalFileStore(str(conversation_dir)))
+        assert reopened[reopened.get_index(orphan.id)].parent_id == legacy_ids[-1]

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -14,6 +14,7 @@ from pydantic import SecretStr
 from openhands.sdk.agent import Agent
 from openhands.sdk.context.view import View
 from openhands.sdk.conversation import Conversation, LocalConversation
+from openhands.sdk.conversation.event_store import EventLog
 from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.event.base import Event
@@ -23,6 +24,7 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.event.types import ROOT_PARENT_ID, SourceType
 from openhands.sdk.event.user_action import PauseEvent
+from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
 from openhands.sdk.tool.schema import Action
 
@@ -634,3 +636,89 @@ def test_fork_preserves_empty_head():
         fork = conv.fork()
         assert fork.state.head_is_empty is True
         assert _view_ids(fork) == []
+
+
+def _build_orphaned_legacy_log(events, n_legacy: int = 3):
+    """Reproduce the exact pre-#4068 on-disk damage in ``events``.
+
+    Shape written to disk: ``n_legacy`` legacy events (no ``parent_id``), then a
+    non-tree artifact (``ConversationStateUpdateEvent`` — the interrupted-startup
+    tail), then the post-resume event wrongly stamped ``parent_id == "__root__"``
+    (which orphaned everything below it). Returns ``(legacy_events, orphan_event)``.
+    """
+    legacy = [_msg(f"legacy-{i}") for i in range(n_legacy)]
+    for ev in legacy:
+        # Legacy events carry no parent_id: write pre-tree shape directly.
+        events.append(ev.model_copy(update={"parent_id": None}))
+    artifact = ConversationStateUpdateEvent(
+        parent_id=legacy[-1].id, key="execution_status", value="idle"
+    )
+    events.append(artifact)
+    orphan = _msg("post-resume")
+    events.append(orphan)
+    # Stamp the orphaning root exactly as the buggy code left it on disk.
+    events.rewrite_event(
+        len(events) - 1, orphan.model_copy(update={"parent_id": ROOT_PARENT_ID})
+    )
+    return legacy, orphan
+
+
+def test_migration_heals_orphaned_root_over_legacy_tail():
+    """Resuming a conversation damaged by the pre-#4068 bug restores history.
+
+    Reproduce the exact broken shape (legacy log + artifact tail + a post-resume
+    event wrongly stamped ``__root__``, persisted that way, orphaning all prior
+    events). On the next resume the one-time migration must re-link that event to
+    the legacy tail so the full history is reachable again — durably on disk.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        legacy, orphan = _build_orphaned_legacy_log(conv.state.events)
+        conv_id = conv.id
+        conv.close()
+
+        # Confirm the damage is real before the migration runs.
+        broken = EventLog(LocalFileStore(str(Path(tmp) / conv_id.hex)))
+        assert broken[len(broken) - 1].parent_id == ROOT_PARENT_ID
+        assert [e.id for e in broken.path_to_root(orphan.id)] == [orphan.id]
+
+        # Resume: the migration runs inside ConversationState.create.
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        legacy_ids = [e.id for e in legacy]
+
+        # The orphaned event is re-linked to the legacy tail (not __root__).
+        healed = _by_id(resumed.state.events, orphan.id)
+        assert healed.parent_id == legacy_ids[-1]
+        assert healed.parent_id != ROOT_PARENT_ID
+        # Full legacy history is reachable again, in order (artifact not on branch).
+        reachable = [e.id for e in resumed.state.events.path_to_root(orphan.id)]
+        assert [i for i in reachable if i in set(legacy_ids)] == legacy_ids
+        assert reachable[-1] == orphan.id
+        resumed.close()
+
+        # The repair is durable: a fresh cold read sees the re-link, not __root__.
+        reopened = EventLog(LocalFileStore(str(Path(tmp) / conv_id.hex)))
+        orphan_idx = reopened.get_index(orphan.id)
+        assert reopened[orphan_idx].parent_id == legacy_ids[-1]
+
+
+def test_migration_leaves_deliberate_feature_root_untouched():
+    """The migration must not rewrite a legitimate feature-created root.
+
+    ``navigate_to(None)`` then emitting starts a real new root (``__root__``) in a
+    genuine tree log — events before it carry ``parent_id`` values. That is not the
+    legacy-orphan shape, so the migration must leave it alone on resume.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        _emit(conv, _msg("first"))  # real tree event (gets a parent_id)
+        conv.navigate_to(None)
+        fresh_root = _emit(conv, _msg("fresh root"))  # legitimate __root__
+        assert _by_id(conv.state.events, fresh_root.id).parent_id == ROOT_PARENT_ID
+        conv_id = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        # Untouched: it is still a deliberate root.
+        assert _by_id(resumed.state.events, fresh_root.id).parent_id == ROOT_PARENT_ID
+        resumed.close()


### PR DESCRIPTION
HUMAN:
This PR proposes a one-time migration of the affected conversations fixed by 4068

<!-- Human author: please replace this comment before marking ready for review. -->

---

AGENT:

## Why

Before #4068, resuming a **pre-event-tree** conversation whose stored tail was a
non-tree artifact (a `ConversationStateUpdateEvent` / `ConversationErrorEvent`
written during an interrupted startup) could stamp the first post-resume event
with `parent_id == "__root__"`. `_effective_parent_id` treats `"__root__"` as a
hard root, so `path_to_root` stops there and **every older event is orphaned from
the LLM's view** — even though all event files are intact on disk.

#4068 stops *new* resumes from producing this, but conversations **already written**
with the bad `__root__` stay broken until repaired. Users are hitting this in the
wild (reported by @kripper: orphaned history on resume across the 1.29.3→1.33.x
boundary). There is currently no automatic recovery — it requires a hand-edit of a
single event file.

## Summary

- **`EventLog.rewrite_event(idx, event)`** — overwrite an already-persisted event in
  place (same idx + id, filename unchanged, under the write lock) so a one-time
  migration can repair a single field without appending or reordering the log.
- **`ConversationState._migrate_orphaned_root_tail()`** — a tightly-guarded on-disk
  repair, run once on the resume path (before `rebuild_view`). It heals exactly the
  bug's fingerprint and re-links the wrongly-rooted event to the legacy tail.
- Tests: 2 unit + 1 cross (see below).

### What gets healed (and what does not)

An event at `idx > 0` with `parent_id == "__root__"` is repaired **only if**:
1. it sits directly after a **non-tree artifact** (`ConversationStateUpdateEvent` /
   `ConversationErrorEvent`) — the stale tail that caused the bug; a deliberate
   `navigate_to(None)` root sits after a *real* event, so this excludes it; **and**
2. every real (non-artifact) event before it carries **no** `parent_id` (a genuine
   legacy log, not a real tree with branches).

When both hold, the event is re-linked to the nearest preceding real event,
reconnecting history. Genuine tree roots, deliberate `navigate_to(None)` roots, and
real branch points are left untouched.

## Issue Number

Related to the orphaned-history-on-resume reports (OpenHands/OpenHands#15247 is a
neighbouring resume-robustness issue in the same area). This PR is the one-time
migration for the `__root__`-at-the-tail case.

## How to Test

```bash
# The cross test reproduces the bug from a REAL session, then resumes and proves the heal:
uv run python -m pytest tests/cross/test_conversation_restore_behavior.py \
  -k test_restore_migrates_orphaned_root_and_restores_history -q

# Unit tests: heal the damaged shape, and leave a deliberate root untouched:
uv run python -m pytest tests/sdk/conversation/local/test_conversation_tree.py \
  -k "migration_heals or migration_leaves" -q

# Full relevant suites:
uv run python -m pytest tests/sdk/conversation/local/test_conversation_tree.py \
  tests/cross/test_conversation_restore_behavior.py -q
```

**Result on this branch:**
- `test_restore_migrates_orphaned_root_and_restores_history` — PASS
- `test_migration_heals_orphaned_root_over_legacy_tail` — PASS
- `test_migration_leaves_deliberate_feature_root_untouched` — PASS
- Full suites: **42 passed**
- `pyright`: 0 errors; `ruff` lint + format: clean; all pre-commit hooks pass.

The cross test is not a mock: it runs a real `LocalConversation` session to produce
a genuine event log, downgrades it to the pre-tree shape, appends the interrupted
artifact + the wrongly-`__root__` post-resume event, asserts history is orphaned
*before* migration, then resumes under this code and asserts (a) the event is
re-linked to the legacy tail, (b) all legacy events are reachable again in order,
(c) continuing the conversation chains onto the healed tail, and (d) the repair is
durable on disk after reopening the log.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The migration is idempotent: after healing, the event no longer has `__root__`, so
  a subsequent resume is a no-op.
- It only touches the resume path, never fresh conversation creation.
- Only rewrites the single offending event's `parent_id`; it never bulk-strips
  `parent_id`s or reorders the log.
