### PR TITLE
fix(mcp): validate secrets after parsing

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -31,10 +31,10 @@ from openhands.sdk.utils.pydantic_secrets import (
 )
 
 
-def _validate_optional_secret(value: object, info: ValidationInfo) -> object:
-    if isinstance(value, str | SecretStr):
-        return validate_secret(value, info)
-    return value
+def _validate_optional_secret(
+    value: SecretStr | None, info: ValidationInfo
+) -> SecretStr | None:
+    return validate_secret(value, info)
 
 
 def _serialize_optional_secret(
@@ -45,17 +45,14 @@ def _serialize_optional_secret(
     return cast(str | None, serialize_secret(value, info))
 
 
-def _validate_secret_map(value: object, info: ValidationInfo) -> object:
-    if not isinstance(value, dict):
-        return value
-    validated = {}
+def _validate_secret_map(
+    value: dict[str, SecretStr], info: ValidationInfo
+) -> dict[str, SecretStr]:
+    validated: dict[str, SecretStr] = {}
     for key, item in value.items():
-        if isinstance(item, str | SecretStr):
-            secret = validate_secret(item, info)
-            if secret is not None:
-                validated[key] = secret
-        else:
-            validated[key] = item
+        secret = validate_secret(item, info)
+        if secret is not None:
+            validated[key] = secret
     return validated
 
 
@@ -111,9 +108,11 @@ class MCPApiKeyAuthCredential(_MCPBaseModel):
     value: SecretStr | None = None
     header_name: str | None = None
 
-    @field_validator("value", mode="before")
+    @field_validator("value", mode="after")
     @classmethod
-    def _validate_value(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_value(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("value", when_used="always")
@@ -135,9 +134,11 @@ class MCPBearerAuthCredential(_MCPBaseModel):
     strategy: Literal["bearer"]
     value: SecretStr | None = None
 
-    @field_validator("value", mode="before")
+    @field_validator("value", mode="after")
     @classmethod
-    def _validate_value(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_value(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("value", when_used="always")
@@ -157,9 +158,11 @@ class MCPBasicAuthCredential(_MCPBaseModel):
     username: str
     password: SecretStr | None = None
 
-    @field_validator("password", mode="before")
+    @field_validator("password", mode="after")
     @classmethod
-    def _validate_password(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_password(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("password", when_used="always")
@@ -183,9 +186,11 @@ class MCPHeaderAuthCredential(_MCPBaseModel):
     strategy: Literal["header"]
     headers: dict[str, SecretStr] = Field(default_factory=dict)
 
-    @field_validator("headers", mode="before")
+    @field_validator("headers", mode="after")
     @classmethod
-    def _validate_headers(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_headers(
+        cls, value: dict[str, SecretStr], info: ValidationInfo
+    ) -> dict[str, SecretStr]:
         return _validate_secret_map(value, info)
 
     @field_serializer("headers", when_used="always")
@@ -204,9 +209,11 @@ class MCPOAuthTokenState(_MCPBaseModel):
     access_token: SecretStr | None = None
     refresh_token: SecretStr | None = None
 
-    @field_validator("access_token", "refresh_token", mode="before")
+    @field_validator("access_token", "refresh_token", mode="after")
     @classmethod
-    def _validate_secret(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_secret(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("access_token", "refresh_token", when_used="always")
@@ -221,9 +228,11 @@ class MCPOAuthClientInfoState(_MCPBaseModel):
 
     client_secret: SecretStr | None = None
 
-    @field_validator("client_secret", mode="before")
+    @field_validator("client_secret", mode="after")
     @classmethod
-    def _validate_client_secret(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_client_secret(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("client_secret", when_used="always")
@@ -257,9 +266,11 @@ class MCPOAuthAuthentication(_MCPBaseModel):
     client_secret: SecretStr | None = None
     additional_client_metadata: dict[str, Any] | None = None
 
-    @field_validator("client_secret", mode="before")
+    @field_validator("client_secret", mode="after")
     @classmethod
-    def _validate_client_secret(cls, value: object, info: ValidationInfo) -> object:
+    def _validate_client_secret(
+        cls, value: SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
         return _validate_optional_secret(value, info)
 
     @field_serializer("client_secret", when_used="always")
@@ -431,10 +442,14 @@ class MCPServer(_MCPBaseModel):
     headers: dict[str, SecretStr] | None = None
     auth: MCPAuthCredential | None = None
 
-    @field_validator("env", "headers", mode="before")
+    @field_validator("env", "headers", mode="after")
     @classmethod
-    def _validate_secret_mapping(cls, value: object, info: ValidationInfo) -> object:
-        return _validate_secret_map(value, info)
+    def _validate_secret_mapping(
+        cls,
+        value: dict[str, SecretStr] | None,
+        info: ValidationInfo,
+    ) -> dict[str, SecretStr] | None:
+        return _validate_secret_map(value, info) if value is not None else None
 
     @field_serializer("env", "headers", when_used="always")
     def _serialize_secret_mapping(

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -46,7 +46,10 @@ from openhands.sdk.event.llm_convertible import (
 from openhands.sdk.io.local import LocalFileStore
 from openhands.sdk.io.memory import InMemoryFileStore
 from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.mcp.config import coerce_mcp_config
 from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 from openhands.tools.terminal import TerminalAction, TerminalObservation
 from tests.agent_server.stress.scripts import (
@@ -1775,6 +1778,45 @@ class TestEventServiceSaveMeta:
         meta_file = conv_dir / "meta.json"
         loaded = StoredConversation.model_validate_json(meta_file.read_text())
         assert loaded.updated_at == original_updated_at
+
+    @pytest.mark.asyncio
+    async def test_save_meta_round_trips_agent_definition_mcp_secrets(
+        self, sample_stored_conversation, tmp_path
+    ):
+        cipher = Cipher("stored-conversation-mcp-secret")
+        sample_stored_conversation.agent_definitions = [
+            AgentDefinition(
+                name="web-researcher",
+                mcp_config=coerce_mcp_config(
+                    {
+                        "tavily": {
+                            "command": "npx",
+                            "args": ["-y", "tavily-mcp@0.2.1"],
+                            "env": {"TAVILY_API_KEY": "${TAVILY_API_KEY}"},
+                        }
+                    }
+                ),
+            )
+        ]
+        service = EventService(
+            stored=sample_stored_conversation,
+            conversations_dir=tmp_path,
+            cipher=cipher,
+        )
+        service.conversation_dir.mkdir(parents=True)
+
+        await service.save_meta()
+
+        payload = (service.conversation_dir / "meta.json").read_text()
+        assert "${TAVILY_API_KEY}" not in payload
+        loaded = StoredConversation.model_validate_json(
+            payload,
+            context={"cipher": cipher},
+        )
+        assert loaded.agent_definitions[0].mcp_config is not None
+        env = loaded.agent_definitions[0].mcp_config["tavily"].env
+        assert env is not None
+        assert env["TAVILY_API_KEY"].get_secret_value() == "${TAVILY_API_KEY}"
 
     @pytest.mark.asyncio
     async def test_switch_acp_model_persists_to_meta(self, tmp_path):

--- a/tests/sdk/mcp/test_mcp_config_secrets.py
+++ b/tests/sdk/mcp/test_mcp_config_secrets.py
@@ -1,0 +1,143 @@
+from openhands.sdk.mcp.config import coerce_mcp_config, dump_mcp_config
+from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
+
+
+def test_all_mcp_secret_fields_round_trip_through_encrypted_json() -> None:
+    raw_config = {
+        "stdio": {
+            "command": "echo",
+            "env": {"ENV_TOKEN": "env-secret"},
+            "headers": {"X-Top-Level": "header-secret"},
+        },
+        "header": {
+            "url": "https://example.com/header",
+            "auth": {
+                "strategy": "header",
+                "headers": {"X-Auth": "auth-header-secret"},
+            },
+        },
+        "api-key": {
+            "url": "https://example.com/api-key",
+            "auth": {"strategy": "api_key", "value": "api-key-secret"},
+        },
+        "bearer": {
+            "url": "https://example.com/bearer",
+            "auth": {"strategy": "bearer", "value": "bearer-secret"},
+        },
+        "basic": {
+            "url": "https://example.com/basic",
+            "auth": {
+                "strategy": "basic",
+                "username": "user",
+                "password": "basic-secret",
+            },
+        },
+        "oauth": {
+            "url": "https://example.com/oauth",
+            "auth": {
+                "strategy": "oauth2",
+                "authentication": {
+                    "type": "oauth",
+                    "client_id": "client-id",
+                    "client_secret": "oauth-config-secret",
+                },
+                "state": {
+                    "tokens": {
+                        "access_token": "oauth-access-secret",
+                        "refresh_token": "oauth-refresh-secret",
+                    },
+                    "client_info": {"client_secret": "oauth-state-secret"},
+                },
+            },
+        },
+    }
+    cipher = Cipher("mcp-secret-round-trip")
+    definition = AgentDefinition(
+        name="all-mcp-secrets",
+        mcp_config=coerce_mcp_config(raw_config),
+    )
+
+    payload = definition.model_dump_json(context={"cipher": cipher})
+    restored = AgentDefinition.model_validate_json(
+        payload,
+        context={"cipher": cipher},
+    )
+
+    assert restored.mcp_config is not None
+    assert dump_mcp_config(restored.mcp_config) == raw_config
+    for secret in (
+        "env-secret",
+        "header-secret",
+        "auth-header-secret",
+        "api-key-secret",
+        "bearer-secret",
+        "basic-secret",
+        "oauth-config-secret",
+        "oauth-access-secret",
+        "oauth-refresh-secret",
+        "oauth-state-secret",
+    ):
+        assert secret not in payload
+
+
+def test_mcp_secret_validation_drops_empty_and_redacted_values() -> None:
+    config = coerce_mcp_config(
+        {
+            "stdio": {
+                "command": "echo",
+                "env": {
+                    "EMPTY": "",
+                    "SPACE": " ",
+                    "MASK": REDACTED_SECRET_VALUE,
+                    "KEEP": "env-value",
+                },
+                "headers": {
+                    "EMPTY": "",
+                    "SPACE": " ",
+                    "MASK": REDACTED_SECRET_VALUE,
+                    "KEEP": "header-value",
+                },
+            },
+            "api-key": {
+                "url": "https://example.com/api-key",
+                "auth": {
+                    "strategy": "api_key",
+                    "value": REDACTED_SECRET_VALUE,
+                },
+            },
+            "oauth": {
+                "url": "https://example.com/oauth",
+                "auth": {
+                    "strategy": "oauth2",
+                    "authentication": {
+                        "type": "oauth",
+                        "client_secret": REDACTED_SECRET_VALUE,
+                    },
+                    "state": {
+                        "tokens": {"access_token": REDACTED_SECRET_VALUE},
+                    },
+                },
+            },
+        }
+    )
+
+    assert dump_mcp_config(config) == {
+        "stdio": {
+            "command": "echo",
+            "env": {"KEEP": "env-value"},
+            "headers": {"KEEP": "header-value"},
+        },
+        "api-key": {
+            "url": "https://example.com/api-key",
+            "auth": {"strategy": "api_key"},
+        },
+        "oauth": {
+            "url": "https://example.com/oauth",
+            "auth": {
+                "strategy": "oauth2",
+                "authentication": {"type": "oauth"},
+            },
+        },
+    }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix secrets pydantic validation 

---

AGENT:

## Why

Persisted conversations containing agent definitions with MCP secrets cannot be
loaded through Pydantic's JSON validation path. The MCP validators run before
core parsing but return final `SecretStr` objects, which JSON-mode validation
then rejects as non-string input.

## Summary

- Normalize every MCP secret after Pydantic parses its declared `SecretStr` type.
- Cover env/header maps and API key, bearer, basic, header, and OAuth credentials.
- Preserve encryption plus empty, whitespace, and redacted-value filtering.
- Exercise the real encrypted conversation metadata save/restart boundary.

## Issue Number

Closes #4096.

## How to Test

Run the regression and persistence tests:

```bash
uv run pytest -q tests/sdk/mcp/test_mcp_config_secrets.py \
  tests/agent_server/test_event_service.py::TestEventServiceSaveMeta::test_save_meta_round_trips_agent_definition_mcp_secrets
```

Local result: `3 passed`.

Run the two complete CI test domains:

```bash
CI=true uv run python -m pytest -q -n 4 \
  --basetemp=/tmp/sdk-4096-validation tests/sdk
CI=true uv run python -m pytest -q -n 4 tests/agent_server
```

Local results:

- SDK: `5401 passed, 9 skipped, 13 xfailed`
- Agent server: `1463 passed`

Run the repository-wide quality gate:

```bash
uv run pre-commit run --all-files --show-diff-on-failure
```

All hooks passed, including Ruff formatting/linting, pycodestyle, Pyright,
import dependency rules, and tool registration checks.

I also ran a production-path restart reproduction outside pytest:

1. Started a real `ConversationService` with four agent definitions and
   `web-researcher` at index 3.
2. Persisted its Tavily environment placeholder through encrypted `meta.json`.
3. Closed the service and constructed a new `ConversationService` from the same
   persistence directory and cipher.
4. Verified the conversation loaded and the decrypted placeholder remained
   `${TAVILY_API_KEY}`.

Observed output:

```text
agent_definitions=4
web_researcher_index=3
meta_secret=encrypted
restart=loaded
```

## Video/Screenshots

Not applicable; this is a server-side persistence fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This fixes the validation-phase mismatch rather than special-casing MCP env
maps. It therefore also covers scalar authentication and OAuth secrets that
would otherwise fail at the same JSON reload boundary.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d52dc56-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d52dc56-python \
  ghcr.io/openhands/agent-server:d52dc56-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d52dc56-golang-amd64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-golang-amd64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-golang-amd64
ghcr.io/openhands/agent-server:d52dc56-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d52dc56-golang-arm64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-golang-arm64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-golang-arm64
ghcr.io/openhands/agent-server:d52dc56-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d52dc56-java-amd64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-java-amd64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-java-amd64
ghcr.io/openhands/agent-server:d52dc56-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d52dc56-java-arm64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-java-arm64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-java-arm64
ghcr.io/openhands/agent-server:d52dc56-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d52dc56-python-amd64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-python-amd64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-python-amd64
ghcr.io/openhands/agent-server:d52dc56-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d52dc56-python-arm64
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-python-arm64
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-python-arm64
ghcr.io/openhands/agent-server:d52dc56-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d52dc56-golang
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-golang
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-golang
ghcr.io/openhands/agent-server:d52dc56-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d52dc56-java
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-java
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-java
ghcr.io/openhands/agent-server:d52dc56-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d52dc56-python
ghcr.io/openhands/agent-server:d52dc562962dc3eadc3db2bdb439df80207e171c-python
ghcr.io/openhands/agent-server:fix-mcp-secret-json-validation-python
ghcr.io/openhands/agent-server:d52dc56-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d52dc56-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d52dc56-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->