### PR TITLE
feat: surface plugin contents in the agent-server plugins API

### DIFF
--- a/openhands-agent-server/openhands/agent_server/plugins_router.py
+++ b/openhands-agent-server/openhands/agent_server/plugins_router.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 from openhands.agent_server.plugins_service import (
     MarketplacePluginInfo,
+    PluginSkillSummary,
     service_disable_plugin,
     service_enable_plugin,
     service_get_installed_plugin,
@@ -23,11 +24,13 @@ from openhands.agent_server.plugins_service import (
     service_install_plugin,
     service_list_available_plugins,
     service_list_installed_plugins,
+    service_load_plugin_contents,
+    service_plugin_contents,
     service_uninstall_plugin,
     service_update_plugin,
 )
 from openhands.sdk.extensions.fetch import ExtensionFetchError
-from openhands.sdk.plugin import InstalledPluginInfo, PluginFetchError
+from openhands.sdk.plugin import InstalledPluginInfo, Plugin, PluginFetchError
 
 
 plugins_router = APIRouter(prefix="/plugins", tags=["Plugins"])
@@ -73,6 +76,14 @@ class PluginInfo(BaseModel):
     name: str
     version: str = ""
     description: str = ""
+    path: str = Field(default="", description="Path to the plugin directory")
+    skills: list[PluginSkillSummary] = Field(
+        default_factory=list, description="Skills bundled in the plugin"
+    )
+    files: list[str] = Field(
+        default_factory=list,
+        description="Plugin files, relative to the plugin directory",
+    )
 
 
 class PluginsResponse(BaseModel):
@@ -119,6 +130,14 @@ class InstalledPluginResponse(BaseModel):
     )
     installed_at: str = Field(description="ISO 8601 timestamp of installation")
     install_path: str = Field(description="Path where the plugin is installed")
+    skills: list[PluginSkillSummary] | None = Field(
+        default=None,
+        description="Skills bundled in the plugin (None if it failed to load)",
+    )
+    files: list[str] | None = Field(
+        default=None,
+        description="Plugin files, relative to install_path (None if load failed)",
+    )
 
     @classmethod
     def from_plugin_info(cls, info: InstalledPluginInfo) -> "InstalledPluginResponse":
@@ -173,6 +192,28 @@ class MarketplaceCatalogResponse(BaseModel):
     plugins: list[MarketplacePluginInfo]
 
 
+def _installed_response(info: InstalledPluginInfo) -> InstalledPluginResponse:
+    """Build an installed-plugin response enriched with the plugin's contents."""
+    response = InstalledPluginResponse.from_plugin_info(info)
+    contents = service_load_plugin_contents(info.install_path)
+    if contents is not None:
+        response.skills, response.files = contents
+    return response
+
+
+def _plugin_info(plugin: Plugin) -> PluginInfo:
+    """Build an available-plugin summary including its contents."""
+    skills, files = service_plugin_contents(plugin)
+    return PluginInfo(
+        name=plugin.name,
+        version=plugin.version,
+        description=plugin.description,
+        path=plugin.path,
+        skills=skills,
+        files=files,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -193,12 +234,7 @@ def get_plugins(request: PluginsRequest) -> PluginsResponse:
         load_project=request.load_project,
         project_dir=request.project_dir,
     )
-    return PluginsResponse(
-        plugins=[
-            PluginInfo(name=p.name, version=p.version, description=p.description)
-            for p in plugins
-        ]
-    )
+    return PluginsResponse(plugins=[_plugin_info(p) for p in plugins])
 
 
 @plugins_router.post(
@@ -219,7 +255,7 @@ def install_plugin_endpoint(request: InstallPluginRequest) -> InstalledPluginRes
             repo_path=request.repo_path,
             force=request.force,
         )
-        return InstalledPluginResponse.from_plugin_info(info)
+        return _installed_response(info)
     except FileExistsError:
         raise HTTPException(
             status_code=409,
@@ -242,7 +278,7 @@ def list_installed_plugins_endpoint() -> InstalledPluginsListResponse:
     """List all installed plugins (enabled and disabled)."""
     plugins = service_list_installed_plugins()
     return InstalledPluginsListResponse(
-        plugins=[InstalledPluginResponse.from_plugin_info(info) for info in plugins]
+        plugins=[_installed_response(info) for info in plugins]
     )
 
 
@@ -261,7 +297,7 @@ def get_installed_plugin_endpoint(
             status_code=404,
             detail=f"Plugin '{plugin_name}' is not installed",
         )
-    return InstalledPluginResponse.from_plugin_info(info)
+    return _installed_response(info)
 
 
 @plugins_router.patch(
@@ -312,7 +348,7 @@ def refresh_plugin_endpoint(plugin_name: PluginNamePath) -> UpdatePluginResponse
         )
     return UpdatePluginResponse(
         message=f"Plugin '{plugin_name}' updated",
-        plugin=InstalledPluginResponse.from_plugin_info(info),
+        plugin=_installed_response(info),
     )
 
 

--- a/openhands-agent-server/openhands/agent_server/plugins_service.py
+++ b/openhands-agent-server/openhands/agent_server/plugins_service.py
@@ -14,6 +14,7 @@ counterparts (``skills_service.py``) so the router stays focused on HTTP:
 """
 
 import json
+import os
 from pathlib import Path
 from time import monotonic
 
@@ -128,6 +129,73 @@ def service_list_available_plugins(
 
 
 # ---------------------------------------------------------------------------
+# Plugin contents (bundled skills + file listing)
+# ---------------------------------------------------------------------------
+
+# Directories never listed in a plugin's file tree. Whole-repo installs copy
+# the fetched clone verbatim (including ``.git``), which would flood the
+# listing with repository internals.
+_PLUGIN_FILES_EXCLUDED_DIRS = {".git"}
+# Upper bound on listed files so a pathological plugin (e.g. a whole-repo
+# install of a large repository) cannot bloat API payloads.
+_PLUGIN_FILES_LIMIT = 2000
+
+
+class PluginSkillSummary(BaseModel):
+    """Summary of a skill bundled in a plugin."""
+
+    name: str
+    description: str | None = None
+
+
+def _list_plugin_files(root: Path) -> list[str]:
+    """List a plugin directory's files as sorted, POSIX, root-relative paths.
+
+    Uses ``os.walk`` so excluded directories are pruned before being descended
+    into, and symlinked directories are never followed (real plugins ship
+    manifest-dir symlinks such as ``.claude-plugin -> .plugin``).
+    """
+    files: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _PLUGIN_FILES_EXCLUDED_DIRS]
+        for filename in filenames:
+            files.append((Path(dirpath) / filename).relative_to(root).as_posix())
+    files.sort()
+    return files[:_PLUGIN_FILES_LIMIT]
+
+
+def service_plugin_contents(
+    plugin: Plugin,
+) -> tuple[list[PluginSkillSummary], list[str]]:
+    """Contents of an already-loaded plugin: bundled skills + file listing.
+
+    Skills include command-derived ones (``<plugin>:<command>``), matching what
+    the plugin actually contributes to a conversation.
+    """
+    skills = [
+        PluginSkillSummary(name=skill.name, description=skill.description)
+        for skill in plugin.get_all_skills()
+    ]
+    return skills, _list_plugin_files(Path(plugin.path))
+
+
+def service_load_plugin_contents(
+    plugin_dir: str | Path,
+) -> tuple[list[PluginSkillSummary], list[str]] | None:
+    """Load a plugin directory's contents, or None if it cannot be loaded.
+
+    Never raises: a corrupt or vanished plugin directory must not break the
+    listings that embed these contents.
+    """
+    try:
+        plugin = Plugin.load(plugin_dir)
+    except Exception as e:
+        logger.warning(f"Failed to load plugin contents from {plugin_dir}: {e}")
+        return None
+    return service_plugin_contents(plugin)
+
+
+# ---------------------------------------------------------------------------
 # Plugins-only marketplace catalog
 # ---------------------------------------------------------------------------
 
@@ -151,6 +219,12 @@ class MarketplacePluginInfo(BaseModel):
     ref: str | None = None
     repo_path: str | None = None
     installed: bool
+    # Local contents — populated when the entry resolves to a directory in the
+    # local marketplace clone; None when contents are not locally available
+    # (e.g. a structured source pointing at another repository).
+    path: str | None = None
+    skills: list[PluginSkillSummary] | None = None
+    files: list[str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -163,9 +237,13 @@ class MarketplacePluginInfo(BaseModel):
 # transient fetch failure) is NOT cached, so one flaky fetch does not blank the
 # catalog for the whole TTL.
 #
-# Type: (timestamp, list-of-(name, description, source, ref, repo_path)) or None
-_PluginCatalogEntry = tuple[str, str | None, str, str | None, str | None]
-_plugin_catalog_cache: tuple[float, list[_PluginCatalogEntry]] | None = None
+# Cached entries are full MarketplacePluginInfo objects (including contents)
+# stored with ``installed=False``; serving stamps the fresh installed flag via
+# a shallow ``model_copy``, so the ``skills``/``files`` lists are shared across
+# requests — they are never mutated after construction.
+#
+# Type: (timestamp, catalog entries with installed=False) or None
+_plugin_catalog_cache: tuple[float, list[MarketplacePluginInfo]] | None = None
 _PLUGIN_CATALOG_TTL_SECONDS = 300  # 5 minutes
 
 
@@ -211,15 +289,8 @@ def service_get_plugins_marketplace_catalog(
         p.name for p in list_installed_plugins(installed_dir=installed_dir)
     }
     return [
-        MarketplacePluginInfo(
-            name=name,
-            description=desc,
-            source=src,
-            ref=ref,
-            repo_path=repo_path,
-            installed=name in installed_names,
-        )
-        for name, desc, src, ref, repo_path in entries
+        entry.model_copy(update={"installed": entry.name in installed_names})
+        for entry in entries
     ]
 
 
@@ -238,12 +309,15 @@ def _is_true_plugin(raw_source: object) -> bool:
     return subpath.startswith(_PLUGINS_SUBPATH_PREFIX)
 
 
-def _fetch_plugin_catalog_entries(marketplace_path: str) -> list[_PluginCatalogEntry]:
+def _fetch_plugin_catalog_entries(
+    marketplace_path: str,
+) -> list[MarketplacePluginInfo]:
     """Fetch the marketplace and keep only true plugins.
 
-    Slow path: git fetch + read the marketplace JSON. Returns
-    ``(name, description, source, ref, repo_path)`` tuples, or an empty list on
-    error.
+    Slow path: git fetch + read the marketplace JSON. Returns catalog entries
+    with ``installed=False`` (the caller stamps the fresh value), enriched with
+    local contents (``path``/``skills``/``files``) when an entry resolves to a
+    directory inside the local clone. Returns an empty list on error.
     """
     cache_dir = get_skills_cache_dir()
     repo_path = update_skills_repository(
@@ -282,7 +356,7 @@ def _fetch_plugin_catalog_entries(marketplace_path: str) -> list[_PluginCatalogE
             logger.warning(f"Failed to load marketplace: {e}, {e2}")
             return []
 
-    entries: list[_PluginCatalogEntry] = []
+    entries: list[MarketplacePluginInfo] = []
     for plugin in marketplace.plugins:
         if not _is_true_plugin(plugin.source):
             continue
@@ -290,6 +364,29 @@ def _fetch_plugin_catalog_entries(marketplace_path: str) -> list[_PluginCatalogE
         # this yields an absolute path with ref/repo_path None; structured
         # github/url sources yield their ref + subpath.
         source, ref, repo_path = marketplace.resolve_plugin_source(plugin)
-        entries.append((plugin.name, plugin.description, source, ref, repo_path))
+        entry = MarketplacePluginInfo(
+            name=plugin.name,
+            description=plugin.description,
+            source=source,
+            ref=ref,
+            repo_path=repo_path,
+            installed=False,
+        )
+        # A local ./plugins/<name> entry resolves to a directory inside the
+        # cached clone, so its contents can be loaded from disk. Structured
+        # github/url sources may point at other repositories — no local copy,
+        # so their contents stay None.
+        if ref is None and repo_path is None and Path(source).is_dir():
+            contents = service_load_plugin_contents(source)
+            if contents is not None:
+                skills, files = contents
+                entry = entry.model_copy(
+                    update={
+                        "path": to_posix_path(source),
+                        "skills": skills,
+                        "files": files,
+                    }
+                )
+        entries.append(entry)
 
     return entries

--- a/tests/agent_server/test_plugins_router.py
+++ b/tests/agent_server/test_plugins_router.py
@@ -107,6 +107,52 @@ def test_refresh_returns_updated_plugin(client: TestClient, tmp_path: Path):
     assert refreshed.json()["plugin"]["name"] == "demo-plugin"
 
 
+def test_installed_plugin_carries_bundled_skills(client: TestClient, tmp_path: Path):
+    src = _make_installable_plugin(tmp_path / "src", "demo-plugin")
+    commands = src / "commands"
+    commands.mkdir()
+    (commands / "greet.md").write_text("---\ndescription: Say hello\n---\nHello!")
+    client.post("/plugins/install", json={"source": str(src)})
+
+    listed = client.get("/plugins/installed")
+
+    assert listed.status_code == 200
+    assert listed.json()["plugins"][0]["skills"] == [
+        {"name": "demo-plugin:greet", "description": "Say hello"}
+    ]
+
+
+def test_installed_plugin_lists_files_excluding_git_internals(
+    client: TestClient, tmp_path: Path
+):
+    src = _make_installable_plugin(tmp_path / "src", "demo-plugin")
+    (src / "README.md").write_text("# Demo")
+    (src / ".git").mkdir()
+    (src / ".git" / "config").write_text("[core]")
+    client.post("/plugins/install", json={"source": str(src)})
+
+    got = client.get("/plugins/installed/demo-plugin")
+
+    assert got.status_code == 200
+    assert got.json()["files"] == [".plugin/plugin.json", "README.md"]
+
+
+def test_corrupt_installed_plugin_degrades_to_metadata_only(
+    client: TestClient, tmp_path: Path
+):
+    src = _make_installable_plugin(tmp_path / "src", "demo-plugin")
+    install = client.post("/plugins/install", json={"source": str(src)})
+    manifest = Path(install.json()["install_path"]) / ".plugin" / "plugin.json"
+    manifest.write_text("{not json")
+
+    got = client.get("/plugins/installed/demo-plugin")
+
+    assert got.status_code == 200
+    assert got.json()["name"] == "demo-plugin"
+    assert got.json()["skills"] is None
+    assert got.json()["files"] is None
+
+
 def test_list_available_returns_plugin_summaries(
     client: TestClient, tmp_path: Path, monkeypatch
 ):
@@ -130,6 +176,9 @@ def test_list_available_returns_plugin_summaries(
                 "name": "available-plugin",
                 "version": "1.0.0",
                 "description": "available-plugin",
+                "path": plugin.path,
+                "skills": [],
+                "files": [".plugin/plugin.json"],
             }
         ]
     }

--- a/tests/agent_server/test_plugins_service.py
+++ b/tests/agent_server/test_plugins_service.py
@@ -186,6 +186,79 @@ def test_catalog_marks_installed_plugins(tmp_path: Path, monkeypatch):
     assert installed_by_name["available-plugin"] is False
 
 
+def test_catalog_enriches_local_plugin_entries_with_contents(
+    tmp_path: Path, monkeypatch
+):
+    # Arrange: the catalog entry's ./plugins/ source exists inside the repo
+    # clone, with a bundled skill and a docs file.
+    repo = _write_marketplace(
+        tmp_path / "ext",
+        [{"name": "local-plugin", "source": "./plugins/local-plugin"}],
+    )
+    plugin_dir = _make_installable_plugin(
+        repo / "plugins" / "local-plugin", "local-plugin"
+    )
+    skill_dir = plugin_dir / "skills" / "hello"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: hello\ndescription: Say hello politely\n---\nGreet the user."
+    )
+    (plugin_dir / "README.md").write_text("# Local plugin")
+    monkeypatch.setattr(
+        plugins_service, "update_skills_repository", lambda *a, **k: repo
+    )
+    installed = tmp_path / "installed"
+    installed.mkdir()
+
+    # Act
+    catalog = service_get_plugins_marketplace_catalog(installed_dir=installed)
+
+    # Assert: the entry carries its locally-loadable contents.
+    entry = catalog[0]
+    assert entry.path is not None
+    assert entry.path.endswith("plugins/local-plugin")
+    assert [(s.name, s.description) for s in entry.skills or []] == [
+        ("hello", "Say hello politely")
+    ]
+    assert entry.files == [
+        ".plugin/plugin.json",
+        "README.md",
+        "skills/hello/SKILL.md",
+    ]
+
+
+def test_catalog_leaves_contents_unset_for_remote_sources(tmp_path: Path, monkeypatch):
+    # Arrange: a structured github source — the plugin lives in another
+    # repository, so there is no local copy to load contents from.
+    repo = _write_marketplace(
+        tmp_path / "ext",
+        [
+            {
+                "name": "gh-plugin",
+                "source": {
+                    "source": "github",
+                    "repo": "owner/repo",
+                    "ref": "v1.0.0",
+                    "path": "plugins/gh-plugin",
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        plugins_service, "update_skills_repository", lambda *a, **k: repo
+    )
+    installed = tmp_path / "installed"
+    installed.mkdir()
+
+    # Act
+    catalog = service_get_plugins_marketplace_catalog(installed_dir=installed)
+
+    # Assert
+    assert catalog[0].path is None
+    assert catalog[0].skills is None
+    assert catalog[0].files is None
+
+
 class TestPluginsMarketplaceRoute:
     def test_marketplace_route_returns_plugins_payload(self, monkeypatch):
         # Arrange
@@ -222,6 +295,9 @@ class TestPluginsMarketplaceRoute:
                     "ref": "v1",
                     "repo_path": "plugins/p",
                     "installed": True,
+                    "path": None,
+                    "skills": None,
+                    "files": None,
                 }
             ]
         }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

**End-to-end verification** (not just unit tests). I started a real uvicorn server that mounts the actual `plugins_router` under `/api` (install store redirected to a temp dir) and drove the new fields with a real `httpx` client over a live socket — plus the full test/lint/type suite for the changed area.

```
# 1. Unit + endpoint tests (drive the real FastAPI routes against on-disk plugins)
$ uv run pytest tests/agent_server/test_plugins_router.py \
                tests/agent_server/test_plugins_service.py -q
17 passed in 0.26s        # 10 router + 7 service; 5 of them new

$ uv run ruff check <changed files>
All checks passed!

$ uv run pyright plugins_router.py plugins_service.py
0 errors, 0 warnings, 0 informations

```

```jsonc
# 2. Live server over real HTTP (uvicorn + httpx), abridged responses:

# Install then read back the installed copy — command-derived skill + files,
# with .git/config correctly pruned from the listing:
GET /api/plugins/installed/city-weather  -> 200
{
  "name": "city-weather",
  "skills": [ { "name": "city-weather:now", "description": "Report the current weather" } ],
  "files":  [ ".plugin/plugin.json", "README.md", "commands/now.md" ]
}

# Ambient plugins via POST /api/plugins carry path/skills/files, including both
# SKILL.md-derived and command-derived skills:
POST /api/plugins  -> 200
{ "name": "hello-local",
  "skills": [ { "name": "hello-local-greeting", ... }, { "name": "hello-local:greet", ... } ],
  "files":  [ ".plugin/plugin.json", "README.md", "commands/greet.md", "skills/greet/SKILL.md" ] }

# Corrupt the manifest on disk, re-fetch — metadata-only, no 500:
GET /api/plugins/installed/city-weather  -> 200
{ "name": "city-weather", "skills": null, "files": null }

```

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

Plugins can be opened in the GUI's **Customize > Plugins** view, but the detail modal only shows metadata — there is no visibility into what a plugin contains (Linear APP-2701). The agent-server plugins API never surfaced contents even though the SDK already parses bundled skills, commands, and files from disk, so the GUI has nothing to render.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `InstalledPluginResponse` gains optional `skills`/`files` (relative to `install_path`), populated for install/list/get/refresh via a shared helper; `None` when the plugin directory fails to load, so a corrupt plugin can never break a listing.
- `PluginInfo` (`POST /api/plugins`) gains `path`/`skills`/`files` from the already-loaded `Plugin` objects; `MarketplacePluginInfo` gains the same for catalog entries that resolve to a directory in the local extensions clone (remote sources stay `None`), with the cache now storing full entries and stamping a fresh `installed` flag per request.
- Skills come from `Plugin.get_all_skills()` (command-derived `:` skills included); file listings walk with `os.walk`, prune `.git`, never follow symlinked directories, and are capped at 2000 sorted POSIX paths.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `c5379ec3f852` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1434,0 +1435 @@
+schema InstalledPluginResponse property files optional schema=anyOf=[type="array" items=type="string",type="null"]
@@ -1439,0 +1441 @@
+schema InstalledPluginResponse property skills optional schema=anyOf=[type="array" items=PluginSkillSummary,type="null"]
@@ -1775,0 +1778 @@
+schema MarketplacePluginInfo property files optional schema=anyOf=[type="array" items=type="string",type="null"]
@@ -1777,0 +1781 @@
+schema MarketplacePluginInfo property path optional schema=anyOf=[type="string",type="null"]
@@ -1779,0 +1784 @@
+schema MarketplacePluginInfo property skills optional schema=anyOf=[type="array" items=PluginSkillSummary,type="null"]
@@ -1915,0 +1921 @@
+schema PluginInfo property files optional schema=type="array" items=type="string"
@@ -1916,0 +1923,2 @@
+schema PluginInfo property path optional schema=type="string" default=""
+schema PluginInfo property skills optional schema=type="array" items=PluginSkillSummary
@@ -1918,0 +1927,3 @@
+schema PluginSkillSummary property description optional schema=anyOf=[type="string",type="null"]
+schema PluginSkillSummary property name required schema=type="string"
+schema PluginSkillSummary type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `uv run pytest tests/agent_server/test_plugins_router.py tests/agent_server/test_plugins_service.py` — 17 pass (5 new: bundled skills, file listing with `.git` pruned, corrupt-plugin degradation, local catalog enrichment, remote-source left unset).
2. Live check: start the agent-server (`uv run agent-server --host 127.0.0.1 --port 8000`), install a plugin that has a `commands/` entry (e.g. a `city-weather` plugin with `commands/now.md`), then:

- `GET /api/plugins/installed/<name>` → response includes `skills` (with the command-derived `<name>:now`) and `files`.
- `POST /api/plugins` with a `cwd` containing a local plugin → `path`/`skills`/`files` present.
- `GET /api/plugins/marketplace` → local `./plugins/*` entries carry contents; remote sources have `path`/`skills`/`files` = `null`.
- Corrupt the installed plugin's `.plugin/plugin.json` and re-fetch → response is still `200` with `skills`/`files` = `null` (metadata only).

3. `uv run ruff check` and `uv run pyright` on the changed files — clean.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/348c1c32-c185-45f8-ac53-e086d8fa8684

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:13ac1e7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-13ac1e7-python \
  ghcr.io/openhands/agent-server:13ac1e7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:13ac1e7-golang-amd64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-2734-golang-amd64
ghcr.io/openhands/agent-server:13ac1e7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:13ac1e7-golang-arm64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-2734-golang-arm64
ghcr.io/openhands/agent-server:13ac1e7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:13ac1e7-java-amd64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-2734-java-amd64
ghcr.io/openhands/agent-server:13ac1e7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:13ac1e7-java-arm64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-2734-java-arm64
ghcr.io/openhands/agent-server:13ac1e7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:13ac1e7-python-amd64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-2734-python-amd64
ghcr.io/openhands/agent-server:13ac1e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:13ac1e7-python-arm64
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-2734-python-arm64
ghcr.io/openhands/agent-server:13ac1e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:13ac1e7-golang
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-golang
ghcr.io/openhands/agent-server:hieptl-app-2734-golang
ghcr.io/openhands/agent-server:13ac1e7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:13ac1e7-java
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-java
ghcr.io/openhands/agent-server:hieptl-app-2734-java
ghcr.io/openhands/agent-server:13ac1e7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:13ac1e7-python
ghcr.io/openhands/agent-server:13ac1e7c72c57a246b95c9b4269487ac67421e7d-python
ghcr.io/openhands/agent-server:hieptl-app-2734-python
ghcr.io/openhands/agent-server:13ac1e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `13ac1e7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `13ac1e7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->