### PR TITLE
feat(conversation): add client message context

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -848,7 +848,9 @@ class ConversationService:
             message = Message(
                 role=initial_message.role, content=initial_message.content
             )
-            await event_service.send_message(message, True)
+            await event_service.send_message(
+                message, True, client_context=initial_message.client_context
+            )
 
         state = await event_service.get_state()
         conversation_info = _compose_conversation_info(event_service.stored, state)

--- a/openhands-agent-server/openhands/agent_server/event_router.py
+++ b/openhands-agent-server/openhands/agent_server/event_router.py
@@ -206,7 +206,9 @@ async def send_message(
 ) -> Success:
     """Send a message to a conversation"""
     message = Message(role=request.role, content=request.content)
-    await event_service.send_message(message, request.run)
+    await event_service.send_message(
+        message, request.run, client_context=request.client_context
+    )
     return Success()
 
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,8 +1,10 @@
 import asyncio
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -486,9 +488,15 @@ class EventService:
         return results
 
     async def send_message(
-        self, message: Message, run: bool = False, _from_goal_loop: bool = False
+        self,
+        message: Message,
+        run: bool = False,
+        _from_goal_loop: bool = False,
+        *,
+        client_context: Sequence[TextContent] | None = None,
     ):
-        if not self._conversation:
+        conversation = self._conversation
+        if not conversation:
             raise ValueError("inactive_service")
         # A normal user message supersedes any active /goal loop in this
         # conversation. The goal loop's own messages pass _from_goal_loop=True.
@@ -496,7 +504,18 @@ class EventService:
             await self.stop_goal_loop()
         explicit_interrupt_generation = self._explicit_interrupt_generation
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._conversation.send_message, message)
+        if client_context:
+            send_message = partial(
+                conversation.send_message,
+                message,
+                client_context=client_context,
+            )
+            await loop.run_in_executor(
+                None,
+                send_message,
+            )
+        else:
+            await loop.run_in_executor(None, conversation.send_message, message)
         if run:
             if self._explicit_interrupt_generation != explicit_interrupt_generation:
                 return

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -1,6 +1,6 @@
 import contextlib
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterable, Mapping
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
@@ -15,7 +15,7 @@ from openhands.sdk.conversation.types import (
 )
 from openhands.sdk.event.types import EventID
 from openhands.sdk.llm.llm import LLM
-from openhands.sdk.llm.message import Message
+from openhands.sdk.llm.message import Message, TextContent
 from openhands.sdk.observability.laminar import (
     RootSpan,
     end_root_span,
@@ -196,7 +196,13 @@ class BaseConversation(ABC):
     def conversation_stats(self) -> ConversationStats: ...
 
     @abstractmethod
-    def send_message(self, message: str | Message, sender: str | None = None) -> None:
+    def send_message(
+        self,
+        message: str | Message,
+        sender: str | None = None,
+        *,
+        client_context: Sequence[TextContent] | None = None,
+    ) -> None:
         """Send a message to the agent.
 
         Args:
@@ -206,6 +212,7 @@ class BaseConversation(ABC):
                    message origin in multi-agent scenarios. For example, when
                    one agent delegates to another, the sender can be set to
                    identify which agent is sending the message.
+            client_context: Hidden context appended to the message for LLM input.
         """
         ...
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1626,7 +1626,13 @@ class LocalConversation(BaseConversation):
             }
 
     @observe(name="conversation.send_message")
-    def send_message(self, message: str | Message, sender: str | None = None) -> None:
+    def send_message(
+        self,
+        message: str | Message,
+        sender: str | None = None,
+        *,
+        client_context: Sequence[TextContent] | None = None,
+    ) -> None:
         """Send a message to the agent.
 
         Args:
@@ -1636,6 +1642,7 @@ class LocalConversation(BaseConversation):
                    message origin in multi-agent scenarios. For example, when
                    one agent delegates to another, the sender can be set to
                    identify which agent is sending the message.
+            client_context: Hidden context appended to the message for LLM input.
         """
         # ACPAgent startup can take much longer than a normal send_message()
         # round-trip because it launches and initializes a subprocess-backed
@@ -1661,7 +1668,7 @@ class LocalConversation(BaseConversation):
 
             # TODO: We should add test cases for all these scenarios
             activated_skill_names: list[str] = []
-            extended_content: list[TextContent] = []
+            extended_content = list(client_context or ())
 
             # Handle per-turn user message (i.e., knowledge agent trigger)
             if self.agent.agent_context:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -5,7 +5,7 @@ import os
 import threading
 import time
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, SupportsIndex, overload
 from urllib.parse import quote, urlparse
@@ -1106,7 +1106,13 @@ class RemoteConversation(BaseConversation):
         )
 
     @observe(name="conversation.send_message")
-    def send_message(self, message: str | Message, sender: str | None = None) -> None:
+    def send_message(
+        self,
+        message: str | Message,
+        sender: str | None = None,
+        *,
+        client_context: Sequence[TextContent] | None = None,
+    ) -> None:
         if isinstance(message, str):
             message = Message(role="user", content=[TextContent(text=message)])
         assert message.role == "user", (
@@ -1119,6 +1125,10 @@ class RemoteConversation(BaseConversation):
         }
         if sender is not None:
             payload["sender"] = sender
+        if client_context:
+            payload["client_context"] = [
+                content.model_dump() for content in client_context
+            ]
         _send_request(
             self._client,
             "POST",

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -65,6 +65,10 @@ class SendMessageRequest(BaseModel):
 
     role: Literal["user", "system", "assistant", "tool"] = "user"
     content: list[TextContent | ImageContent] = Field(default_factory=list)
+    client_context: list[TextContent] = Field(
+        default_factory=list,
+        description="Hidden client context appended to the message for LLM input",
+    )
     run: bool = Field(
         default=False,
         description="Whether the agent loop should automatically run if not running",

--- a/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
@@ -46,7 +46,8 @@ class MessageEvent(LLMConvertibleEvent):
         default_factory=list, description="List of activated skill name"
     )
     extended_content: list[TextContent] = Field(
-        default_factory=list, description="List of content added by agent context"
+        default_factory=list,
+        description="Hidden context appended to the message for LLM input",
     )
     sender: str | None = Field(
         default=None,
@@ -102,9 +103,7 @@ class MessageEvent(LLMConvertibleEvent):
                 isinstance(c, ImageContent) for c in self.extended_content
             ), "Extended content should not contain images"
             text_parts = content_to_str(self.extended_content)
-            content.append(
-                "\n\nPrompt Extension based on Agent Context:\n", style="bold"
-            )
+            content.append("\n\nPrompt Extension:\n", style="bold")
             content.append(" ".join(text_parts))
 
         # Display critic result if available

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -28,6 +28,7 @@ from openhands.agent_server.models import (
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
+    SendMessageRequest,
     StartConversationRequest,
     StoredConversation,
     UpdateConversationRequest,
@@ -200,6 +201,51 @@ async def test_start_conversation_registers_and_injects_client_tools(
     from openhands.sdk.tool.registry import list_registered_tools
 
     assert "srv_show_dialog" in list_registered_tools()
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_forwards_initial_message_client_context(
+    conversation_service, tmp_path
+):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    client_context = TextContent(text="hidden runtime context")
+    agent = Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[])
+    workspace = LocalWorkspace(working_dir=str(workspace_dir))
+    request = StartConversationRequest(
+        agent=agent,
+        workspace=workspace,
+        confirmation_policy=NeverConfirm(),
+        initial_message=SendMessageRequest(
+            content=[TextContent(text="visible request")],
+            client_context=[client_context],
+        ),
+    )
+    event_service = AsyncMock(spec=EventService)
+
+    async def fake_start_event_service(stored: StoredConversation):
+        event_service.stored = stored
+        event_service.get_state.return_value = ConversationState(
+            id=stored.id,
+            agent=stored.agent,
+            workspace=stored.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=stored.confirmation_policy,
+        )
+        return event_service
+
+    with patch.object(
+        conversation_service,
+        "_start_event_service",
+        side_effect=fake_start_event_service,
+    ):
+        await conversation_service.start_conversation(request)
+
+    event_service.send_message.assert_awaited_once_with(
+        Message(role="user", content=[TextContent(text="visible request")]),
+        True,
+        client_context=[client_context],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_event_router.py
+++ b/tests/agent_server/test_event_router.py
@@ -192,6 +192,32 @@ class TestSendMessageEndpoint:
             client.app.dependency_overrides.clear()
 
     @pytest.mark.asyncio
+    async def test_send_message_with_client_context(
+        self, client, sample_conversation_id, mock_event_service
+    ):
+        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+
+        try:
+            response = client.post(
+                f"/api/conversations/{sample_conversation_id}/events",
+                json={
+                    "role": "user",
+                    "content": [{"type": "text", "text": "visible request"}],
+                    "client_context": [
+                        {"type": "text", "text": "hidden runtime context"}
+                    ],
+                },
+            )
+
+            assert response.status_code == 200
+            call_args = mock_event_service.send_message.call_args
+            assert call_args.kwargs["client_context"] == [
+                TextContent(text="hidden runtime context")
+            ]
+        finally:
+            client.app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
     async def test_send_message_conversation_not_found(
         self, client, sample_conversation_id
     ):

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2747,7 +2747,7 @@ class TestEventServiceClose:
             def conversation_stats(self):
                 return mock.conversation_stats
 
-            def send_message(self, message, sender=None):
+            def send_message(self, message, sender=None, *, client_context=None):
                 pass
 
             def run(self):

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -23,7 +23,7 @@ from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelRespons
 from pydantic import SecretStr
 
 from openhands.agent_server.__main__ import preload_modules
-from openhands.sdk import LLM, Agent, AgentContext, Conversation
+from openhands.sdk import LLM, Agent, AgentContext, Conversation, TextContent
 from openhands.sdk.conversation import RemoteConversation
 from openhands.sdk.event import (
     ActionEvent,
@@ -477,7 +477,8 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
     )  # RemoteConversation
 
     # Send a message and run
-    conv.send_message("Say hello")
+    client_context = TextContent(text="hidden runtime context")
+    conv.send_message("Say hello", client_context=[client_context])
     conv.run()
 
     # Validate state transitions and that we received an assistant message
@@ -487,6 +488,7 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
     # Wait for WS-delivered events and validate them using proper type checking
     found_state_update = False
     found_agent_event = False
+    found_client_context = False
 
     for i in range(50):  # up to ~5s
         events = state.events
@@ -513,6 +515,9 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
         for e in events:
             if isinstance(e, SystemPromptEvent) and e.source == "agent":
                 found_agent_event = True
+
+            if isinstance(e, MessageEvent) and e.source == "user":
+                found_client_context = e.extended_content == [client_context]
 
             if isinstance(e, ConversationStateUpdateEvent):
                 found_state_update = True
@@ -543,7 +548,7 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
         # condition where the event is published before the WebSocket subscription
         # completes. The event IS persisted on the server, but RemoteEventsList
         # may miss it. See: https://github.com/OpenHands/software-agent-sdk/issues/1785
-        if found_agent_event and found_state_update:
+        if found_agent_event and found_state_update and found_client_context:
             break
         time.sleep(0.1)
 
@@ -552,6 +557,7 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
         f"Expected to find ConversationStateUpdateEvent. "
         f"Found {len(state.events)} events: {[type(e).__name__ for e in state.events]}"
     )
+    assert found_client_context, "Expected hidden client context on the user event"
     assert found_agent_event, (
         "Expected to find an agent event "
         "(SystemPromptEvent, MessageEvent, or ActionEvent). "

--- a/tests/sdk/conversation/local/test_conversation_send_message.py
+++ b/tests/sdk/conversation/local/test_conversation_send_message.py
@@ -76,6 +76,23 @@ def test_send_message_with_string_creates_correct_message():
     assert message.content[0].text == test_text
 
 
+def test_send_message_appends_client_context_only_for_llm_input():
+    agent = SendMessageDummyAgent()
+    conversation = Conversation(agent=agent)
+
+    client_context = TextContent(text="hidden runtime context")
+    conversation.send_message("visible request", client_context=[client_context])
+
+    user_event = conversation.state.events[-1]
+    assert isinstance(user_event, MessageEvent)
+    assert user_event.extended_content == [client_context]
+    assert user_event.llm_message.content == [TextContent(text="visible request")]
+    assert user_event.to_llm_message().content == [
+        TextContent(text="visible request"),
+        client_context,
+    ]
+
+
 def test_send_message_string_equivalent_to_message_object():
     """Test that send_message with string produces the same result as with Message object."""  # noqa: E501
     agent1 = SendMessageDummyAgent()

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -701,6 +701,45 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_send_message_with_client_context(self, mock_ws_client):
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+        mock_ws_client.return_value = Mock()
+
+        conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
+        conversation.send_message(
+            "visible request",
+            client_context=[TextContent(text="hidden runtime context")],
+        )
+
+        request_call = next(
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST"
+            and call[0][1] == f"/api/conversations/{conversation_id}/events"
+        )
+        assert request_call.kwargs["json"] == {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "visible request",
+                    "cache_prompt": False,
+                }
+            ],
+            "run": False,
+            "client_context": [
+                {
+                    "type": "text",
+                    "text": "hidden runtime context",
+                    "cache_prompt": False,
+                }
+            ],
+        }
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_remote_conversation_send_message_invalid_role(self, mock_ws_client):
         """Test sending a message with invalid role raises assertion error."""
         # Setup mocks

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -44,7 +44,13 @@ class MockConversation(BaseConversation):
     def run(self) -> None:
         pass
 
-    def send_message(self, message: Any, sender: str | None = None) -> None:
+    def send_message(
+        self,
+        message: Any,
+        sender: str | None = None,
+        *,
+        client_context: Any = None,
+    ) -> None:
         pass
 
     def set_confirmation_policy(self, policy: Any) -> None:

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -309,7 +309,7 @@ def test_message_event_visualize():
     text_content = result.plain
     assert "Hello, how can you help me?" in text_content
     assert "Activated Skills: helper, analyzer" in text_content
-    assert "Prompt Extension based on Agent Context:" in text_content
+    assert "Prompt Extension:" in text_content
     assert "Additional context" in text_content
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

Runtime and UI context is owned by the client, can change independently of the agent profile, and should retain user-role semantics. Encoding it as a trusted launch-time system-message augmentation conflates ownership and lifecycle. This replaces the generic launch augmentation proposed in #4030 with context attached to a user message.

## Summary

- Add optional `client_context` to local and remote `send_message`, initial conversation messages, and the REST event endpoint.
- Persist client context as `MessageEvent.extended_content`: it is included in LLM input without changing the visible message content.
- Cover serialization, routing, persistence, visualization, and a real `RemoteConversation` → agent-server round trip.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `56ac31719f91` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -2012,0 +2013 @@
+schema SendMessageRequest property client_context optional schema=type="array" items=TextContent
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Supersedes #4030. Canvas consumer: [OpenHands/agent-canvas#1782](https://github.com/OpenHands/agent-canvas/pull/1782). Documentation: [OpenHands/docs#622](https://github.com/OpenHands/docs/pull/622). Related transport work: #4078.

## How to Test

Focused behavior and live-server coverage:

```bash
.venv-client-context/bin/pytest -q \
  tests/sdk/conversation/local/test_conversation_send_message.py \
  tests/sdk/conversation/remote/test_remote_conversation.py \
  tests/agent_server/test_event_router.py \
  tests/sdk/conversation/test_visualizer.py \
  tests/agent_server/test_conversation_service.py::test_start_conversation_forwards_initial_message_client_context \
  tests/cross/test_remote_conversation_live_server.py::test_remote_conversation_over_real_server
```

Result: `116 passed`. The live-server test starts the actual agent server, sends `client_context` through `RemoteConversation`, and verifies it is persisted on the user `MessageEvent`.

```bash
.venv-client-context/bin/pytest -q tests/agent_server/test_event_service.py::TestEventServiceSendMessage
```

Result: `18 passed`.

Direct isolated-environment checks on all changed Python files:

```bash
.venv-client-context/bin/ruff format --check <changed Python files>
.venv-client-context/bin/ruff check <changed Python files>
.venv-client-context/bin/pyright <changed production Python files>
```

Results: `14 files already formatted`, `All checks passed`, and `0 errors, 0 warnings, 0 informations`.

## Video/Screenshots

Not applicable; this is an SDK and API change with real-server test coverage.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is additive. `client_context` is persisted with the conversation and is not a security boundary; clients must not put secrets in it. The Canvas consumer should land after an agent-server release containing this API.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2b0b4b2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2b0b4b2-python \
  ghcr.io/openhands/agent-server:2b0b4b2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2b0b4b2-golang-amd64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-golang-amd64
ghcr.io/openhands/agent-server:client-message-context-golang-amd64
ghcr.io/openhands/agent-server:2b0b4b2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2b0b4b2-golang-arm64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-golang-arm64
ghcr.io/openhands/agent-server:client-message-context-golang-arm64
ghcr.io/openhands/agent-server:2b0b4b2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2b0b4b2-java-amd64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-java-amd64
ghcr.io/openhands/agent-server:client-message-context-java-amd64
ghcr.io/openhands/agent-server:2b0b4b2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2b0b4b2-java-arm64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-java-arm64
ghcr.io/openhands/agent-server:client-message-context-java-arm64
ghcr.io/openhands/agent-server:2b0b4b2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2b0b4b2-python-amd64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-python-amd64
ghcr.io/openhands/agent-server:client-message-context-python-amd64
ghcr.io/openhands/agent-server:2b0b4b2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2b0b4b2-python-arm64
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-python-arm64
ghcr.io/openhands/agent-server:client-message-context-python-arm64
ghcr.io/openhands/agent-server:2b0b4b2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2b0b4b2-golang
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-golang
ghcr.io/openhands/agent-server:client-message-context-golang
ghcr.io/openhands/agent-server:2b0b4b2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2b0b4b2-java
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-java
ghcr.io/openhands/agent-server:client-message-context-java
ghcr.io/openhands/agent-server:2b0b4b2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2b0b4b2-python
ghcr.io/openhands/agent-server:2b0b4b26207a0cad21e29a1b39f40fa691d02b04-python
ghcr.io/openhands/agent-server:client-message-context-python
ghcr.io/openhands/agent-server:2b0b4b2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2b0b4b2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2b0b4b2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->