### PR TITLE
fix(mcp): handle SecretStr correctly during JSON deserialization

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -28,6 +28,7 @@ from openhands.sdk.utils.pydantic_secrets import (
     resolve_expose_mode,
     serialize_secret,
     validate_secret,
+    validate_secret_dict,
 )
 
 
@@ -46,17 +47,7 @@ def _serialize_optional_secret(
 
 
 def _validate_secret_map(value: object, info: ValidationInfo) -> object:
-    if not isinstance(value, dict):
-        return value
-    validated = {}
-    for key, item in value.items():
-        if isinstance(item, str | SecretStr):
-            secret = validate_secret(item, info)
-            if secret is not None:
-                validated[key] = secret
-        else:
-            validated[key] = item
-    return validated
+    return validate_secret_dict(value, info, description="MCP env")
 
 
 def _serialize_secret_map(

--- a/tests/sdk/mcp/test_mcp_config_deserialization.py
+++ b/tests/sdk/mcp/test_mcp_config_deserialization.py
@@ -1,0 +1,39 @@
+from pydantic import SecretStr
+
+from openhands.sdk.mcp.config import MCPServer
+from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.utils.cipher import Cipher
+
+
+def test_mcp_config_json_deserialization_with_cipher():
+    """Verify that AgentDefinition can be deserialized from JSON under a cipher context
+
+    when mcp_config contains encrypted SecretStr env variables.
+    """
+    cipher = Cipher("test-key")
+    agent_def = AgentDefinition(
+        name="web-researcher",
+        description="test",
+        mcp_config={
+            "tavily": MCPServer(
+                command="npx",
+                args=["-y", "tavily-mcp@0.2.1"],
+                env={"TAVILY_API_KEY": SecretStr("test-key")},
+            )
+        },
+        tools=["browser_tool_set"],
+        system_prompt="prompt",
+    )
+
+    # Serialize with cipher context (which encrypts SecretStr using cipher)
+    json_data = agent_def.model_dump_json(context={"cipher": cipher})
+
+    # Validate/deserialize with cipher context (which decrypts and validates them)
+    loaded = AgentDefinition.model_validate_json(json_data, context={"cipher": cipher})
+
+    assert loaded.mcp_config is not None
+    assert "tavily" in loaded.mcp_config
+    tavily_env = loaded.mcp_config["tavily"].env
+    assert tavily_env is not None
+    assert isinstance(tavily_env["TAVILY_API_KEY"], SecretStr)
+    assert tavily_env["TAVILY_API_KEY"].get_secret_value() == "test-key"


### PR DESCRIPTION
## Why

Related to OpenHands/OpenHands#15248.

Loading stored conversations containing MCP server configuration can fail during `model_validate_json` with a Pydantic validation error.

The root cause is that `_validate_secret_map` returns `SecretStr` objects during JSON deserialization. Under Pydantic's JSON-mode validation, dictionary values are expected to be plain strings before being converted into `SecretStr`, causing conversation restoration to fail.

## Summary

- Replace the custom secret mapping logic with `validate_secret_dict`.
- Return decrypted string values instead of `SecretStr` objects during JSON deserialization.
- Add a regression test covering MCP configuration deserialization.

## Testing

```bash
uv run pytest tests/sdk/mcp/test_mcp_config_deserialization.py
uv run pytest tests/sdk/mcp/
uv run ruff check
uv run ruff format --check
uv run pyright
```

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation