### PR TITLE
fix(visualizer): show per-request token usage alongside cumulative totals

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
@@ -26,6 +26,7 @@ from openhands.sdk.event import (
 )
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation, CondensationRequest
+from openhands.sdk.llm.utils.metrics import TokenUsage
 
 
 logger = logging.getLogger(__name__)
@@ -355,7 +356,7 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
         title_color = config.color(event) if callable(config.color) else config.color
 
         # Build subtitle if needed
-        subtitle = self._format_metrics_subtitle() if config.show_metrics else None
+        subtitle = self._format_metrics_subtitle(event) if config.show_metrics else None
 
         return build_event_block(
             content=content,
@@ -364,7 +365,33 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
             subtitle=subtitle,
         )
 
-    def _format_metrics_subtitle(self) -> str | None:
+    def _find_request_usage(self, event: Event | None) -> TokenUsage | None:
+        """Find the TokenUsage for the LLM request that produced ``event``.
+
+        Matches on ``TokenUsage.response_id``, not on list position: telemetry
+        records ``TokenUsage.response_id = resp.id`` and events carry
+        ``llm_response_id = llm_response.id``, so these ids correspond
+        one-to-one. We deliberately do NOT use
+        ``get_combined_metrics().token_usages[-1]`` because that list merges
+        usages across every usage id (agent, condenser, ...) and is not
+        chronological across them.
+        """
+        response_id = getattr(event, "llm_response_id", None)
+        if not response_id:
+            return None
+
+        stats = self.conversation_stats
+        if not stats:
+            return None
+
+        for metrics in stats.usage_to_metrics.values():
+            for usage in reversed(metrics.token_usages):
+                if usage.response_id == response_id:
+                    return usage
+
+        return None
+
+    def _format_metrics_subtitle(self, event: Event | None = None) -> str | None:
         """Format LLM metrics as a visually appealing subtitle string with icons,
         colors, and k/m abbreviations using conversation stats."""
         stats = self.conversation_stats
@@ -391,8 +418,19 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
                 return str(n)
             return f"{val:.2f}".rstrip("0").rstrip(".") + suffix
 
-        input_tokens = abbr(usage.prompt_tokens or 0)
-        output_tokens = abbr(usage.completion_tokens or 0)
+        request_usage = self._find_request_usage(event)
+        if request_usage is not None:
+            input_str = (
+                f"↑ input {abbr(request_usage.prompt_tokens or 0)} "
+                f"(total {abbr(usage.prompt_tokens or 0)})"
+            )
+            output_str = (
+                f"↓ output {abbr(request_usage.completion_tokens or 0)} "
+                f"(total {abbr(usage.completion_tokens or 0)})"
+            )
+        else:
+            input_str = f"↑ input {abbr(usage.prompt_tokens or 0)}"
+            output_str = f"↓ output {abbr(usage.completion_tokens or 0)}"
 
         # Cache hit rate is derived on Metrics; the visualizer just formats it.
         rate = combined_metrics.cache_hit_rate
@@ -404,11 +442,11 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
 
         # Build with fixed color scheme
         parts: list[str] = []
-        parts.append(f"[cyan]↑ input {input_tokens}[/cyan]")
+        parts.append(f"[cyan]{input_str}[/cyan]")
         parts.append(f"[magenta]cache hit {cache_rate}[/magenta]")
         if reasoning_tokens > 0:
             parts.append(f"[yellow] reasoning {abbr(reasoning_tokens)}[/yellow]")
-        parts.append(f"[blue]↓ output {output_tokens}[/blue]")
+        parts.append(f"[blue]{output_str}[/blue]")
         parts.append(f"[green]$ {cost_str}[/green]")
 
         return "Tokens: " + " • ".join(parts)

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -609,6 +609,157 @@ def test_metrics_abbreviation_formatting():
         )
 
 
+def test_metrics_subtitle_shows_per_request_and_cumulative():
+    """Two sequential requests on the same LLM: the subtitle for the latest
+    event should show both the per-request usage and the running cumulative
+    total, not just the total (#4105)."""
+    stats = ConversationStats()
+    metrics = Metrics(model_name="test-model")
+    metrics.add_token_usage(
+        prompt_tokens=4390,
+        completion_tokens=144,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="response_1",
+    )
+    metrics.add_token_usage(
+        prompt_tokens=4630,
+        completion_tokens=114,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="response_2",
+    )
+    stats.usage_to_metrics["agent"] = metrics
+
+    visualizer = DefaultConversationVisualizer()
+    mock_state = MagicMock()
+    mock_state.stats = stats
+    visualizer.initialize(mock_state)
+
+    tool_call = create_tool_call("call_1", "test", {})
+    event = ActionEvent(
+        thought=[TextContent(text="Testing")],
+        action=VisualizerMockAction(command="test"),
+        tool_name="test",
+        tool_call_id="call_1",
+        tool_call=tool_call,
+        llm_response_id="response_2",
+    )
+
+    subtitle = visualizer._format_metrics_subtitle(event)
+    assert subtitle is not None
+    # Per-request usage (the second request only).
+    assert "4.63K" in subtitle
+    assert "114" in subtitle
+    # Cumulative usage (both requests combined).
+    assert "9.02K" in subtitle
+    assert "258" in subtitle
+
+
+def test_metrics_subtitle_matches_by_response_id_not_last_index():
+    """Regression: get_combined_metrics().token_usages[-1] merges usages
+    across every usage id (agent, condenser, ...) and is not chronological
+    across them. Per-request usage must be looked up by response_id, which
+    telemetry sets to the same id events carry as llm_response_id (#4105)."""
+    stats = ConversationStats()
+
+    # Condenser usage id is inserted first...
+    condenser_metrics = Metrics(model_name="test-model")
+    condenser_metrics.add_token_usage(
+        prompt_tokens=2000,
+        completion_tokens=50,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="condenser_response",
+    )
+    stats.usage_to_metrics["condenser"] = condenser_metrics
+
+    # ...then the agent usage id, which lands last in the merged list.
+    agent_metrics = Metrics(model_name="test-model")
+    agent_metrics.add_token_usage(
+        prompt_tokens=999,
+        completion_tokens=9,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="agent_response",
+    )
+    stats.usage_to_metrics["agent"] = agent_metrics
+
+    # Sanity check: naive token_usages[-1] would return the agent usage, not
+    # the condenser usage this test looks up.
+    combined = stats.get_combined_metrics()
+    assert combined.token_usages[-1].response_id == "agent_response"
+
+    visualizer = DefaultConversationVisualizer()
+    mock_state = MagicMock()
+    mock_state.stats = stats
+    visualizer.initialize(mock_state)
+
+    tool_call = create_tool_call("call_1", "test", {})
+    event = ActionEvent(
+        thought=[TextContent(text="Testing")],
+        action=VisualizerMockAction(command="test"),
+        tool_name="test",
+        tool_call_id="call_1",
+        tool_call=tool_call,
+        llm_response_id="condenser_response",
+    )
+
+    request_usage = visualizer._find_request_usage(event)
+    assert request_usage is not None
+    assert request_usage.prompt_tokens == 2000
+    assert request_usage.completion_tokens == 50
+
+
+def test_metrics_subtitle_fallback_without_request_match():
+    """No event, or an event whose response_id is unknown, keeps the exact
+    totals-only format (#4105)."""
+    stats = ConversationStats()
+    metrics = Metrics(model_name="test-model")
+    metrics.add_token_usage(
+        prompt_tokens=1000,
+        completion_tokens=100,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="response_1",
+    )
+    stats.usage_to_metrics["agent"] = metrics
+
+    visualizer = DefaultConversationVisualizer()
+    mock_state = MagicMock()
+    mock_state.stats = stats
+    visualizer.initialize(mock_state)
+
+    # No event at all.
+    subtitle_no_event = visualizer._format_metrics_subtitle()
+    assert subtitle_no_event is not None
+    assert "(total" not in subtitle_no_event
+
+    # Event carries a response_id that doesn't match any recorded usage.
+    tool_call = create_tool_call("call_1", "test", {})
+    event = ActionEvent(
+        thought=[TextContent(text="Testing")],
+        action=VisualizerMockAction(command="test"),
+        tool_name="test",
+        tool_call_id="call_1",
+        tool_call=tool_call,
+        llm_response_id="unknown_response",
+    )
+    subtitle_unknown = visualizer._format_metrics_subtitle(event)
+    assert subtitle_unknown is not None
+    assert "(total" not in subtitle_unknown
+
+
 def test_event_base_fallback_visualize():
     """Test that Event provides fallback visualization."""
     event = _UnknownEventForVisualizerTest()


### PR DESCRIPTION
Fixes #4105

## Problem

`_format_metrics_subtitle()` in `openhands-sdk/openhands/sdk/conversation/visualizer/default.py` only rendered `accumulated_token_usage`. Since this line is shown under every event, the cumulative total is easy to misread as the size of the latest request.

Example from the issue: first request ↑4.39K, second request ↑4.63K → the UI showed ↑9.02K under the second event, which reads like a huge context jump when it's actually just the running total.

## Solution

- `_format_metrics_subtitle` now takes an optional `event` parameter. The call site in `_create_event_block` passes the current event: `self._format_metrics_subtitle(event)`.
- Added `_find_request_usage(event)`, which looks up the `TokenUsage` for the LLM request that produced `event` by matching `getattr(event, "llm_response_id", None)` against `TokenUsage.response_id`, scanning **all** `stats.usage_to_metrics` values (iterating each `metrics.token_usages` in reverse).
- When a per-request usage is found, input/output are rendered as `↑ input <request> (total <cumulative>)` and `↓ output <request> (total <cumulative>)`, keeping colors, separators, cache-hit, reasoning, and cost parts unchanged. When no match is found (no event passed, `llm_response_id` missing, or no matching `response_id`), the output is byte-for-byte identical to the current totals-only format.

### Why match on `response_id` instead of `token_usages[-1]`

`ConversationStats.get_combined_metrics()` merges `Metrics` from every usage id (agent, condenser, ...) by iterating `usage_to_metrics.values()` and calling `Metrics.merge()`, which just concatenates each `Metrics.token_usages` list in dict-insertion order. That means the merged `token_usages` list is grouped by usage id, not sorted by time — `token_usages[-1]` is simply "last usage of whichever usage id was inserted last," not "the request that produced the current event." If a condenser call happens after the last agent call chronologically, or the condenser's usage id was registered after the agent's, `token_usages[-1]` can point at the wrong request entirely (see the added regression test).

Response ids don't have this problem: telemetry stamps `TokenUsage.response_id = resp.id` when it records usage, and every LLM-produced event has `llm_response_id = llm_response.id`. These come from the same underlying LLM response object, so matching on that id — scanned across all usage ids, not just the merged/sorted list — reliably finds the exact request behind the event, regardless of insertion order or how many usage ids are in play.

## Tests

Added to `tests/sdk/conversation/test_visualizer.py`:
- `test_metrics_subtitle_shows_per_request_and_cumulative`: two sequential requests on one LLM (4390/144 then 4630/114 tokens) — asserts both the per-request values (4.63K, 114) and the cumulative totals (9.02K, 258) appear in the subtitle for the second event.
- `test_metrics_subtitle_matches_by_response_id_not_last_index`: two usage ids (condenser inserted first, then agent) — asserts `_find_request_usage` returns the condenser request by `response_id` even though `get_combined_metrics().token_usages[-1]` would return the (wrong) agent request.
- `test_metrics_subtitle_fallback_without_request_match`: calling `_format_metrics_subtitle()` with no event, and with an event carrying an unknown `llm_response_id`, must not contain `"(total"` — i.e. falls back to the exact existing totals-only output.

All existing visualizer tests pass unchanged (they call `_format_metrics_subtitle()` with no event, which is the fallback path).

- [x] `uv sync`
- [x] `uv run pytest tests/sdk/conversation/test_visualizer.py` (27 passed)
- [x] `uv run pytest tests/sdk/conversation/` (739 passed, no regressions)
- [x] `uv run ruff format`
- [x] `uv run ruff check --fix`
- [x] `uv run pyright` on the modified file (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)