### PR TITLE
feat(tool): add structured outcome to FinishAction for infeasible tasks

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/builtins/finish.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/finish.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Literal, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from rich.text import Text
 
 from openhands.sdk.tool.tool import (
@@ -20,13 +20,42 @@ if TYPE_CHECKING:
 
 class FinishAction(Action):
     message: str = Field(description="Final message to send to the user.")
+    outcome: Literal["success", "infeasible"] = Field(
+        default="success",
+        description=(
+            "Outcome of the task. Use 'success' when the task was completed, "
+            "or 'infeasible' when the task cannot be completed as requested."
+        ),
+    )
+    reason: str | None = Field(
+        default=None,
+        description=(
+            "Reason the task is infeasible. Required (non-empty) when outcome "
+            "is 'infeasible'."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_reason(self) -> Self:
+        if self.reason is not None and not self.reason.strip():
+            raise ValueError("reason must be a non-empty string when provided")
+        if self.outcome == "infeasible" and self.reason is None:
+            raise ValueError("reason is required when outcome is 'infeasible'")
+        return self
 
     @property
     def visualize(self) -> Text:
         """Return Rich Text representation of this action."""
         content = Text()
-        content.append("Finish with message:\n", style="bold blue")
-        content.append(self.message)
+        if self.outcome == "infeasible":
+            content.append("Finish (infeasible) with message:\n", style="bold red")
+            content.append(self.message)
+            if self.reason:
+                content.append("\nReason: ", style="bold red")
+                content.append(self.reason)
+        else:
+            content.append("Finish with message:\n", style="bold blue")
+            content.append(self.message)
         return content
 
 
@@ -48,6 +77,11 @@ TOOL_DESCRIPTION = """Signals the completion of the current task or conversation
 Use this tool when:
 - You have successfully completed the user's requested task
 - You cannot proceed further due to technical limitations or missing information
+
+Set `outcome` to declare the result explicitly:
+- "success" (default): the task was completed as requested
+- "infeasible": the task cannot be completed as requested; in this case
+  `reason` must be provided with a non-empty explanation of why
 
 The message should include:
 - A clear summary of actions taken and their results

--- a/tests/sdk/tool/test_finish_tool.py
+++ b/tests/sdk/tool/test_finish_tool.py
@@ -1,0 +1,123 @@
+"""Tests for FinishAction outcome declaration (success vs. infeasible)."""
+
+import pytest
+from pydantic import ValidationError
+
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.tool.builtins.finish import (
+    FinishAction,
+    FinishExecutor,
+    FinishObservation,
+    FinishTool,
+)
+
+
+def _make_action_event(action: FinishAction) -> ActionEvent:
+    tool_call = MessageToolCall(
+        id="test-call-id", name="finish", arguments="{}", origin="completion"
+    )
+    return ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Finishing the task")],
+        action=action,
+        tool_name="finish",
+        tool_call_id="test-call-id",
+        tool_call=tool_call,
+        llm_response_id="test-response-id",
+    )
+
+
+def test_finish_action_defaults_to_success():
+    """Existing behavior is unchanged: message-only actions succeed."""
+    action = FinishAction(message="Task completed")
+    assert action.outcome == "success"
+    assert action.reason is None
+
+
+def test_finish_action_infeasible_with_reason():
+    action = FinishAction(
+        message="Cannot complete the task",
+        outcome="infeasible",
+        reason="The referenced API does not exist in this codebase",
+    )
+    assert action.outcome == "infeasible"
+    assert action.reason == "The referenced API does not exist in this codebase"
+
+
+def test_finish_action_infeasible_requires_reason():
+    with pytest.raises(ValidationError, match="reason is required"):
+        FinishAction(message="Cannot do it", outcome="infeasible")
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "\n\t"])
+def test_finish_action_rejects_empty_reason(reason: str):
+    with pytest.raises(ValidationError, match="non-empty"):
+        FinishAction(message="Cannot do it", outcome="infeasible", reason=reason)
+
+
+@pytest.mark.parametrize("reason", ["", "   "])
+def test_finish_action_rejects_empty_reason_even_on_success(reason: str):
+    with pytest.raises(ValidationError, match="non-empty"):
+        FinishAction(message="Done", outcome="success", reason=reason)
+
+
+def test_finish_action_rejects_unknown_outcome():
+    with pytest.raises(ValidationError):
+        FinishAction(message="Done", outcome="partial")  # type: ignore[arg-type]
+
+
+def test_outcome_detectable_from_action_event_without_text_parsing():
+    """Orchestrators can read the verdict off the ActionEvent directly."""
+    event = _make_action_event(
+        FinishAction(
+            message="This task cannot be completed.",
+            outcome="infeasible",
+            reason="Required credentials are not available",
+        )
+    )
+    assert isinstance(event.action, FinishAction)
+    assert event.action.outcome == "infeasible"
+    assert event.action.reason == "Required credentials are not available"
+
+
+def test_executor_returns_observation_for_infeasible_outcome():
+    executor = FinishExecutor()
+    observation = executor(
+        FinishAction(
+            message="Cannot proceed",
+            outcome="infeasible",
+            reason="Feature depends on an unreachable service",
+        )
+    )
+    assert isinstance(observation, FinishObservation)
+
+
+def test_finish_action_serialization_roundtrip():
+    action = FinishAction(
+        message="Cannot proceed",
+        outcome="infeasible",
+        reason="Repository is read-only",
+    )
+    restored = FinishAction.model_validate(action.model_dump())
+    assert restored == action
+
+
+def test_tool_schema_exposes_outcome_and_reason():
+    (tool,) = FinishTool.create()
+    schema = tool.action_type.model_json_schema()
+    assert "outcome" in schema["properties"]
+    assert "reason" in schema["properties"]
+    # message stays the only required field for backward compatibility
+    assert schema.get("required", []) == ["message"]
+
+
+def test_infeasible_visualization_mentions_reason():
+    action = FinishAction(
+        message="Cannot proceed",
+        outcome="infeasible",
+        reason="Repository is read-only",
+    )
+    text = action.visualize.plain
+    assert "infeasible" in text
+    assert "Repository is read-only" in text


### PR DESCRIPTION
HUMAN:

I ran into this limitation while building fully autonomous agents (no human-in-the-loop): when a task turned out to be impossible, the agent had no native way to signal an error or incomplete task to the orchestrator — `FinishAction` only carries free text. My workaround was a custom tool that triggered a finish action with an explicit failure signal, which is essentially what this PR upstreams properly, following Option A of RFC #4106.

AGENT:

## Why

Implements Option A of RFC #4106. Today `FinishAction` carries only a free-text `message`, so CI systems, benchmark runners and orchestrators cannot distinguish "task completed" from "agent deliberately declared the task impossible" without parsing text or running an extra LLM judge. `ConversationExecutionStatus` tracks execution state (not the agent's verdict) and `AgentErrorEvent` covers system errors (not deliberate decisions).

## Summary

- `FinishAction` gains `outcome: Literal["success", "infeasible"]` (default `"success"`) and an optional `reason: str | None`, so the verdict is machine-readable directly off the `ActionEvent` — no text parsing needed.
- A model validator requires a non-empty `reason` when `outcome="infeasible"` and rejects empty/whitespace-only reasons everywhere; the finish tool description tells the agent how to use the new fields, and `visualize` renders infeasible finishes in red with the reason.
- Fully backward compatible: `message` remains the only required field, the default outcome is `"success"`, and terminal behavior is untouched (the agent keys termination on the finish tool name, not the outcome).

## Issue Number

#4106

## How to Test

Run the new test suite (14 tests covering infeasibility declaration, empty-reason rejection, ActionEvent detectability, schema shape, serialization roundtrip, executor and visualization):

```
uv run pytest tests/sdk/tool/test_finish_tool.py -v
```

Also exercised end-to-end outside the unit tests, driving the real `FinishTool` instance created by `FinishTool.create()` through its executor:

```
default: success None
infeasible: infeasible | reason: API does not exist | obs: FinishObservation
empty reason rejected: Value error, reason must be a non-empty string when provided
missing reason rejected: Value error, reason is required when outcome is 'infeasible'
outcome enum: ['success', 'infeasible']
required: ['message']
```

Regression check — all 348 existing tests touching `FinishAction` pass unchanged (`tests/sdk/tool`, `tests/sdk/conversation/test_agent_final_response.py`, `tests/sdk/critic`, `tests/sdk/event/test_resume_transcript.py`, `tests/sdk/agent/test_iterative_refinement.py`, `tests/agent_server/test_conversation_response.py`, `tests/agent_server/test_openapi_discriminator.py`). `ruff check`, `ruff format --check` and `pyright` are clean on the changed files.

## Video/Screenshots

Terminal output from the end-to-end run is included above (library change, no GUI surface).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Option B from the RFC (a separate `ReportFailureTool`) was not implemented, per the RFC's stated preference for Option A. If maintainers later want `outcome` surfaced in `ConversationExecutionStatus` or the agent server API models, that can be a follow-up.
