### PR TITLE
feat(browser): record visible sessions as WebM

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -313,7 +313,7 @@ RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     # GUI bits (remove entirely if headless)
-    tigervnc-standalone-server xfce4 dbus-x11 novnc websockify \
+    tigervnc-standalone-server xfce4 dbus-x11 novnc websockify ffmpeg \
     # Browser
     $(if grep -q "ubuntu" /etc/os-release; then echo "chromium-browser"; else echo "chromium"; fi); \
   apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -773,6 +773,89 @@ class BrowserStopRecordingTool(
         ]
 
 
+# ============================================
+# `browser_start_video_recording`
+# ============================================
+class BrowserStartVideoRecordingAction(BrowserAction):
+    """Schema for starting visible browser video recording."""
+
+    pass
+
+
+BROWSER_START_VIDEO_RECORDING_DESCRIPTION = """Start recording the visible browser
+desktop to a WebM video file.
+
+The browser must run in headed mode on an X11 display. Use this before exercising a
+user-visible interaction that needs video evidence, then call
+browser_stop_video_recording to finalize the file.
+"""
+
+
+class BrowserStartVideoRecordingTool(
+    ToolDefinition[BrowserStartVideoRecordingAction, BrowserObservation]
+):
+    """Tool for starting encoded browser video recording."""
+
+    @classmethod
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
+        return [
+            cls(
+                description=BROWSER_START_VIDEO_RECORDING_DESCRIPTION,
+                action_type=BrowserStartVideoRecordingAction,
+                observation_type=BrowserObservation,
+                annotations=ToolAnnotations(
+                    title="browser_start_video_recording",
+                    readOnlyHint=False,
+                    destructiveHint=False,
+                    idempotentHint=False,
+                    openWorldHint=False,
+                ),
+                executor=executor,
+            )
+        ]
+
+
+# ============================================
+# `browser_stop_video_recording`
+# ============================================
+class BrowserStopVideoRecordingAction(BrowserAction):
+    """Schema for stopping visible browser video recording."""
+
+    pass
+
+
+BROWSER_STOP_VIDEO_RECORDING_DESCRIPTION = """Stop the visible browser recording and
+finalize its WebM file.
+
+The result includes the absolute sandbox path. Pass that path to an artifact publishing
+tool when the recording should be attached to a session or pull request.
+"""
+
+
+class BrowserStopVideoRecordingTool(
+    ToolDefinition[BrowserStopVideoRecordingAction, BrowserObservation]
+):
+    """Tool for stopping encoded browser video recording."""
+
+    @classmethod
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
+        return [
+            cls(
+                description=BROWSER_STOP_VIDEO_RECORDING_DESCRIPTION,
+                action_type=BrowserStopVideoRecordingAction,
+                observation_type=BrowserObservation,
+                annotations=ToolAnnotations(
+                    title="browser_stop_video_recording",
+                    readOnlyHint=False,
+                    destructiveHint=False,
+                    idempotentHint=False,
+                    openWorldHint=False,
+                ),
+                executor=executor,
+            )
+        ]
+
+
 class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
     """A set of all browser tools.
 
@@ -856,6 +939,8 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
             BrowserSetStorageTool,
             BrowserStartRecordingTool,
             BrowserStopRecordingTool,
+            BrowserStartVideoRecordingTool,
+            BrowserStopVideoRecordingTool,
         ]:
             tools.extend(tool_class.create(executor))
         return tools

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -29,6 +29,7 @@ from openhands.tools.browser_use.definition import (
     BrowserObservation,
 )
 from openhands.tools.browser_use.server import CustomBrowserUseServer
+from openhands.tools.browser_use.video_recording import BrowserVideoRecorder
 from openhands.tools.utils.timeout import (
     TimeoutError as ToolTimeoutError,
     run_with_timeout,
@@ -405,6 +406,7 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
         self._cleanup_initiated = False
         self._action_timeout_seconds = action_timeout_seconds
         self._consecutive_failures = 0
+        self._video_recorder = BrowserVideoRecorder(full_output_save_dir)
 
     def __call__(
         self,
@@ -496,7 +498,9 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
             BrowserScrollAction,
             BrowserSetStorageAction,
             BrowserStartRecordingAction,
+            BrowserStartVideoRecordingAction,
             BrowserStopRecordingAction,
+            BrowserStopVideoRecordingAction,
             BrowserSwitchTabAction,
             BrowserTypeAction,
         )
@@ -534,6 +538,10 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
                 result = await self.start_recording()
             elif isinstance(action, BrowserStopRecordingAction):
                 result = await self.stop_recording()
+            elif isinstance(action, BrowserStartVideoRecordingAction):
+                result = await self.start_video_recording()
+            elif isinstance(action, BrowserStopVideoRecordingAction):
+                result = await self.stop_video_recording()
             else:
                 error_msg = f"Unsupported action type: {type(action)}"
                 return BrowserObservation.from_text(
@@ -683,6 +691,15 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
         await self._ensure_initialized()
         return await self._server._stop_recording()
 
+    async def start_video_recording(self) -> str:
+        """Start recording the visible browser desktop to WebM."""
+        await self._ensure_initialized()
+        return await self._video_recorder.start()
+
+    async def stop_video_recording(self) -> str:
+        """Stop the visible browser recording and finalize the WebM file."""
+        return await self._video_recorder.stop()
+
     async def close_browser(self) -> str:
         """Close the browser session."""
         if self._initialized:
@@ -694,6 +711,8 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
     async def cleanup(self):
         """Cleanup browser resources."""
         try:
+            if self._video_recorder.is_recording:
+                await self._video_recorder.stop()
             # Use _close_all_sessions instead of close_browser because it calls
             # session.kill() which properly stops the event bus and drains
             # pending events (including BrowserKillEvent that terminates the

--- a/openhands-tools/openhands/tools/browser_use/video_recording.py
+++ b/openhands-tools/openhands/tools/browser_use/video_recording.py
@@ -1,0 +1,124 @@
+"""Visible desktop video recording for browser QA evidence."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import signal
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+VIDEO_OUTPUT_DIR = "browser_videos"
+
+
+class BrowserVideoRecorder:
+    """Record the X11 desktop containing the headed browser to WebM."""
+
+    def __init__(self, output_root: str | None) -> None:
+        self._output_root = output_root
+        self._process: asyncio.subprocess.Process | None = None
+        self._output_path: Path | None = None
+
+    @property
+    def is_recording(self) -> bool:
+        return self._process is not None and self._process.returncode is None
+
+    async def start(self) -> str:
+        if self.is_recording:
+            assert self._output_path is not None
+            return f"Error: Video recording is already active at {self._output_path}"
+
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            return "Error: ffmpeg is required for browser video recording"
+
+        display = os.getenv("DISPLAY")
+        if display is None:
+            return "Error: DISPLAY is required for visible browser video recording"
+
+        geometry = os.getenv("VNC_GEOMETRY", "1280x800")
+        if not self._valid_geometry(geometry):
+            return f"Error: Invalid VNC_GEOMETRY value: {geometry}"
+
+        output_root = (
+            Path(self._output_root)
+            if self._output_root is not None
+            else Path.cwd() / ".agent_tmp" / "browser_observations"
+        )
+        output_dir = output_root / VIDEO_OUTPUT_DIR
+        output_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        self._output_path = (output_dir / f"browser-{timestamp}.webm").resolve()
+
+        self._process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-y",
+            "-f",
+            "x11grab",
+            "-framerate",
+            "15",
+            "-video_size",
+            geometry,
+            "-i",
+            f"{display}.0",
+            "-an",
+            "-c:v",
+            "libvpx-vp9",
+            "-deadline",
+            "realtime",
+            "-cpu-used",
+            "8",
+            "-b:v",
+            "1M",
+            str(self._output_path),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.sleep(0.5)
+        if self._process.returncode is not None:
+            returncode = self._process.returncode
+            self._reset()
+            return f"Error: ffmpeg exited before recording started ({returncode})"
+
+        return f"Browser video recording started: {self._output_path}"
+
+    async def stop(self) -> str:
+        if not self.is_recording:
+            return "Error: Browser video recording is not active"
+
+        assert self._process is not None
+        assert self._output_path is not None
+        process = self._process
+        output_path = self._output_path
+        process.send_signal(signal.SIGINT)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=10)
+        except TimeoutError:
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+        self._reset()
+
+        if not output_path.is_file() or output_path.stat().st_size == 0:
+            return "Error: Browser video recording did not produce a file"
+        return f"Browser video recording saved: {output_path}"
+
+    @staticmethod
+    def _valid_geometry(geometry: str) -> bool:
+        width, separator, height = geometry.partition("x")
+        return (
+            separator == "x"
+            and width.isdigit()
+            and height.isdigit()
+            and int(width) > 0
+            and int(height) > 0
+        )
+
+    def _reset(self) -> None:
+        self._process = None
+        self._output_path = None

--- a/tests/tools/browser_use/test_browser_toolset.py
+++ b/tests/tools/browser_use/test_browser_toolset.py
@@ -68,7 +68,7 @@ def test_browser_toolset_create_returns_list():
         tools = BrowserToolSet.create(conv_state=conv_state)
 
         assert isinstance(tools, list)
-        assert len(tools) == 14  # All browser tools (including recording tools)
+        assert len(tools) == 16  # All browser tools (including recording tools)
 
         # Verify all items are Tool instances
         for tool in tools:
@@ -100,6 +100,8 @@ def test_browser_toolset_create_includes_all_browser_tools():
             "browser_set_storage",
             "browser_start_recording",
             "browser_stop_recording",
+            "browser_start_video_recording",
+            "browser_stop_video_recording",
         ]
 
         # Verify all expected tools are present

--- a/tests/tools/browser_use/test_video_recording.py
+++ b/tests/tools/browser_use/test_video_recording.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openhands.tools.browser_use.video_recording import BrowserVideoRecorder
+
+
+@pytest.mark.asyncio
+async def test_video_recorder_returns_absolute_webm_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISPLAY", ":1")
+    monkeypatch.setenv("VNC_GEOMETRY", "1280x800")
+    process = MagicMock()
+    process.returncode = None
+    process.wait = AsyncMock(return_value=0)
+    output_path: Path | None = None
+
+    async def create_process(*args, **_kwargs):
+        nonlocal output_path
+        output_path = Path(args[-1])
+        return process
+
+    recorder = BrowserVideoRecorder(str(tmp_path))
+    with (
+        patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("asyncio.create_subprocess_exec", side_effect=create_process),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        start_result = await recorder.start()
+        assert output_path is not None
+        output_path.write_bytes(b"webm")
+        stop_result = await recorder.stop()
+
+    assert str(output_path.resolve()) in start_result
+    assert str(output_path.resolve()) in stop_result
+    process.send_signal.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_video_recorder_requires_ffmpeg(tmp_path):
+    recorder = BrowserVideoRecorder(str(tmp_path))
+
+    with patch("shutil.which", return_value=None):
+        result = await recorder.start()
+
+    assert result == "Error: ffmpeg is required for browser video recording"
+
+
+@pytest.mark.asyncio
+async def test_video_recorder_terminates_process_after_timeout(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISPLAY", ":1")
+    process = MagicMock()
+    process.returncode = None
+    process.wait = AsyncMock(return_value=0)
+
+    recorder = BrowserVideoRecorder(str(tmp_path))
+    with (
+        patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        await recorder.start()
+
+    output_path = recorder._output_path
+    assert output_path is not None
+    output_path.write_bytes(b"webm")
+    process.wait = AsyncMock(side_effect=[TimeoutError, 0])
+
+    result = await recorder.stop()
+
+    assert result.startswith("Browser video recording saved:")
+    process.terminate.assert_called_once()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Browser agents can capture screenshots and rrweb replay data, but cannot create encoded video evidence of the visible UI they operate.

## Summary

- add visible X11 recording actions to `BrowserToolSet`
- encode VP9 WebM with FFmpeg and return an absolute artifact path
- install FFmpeg in full Agent Server images while retaining rrweb compatibility

## Issue Number

N/A

## How to Test

1. Build the source Agent Server image with `docker build --target source -t openhands-agent-server:computer-use-dev -f openhands-agent-server/openhands/agent_server/docker/Dockerfile .`.
2. Run it with `OH_ENABLE_VNC=true` and expose ports 8000 and 8002.
3. Execute `BrowserNavigateAction`, `BrowserStartVideoRecordingAction`, wait while interacting, then execute `BrowserStopVideoRecordingAction`.
4. Verify the returned absolute WebM path with `ffprobe`.

Validated locally:
- `uv run pytest tests/tools/browser_use`: 151 passed
- all touched-file pre-commit hooks passed
- noVNC returned HTTP 200 and rendered the headed browser
- generated WebM: VP9, 1280x800, 3.6 seconds, 943854 bytes

## Video/Screenshots

A live noVNC session and encoded WebM were verified locally. The generated file was temporary test evidence and was not committed.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The recorder is additive. Existing `browser_start_recording` and `browser_stop_recording` continue to produce rrweb JSON. Video capture requires the full image with headed X11/VNC enabled; minimal images return a clear missing-FFmpeg/display error.