### PR TITLE
fix(acp): bound ACP server startup with a timeout

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1021,15 +1021,20 @@ def _classify_acp_init_error(exc: BaseException) -> str:
     - ``ACPAuthRequired``: a credential failure — the explicit ``-32000`` auth code,
       or a ``-32603`` whose message/data reveals an upstream 401/403 (see
       :func:`_acp_error_indicates_auth`).  The most actionable cloud failure.
+    - ``ACPStartupTimeout``: startup did not complete within
+      ``acp_startup_timeout`` — e.g. the server hung on ``authenticate()``
+      without ever returning an error (see :meth:`ACPAgent._start_acp_server`).
     - ``ACPSpawnError``: the subprocess could not be launched — the CLI binary is
       missing or not executable (``FileNotFoundError`` / ``PermissionError`` from
       ``create_subprocess_exec``).
     - ``ACPInitError``: anything else during the protocol handshake or session
-      creation (timeouts, transport drops, unexpected protocol errors, cwd
-      mismatch surfaced by the server).
+      creation (transport drops, unexpected protocol errors, cwd mismatch
+      surfaced by the server).
     """
     if _acp_error_indicates_auth(exc):
         return "ACPAuthRequired"
+    if isinstance(exc, TimeoutError):
+        return "ACPStartupTimeout"
     if isinstance(exc, (FileNotFoundError, PermissionError)):
         return "ACPSpawnError"
     return "ACPInitError"
@@ -1533,6 +1538,18 @@ class ACPAgent(AgentBase):
             "only aborted after this many seconds with no activity at all. "
             "Prevents indefinite hangs when the ACP server stops responding "
             "without killing legitimately long-running work."
+        ),
+    )
+    acp_startup_timeout: float = Field(
+        default=90.0,
+        description=(
+            "Timeout in seconds for ACP server startup: spawning the "
+            "subprocess, the initialize/authenticate handshake, and "
+            "new_session()/load_session(). Unlike acp_prompt_timeout, this "
+            "is a hard deadline rather than an idle deadline, since startup "
+            "has no intermediate progress signal to reset it against. "
+            "Prevents an indefinite hang when the ACP server blocks on "
+            "authentication (e.g. an expired token) without ever raising."
         ),
     )
     acp_model: str | None = Field(
@@ -2306,6 +2323,13 @@ class ACPAgent(AgentBase):
                         companion,
                     )
 
+    def _startup_timeout_message(self) -> str:
+        return (
+            f"ACP startup timed out after {self.acp_startup_timeout:.0f}s "
+            "waiting for the ACP server to spawn, authenticate, and "
+            "create/load a session"
+        )
+
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
         client = _OpenHandsACPBridge()
@@ -2671,14 +2695,19 @@ class ACPAgent(AgentBase):
         # _conn / _process / _filtered_reader are assigned to the instance inside
         # _init() so a mid-init failure can be cleaned up; only the
         # success-only fields (including the resolved model state) are returned.
-        (
-            self._session_id,
-            self._agent_name,
-            self._agent_version,
-            self._current_model_id,
-            self._available_models,
-            self._model_override_applied,
-        ) = self._executor.run_async(_init)
+        try:
+            (
+                self._session_id,
+                self._agent_name,
+                self._agent_version,
+                self._current_model_id,
+                self._available_models,
+                self._model_override_applied,
+            ) = self._executor.run_async(_init, timeout=self.acp_startup_timeout)
+        except TimeoutError:
+            # run_async's own TimeoutError carries no message (anyio.fail_after);
+            # raise a descriptive one so _acp_error_detail (str(exc)) isn't blank.
+            raise TimeoutError(self._startup_timeout_message()) from None
         self._working_dir = working_dir
 
     def _reset_client_for_turn(

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -256,6 +256,14 @@ class ACPAgentProfile(AgentProfileBase):
             "resets on every update from the server."
         ),
     )
+    acp_startup_timeout: float = Field(
+        default=90.0,
+        gt=0,
+        description=(
+            "Timeout (seconds) for ACP server startup: spawn, "
+            "initialize/authenticate, and new_session()/load_session()."
+        ),
+    )
     acp_command: str | None = Field(
         default=None,
         description=(

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -294,6 +294,7 @@ def _build_acp_settings(
         "acp_model": profile.acp_model,
         "acp_session_mode": profile.acp_session_mode,
         "acp_prompt_timeout": profile.acp_prompt_timeout,
+        "acp_startup_timeout": profile.acp_startup_timeout,
         "acp_command": command,
         "acp_args": list(profile.acp_args) if profile.acp_args else [],
         "mcp_config": mcp_config,

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -46,6 +46,7 @@ def build_seed_profile(
             acp_model=agent_settings.acp_model,
             acp_session_mode=agent_settings.acp_session_mode,
             acp_prompt_timeout=agent_settings.acp_prompt_timeout,
+            acp_startup_timeout=agent_settings.acp_startup_timeout,
             # Settings store the command as a token list; the profile holds a
             # single (re-parseable) string. Empty list => use the server default.
             acp_command=(

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1534,6 +1534,28 @@ class ACPAgentSettings(AgentSettingsBase):
             ).model_dump(),
         },
     )
+    acp_startup_timeout: float = Field(
+        default=90.0,
+        gt=0,
+        description=(
+            "Timeout (seconds) for ACP server startup: spawning the "
+            "subprocess, the initialize/authenticate handshake, and "
+            "new_session()/load_session(). A hard deadline, unlike "
+            "acp_prompt_timeout, since startup has no intermediate progress "
+            "signal to reset it against."
+        ),
+        json_schema_extra={
+            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
+                label="ACP startup timeout (seconds)",
+                prominence=SettingProminence.MINOR,
+            ).model_dump(),
+            SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
+                key="acp",
+                label="ACP (Agent Client Protocol)",
+                variant="acp",
+            ).model_dump(),
+        },
+    )
     mcp_config: dict[str, MCPServer] = Field(
         default_factory=dict,
         description=(
@@ -1775,6 +1797,7 @@ class ACPAgentSettings(AgentSettingsBase):
             acp_model=self.acp_model,
             acp_session_mode=self.acp_session_mode,
             acp_prompt_timeout=self.acp_prompt_timeout,
+            acp_startup_timeout=self.acp_startup_timeout,
             acp_isolate_data_dir=self.acp_isolate_data_dir,
             acp_file_secrets=list(self.acp_file_secrets),
             agent_context=self.agent_context,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -773,6 +773,9 @@ class TestClassifyACPInitError:
         exc = ACPRequestError(-32603, "Internal error")
         assert _classify_acp_init_error(exc) == "ACPInitError"
 
+    def test_timeout_error_is_startup_timeout(self):
+        assert _classify_acp_init_error(TimeoutError()) == "ACPStartupTimeout"
+
     def test_file_not_found_is_spawn_error(self):
         assert _classify_acp_init_error(FileNotFoundError()) == "ACPSpawnError"
 
@@ -6569,6 +6572,49 @@ class TestACPSessionIdPersistence:
         assert kwargs["cwd"] == str(workspace)
         conn2.new_session.assert_not_awaited()
         assert agent2._session_id == "roundtrip-sess"
+
+    def test_start_acp_server_bounds_a_hung_handshake_call(self, tmp_path):
+        """A hung ACP call during the handshake (e.g. codex-acp blocking on an
+        expired id_token inside authenticate(), #3629) used to freeze
+        init_state() forever. acp_startup_timeout now bounds the whole
+        _init() coroutine, and the resulting bare TimeoutError (raised by
+        anyio.fail_after with no message) is converted to a descriptive one."""
+        agent = _make_agent(acp_startup_timeout=0.05)
+        state = _make_state(tmp_path)
+        conn = self._make_conn()
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(10)
+
+        conn.initialize = _hang
+
+        with pytest.raises(TimeoutError, match="ACP startup timed out after 0s"):
+            self._patched_start_acp_server(agent, state, conn=conn)
+
+    def test_init_state_surfaces_startup_timeout(self, tmp_path):
+        """The converted TimeoutError reaches the client as a typed
+        ACPStartupTimeout ConversationErrorEvent, not a generic ACPInitError,
+        via the same init_state() cold-start path as other classified
+        failures."""
+        agent = _make_agent(acp_startup_timeout=0.05)
+        state = _make_state(tmp_path)
+        conn = self._make_conn()
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(10)
+
+        conn.initialize = _hang
+        events: list = []
+
+        with self._transport_patches(conn):
+            with pytest.raises(TimeoutError):
+                agent.init_state(state, on_event=events.append)
+
+        errors = [e for e in events if isinstance(e, ConversationErrorEvent)]
+        assert len(errors) == 1
+        assert errors[0].code == "ACPStartupTimeout"
+        assert "ACP startup timed out after 0s" in errors[0].detail
+        assert state.execution_status == ConversationExecutionStatus.ERROR
 
 
 class TestACPSecretsEnvInjection:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -168,6 +168,7 @@ def test_acp_agent_settings_export_schema_has_acp_section() -> None:
         "acp_model",
         "acp_session_mode",
         "acp_prompt_timeout",
+        "acp_startup_timeout",
     }
     # Server picker + model are both critical — users pick server then
     # model. Raw command is a minor override for power users.


### PR DESCRIPTION
HUMAN:

Picked this up from the open issue tracker, fix verified locally.

---

AGENT:

## Why

`ACPAgent._start_acp_server` runs its spawn + `initialize()`/`authenticate()`/`new_session()`/`load_session()` coroutine (`_init()`) via `self._executor.run_async(_init)` with no timeout. If any of those ACP calls hang — e.g. codex-acp blocking indefinitely on `authenticate()` when the local `id_token` is expired — the coroutine never returns and never raises, so `init_state()` freezes forever. Because a silent hang never raises, the existing `try/except` in `init_state()` that emits a typed `ConversationErrorEvent` is never reached, and the client sees no error at all — just a spinner forever.

## Summary

- Added `acp_startup_timeout: float` (default 90s) to `ACPAgent`, mirroring the existing `acp_prompt_timeout` idle-timeout field.
- Passed `timeout=self.acp_startup_timeout` to the existing `run_async(...)` call (it already supports a `timeout` kwarg via `anyio.fail_after`, already used elsewhere in this file for the prompt-turn idle timeout).
- The resulting bare `TimeoutError` (`anyio.fail_after` raises one with no message) is caught and re-raised with a descriptive message, mirroring `_idle_timeout_message()`'s pattern for the turn-loop path.
- Added an `ACPStartupTimeout` branch to `_classify_acp_init_error()` so `init_state()`'s existing cold-start error handler emits a typed `ConversationErrorEvent` instead of the generic `ACPInitError`.
- Wired the new field through every place that already mirrors `acp_prompt_timeout`: `ACPAgentSettings` (+ its `create_agent()` pass-through), `ACPAgentProfile`, and the two settings↔profile conversion helpers (`profiles/seed.py`, `profiles/resolver.py`).

## Issue Number

#3629

## How to Test

Ran the full local test suite after the change:

```
uv run pytest tests/sdk/agent/test_acp_agent.py tests/sdk/test_settings.py tests/sdk/profiles/ \
  tests/agent_server/test_settings_router.py tests/agent_server/test_conversation_router.py -q
# 832 passed

uv run pyright openhands-sdk/openhands/sdk/agent/acp_agent.py openhands-sdk/openhands/sdk/settings/model.py \
  openhands-sdk/openhands/sdk/profiles/agent_profile.py openhands-sdk/openhands/sdk/profiles/seed.py \
  openhands-sdk/openhands/sdk/profiles/resolver.py
# 0 errors

make lint
# All checks passed!
```

Added two new regression tests that reproduce the reported hang directly: `test_start_acp_server_bounds_a_hung_handshake_call` makes `conn.initialize()` hang for 10s with `acp_startup_timeout=0.05`, and asserts `_start_acp_server` raises a descriptive `TimeoutError` well before the 10s would elapse (test runs in well under a second). `test_init_state_surfaces_startup_timeout` drives the same hang through the full `init_state()` path and asserts the client-facing `ConversationErrorEvent` carries code `ACPStartupTimeout` and the descriptive detail message. Also added `test_timeout_error_is_startup_timeout` for the classifier unit.

Pre-commit hooks (ruff format, ruff lint, pycodestyle, pyright, import-dependency rules, tool-subclass registration) all passed on commit.

## Video/Screenshots

Not applicable — backend Python logic fix with no UI surface; verified via the tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

New field defaults to 90s, within the 60-90s range suggested in the issue. No breaking changes — existing callers get the new timeout automatically with a sane default; no config migration needed.
