### PR TITLE
fix(llm): skip unauthenticated managed proxy model-info lookup

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -36,7 +36,10 @@ def _get_model_info_from_litellm_proxy(
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        response = httpx.get(f"{base_url}/v1/model/info", headers=headers)
+        normalized_base_url = base_url.rstrip("/")
+        if normalized_base_url.endswith("/v1"):
+            normalized_base_url = normalized_base_url[:-3]
+        response = httpx.get(f"{normalized_base_url}/v1/model/info", headers=headers)
         data = response.json().get("data", [])
         # Match against either the public alias (`model_name`) or the
         # underlying provider/model_name form (`litellm_params.model`). The proxy itself

--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -7,10 +7,19 @@ from litellm.types.utils import ModelInfo
 from litellm.utils import get_model_info
 from pydantic import SecretStr
 
-from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
+from openhands.sdk.llm.utils.openhands_provider import (
+    is_openhands_proxy_base_url,
+    litellm_call_kwargs,
+)
 
 
 logger = getLogger(__name__)
+
+
+def _get_api_key_value(secret_api_key: SecretStr | str | None) -> str | None:
+    if isinstance(secret_api_key, SecretStr):
+        return secret_api_key.get_secret_value()
+    return secret_api_key
 
 
 @lru_cache
@@ -23,10 +32,9 @@ def _get_model_info_from_litellm_proxy(
     logger.debug(f"Get model_info_from_litellm_proxy:{cache_key}")
     try:
         headers = {}
-        if isinstance(secret_api_key, SecretStr):
-            secret_api_key = secret_api_key.get_secret_value()
-        if secret_api_key:
-            headers["Authorization"] = f"Bearer {secret_api_key}"
+        api_key = _get_api_key_value(secret_api_key)
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
         response = httpx.get(f"{base_url}/v1/model/info", headers=headers)
         data = response.json().get("data", [])
@@ -65,6 +73,7 @@ def get_litellm_model_info(
     call_kwargs = litellm_call_kwargs(model, base_url)
     model = call_kwargs["model"]
     base_url = call_kwargs["api_base"]
+    api_key = _get_api_key_value(secret_api_key)
 
     # Try to get model info via openrouter or litellm proxy first
     try:
@@ -76,17 +85,23 @@ def get_litellm_model_info(
         logger.debug(f"get_model_info(openrouter) failed: {e}")
 
     if model.startswith("litellm_proxy/") and base_url:
-        # Use the current hour as a cache key - only refresh hourly
-        cache_key = int(time.time() / 3600)
+        if is_openhands_proxy_base_url(base_url) and not api_key:
+            logger.debug(
+                "Skipping unauthenticated model-info lookup for managed "
+                "OpenHands proxy"
+            )
+        else:
+            # Use the current hour as a cache key - only refresh hourly
+            cache_key = int(time.time() / 3600)
 
-        model_info = _get_model_info_from_litellm_proxy(
-            secret_api_key=secret_api_key,
-            base_url=base_url,
-            model=model,
-            cache_key=cache_key,
-        )
-        if model_info:
-            return model_info
+            model_info = _get_model_info_from_litellm_proxy(
+                secret_api_key=api_key,
+                base_url=base_url,
+                model=model,
+                cache_key=cache_key,
+            )
+            if model_info:
+                return model_info
 
     # Fallbacks: try base name variants
     try:

--- a/tests/sdk/llm/test_model_info_proxy_lookup.py
+++ b/tests/sdk/llm/test_model_info_proxy_lookup.py
@@ -13,6 +13,8 @@ aliases (claude-opus-4-8 vision still off).
 
 from unittest.mock import patch
 
+from pydantic import SecretStr
+
 from openhands.sdk.llm.utils.model_info import (
     _get_model_info_from_litellm_proxy,
     get_litellm_model_info,
@@ -111,12 +113,89 @@ def test_get_litellm_model_info_uses_proxy_match_for_provider_prefixed_id():
     assert info.get("supports_vision") is True
 
 
+def test_managed_openhands_provider_skips_proxy_lookup_without_api_key():
+    with (
+        patch("openhands.sdk.llm.utils.model_info.httpx.get") as httpx_get,
+        patch("openhands.sdk.llm.utils.model_info.get_model_info", return_value=None),
+    ):
+        for missing_key in (None, "", SecretStr("")):
+            info = get_litellm_model_info(
+                secret_api_key=missing_key,
+                base_url=None,
+                model="openhands/claude-opus-4-8",
+            )
+            assert info is None
+
+    httpx_get.assert_not_called()
+
+
+def test_managed_proxy_url_skips_lookup_without_api_key():
+    with (
+        patch("openhands.sdk.llm.utils.model_info.httpx.get") as httpx_get,
+        patch("openhands.sdk.llm.utils.model_info.get_model_info", return_value=None),
+    ):
+        info = get_litellm_model_info(
+            secret_api_key=None,
+            base_url="https://llm-proxy.app.all-hands.dev/v1/",
+            model="litellm_proxy/claude-opus-4-8",
+        )
+
+    assert info is None
+    httpx_get.assert_not_called()
+
+
+def test_authless_custom_litellm_proxy_still_queries_model_info():
+    with patch(
+        "openhands.sdk.llm.utils.model_info.httpx.get",
+        return_value=_FakeResponse(_PROXY_RESPONSE),
+    ) as httpx_get:
+        info = get_litellm_model_info(
+            secret_api_key=None,
+            base_url="https://proxy.example",
+            model="litellm_proxy/claude-opus-4-8",
+        )
+
+    assert info is not None
+    assert info.get("supports_vision") is True
+    httpx_get.assert_called_once_with(
+        "https://proxy.example/v1/model/info",
+        headers={},
+    )
+
+
+def test_custom_openhands_proxy_without_api_key_still_queries_model_info():
+    with patch(
+        "openhands.sdk.llm.utils.model_info.httpx.get",
+        return_value=_FakeResponse(_PROXY_RESPONSE),
+    ) as httpx_get:
+        info = get_litellm_model_info(
+            secret_api_key=None,
+            base_url="https://custom-openhands.example",
+            model="openhands/claude-opus-4-8",
+        )
+
+    assert info is not None
+    assert info.get("supports_vision") is True
+    httpx_get.assert_called_once_with(
+        "https://custom-openhands.example/v1/model/info",
+        headers={},
+    )
+
+
 def test_get_litellm_model_info_uses_proxy_for_openhands_provider_model():
-    with patch("openhands.sdk.llm.utils.model_info.httpx.get", _patched_httpx_get):
+    with patch(
+        "openhands.sdk.llm.utils.model_info.httpx.get",
+        return_value=_FakeResponse(_PROXY_RESPONSE),
+    ) as httpx_get:
         info = get_litellm_model_info(
             secret_api_key="k",
             base_url=None,
             model="openhands/claude-opus-4-8",
         )
+
     assert info is not None
     assert info.get("supports_vision") is True
+    httpx_get.assert_called_once_with(
+        "https://llm-proxy.app.all-hands.dev/v1/model/info",
+        headers={"Authorization": "Bearer k"},
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->
<!-- AI/LLM agents: Do not edit the HUMAN section. -->

HUMAN:

I reviewed the implementation and ran the focused model-info proxy tests,
Ruff lint, and Ruff formatting checks locally. All passed.

AGENT:

---

## Why

Constructing an `LLM` for an `openhands/*` model translates it to the managed
LiteLLM proxy before model-info discovery. When no API key is available, the SDK
currently still calls `/v1/model/info` without authentication. The managed proxy
cannot return key-scoped metadata in that case, responds with 401, and the SDK
falls back to static LiteLLM metadata anyway.

This creates avoidable unauthenticated traffic during startup, profile loading,
validation, and deserialization.

## Summary

- Recognize the managed OpenHands proxy using the existing normalized URL helper.
- Skip proxy model-info discovery only when that managed proxy has no API key.
- Continue using the existing static LiteLLM metadata fallback.
- Preserve authenticated managed-proxy discovery and Bearer-token behavior.
- Preserve unauthenticated discovery for generic or custom LiteLLM proxies.
- Preserve custom `openhands/*` proxy URLs instead of treating them as managed.
- Add focused regression coverage for each behavior.

## Issue Number

Closes #4098

## How to Test

```bash
uv run pytest tests/sdk/llm/test_model_info_proxy_lookup.py
uv run ruff check   openhands-sdk/openhands/sdk/llm/utils/model_info.py   tests/sdk/llm/test_model_info_proxy_lookup.py
uv run ruff format --check   openhands-sdk/openhands/sdk/llm/utils/model_info.py   tests/sdk/llm/test_model_info_proxy_lookup.py
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore