### PR TITLE
fix(llm): retry empty chat streams

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2118,6 +2118,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     on_token(chunk)
                     chunks.append(chunk)
                 ret = litellm.stream_chunk_builder(chunks, messages=messages)
+                if ret is None:
+                    raise LLMNoResponseError("Streaming response contained no chunks.")
 
             assert isinstance(ret, ModelResponse), (
                 f"Expected ModelResponse, got {type(ret)}"
@@ -2163,6 +2165,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         await _invoke_token_callback(on_token, chunk)
                         chunks.append(chunk)
                 ret = litellm.stream_chunk_builder(chunks, messages=messages)
+                if ret is None:
+                    raise LLMNoResponseError("Streaming response contained no chunks.")
 
             assert isinstance(ret, ModelResponse), (
                 f"Expected ModelResponse, got {type(ret)}"

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -114,6 +114,35 @@ def test_no_response_retry_bumps_temperature(mock_completion, base_llm: LLM) -> 
     assert second_kwargs.get("temperature") == 1.0
 
 
+@patch("openhands.sdk.llm.llm.litellm_completion")
+@patch("openhands.sdk.llm.llm.litellm.stream_chunk_builder")
+def test_empty_stream_retries_then_succeeds(
+    mock_stream_builder, mock_completion
+) -> None:
+    streaming_llm = LLM(
+        usage_id="test-empty-stream-sync",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
+        temperature=0.0,
+        stream=True,
+    )
+    mock_completion.side_effect = [iter(()), iter(())]
+    mock_stream_builder.side_effect = [None, create_mock_response("success")]
+
+    resp = streaming_llm.completion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_completion.call_count == 2
+    _, second_kwargs = mock_completion.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
+
+
 # ------------------------------------------------------------------
 # Async acompletion tests
 # ------------------------------------------------------------------
@@ -186,6 +215,46 @@ async def test_async_no_response_exhausts_retries(
         )
 
     assert mock_acompletion.call_count == base_llm.num_retries
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+@patch("openhands.sdk.llm.llm.litellm.stream_chunk_builder")
+async def test_async_empty_stream_retries_then_succeeds(
+    mock_stream_builder, mock_acompletion: AsyncMock
+) -> None:
+    class _EmptyAsyncStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    streaming_llm = LLM(
+        usage_id="test-empty-stream-async",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
+        temperature=0.0,
+        stream=True,
+    )
+    mock_acompletion.side_effect = [_EmptyAsyncStream(), _EmptyAsyncStream()]
+    mock_stream_builder.side_effect = [None, create_mock_response("success")]
+
+    resp = await streaming_llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_acompletion.call_count == 2
+    _, second_kwargs = mock_acompletion.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->
<!-- AI/LLM agents: Do not edit the HUMAN section. -->

HUMAN:

I ran the focused no-response retry test suite and Ruff checks locally. All passed.

AGENT:

---

## Why

The chat-completion streaming paths rebuild collected chunks with
`litellm.stream_chunk_builder`. When a provider returns an HTTP-successful but
empty stream, LiteLLM returns `None`. The SDK then reaches its
`assert isinstance(ret, ModelResponse)` and exposes an unhelpful, non-retryable
`AssertionError`.

The non-streaming path already represents an empty model response as
`LLMNoResponseError`, which is part of the SDK retry policy. Streaming should
follow the same contract.

## Summary

- Raise `LLMNoResponseError` when synchronous chat streaming produces no chunks.
- Apply the same behavior to asynchronous chat streaming.
- Add focused sync and async regression tests proving the empty stream is retried
  and the next valid attempt succeeds.
- Keep the change limited to item 2 of the streaming audit; the other findings
  remain separate work.

## Issue Number

Addresses item 2 in #4077.

## How to Test

```bash
uv run pytest tests/sdk/llm/test_llm_no_response_retry.py
uv run ruff check \
  openhands-sdk/openhands/sdk/llm/llm.py \
  tests/sdk/llm/test_llm_no_response_retry.py
uv run ruff format --check \
  openhands-sdk/openhands/sdk/llm/llm.py \
  tests/sdk/llm/test_llm_no_response_retry.py
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
