### PR TITLE
feat(agent-server): publish python-lite image

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -270,17 +270,38 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Explicit matrix: 3 variants × 2 architectures = 6 jobs
+                # Explicit matrix: 4 variants × 2 architectures = 8 jobs
                 # Each job specifies exactly what it builds and where it runs
                 include:
                     # Python variant
                     - variant: python
+                      custom_tags: python
+                      image_flavor: default
                       arch: amd64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: python
+                      custom_tags: python
+                      image_flavor: default
+                      arch: arm64
+                      base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
+                      runner: ubuntu-24.04-arm
+                      platform: linux/arm64
+
+                    # Python variant without preinstalled ACP providers
+                    - variant: python-lite
+                      custom_tags: python
+                      image_flavor: lite
+                      arch: amd64
+                      base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
+                      runner: ubuntu-24.04
+                      platform: linux/amd64
+
+                    - variant: python-lite
+                      custom_tags: python
+                      image_flavor: lite
                       arch: arm64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04-arm
@@ -288,12 +309,16 @@ jobs:
 
                     # Java variant
                     - variant: java
+                      custom_tags: java
+                      image_flavor: default
                       arch: amd64
                       base_image: eclipse-temurin:17-jdk
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: java
+                      custom_tags: java
+                      image_flavor: default
                       arch: arm64
                       base_image: eclipse-temurin:17-jdk
                       runner: ubuntu-24.04-arm
@@ -301,12 +326,16 @@ jobs:
 
                     # Golang variant
                     - variant: golang
+                      custom_tags: golang
+                      image_flavor: default
                       arch: amd64
                       base_image: golang:1.21-bookworm
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: golang
+                      custom_tags: golang
+                      image_flavor: default
                       arch: arm64
                       base_image: golang:1.21-bookworm
                       runner: ubuntu-24.04-arm
@@ -317,7 +346,8 @@ jobs:
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
             BASE_IMAGE: ${{ inputs.base_image != '' && inputs.base_image || matrix.base_image }}
-            CUSTOM_TAGS: ${{ matrix.variant }}
+            CUSTOM_TAGS: ${{ matrix.custom_tags }}
+            IMAGE_FLAVOR: ${{ matrix.image_flavor }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}
             TARGET: binary
@@ -402,6 +432,7 @@ jobs:
                       BASE_IMAGE=${{ env.BASE_IMAGE }}
                       OPENHANDS_BUILD_GIT_SHA=${{ env.SDK_SHA }}
                       OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}
+                      INSTALL_ACP=${{ steps.prep.outputs.install_acp }}
 
             - name: Cleanup build context
               if: always()
@@ -472,7 +503,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                variant: [python, java, golang]
+                variant: [python, python-lite, java, golang]
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
 

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -8,6 +8,7 @@ ARG USERNAME=openhands
 ARG UID=10001
 ARG GID=10001
 ARG PORT=8000
+ARG INSTALL_ACP=1
 # Opt-in build flag for the Vertex AI extra (`openhands-sdk[vertex]`). Off by
 # default to keep the published image lean. Pass `--build-arg ENABLE_VERTEX=1`
 # to bundle google-cloud-aiplatform so the resulting binary supports
@@ -85,7 +86,7 @@ RUN test -x /agent-server/dist/openhands-agent-server
 # Suitable for running in headless/evaluation mode.
 ####################################################################################
 FROM ${BASE_IMAGE} AS base-image-minimal
-ARG USERNAME UID GID PORT
+ARG USERNAME UID GID PORT INSTALL_ACP
 
 
 ARG OPENHANDS_BUILD_GIT_SHA=unknown
@@ -160,7 +161,11 @@ RUN set -eux; \
 # 22 glibc tarball. When that happens we leave $ACP_NODE_DIR empty and skip
 # ACP setup so the rest of the build (and non-ACP agents) still work.
 ENV ACP_NODE_DIR=/opt/acp-node
-RUN set -ux; \
+RUN if [ "${INSTALL_ACP}" != "1" ]; then \
+      echo "Skipping preinstalled ACP providers"; \
+      exit 0; \
+    fi; \
+    set -ux; \
     mkdir -p "$ACP_NODE_DIR"; \
     ARCH=$(uname -m); \
     NARCH=""; \

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -27,6 +27,7 @@ import time
 import tomllib
 from contextlib import chdir
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -383,6 +384,7 @@ class BuildOptions(BaseModel):
         default="", description="Comma-separated list of custom tags."
     )
     image: str = Field(default="ghcr.io/openhands/agent-server")
+    image_flavor: Literal["default", "lite"] = Field(default="default")
     target: TargetType = Field(default="binary")
     platforms: list[PlatformType] = Field(default=["linux/amd64"])
     push: bool | None = Field(
@@ -493,18 +495,26 @@ class BuildOptions(BaseModel):
         if not self.release_tag_source:
             return []
         return [
-            f"{release_tag}-{custom_tag}"
+            f"{release_tag}-{custom_tag}{self.flavor_suffix}"
             for custom_tag in self.custom_tag_list
             for release_tag in _release_tag_aliases(self.release_tag_source)
         ]
 
     @property
+    def flavor_suffix(self) -> str:
+        return "" if self.image_flavor == "default" else f"-{self.image_flavor}"
+
+    @property
+    def install_acp(self) -> bool:
+        return self.image_flavor != "lite"
+
+    @property
     def base_tag(self) -> str:
-        return f"{self.short_sha}-{self.base_image_slug}"
+        return f"{self.short_sha}-{self.base_image_slug}{self.flavor_suffix}"
 
     @property
     def cache_tags(self) -> tuple[str, str]:
-        base = f"buildcache-{self.target}-{self.base_image_slug}"
+        base = f"buildcache-{self.target}-{self.base_image_slug}{self.flavor_suffix}"
         if self.git_ref in ("main", "refs/heads/main"):
             return f"{base}-main", base
         elif self.git_ref != "unknown":
@@ -518,6 +528,7 @@ class BuildOptions(BaseModel):
         arch_suffix = f"-{self.arch}" if self.arch else ""
 
         for custom_tag in self.custom_tag_list:
+            custom_tag = f"{custom_tag}{self.flavor_suffix}"
             tags.extend(
                 [
                     f"{self.image}:{self.short_sha}-{custom_tag}{arch_suffix}",
@@ -834,6 +845,8 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
         f"OPENHANDS_BUILD_GIT_SHA={opts.git_sha}",
         "--build-arg",
         f"OPENHANDS_BUILD_GIT_REF={opts.git_ref}",
+        "--build-arg",
+        f"INSTALL_ACP={int(opts.install_acp)}",
     ]
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]
@@ -998,6 +1011,12 @@ def main(argv: list[str]) -> int:
         help="Image repo/name (default from $IMAGE).",
     )
     parser.add_argument(
+        "--image-flavor",
+        default=_env("IMAGE_FLAVOR", "default"),
+        choices=("default", "lite"),
+        help="Image flavor (default from $IMAGE_FLAVOR).",
+    )
+    parser.add_argument(
         "--target",
         default=_env("TARGET", "binary"),
         choices=sorted(VALID_TARGETS),
@@ -1073,6 +1092,7 @@ def main(argv: list[str]) -> int:
             base_image=args.base_image,
             custom_tags=args.custom_tags,
             image=args.image,
+            image_flavor=args.image_flavor,
             target=args.target,  # type: ignore
             platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
             push=None,  # Not relevant for build-ctx-only
@@ -1095,6 +1115,7 @@ def main(argv: list[str]) -> int:
                 else:
                     fh.write("versioned_tags_csv=\n")
                 fh.write(f"base_image_slug={opts.base_image_slug}\n")
+                fh.write(f"install_acp={int(opts.install_acp)}\n")
             logger.info("[build] Wrote outputs to $GITHUB_OUTPUT")
 
         # Also print to stdout for debugging/local use
@@ -1121,6 +1142,7 @@ def main(argv: list[str]) -> int:
         base_image=args.base_image,
         custom_tags=args.custom_tags,
         image=args.image,
+        image_flavor=args.image_flavor,
         target=args.target,  # type: ignore
         platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
         push=push,

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import tarfile
 from pathlib import Path
+from typing import Literal
 from unittest.mock import patch
 
 import pytest
@@ -454,6 +455,29 @@ def test_all_tags_include_short_long_sha_and_branch():
     ]
 
 
+def test_lite_flavor_has_distinct_image_and_cache_tags():
+    from openhands.agent_server.docker.build import BuildOptions
+
+    opts = BuildOptions(
+        base_image="python:3.13",
+        custom_tags="python",
+        git_sha="abc1234567890fedcba",
+        git_ref="refs/heads/main",
+        image_flavor="lite",
+        include_base_tag=False,
+    )
+
+    assert opts.all_tags == [
+        "ghcr.io/openhands/agent-server:abc1234-python-lite",
+        "ghcr.io/openhands/agent-server:abc1234567890fedcba-python-lite",
+        "ghcr.io/openhands/agent-server:main-python-lite",
+    ]
+    assert opts.cache_tags == (
+        "buildcache-binary-python_tag_3.13-lite-main",
+        "buildcache-binary-python_tag_3.13-lite",
+    )
+
+
 def test_all_tags_includes_versioned_tags():
     """Test that all_tags includes bare semver aliases when enabled for a tag build."""
     from openhands.agent_server.docker.build import BuildOptions
@@ -802,6 +826,52 @@ def test_build_with_telemetry_returns_parsed_buildkit_fields(tmp_path: Path):
     assert result.telemetry.export_manifest_seconds == 3.7
     assert result.telemetry.cache_import_miss_count == 1
     assert result.telemetry.cached_step_count == 1
+
+
+@pytest.mark.parametrize(
+    ("image_flavor", "install_acp"), (("default", "1"), ("lite", "0"))
+)
+def test_image_flavor_controls_acp_build_arg(
+    tmp_path: Path,
+    image_flavor: Literal["default", "lite"],
+    install_acp: str,
+):
+    from openhands.agent_server.docker.build import (
+        BuildOptions,
+        _default_sdk_project_root,
+        build,
+    )
+
+    ctx = tmp_path / "ctx"
+    ctx.mkdir()
+    docker_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: str | None = None):
+        if cmd[:3] == ["docker", "buildx", "inspect"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="Driver: docker\n")
+        docker_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    opts = BuildOptions(
+        custom_tags="python",
+        git_sha="abc1234567890",
+        git_ref="refs/heads/main",
+        image_flavor=image_flavor,
+        push=True,
+        sdk_project_root=_default_sdk_project_root(),
+    )
+
+    with (
+        patch(
+            "openhands.agent_server.docker.build._make_build_context",
+            return_value=ctx,
+        ),
+        patch("openhands.agent_server.docker.build._run", side_effect=fake_run),
+        patch("openhands.agent_server.docker.build.shutil.rmtree"),
+    ):
+        build(opts)
+
+    assert f"INSTALL_ACP={install_acp}" in docker_calls[0]
 
 
 def test_build_with_telemetry_preserves_telemetry_on_failure(tmp_path: Path):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Add a lite image flavor that skips preinstalled ACP providers and namespaces its image/cache tags with -lite.


---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The published Python agent-server image preinstalls three ACP providers and a dedicated Node runtime under `/opt/acp-node`. That payload is useful for offline/immediate ACP startup, but it adds roughly 1.2 GB even for clients that can install the selected provider on first use.

This adds an opt-in lighter image without changing any existing image tag or build target.

## Summary

- Add a `lite` image flavor that skips preinstalled ACP providers and namespaces its image/cache tags with `-lite`.
- Publish multi-arch `python-lite` images alongside the existing `python`, `java`, and `golang` images.
- Keep the default flavor ACP-preloaded and cover both build modes with tag and build-argument tests.

## Issue Number

Closes #4067

## How to Test

Unit/static verification:

```bash
.venv/bin/pytest tests/agent_server/test_docker_build.py -q
# 42 passed

UV_FROZEN=1 .venv/bin/pre-commit run --files \
  openhands-agent-server/openhands/agent_server/docker/build.py \
  tests/agent_server/test_docker_build.py \
  openhands-agent-server/openhands/agent_server/docker/Dockerfile \
  .github/workflows/server.yml
# all hooks passed
```

Built the full binary image (not only a base stage):

```bash
.venv/bin/python openhands-agent-server/openhands/agent_server/docker/build.py \
  --load \
  --image local/openhands-agent-server \
  --custom-tags python \
  --image-flavor lite \
  --platforms linux/arm64
# target='binary', INSTALL_ACP=0, completed in 497.372s
```

Verified the final image payload and launched the real server:

```bash
docker run --rm --entrypoint /bin/sh \
  local/openhands-agent-server:agent-server-python-lite-python-lite \
  -lc 'test ! -e /opt/acp-node && ! command -v claude-agent-acp && ! command -v codex-acp && ! command -v gemini && test -x /usr/local/bin/openhands-agent-server'

docker run -d --name agent-server-lite -p 127.0.0.1:18080:8000 \
  local/openhands-agent-server:agent-server-python-lite-python-lite --port 8000

curl -fsS http://127.0.0.1:18080/health
# {"status":"ok"}

curl -fsS http://127.0.0.1:18080/server_info
# version: 1.35.0
```

The locally built lite image was 3.67 GB unpacked. The available `1.30.0-python` full image was 5.26 GB; because those commits differ, this is directional rather than a controlled size comparison.

## Video/Screenshots

Not applicable; this is an image/build change. Runtime output is included above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Existing tags and clients remain on the ACP-preloaded default:

- OpenHands continues to use `*-python`.
- Benchmarks continue to build `source-minimal` with `INSTALL_ACP=1` by default.
- Agent Canvas will opt into `python-lite` in a coordinated PR and use the SDK's pinned `npx` provider commands on first ACP use.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python-lite | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3068661-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3068661-python \
  ghcr.io/openhands/agent-server:3068661-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3068661-golang-amd64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-golang-amd64
ghcr.io/openhands/agent-server:agent-server-python-lite-golang-amd64
ghcr.io/openhands/agent-server:3068661-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3068661-golang-arm64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-golang-arm64
ghcr.io/openhands/agent-server:agent-server-python-lite-golang-arm64
ghcr.io/openhands/agent-server:3068661-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3068661-java-amd64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-java-amd64
ghcr.io/openhands/agent-server:agent-server-python-lite-java-amd64
ghcr.io/openhands/agent-server:3068661-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3068661-java-arm64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-java-arm64
ghcr.io/openhands/agent-server:agent-server-python-lite-java-arm64
ghcr.io/openhands/agent-server:3068661-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3068661-python-amd64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python-amd64
ghcr.io/openhands/agent-server:agent-server-python-lite-python-amd64
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3068661-python-arm64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python-arm64
ghcr.io/openhands/agent-server:agent-server-python-lite-python-arm64
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3068661-python-lite-amd64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python-lite-amd64
ghcr.io/openhands/agent-server:agent-server-python-lite-python-lite-amd64
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-lite-amd64
ghcr.io/openhands/agent-server:3068661-python-lite-arm64
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python-lite-arm64
ghcr.io/openhands/agent-server:agent-server-python-lite-python-lite-arm64
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-lite-arm64
ghcr.io/openhands/agent-server:3068661-golang
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-golang
ghcr.io/openhands/agent-server:agent-server-python-lite-golang
ghcr.io/openhands/agent-server:3068661-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3068661-java
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-java
ghcr.io/openhands/agent-server:agent-server-python-lite-java
ghcr.io/openhands/agent-server:3068661-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3068661-python-lite
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python-lite
ghcr.io/openhands/agent-server:agent-server-python-lite-python-lite
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-lite
ghcr.io/openhands/agent-server:3068661-python
ghcr.io/openhands/agent-server:3068661ab37783790bde5ac7eb6a357659a188c3-python
ghcr.io/openhands/agent-server:agent-server-python-lite-python
ghcr.io/openhands/agent-server:3068661-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3068661-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3068661-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->