### PR TITLE
fix(task): propagate interruptions to active subagents

### DIFF
--- a/openhands-tools/openhands/tools/task/impl.py
+++ b/openhands-tools/openhands/tools/task/impl.py
@@ -67,3 +67,7 @@ class TaskExecutor(ToolExecutor):
 
     def close(self) -> None:
         self._manager.close()
+
+    def interrupt(self) -> None:
+        """Interrupt all active sub-agent tasks."""
+        self._manager.interrupt()

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -45,6 +45,9 @@ ConfirmationHandler = Callable[[str, list["ActionEvent"]], bool]
 logger = get_logger(__name__)
 
 _SUBAGENTS_DIR: Final[str] = "subagents"
+_INTERRUPTED_BEFORE_START_ERROR: Final[str] = (
+    "Sub-agent task was interrupted before it started."
+)
 
 
 class TaskStatus(StrEnum):
@@ -103,6 +106,7 @@ class TaskManager:
 
         self._tasks: dict[str, Task] = {}
         self._tasks_lock = threading.Lock()
+        self._interrupt_generation = 0
 
         # Set once in _ensure_parent: uses the parent's subagents dir
         # when the parent persists, otherwise a temporary directory.
@@ -180,6 +184,7 @@ class TaskManager:
         Returns:
             TaskState with the final result.
         """
+        interrupt_generation = self._get_interrupt_generation()
         if conversation:
             self._ensure_parent(conversation)
 
@@ -197,7 +202,16 @@ class TaskManager:
         return self._run_task(
             task=task,
             prompt=prompt,
+            interrupt_generation=interrupt_generation,
         )
+
+    def _get_interrupt_generation(self) -> int:
+        with self._tasks_lock:
+            return self._interrupt_generation
+
+    def _was_interrupted(self, generation: int) -> bool:
+        with self._tasks_lock:
+            return generation != self._interrupt_generation
 
     def _resume_task(self, resume: str, subagent_type: str) -> Task:
         """Resume a sub-agent task."""
@@ -344,8 +358,15 @@ class TaskManager:
         )
         return sub_agent
 
-    def _run_task(self, task: Task, prompt: str) -> Task:
+    def _run_task(
+        self,
+        task: Task,
+        prompt: str,
+        interrupt_generation: int | None = None,
+    ) -> Task:
         """Run a task synchronously."""
+        if interrupt_generation is None:
+            interrupt_generation = self._get_interrupt_generation()
         if task.conversation is None:
             raise RuntimeError(f"Task '{task.id}' has no conversation to run.")
         # Get parent name for sender info
@@ -355,6 +376,11 @@ class TaskManager:
             parent_name = getattr(parent._visualizer, "_name", None)
 
         try:
+            if self._was_interrupted(interrupt_generation):
+                task.set_error(_INTERRUPTED_BEFORE_START_ERROR)
+                logger.info("Task '%s' was interrupted before it started.", task.id)
+                return task
+
             task.conversation.send_message(prompt, sender=parent_name)
             self._run_until_finished(task.id, task.conversation)
             status = task.conversation.state.execution_status
@@ -453,6 +479,7 @@ class TaskManager:
     def interrupt(self) -> None:
         """Interrupt all active sub-agent conversations."""
         with self._tasks_lock:
+            self._interrupt_generation += 1
             active_tasks = tuple(
                 (task.id, task.conversation)
                 for task in self._tasks.values()

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -10,6 +10,7 @@ a temporary directory, ensuring the state can be restored
 if the task is resumed for further work later.
 """
 
+import asyncio
 import shutil
 import tempfile
 import threading
@@ -400,7 +401,13 @@ class TaskManager:
         self, task_id: str, conversation: LocalConversation
     ) -> None:
         """Run a sub-agent conversation to completion, handling confirmations."""
-        conversation.run()
+        asyncio.run(self._arun_until_finished(task_id, conversation))
+
+    async def _arun_until_finished(
+        self, task_id: str, conversation: LocalConversation
+    ) -> None:
+        """Run a sub-agent asynchronously so in-flight work can be interrupted."""
+        await conversation.arun()
         while (
             conversation.state.execution_status
             == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
@@ -412,10 +419,10 @@ class TaskManager:
             if self._confirmation_handler is None or self._confirmation_handler(
                 task_id, pending
             ):
-                conversation.run()
+                await conversation.arun()
             else:
                 conversation.reject_pending_actions("User rejected the actions")
-                conversation.run()
+                await conversation.arun()
 
     def _set_confirmation_policy(
         self,
@@ -443,8 +450,24 @@ class TaskManager:
                 task.conversation.conversation_stats.get_combined_metrics()
             )
 
+    def interrupt(self) -> None:
+        """Interrupt all active sub-agent conversations."""
+        with self._tasks_lock:
+            active_tasks = tuple(
+                (task.id, task.conversation)
+                for task in self._tasks.values()
+                if task.status == TaskStatus.RUNNING and task.conversation is not None
+            )
+
+        for task_id, conversation in active_tasks:
+            try:
+                conversation.interrupt()
+            except Exception:
+                logger.warning("Error interrupting task '%s'", task_id, exc_info=True)
+
     def close(self) -> None:
         """Clean up temporary directory (if used) and remove all created tasks."""
+        self.interrupt()
         # Only clean up when using a temp dir (parent had no persistence).
         # When the parent persists, subagent data lives under its directory.
         parent_persists = (

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -1,7 +1,7 @@
 import uuid
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
@@ -323,6 +323,33 @@ class TestTaskManager:
         assert not manager._persistence_dir.exists()
         assert len(manager._tasks) == 0
 
+    def test_interrupt_pauses_only_running_tasks(self, tmp_path):
+        manager, _ = _manager_with_parent(tmp_path)
+        register_builtins_agents()
+        running = manager._create_task(
+            subagent_type="general-purpose",
+            description="running task",
+        )
+        completed = manager._create_task(
+            subagent_type="general-purpose",
+            description="completed task",
+        )
+        completed.set_result("done")
+        assert running.conversation is not None
+        assert completed.conversation is not None
+
+        manager.interrupt()
+        manager.interrupt()
+
+        assert (
+            running.conversation.state.execution_status
+            == ConversationExecutionStatus.PAUSED
+        )
+        assert (
+            completed.conversation.state.execution_status
+            == ConversationExecutionStatus.IDLE
+        )
+
     def test_returns_local_conversation(self, tmp_path):
         manager, _ = _manager_with_parent(tmp_path)
         register_builtins_agents()
@@ -397,7 +424,9 @@ class TestTaskManager:
 
 def _make_task_with_mock_conv(task_id: str, **conv_kwargs) -> Task:
     """Create a Task with a MagicMock conversation, bypassing Pydantic validation."""
+    arun_side_effect = conv_kwargs.pop("arun.side_effect", None)
     mock_conv = MagicMock(**conv_kwargs)
+    mock_conv.arun = AsyncMock(side_effect=arun_side_effect)
     # Default to a FINISHED run; a non-FINISHED status is now surfaced as an error,
     # so override state.execution_status to test stuck/paused paths.
     mock_conv.state.execution_status = ConversationExecutionStatus.FINISHED
@@ -453,7 +482,7 @@ class TestRunTask:
         conversation.send_message.assert_called_once_with(  # type: ignore[attr-defined]
             "do something", sender=None
         )
-        conversation.run.assert_called_once()  # type: ignore[attr-defined]
+        conversation.arun.assert_awaited_once()  # type: ignore[attr-defined]
 
     @patch(
         "openhands.tools.task.manager.get_agent_final_response",
@@ -480,7 +509,7 @@ class TestRunTask:
         manager, _ = _manager_with_parent(tmp_path)
 
         task = _make_task_with_mock_conv(
-            "task_00000001", **{"run.side_effect": RuntimeError("agent exploded")}
+            "task_00000001", **{"arun.side_effect": RuntimeError("agent exploded")}
         )
         manager._tasks[task.id] = task
 
@@ -514,7 +543,7 @@ class TestRunTask:
         manager, _ = _manager_with_parent(tmp_path)
 
         task = _make_task_with_mock_conv(
-            "task_00000001", **{"run.side_effect": RuntimeError("boom")}
+            "task_00000001", **{"arun.side_effect": RuntimeError("boom")}
         )
         mock_conv = task.conversation
         manager._tasks[task.id] = task

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -1,5 +1,7 @@
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -461,6 +463,26 @@ class TestRunTask:
         with pytest.raises(RuntimeError, match="has no conversation"):
             manager._run_task(task=task, prompt="do something")
 
+    def test_interrupt_after_registration_prevents_subagent_run(self, tmp_path):
+        manager, _ = _manager_with_parent(tmp_path)
+        task = _make_task_with_mock_conv("task_00000001")
+        manager._tasks[task.id] = task
+        interrupt_generation = manager._get_interrupt_generation()
+
+        manager.interrupt()
+        result = manager._run_task(
+            task=task,
+            prompt="do something",
+            interrupt_generation=interrupt_generation,
+        )
+
+        assert result.status == TaskStatus.ERROR
+        assert result.error == "Sub-agent task was interrupted before it started."
+        conversation = task.conversation
+        assert conversation is not None
+        conversation.send_message.assert_not_called()  # type: ignore[attr-defined]
+        conversation.arun.assert_not_awaited()  # type: ignore[attr-defined]
+
     @patch(
         "openhands.tools.task.manager.get_agent_final_response",
         return_value="task result",
@@ -590,8 +612,14 @@ class TestStartTask:
     def teardown_method(self):
         _reset_registry_for_tests()
 
-    def _fake_run_task(self, task: Task, prompt: str) -> Task:
+    def _fake_run_task(
+        self,
+        task: Task,
+        prompt: str,
+        interrupt_generation: int,
+    ) -> Task:
         """Simulate a successful _run_task without hitting the LLM."""
+        assert interrupt_generation >= 0
         task.set_result(f"result for: {prompt}")
         return task
 
@@ -663,6 +691,58 @@ class TestStartTask:
                 resume="task_nonexistent",
                 conversation=parent,
             )
+
+    def test_interrupt_before_registration_prevents_subagent_run(self, tmp_path):
+        manager, parent = _manager_with_parent(tmp_path)
+        register_builtins_agents()
+        create_started = Event()
+        allow_create = Event()
+        original_create_task = manager._create_task
+
+        def delayed_create_task(*args, **kwargs):
+            create_started.set()
+            if not allow_create.wait(timeout=2):
+                raise TimeoutError("Timed out waiting to create the task")
+            return original_create_task(*args, **kwargs)
+
+        with (
+            patch.object(manager, "_create_task", side_effect=delayed_create_task),
+            patch.object(manager, "_run_until_finished") as run_until_finished,
+            ThreadPoolExecutor(max_workers=1) as executor,
+        ):
+            future = executor.submit(
+                manager.start_task,
+                prompt="do the thing",
+                subagent_type="general-purpose",
+                conversation=parent,
+            )
+            try:
+                assert create_started.wait(timeout=1)
+                manager.interrupt()
+            finally:
+                allow_create.set()
+            result = future.result(timeout=2)
+
+        assert result.status == TaskStatus.ERROR
+        assert result.error == "Sub-agent task was interrupted before it started."
+        run_until_finished.assert_not_called()
+
+    def test_task_started_after_interrupt_uses_new_generation(self, tmp_path):
+        manager, parent = _manager_with_parent(tmp_path)
+        register_builtins_agents()
+        manager.interrupt()
+
+        with patch.object(
+            manager, "_run_task", side_effect=self._fake_run_task
+        ) as run_task:
+            result = manager.start_task(
+                prompt="do the thing",
+                subagent_type="general-purpose",
+                conversation=parent,
+            )
+
+        assert result.status == TaskStatus.COMPLETED
+        assert run_task.call_args.kwargs["interrupt_generation"] == 1
 
 
 class TestTaskMetrics:

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -323,7 +323,7 @@ class TestTaskManager:
         assert not manager._persistence_dir.exists()
         assert len(manager._tasks) == 0
 
-    def test_interrupt_pauses_only_running_tasks(self, tmp_path):
+    def test_interrupt_only_targets_running_tasks(self, tmp_path):
         manager, _ = _manager_with_parent(tmp_path)
         register_builtins_agents()
         running = manager._create_task(

--- a/tests/tools/task/test_task_tool_set.py
+++ b/tests/tools/task/test_task_tool_set.py
@@ -1,4 +1,10 @@
+import asyncio
 import json
+import threading
+from typing import cast
+from unittest.mock import MagicMock
+
+from pydantic import PrivateAttr
 
 from openhands.sdk import Agent, Conversation, LocalConversation, Tool
 from openhands.sdk.conversation.state import ConversationExecutionStatus
@@ -8,7 +14,31 @@ from openhands.sdk.subagent.registry import _reset_registry_for_tests, register_
 from openhands.sdk.testing import TestLLM
 from openhands.tools.task import TaskToolSet
 from openhands.tools.task.definition import TASK_TOOL_EXAMPLES, TaskObservation
-from openhands.tools.task.manager import TaskStatus
+from openhands.tools.task.impl import TaskExecutor
+from openhands.tools.task.manager import TaskManager, TaskStatus
+
+
+class InterruptibleSubagentLLM(TestLLM):
+    """Sub-agent LLM that records cancellation of its asynchronous call."""
+
+    _started: threading.Event = PrivateAttr(default_factory=threading.Event)
+    _interrupted: threading.Event = PrivateAttr(default_factory=threading.Event)
+    _release_sync: threading.Event = PrivateAttr(default_factory=threading.Event)
+
+    def completion(self, messages, tools=None, **kwargs):  # type: ignore[override]
+        self._started.set()
+        self._release_sync.wait(timeout=5)
+        return super().completion(messages, tools=tools, **kwargs)
+
+    async def acompletion(  # type: ignore[override]
+        self, messages, tools=None, **kwargs
+    ):
+        self._started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            self._interrupted.set()
+            raise
 
 
 def _task_tool_call(
@@ -116,6 +146,48 @@ class TestTaskToolSetIntegration:
         assert obs.task_id.startswith("task_")
         assert obs.subagent == "test_agent"
         assert "Paris" in obs.text
+
+    async def test_parent_interrupt_stops_active_subagent(self, tmp_path):
+        parent_llm = TestLLM.from_messages(
+            [_task_tool_call("call_1", prompt="Run until interrupted")]
+        )
+        sub_llm = cast(
+            InterruptibleSubagentLLM,
+            InterruptibleSubagentLLM.from_messages(
+                [_text_message("unexpected completion")]
+            ),
+        )
+        _register_simple_agent("test_agent", sub_llm)
+        agent = Agent(llm=parent_llm, tools=[Tool(name=TaskToolSet.name)])
+        conversation = Conversation(
+            agent=agent,
+            workspace=str(tmp_path),
+            visualizer=None,
+        )
+        conversation.send_message("Delegate a long-running task")
+        run_task = asyncio.create_task(conversation.arun())
+
+        try:
+            assert await asyncio.to_thread(sub_llm._started.wait, 1)
+
+            conversation.interrupt()
+            await asyncio.wait_for(run_task, timeout=2)
+
+            assert await asyncio.to_thread(sub_llm._interrupted.wait, 1)
+            assert (
+                conversation.state.execution_status
+                == ConversationExecutionStatus.PAUSED
+            )
+        finally:
+            sub_llm._release_sync.set()
+            conversation.close()
+
+    def test_task_executor_delegates_interrupt_to_manager(self):
+        manager = MagicMock(spec=TaskManager)
+
+        TaskExecutor(manager).interrupt()
+
+        manager.interrupt.assert_called_once_with()
 
     # ── Multiple sequential tasks ───────────────────────────────────
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I reviewed the implementation. Need this thing for production use.
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Interrupting a parent `LocalConversation` while its `task` tool was running only paused the parent. `TaskExecutor` inherited the no-op `ToolExecutor.interrupt()`, so the active subagent continued consuming iterations and model calls.

## Summary

- Delegate `TaskExecutor.interrupt()` to `TaskManager`.
- Interrupt every active subagent conversation without holding the task registry lock during callbacks.
- Track interrupt generations so cancellation is not lost while a subagent is starting.
- Run subagent conversations through `arun()` so an in-flight model request can be cancelled.
- Interrupt active subagents during manager shutdown.
- Add manager, executor, and end-to-end parent/subagent interruption coverage.

## Issue Number

Closes #4107.

## How to Test

- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv run pytest tests/tools/task -q`
- `uv run pytest tests/agent_server/test_openapi_discriminator.py tests/sdk/context/test_agent_context_serialization.py tests/sdk/conversation/local/test_conversation_core.py tests/sdk/conversation/local/test_state_serialization.py tests/tools/file_editor/test_memory_usage.py -q`
- `uv run pytest tests/tools/terminal -q` (311 passed; two environment-contaminated cases passed when rerun in isolation after cleaning a stale tmux server)

End-to-end evidence: `test_parent_interrupt_stops_active_subagent` starts a real parent conversation with `TaskToolSet`, waits for a blocking subagent LLM call, interrupts the parent, and verifies both cancellation of the child request and the parent's `PAUSED` state.

## Video/Screenshots

Not applicable; this changes runtime cancellation behavior and is covered by an end-to-end test.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Notes

The synchronous `TaskManager.start_task()` contract is unchanged. Only the internal subagent run loop is asynchronous so SDK interruption can cancel in-flight work.

Cancellation propagation applies when the parent conversation is driven through `LocalConversation.arun()`. Parents using synchronous `run()` retain cooperative pause semantics and cannot interrupt an in-flight subagent call.

Task subagents now run through `arun()` and therefore use the separate `LLM.acompletion()` path instead of `LLM.completion()`. Custom LLM subclasses used by task subagents must support that asynchronous method.