### PR TITLE
fix(sdk): degrade per event when a stored event cannot be deserialized

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -23,7 +23,7 @@ from openhands.agent_server.pub_sub import PubSub, Subscriber
 from openhands.sdk import LLM, AgentBase, Event, Message, TextContent, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.conversation.base import BaseConversation
-from openhands.sdk.conversation.events_list_base import EventsListBase
+from openhands.sdk.conversation.events_list_base import EventsListBase, readable_events
 from openhands.sdk.conversation.goal import (
     GoalController,
     GoalDone,
@@ -876,7 +876,13 @@ class EventService:
             # the advanced HEAD, so the leaf can lag the on-disk events. (Remote
             # branching is unsupported — #3749 — so there are no abandoned
             # branches to exclude here anyway.)
-            unmatched_actions = ConversationState.get_unmatched_actions(state.events)
+            #
+            # Read it event by event: an unreadable event here would otherwise
+            # raise, and the startup scan drops the whole conversation on any
+            # exception, 404ing a conversation whose other events are all intact
+            # (#4080).
+            events = readable_events(state.events)
+            unmatched_actions = ConversationState.get_unmatched_actions(events)
             if unmatched_actions:
                 first_action = unmatched_actions[0]
                 # Skip if any observation-like event already exists for this
@@ -885,7 +891,7 @@ class EventService:
                 already_observed = any(
                     isinstance(e, ObservationBaseEvent)
                     and e.tool_call_id == first_action.tool_call_id
-                    for e in state.events
+                    for e in events
                 )
                 if not already_observed:
                     error_event = AgentErrorEvent(

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -1,10 +1,14 @@
 # state.py
+import json
 import operator
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, nullcontext
 from typing import SupportsIndex, overload
 
-from openhands.sdk.conversation.events_list_base import EventsListBase
+from openhands.sdk.conversation.events_list_base import (
+    UNREADABLE_EVENT_ERRORS,
+    EventsListBase,
+)
 from openhands.sdk.conversation.persistence_const import (
     EVENT_FILE_PATTERN,
     EVENT_NAME_RE,
@@ -52,6 +56,12 @@ class EventLog(EventsListBase):
         self._id_to_idx: dict[EventID, int] = {}
         self._idx_to_id: dict[int, EventID] = {}
         self._event_cache: dict[int, Event] = {}
+        # idx -> parent to walk to instead, for events that failed to deserialize.
+        # ``active_branch()`` re-walks the branch every agent step. The event itself
+        # is still re-read each walk, deliberately: its kind may become registered
+        # later, once the module defining it is imported. The parent recovery and
+        # the warning are what happen only once.
+        self._unreadable_parents: dict[int, EventID | None] = {}
         self._lock_path = f"{dir_path}/{LOCK_FILE_NAME}"
         self._write_guard = None
         self._length = self._scan_and_build_index()
@@ -88,20 +98,69 @@ class EventLog(EventsListBase):
             return item.id in self._id_to_idx
         return item in self._id_to_idx
 
-    def _effective_parent_id(self, idx: int, event: Event) -> EventID | None:
-        """Resolve the parent of ``event`` (at ``idx``) for tree traversal.
+    def _resolve_parent_id(self, idx: int, parent_id: EventID | None) -> EventID | None:
+        """Resolve the parent link for the event at ``idx`` from its ``parent_id``.
 
         Legacy events predating the tree have no ``parent_id``; they fall back to
         the linear chain (event ``idx - 1``) so old conversations load unbranched
         with no disk rewrite.
         """
-        if event.parent_id == ROOT_PARENT_ID:
+        if parent_id == ROOT_PARENT_ID:
             return None  # explicit root (feature-created root at idx > 0)
-        if event.parent_id is not None:
-            return event.parent_id  # explicit (new events)
+        if parent_id is not None:
+            return parent_id  # explicit (new events)
         if idx == 0:
             return None  # genuine root
         return self.get_id(idx - 1)  # legacy linear chain (back-compat)
+
+    def _effective_parent_id(self, idx: int, event: Event) -> EventID | None:
+        """Resolve the parent of ``event`` (at ``idx``) for tree traversal."""
+        return self._resolve_parent_id(idx, event.parent_id)
+
+    def _unreadable_parent_id(self, idx: int) -> EventID | None:
+        """Resolve the parent of the event at ``idx`` without deserializing it.
+
+        ``parent_id`` is a plain string on the stored payload, so it stays
+        readable when the event as a whole does not validate (an unregistered
+        ``kind``, say). Reading it directly keeps a branch walk on the correct
+        lineage across an event this process cannot materialize.
+
+        The recovered id comes from a payload we just failed to validate, so it is
+        only trusted once it names an event we actually hold. Anything else (an
+        unusable payload, a parent that is not in the index) falls back to the
+        linear chain, which cannot strand the walk.
+        """
+        parent_id: EventID | None = None
+        try:
+            payload = json.loads(self._fs.read(self._path(idx)))
+            if isinstance(payload, dict):
+                raw = payload.get("parent_id")
+                parent_id = raw if isinstance(raw, str) else None
+        except (FileNotFoundError, ValueError, KeyError):
+            parent_id = None
+
+        resolved = self._resolve_parent_id(idx, parent_id)
+        if resolved is not None and resolved not in self._id_to_idx:
+            logger.warning(
+                "Unreadable event at index %d names parent %s, which is not in the "
+                "log; falling back to the linear chain.",
+                idx,
+                resolved,
+            )
+            return self._resolve_parent_id(idx, None)
+        return resolved
+
+    def _skip_unreadable(self, idx: int, exc: Exception) -> EventID | None:
+        """Warn once for the unreadable event at ``idx`` and say where to walk next."""
+        if idx not in self._unreadable_parents:
+            logger.warning(
+                "Skipping unreadable event at index %d (%s): %s",
+                idx,
+                type(exc).__name__,
+                exc,
+            )
+            self._unreadable_parents[idx] = self._unreadable_parent_id(idx)
+        return self._unreadable_parents[idx]
 
     def path_to_root(
         self, leaf_id: EventID | None, limit: int | None = None
@@ -112,6 +171,12 @@ class EventLog(EventsListBase):
         events (walking back from the leaf), so callers wanting a recent window
         stay O(limit) instead of O(branch). Raises ValueError on a cycle, KeyError
         if ``leaf_id`` or an ancestor is missing.
+
+        An event that cannot be deserialized is skipped rather than failing the
+        walk: one unregistered ``kind`` (a custom tool's observation whose module
+        is not imported, or an event from a newer writer) would otherwise strand
+        the whole conversation. ``View.from_events`` drops the action left
+        unpaired by a skipped observation via ``ToolCallMatchingProperty``.
         """
         chain: list[Event] = []
         seen: set[EventID] = set()
@@ -121,7 +186,12 @@ class EventLog(EventsListBase):
                 raise ValueError(f"Cycle in event tree at {cur_id}")
             seen.add(cur_id)
             idx = self.get_index(cur_id)
-            chain.append(evt := self[idx])
+            try:
+                evt = self[idx]
+            except UNREADABLE_EVENT_ERRORS as exc:
+                cur_id = self._skip_unreadable(idx, exc)
+                continue
+            chain.append(evt)
             cur_id = self._effective_parent_id(idx, evt)
         return chain[::-1]
 

--- a/openhands-sdk/openhands/sdk/conversation/events_list_base.py
+++ b/openhands-sdk/openhands/sdk/conversation/events_list_base.py
@@ -1,7 +1,49 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
+from pydantic import ValidationError
+
 from openhands.sdk.event import Event
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+# A stored event this process cannot materialize: its ``kind`` is not registered
+# (a custom tool's observation whose module was never imported, or an event from
+# a newer writer), its file is missing, or its bytes are unusable. Reading one is
+# recoverable per event; it must not fail the whole conversation (#4080).
+UNREADABLE_EVENT_ERRORS = (FileNotFoundError, UnicodeDecodeError, ValidationError)
+
+
+def read_event_or_none(events: Sequence[Event], index: int) -> Event | None:
+    """The event at ``index``, or ``None`` if it cannot be deserialized.
+
+    For callers that would rather drop one event than fail the whole read.
+    """
+    try:
+        return events[index]
+    except UNREADABLE_EVENT_ERRORS as exc:
+        logger.warning(
+            "Skipping unreadable event at index %d (%s): %s",
+            index,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def readable_events(events: Sequence[Event]) -> list[Event]:
+    """Every event in ``events`` that deserializes, skipping any that does not.
+
+    Read by index, so one unreadable event costs only itself. For callers that
+    scan a whole log and must not fail it over a single event (#4080).
+    """
+    return [
+        event
+        for index in range(len(events))
+        if (event := read_event_or_none(events, index)) is not None
+    ]
 
 
 class EventsListBase(Sequence[Event], ABC):

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -13,6 +13,7 @@ from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context.view import View
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
+from openhands.sdk.conversation.events_list_base import read_event_or_none
 from openhands.sdk.conversation.fifo_lock import FIFOLock
 from openhands.sdk.conversation.persistence_const import BASE_STATE, EVENTS_DIR
 from openhands.sdk.conversation.secret_registry import SecretRegistry
@@ -288,7 +289,12 @@ class ConversationState(OpenHandsModel):
 
         artifacts = (ConversationStateUpdateEvent, ConversationErrorEvent)
         for i in range(len(self._events) - 1, -1, -1):
-            if not isinstance(self._events[i], artifacts):
+            event = read_event_or_none(self._events, i)
+            # An event that cannot be deserialized is not one of the artifact kinds
+            # (both are core, always registered), so it is a real tail event: name
+            # it the leaf and let ``path_to_root`` skip over it (#4080). Reading it
+            # strictly here would fail the whole load on one bad trailing event.
+            if event is None or not isinstance(event, artifacts):
                 return self._events.get_id(i)
         return None
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import shutil
 import threading
 import time
@@ -1972,6 +1973,84 @@ class TestEventServiceStartWithRunningStatus:
             assert error_event.tool_call_id == "call_1"
             assert "restart occurred" in error_event.error
             assert "fatal memory error" in error_event.error
+
+    @pytest.mark.asyncio
+    async def test_start_recovers_when_an_event_is_unreadable(
+        self, event_service, tmp_path
+    ):
+        """Crash recovery must survive an event it cannot deserialize (#4080).
+
+        The RUNNING scan reads the whole log. Reading it strictly would raise on an
+        unregistered kind, and the startup scan drops the conversation on any
+        exception, so one unknown event would 404 a conversation whose other events
+        are all intact.
+        """
+        from openhands.sdk.event import AgentErrorEvent
+        from openhands.sdk.event.llm_convertible import ActionEvent
+        from openhands.sdk.llm import MessageToolCall, TextContent
+        from openhands.tools.terminal import TerminalAction
+
+        event_service.conversations_dir = tmp_path
+        conv_dir = tmp_path / event_service.stored.id.hex
+        conv_dir.mkdir(parents=True, exist_ok=True)
+        event_service.stored.workspace = LocalWorkspace(working_dir=str(tmp_path))
+
+        unmatched_action = ActionEvent(
+            id="00000000-0000-0000-0000-000000000001",
+            source="agent",
+            thought=[TextContent(text="I need to run ls command")],
+            action=TerminalAction(command="ls"),
+            tool_name="terminal",
+            tool_call_id="call_1",
+            tool_call=MessageToolCall(
+                id="call_1",
+                name="terminal",
+                arguments='{"command": "ls"}',
+                origin="completion",
+            ),
+            llm_response_id="response_1",
+        )
+        # A real log: the pending action, then an event whose kind is not registered.
+        fs = InMemoryFileStore()
+        fs.write(
+            f"events/event-00000-{unmatched_action.id}.json",
+            unmatched_action.model_dump_json(exclude_none=True),
+        )
+        fs.write(
+            "events/event-00001-00000000-0000-0000-0000-000000000002.json",
+            json.dumps({"kind": "CanvasUIObservation", "result": "x"}),
+        )
+
+        with patch(
+            "openhands.agent_server.event_service.LocalConversation"
+        ) as MockConversation:
+            mock_conv = MagicMock()
+            mock_state = MagicMock()
+            mock_agent = MagicMock()
+
+            mock_state.execution_status = ConversationExecutionStatus.RUNNING
+            mock_state.events = EventLog(fs)
+            mock_state.stats = MagicMock()
+            mock_agent.get_all_llms.return_value = []
+
+            mock_conv._state = mock_state
+            mock_conv.state = mock_state
+            mock_conv.agent = mock_agent
+            mock_conv._on_event = MagicMock()
+            MockConversation.return_value = mock_conv
+
+            # Must not raise: the unreadable event is skipped, not fatal.
+            await event_service.start()
+
+            assert mock_state.execution_status == ConversationExecutionStatus.ERROR
+            # The pending action is still recovered, past the unreadable event.
+            error_events = [
+                call[0][0]
+                for call in mock_conv._on_event.call_args_list
+                if isinstance(call[0][0], AgentErrorEvent)
+            ]
+            assert len(error_events) == 1
+            assert error_events[0].tool_call_id == "call_1"
 
     @pytest.mark.asyncio
     async def test_start_does_not_add_error_event_when_no_unmatched_actions(

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -2,8 +2,9 @@
 and branch-slice fork through a real LocalConversation (no LLM). (#3747, #3748)
 """
 
+import json
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
@@ -15,7 +16,7 @@ from openhands.sdk.agent import Agent
 from openhands.sdk.context.view import View
 from openhands.sdk.conversation import Conversation, LocalConversation
 from openhands.sdk.conversation.state import ConversationState
-from openhands.sdk.event import ActionEvent
+from openhands.sdk.event import ActionEvent, ObservationEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
@@ -24,7 +25,7 @@ from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.event.types import ROOT_PARENT_ID, SourceType
 from openhands.sdk.event.user_action import PauseEvent
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
-from openhands.sdk.tool.schema import Action
+from openhands.sdk.tool.schema import Action, Observation
 
 
 def _agent() -> Agent:
@@ -430,6 +431,72 @@ def test_legacy_resume_never_orphans_history_regardless_of_tail(make_tail):
         assert reachable[-1] == new.id
 
 
+def _make_kind_unregistered(tmpdir: str, event_id: str) -> None:
+    """Rewrite the stored event so its ``kind`` cannot be resolved in this process.
+
+    What a custom tool's event looks like on disk when the module that defines it
+    was never imported: the envelope and its ``parent_id`` are intact, the ``kind``
+    naming the payload type is unknown (#4080).
+    """
+    path = next(Path(tmpdir).rglob(f"*{event_id}.json"))
+    payload = json.loads(path.read_text())
+    # For an observation the unknown kind is the nested one; the envelope is fine.
+    target = payload.get("observation", payload)
+    target["kind"] = "CanvasUIObservation"
+    path.write_text(json.dumps(payload))
+
+
+def test_legacy_resume_with_unreadable_tail_keeps_history():
+    """A legacy log whose stored tail cannot be deserialized still resumes (#4080).
+
+    With no persisted leaf, ``_resolve_active_leaf`` scans back from the tail for
+    the last real event. Reading that tail strictly would fail the entire load on
+    one event whose kind this process does not know, and the agent-server drops
+    the whole conversation on any load exception.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        # Legacy flat log (no parent_id, leaf never advances) — pre-tree shape.
+        legacy = [_msg(f"legacy-{i}") for i in range(3)]
+        for ev in legacy:
+            conv.state.events.append(ev)
+        conv_id = conv.id
+        conv.close()
+        _make_kind_unregistered(tmp, legacy[-1].id)
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+
+        # The unreadable tail is skipped; the rest of the history survives.
+        assert resumed.state.leaf_event_id is None
+        assert _view_ids(resumed) == [e.id for e in legacy[:-1]]
+
+
+def test_resume_drops_action_left_unpaired_by_an_unreadable_observation():
+    """Skipping an observation must not leave its action unpaired in the view.
+
+    The view is what is sent to the LLM, and an action with no matching
+    observation is rejected by the API, so dropping only the observation would
+    trade a dead conversation for a failing one. ``ToolCallMatchingProperty``
+    drops the orphaned action (#4080).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        first = _emit(conv, _msg("draw a chart"))
+        action = _action_event()
+        _emit(conv, action)  # emitting preserves the id, so `action` stays valid
+        observation = _emit(conv, _observation_event(action))
+        last = _emit(conv, _msg("done", source="agent"))
+        conv_id = conv.id
+        conv.close()
+        _make_kind_unregistered(tmp, observation.id)
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+
+        # All four events are on disk; the view keeps the two that still pair up.
+        assert len(resumed.state.events) == 4
+        assert _view_ids(resumed) == [first.id, last.id]
+
+
 def test_parent_id_round_trips_on_disk_and_root_omits_it():
     """parent_id survives persistence; the root event's JSON omits it (additive)."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -500,6 +567,14 @@ class _MockAction(Action):
     command: str
 
 
+class _MockObservation(Observation):
+    result: str
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        return [TextContent(text=self.result)]
+
+
 def _action_event(call_id: str = "call_1") -> ActionEvent:
     """A minimal executable ActionEvent — pending until a matching observation."""
     tool_call = ChatCompletionMessageToolCall(
@@ -515,6 +590,17 @@ def _action_event(call_id: str = "call_1") -> ActionEvent:
         tool_call_id=call_id,
         tool_call=MessageToolCall.from_chat_tool_call(tool_call),
         llm_response_id="resp-1",
+    )
+
+
+def _observation_event(action: ActionEvent) -> ObservationEvent:
+    """The observation that pairs with ``action`` and settles it."""
+    return ObservationEvent(
+        source="environment",
+        observation=_MockObservation(result="ok"),
+        action_id=action.id,
+        tool_name=action.tool_name,
+        tool_call_id=action.tool_call_id,
     )
 
 

--- a/tests/sdk/conversation/test_event_tree.py
+++ b/tests/sdk/conversation/test_event_tree.py
@@ -1,5 +1,8 @@
 """Unit tests for the EventLog tree helpers and back-compat rule (#3747)."""
 
+import json
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -96,3 +99,114 @@ def test_effective_parent_id_rule(idx, expected):
     # idx 0, 1 are legacy (no explicit parent); idx 2 carries parent_id="a".
     log = _log(_event("a"), _event("b"), _event("c", parent_id="a"))
     assert log._effective_parent_id(idx, log[idx]) == expected
+
+
+# Reloading a store from disk re-indexes by filename, and EVENT_NAME_RE only
+# accepts hex-ish ids, so the #4080 tests below need id-shaped ids.
+A, B, C, D, E = "aaaaaaaa", "bbbbbbbb", "cccccccc", "dddddddd", "eeeeeeee"
+
+
+def _unregistered_payload(event_id: str, parent_id: str | None = None) -> str:
+    """A stored event whose ``kind`` is not registered in this process (#4080).
+
+    What a custom tool's observation looks like on disk when the module that
+    defines it was never imported, or an event written by a newer version.
+    """
+    payload: dict[str, object] = {"kind": "CanvasUIObservation", "id": event_id}
+    if parent_id is not None:
+        payload["parent_id"] = parent_id
+    return json.dumps(payload)
+
+
+def _store(*events: MessageEvent) -> InMemoryFileStore:
+    """Persist ``events``, then hand back the bare store for a cold reload."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+    for event in events:
+        log.append(event)
+    return fs
+
+
+def test_path_to_root_skips_event_with_unregistered_kind():
+    """One unloadable event must not strand the branch it sits on (#4080)."""
+    fs = _store(_event(A), _event(B, parent_id=A), _event(C, parent_id=B))
+    fs.write(f"events/event-00001-{B}.json", _unregistered_payload(B, parent_id=A))
+
+    # A cold load, so nothing is served from the in-process event cache.
+    log = EventLog(fs)
+
+    # B is skipped, and A is still reached, so the walk stepped *through* B.
+    assert [e.id for e in log.path_to_root(C)] == [A, C]
+
+
+def test_path_to_root_stays_on_its_branch_across_an_unreadable_event():
+    """Skipping must follow the stored parent_id, not drift onto a sibling branch."""
+    # A -> B -> C  and  A -> D -> E ; D is unreadable but still points at A.
+    fs = _store(
+        _event(A),
+        _event(B, parent_id=A),
+        _event(C, parent_id=B),
+        _event(D, parent_id=A),
+        _event(E, parent_id=D),
+    )
+    fs.write(f"events/event-00003-{D}.json", _unregistered_payload(D, parent_id=A))
+
+    log = EventLog(fs)
+
+    # Without the raw parent_id, the idx-1 fallback would land on C and splice
+    # the sibling branch into this one.
+    assert [e.id for e in log.path_to_root(E)] == [A, E]
+
+
+def test_path_to_root_skips_unreadable_legacy_event():
+    """A legacy (parent-less) event that cannot load falls back to the idx chain."""
+    fs = _store(_event(A), _event(B), _event(C))
+    fs.write(f"events/event-00001-{B}.json", _unregistered_payload(B))
+
+    log = EventLog(fs)
+
+    assert [e.id for e in log.path_to_root(C)] == [A, C]
+
+
+def test_path_to_root_skips_unreadable_leaf():
+    """The unreadable event may be the leaf itself, not only an interior node."""
+    fs = _store(_event(A), _event(B, parent_id=A))
+    fs.write(f"events/event-00001-{B}.json", _unregistered_payload(B, parent_id=A))
+
+    log = EventLog(fs)
+
+    assert [e.id for e in log.path_to_root(B)] == [A]
+
+
+def test_unreadable_event_with_unknown_parent_falls_back_to_linear_chain():
+    """A recovered parent_id is only trusted if it names an event we hold.
+
+    The raw payload failed validation, so its parent_id is not to be trusted
+    blindly: an id that is not in the log would raise KeyError out of the walk
+    and strand the conversation all over again.
+    """
+    fs = _store(_event(A), _event(B, parent_id=A), _event(C, parent_id=B))
+    fs.write(
+        f"events/event-00001-{B}.json",
+        _unregistered_payload(B, parent_id="ffffffff"),  # no such event
+    )
+
+    log = EventLog(fs)
+
+    assert [e.id for e in log.path_to_root(C)] == [A, C]
+
+
+def test_unreadable_event_warns_once_across_repeated_walks(caplog):
+    """``active_branch()`` re-walks the branch every agent step, so one bad event
+    must not warn on every walk for the life of the conversation."""
+    fs = _store(_event(A), _event(B, parent_id=A), _event(C, parent_id=B))
+    fs.write(f"events/event-00001-{B}.json", _unregistered_payload(B, parent_id=A))
+
+    log = EventLog(fs)
+    with caplog.at_level(logging.WARNING):
+        log.path_to_root(C)
+        log.path_to_root(C)
+
+    warnings = [r for r in caplog.records if "Skipping unreadable event" in r.message]
+    assert len(warnings) == 1
+    assert log._unreadable_parents == {1: A}  # parent recovered once, then reused


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

The change and this description were prepared by an AI agent (Claude) on behalf of Josh Kappler. Leaving the HUMAN section and the ready-for-review flip to him, per the template. Opening as a draft for that reason.

## Why

A conversation used a custom tool whose observation subclasses `Observation` with `kind="CanvasUIObservation"`. Resuming without that module imported leaves the kind unregistered, so those events do not deserialize. `Event.model_validate_json` raises, the error propagates up through `rebuild_view` -> `path_to_root`, and the agent-server startup scan wraps the whole per-conversation load in one `try/except`. The conversation is skipped: it 404s and never appears in listings, even though every other event is intact on disk. One unknown event kind takes down the whole conversation.

#3754 already took the skip-unreadable approach for the pagination and search path. This does the same for the load path.

## Summary

- `path_to_root` skips an event it cannot deserialize instead of raising. It recovers the skipped event's `parent_id` from the raw payload (a plain top-level string, still readable when the event as a whole does not validate), so the walk stays on its own branch instead of falling back to the linear chain and splicing in a sibling. That recovered id comes from a payload that just failed validation, so it is only trusted once it names an event we actually hold, and otherwise falls back to the linear chain.
- `_resolve_active_leaf` (the legacy scan, taken when no leaf is persisted) and the RUNNING crash-recovery scan in `EventService.start` now read per event as well. Both scan the full log, so either one raising still dropped the conversation.
- Shared `UNREADABLE_EVENT_ERRORS`, `read_event_or_none` and `readable_events` in `events_list_base.py`, using the same exception set as #3754.

## Issue Number

Closes #4080

## How to Test

Two processes, because the point is that the writer's custom kind is not registered in the reader. `writer.py` defines `CanvasUIObservation` and persists a conversation using it; `reader.py` resumes that same conversation and never imports it.

```python
# writer.py (abridged): a normal turn, user message -> tool call -> custom observation -> reply
class CanvasUIObservation(Observation):
    result: str
    @property
    def to_llm_content(self): return [TextContent(text=self.result)]

state = ConversationState.create(id=conversation_id, agent=agent, workspace=..., persistence_dir=...)
state.append_event(MessageEvent(source="user", llm_message=Message(role="user", content=[TextContent(text="draw a chart")])))
state.append_event(action)  # ActionEvent, tool_name="canvas"
state.append_event(ObservationEvent(source="environment", observation=CanvasUIObservation(result="canvas rendered"),
                                    action_id=action.id, tool_name="canvas", tool_call_id="call_canvas_1"))
state.append_event(MessageEvent(source="agent", llm_message=Message(role="assistant", content=[TextContent(text="Done.")])))

# reader.py: same call, in a process that never imports CanvasUIObservation
state = ConversationState.create(id=conversation_id, agent=agent, workspace=..., persistence_dir=...)
print(f"LOADED: {len(state.events)} events on disk, {len(list(state.view.events))} in the rebuilt view")
```

```
uv run python writer.py /tmp/persist /tmp/work
uv run python reader.py /tmp/persist /tmp/work <conversation_id>
```

Unit tests:

```
uv run pytest tests/sdk/conversation/ tests/sdk/event/ -q          # 871 passed
uv run pytest tests/agent_server/test_event_service.py -q          # 109 passed
```

## Video/Screenshots

Terminal, no GUI surface. Same on-disk conversation in both runs, written once by `writer.py`.

On current main (v1.36.0):

```
wrote 4 events
observation kind on disk: CanvasUIObservation
CONVERSATION_ID=be02ed5e-525e-409c-938c-c6099c95883d

LOAD FAILED: ValidationError
   1 validation error for Event
   -> agent-server logs error_loading_event_service and 404s the conversation
```

With this branch, reading that same conversation directory:

```
INFO  Resumed conversation be02ed5e-525e-409c-938c-c6099c95883d from persistent storage
LOADED: 4 events on disk, 2 in the rebuilt view
   kept MessageEvent (d04de660)
   kept MessageEvent (aa5eae55)
```

The unreadable observation is skipped and both messages survive. The action it would have paired with is dropped from the view by `ToolCallMatchingProperty`, so the view never carries a tool call with no result.

Each of the three new regression tests was also confirmed to fail without its fix: `ValidationError` for the legacy-tail and crash-recovery tests, `KeyError: 'ffffffff'` for the unknown-parent test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This skips the unreadable event. If you would rather retain it opaquely instead (the dummy action/observation idea in #2667), that is a larger change and I am happy to follow up separately.
- `EventLog.__iter__` and `__getitem__` still raise, deliberately, so `len(list(log)) == len(log)` stays honest. Reads outside the load path (the fork path in `local_conversation.py`, the goal loop, `get_agent_final_response`) therefore still surface a `ValidationError`. Those fail one call rather than dropping a conversation at startup, so I left them alone. Say the word if you want them covered here too.
- The unreadable event is re-read on each branch walk on purpose, since its kind may become registered later once the module defining it is imported. Only the parent recovery and the warning are memoized, so a 1,200 event conversation does not re-warn on every agent step.
