### PR TITLE
fix(extensions): match github: source scheme case-insensitively

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/fetch.py
+++ b/openhands-sdk/openhands/sdk/extensions/fetch.py
@@ -58,7 +58,13 @@ def parse_extension_source(source: str) -> tuple[SourceType, str]:
     source = source.strip()
 
     # GitHub shorthand: github:owner/repo
-    if source.startswith("github:"):
+    # Match the scheme case-insensitively: mobile keyboards / browser
+    # autocapitalization often turn "github:" into "Github:" or "GitHub:", and a
+    # case-sensitive check would misclassify those as a local relative path
+    # (they contain "/" and no "://") and fail with a confusing
+    # "path does not exist" error. Only the scheme token is normalized; the
+    # owner/repo remainder is preserved verbatim (repo names are case-sensitive).
+    if source[:7].lower() == "github:":
         repo_path = source[7:]  # Remove "github:" prefix
         # Validate format
         if "/" not in repo_path or repo_path.count("/") > 1:

--- a/tests/sdk/extensions/test_fetch.py
+++ b/tests/sdk/extensions/test_fetch.py
@@ -32,6 +32,22 @@ def test_parse_github_shorthand_with_whitespace():
     assert url == "https://github.com/owner/repo.git"
 
 
+def test_parse_github_shorthand_case_insensitive_scheme():
+    # Mobile keyboards / browser autocapitalization mangle "github:" into
+    # "Github:" or "GitHub:". The scheme must match case-insensitively while the
+    # owner/repo remainder is preserved verbatim.
+    for src in ("Github:owner/repo", "GitHub:owner/repo", "GITHUB:owner/repo"):
+        source_type, url = parse_extension_source(src)
+        assert source_type == SourceType.GITHUB
+        assert url == "https://github.com/owner/repo.git"
+
+
+def test_parse_github_shorthand_preserves_remainder_case():
+    source_type, url = parse_extension_source("GitHub:Owner/RepoName")
+    assert source_type == SourceType.GITHUB
+    assert url == "https://github.com/Owner/RepoName.git"
+
+
 def test_parse_github_shorthand_invalid_format():
     with pytest.raises(ExtensionFetchError, match="Invalid GitHub shorthand"):
         parse_extension_source("github:invalid")


### PR DESCRIPTION
## Problem

`parse_extension_source()` matches the GitHub shorthand scheme case-sensitively (`source.startswith("github:")`). Mobile keyboards and browser autocapitalization frequently turn a typed `github:owner/repo` into `Github:owner/repo` (or `GitHub:owner/repo`).

Because the capitalized form misses the `github:` branch, it falls through to the relative-local-path branch (it contains `/` and no `://`) and is misclassified as `SourceType.LOCAL`. Fetching then fails with a confusing `Local extension path does not exist: …/Github:owner/repo` — giving the user no hint that capitalization was the real problem.

## Fix

Match the `github:` scheme case-insensitively, normalizing **only the scheme token** and preserving the `owner/repo` remainder verbatim (repo names and refs are case-sensitive, so a blanket `.lower()` would be wrong).

```python
if source[:7].lower() == "github:":
    repo_path = source[7:]
    ...
```

## Tests

Added regression tests to `tests/sdk/extensions/test_fetch.py`:
- `test_parse_github_shorthand_case_insensitive_scheme` — `Github:` / `GitHub:` / `GITHUB:` all classify as `GITHUB` -> `https://github.com/owner/repo.git`
- `test_parse_github_shorthand_preserves_remainder_case` — `GitHub:Owner/RepoName` preserves `Owner/RepoName` case

Full file passes: `43 passed`.

## Related

This is the backend/root-cause half of a two-part fix. The frontend trigger (the marketplace source input allowing autocapitalization) is fixed in a companion PR: **OpenHands/OpenHands#15273**. The two layers are complementary — this parser fix protects *every* entry path (paste, deep-links, marketplace catalog entries, API callers), while the frontend PR stops the mangling at the source for the specific field users reported.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:243fe1e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-243fe1e-python \
  ghcr.io/openhands/agent-server:243fe1e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:243fe1e-golang-amd64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-golang-amd64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-golang-amd64
ghcr.io/openhands/agent-server:243fe1e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:243fe1e-golang-arm64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-golang-arm64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-golang-arm64
ghcr.io/openhands/agent-server:243fe1e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:243fe1e-java-amd64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-java-amd64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-java-amd64
ghcr.io/openhands/agent-server:243fe1e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:243fe1e-java-arm64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-java-arm64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-java-arm64
ghcr.io/openhands/agent-server:243fe1e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:243fe1e-python-amd64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-python-amd64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-python-amd64
ghcr.io/openhands/agent-server:243fe1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:243fe1e-python-arm64
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-python-arm64
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-python-arm64
ghcr.io/openhands/agent-server:243fe1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:243fe1e-golang
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-golang
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-golang
ghcr.io/openhands/agent-server:243fe1e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:243fe1e-java
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-java
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-java
ghcr.io/openhands/agent-server:243fe1e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:243fe1e-python
ghcr.io/openhands/agent-server:243fe1e20b9910dd768edf55d76583a99c4ac898-python
ghcr.io/openhands/agent-server:fix-github-scheme-case-insensitive-python
ghcr.io/openhands/agent-server:243fe1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `243fe1e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `243fe1e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->