### PR TITLE
Add injectable remote WebSocket client factory

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections.abc import Callable, Mapping
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, SupportsIndex, overload
+from typing import TYPE_CHECKING, Protocol, SupportsIndex, overload
 from urllib.parse import quote, urlparse
 
 import httpx
@@ -277,6 +277,18 @@ class WebSocketCallbackClient:
             if remaining <= 0:
                 return
             await asyncio.sleep(min(0.1, remaining))
+
+
+class WebSocketClientFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str,
+        conversation_id: str,
+        callback: ConversationCallbackType,
+        api_key: str | None,
+        on_reconnect: Callable[[], object] | None,
+    ) -> WebSocketCallbackClient: ...
 
 
 class RemoteEventsList(EventsListBase):
@@ -725,6 +737,7 @@ class RemoteConversation(BaseConversation):
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        websocket_client_factory: WebSocketClientFactory | None = None,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -762,6 +775,8 @@ class RemoteConversation(BaseConversation):
             observability_tags: Optional root span tags for observability backends.
             observability_span_name: Optional child span name for observability
                       backends. The root span remains named "conversation".
+            websocket_client_factory: Optional callback-client factory. Uses the
+                      default WebSocket callback client when omitted.
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
@@ -988,7 +1003,12 @@ class RemoteConversation(BaseConversation):
         composed_callback = BaseConversation.compose_callbacks(all_callbacks)
 
         # Initialize WebSocket client for callbacks
-        self._ws_client = WebSocketCallbackClient(
+        factory = (
+            WebSocketCallbackClient
+            if websocket_client_factory is None
+            else websocket_client_factory
+        )
+        self._ws_client = factory(
             host=self.workspace.host,
             conversation_id=str(self._id),
             callback=composed_callback,

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections.abc import Callable, Mapping
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Final, SupportsIndex, overload
+from typing import TYPE_CHECKING, Final, Protocol, SupportsIndex, overload
 from urllib.parse import urlparse
 
 import httpx
@@ -284,6 +284,18 @@ class WebSocketCallbackClient:
             if remaining <= 0:
                 return
             await asyncio.sleep(min(0.1, remaining))
+
+
+class WebSocketClientFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str,
+        conversation_id: str,
+        callback: ConversationCallbackType,
+        api_key: str | None,
+        on_reconnect: Callable[[], object] | None,
+    ) -> WebSocketCallbackClient: ...
 
 
 class RemoteEventsList(EventsListBase):
@@ -720,6 +732,7 @@ class RemoteConversation(BaseConversation):
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        websocket_client_factory: WebSocketClientFactory | None = None,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -757,6 +770,8 @@ class RemoteConversation(BaseConversation):
             observability_tags: Optional root span tags for observability backends.
             observability_span_name: Optional child span name for observability
                       backends. The root span remains named "conversation".
+            websocket_client_factory: Optional callback-client factory. Uses the
+                      default WebSocket callback client when omitted.
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
@@ -983,7 +998,8 @@ class RemoteConversation(BaseConversation):
         composed_callback = BaseConversation.compose_callbacks(all_callbacks)
 
         # Initialize WebSocket client for callbacks
-        self._ws_client = WebSocketCallbackClient(
+        factory = websocket_client_factory or WebSocketCallbackClient
+        self._ws_client = factory(
             host=self.workspace.host,
             conversation_id=str(self._id),
             callback=composed_callback,

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -222,6 +222,36 @@ class TestRemoteConversation:
             "to fetch initial events"
         )
 
+    def test_remote_conversation_uses_injected_websocket_factory(self):
+        conversation_id = str(uuid.uuid4())
+        self.setup_mock_client(conversation_id=conversation_id)
+        websocket_client = Mock()
+        websocket_factory = Mock(return_value=websocket_client)
+
+        with patch(
+            "openhands.sdk.conversation.impl.remote_conversation."
+            "WebSocketCallbackClient"
+        ) as default_factory:
+            conversation = RemoteConversation(
+                agent=self.agent,
+                workspace=self.workspace,
+                websocket_client_factory=websocket_factory,
+            )
+
+        default_factory.assert_not_called()
+        websocket_factory.assert_called_once()
+        factory_kwargs = websocket_factory.call_args.kwargs
+        assert factory_kwargs["host"] == self.host
+        assert factory_kwargs["conversation_id"] == conversation_id
+        assert callable(factory_kwargs["callback"])
+        assert factory_kwargs["api_key"] is None
+        assert callable(factory_kwargs["on_reconnect"])
+        websocket_client.start.assert_called_once_with()
+        websocket_client.wait_until_ready.assert_called_once_with(timeout=30.0)
+
+        conversation.close()
+        websocket_client.stop.assert_called_once_with()
+
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1,5 +1,6 @@
 """Tests for RemoteConversation."""
 
+import inspect
 import time
 import uuid
 from unittest.mock import Mock, patch
@@ -15,7 +16,10 @@ from openhands.sdk.conversation.exceptions import (
     ConversationRunError,
     WebSocketConnectionError,
 )
-from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
+from openhands.sdk.conversation.impl.remote_conversation import (
+    RemoteConversation,
+    WebSocketCallbackClient,
+)
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.visualizer import DefaultConversationVisualizer
 from openhands.sdk.event import MessageEvent
@@ -222,6 +226,85 @@ class TestRemoteConversation:
         assert len(get_events_calls) >= 1, (
             "Should have made at least one GET call to /events/search "
             "to fetch initial events"
+        )
+
+    def test_remote_conversation_uses_injected_websocket_factory(self):
+        conversation_id = str(uuid.uuid4())
+        self.setup_mock_client(conversation_id=conversation_id)
+        websocket_client = Mock()
+        websocket_factory = Mock(return_value=websocket_client)
+
+        with patch(
+            "openhands.sdk.conversation.impl.remote_conversation."
+            "WebSocketCallbackClient"
+        ) as default_factory:
+            conversation = RemoteConversation(
+                agent=self.agent,
+                workspace=self.workspace,
+                websocket_client_factory=websocket_factory,
+            )
+
+        default_factory.assert_not_called()
+        websocket_factory.assert_called_once()
+        factory_kwargs = websocket_factory.call_args.kwargs
+        assert factory_kwargs["host"] == self.host
+        assert factory_kwargs["conversation_id"] == conversation_id
+        assert callable(factory_kwargs["callback"])
+        assert factory_kwargs["api_key"] is None
+        assert callable(factory_kwargs["on_reconnect"])
+        websocket_client.start.assert_called_once_with()
+        websocket_client.wait_until_ready.assert_called_once_with(timeout=30.0)
+
+        conversation.close()
+        websocket_client.stop.assert_called_once_with()
+
+    def test_remote_conversation_defaults_to_websocket_callback_client(self):
+        """Omitting the factory must resolve WebSocketCallbackClient at call time.
+
+        The default is looked up when __init__ runs, not captured when the
+        function is defined, so patching the module attribute still takes
+        effect. Binding the class as a default argument value instead would
+        break this and every other test that patches WebSocketCallbackClient.
+        """
+        conversation_id = str(uuid.uuid4())
+        self.setup_mock_client(conversation_id=conversation_id)
+
+        with patch(
+            "openhands.sdk.conversation.impl.remote_conversation."
+            "WebSocketCallbackClient"
+        ) as default_factory:
+            websocket_client = default_factory.return_value
+            conversation = RemoteConversation(
+                agent=self.agent,
+                workspace=self.workspace,
+            )
+
+        default_factory.assert_called_once()
+        factory_kwargs = default_factory.call_args.kwargs
+        assert factory_kwargs["host"] == self.host
+        assert factory_kwargs["conversation_id"] == conversation_id
+        assert callable(factory_kwargs["callback"])
+        assert factory_kwargs["api_key"] is None
+        assert callable(factory_kwargs["on_reconnect"])
+        websocket_client.start.assert_called_once_with()
+        websocket_client.wait_until_ready.assert_called_once_with(timeout=30.0)
+
+        conversation.close()
+        websocket_client.stop.assert_called_once_with()
+
+    def test_websocket_callback_client_matches_factory_protocol(self):
+        """The default client must accept exactly the factory's keywords.
+
+        Guards against the concrete client and the protocol drifting apart,
+        which would only surface when a connection is attempted.
+        """
+        signature = inspect.signature(WebSocketCallbackClient)
+        signature.bind(
+            host="http://localhost:8000",
+            conversation_id=str(uuid.uuid4()),
+            callback=lambda event: None,
+            api_key=None,
+            on_reconnect=lambda: None,
         )
 
     @patch(


### PR DESCRIPTION
HUMAN:

I reviewed the change and its test evidence and consider it ready for review.

---
AGENT:

## Why

`RemoteConversation` currently constructs `WebSocketCallbackClient` directly. This prevents callers from supplying a transport-specific callback client without replacing module globals.

An injectable factory is needed for transports such as WebSocket-over-Unix-domain-socket while preserving the SDK’s existing readiness, reconnect, reconciliation, cleanup, and lifecycle behavior. OpenHands 1.36 also passes an `on_reconnect` callback, so the factory contract must include and forward it.

The default behavior remains unchanged when no factory is provided.

## Summary

- Add a typed `WebSocketClientFactory` protocol accepting `host`, `conversation_id`, `callback`, `api_key`, and `on_reconnect`.
- Add an optional `websocket_client_factory` argument to `RemoteConversation`; default construction still uses `WebSocketCallbackClient`.
- Add focused coverage proving factory selection, keyword propagation, startup, readiness waiting, and shutdown behavior.

## Issue Number

#4708

## How to Test

### SDK tests

From the repository root:

```bash
env OPENHANDS_SUPPRESS_BANNER=1 \
  .venv/bin/python -m pytest \
  tests/sdk/conversation/remote/test_remote_conversation.py \
  tests/sdk/conversation/remote/test_websocket_client.py \
  -q
```

Result:

```text
55 passed in 2.97s
```

Repository checks:

```bash
pre-commit run --files \
  openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py \
  tests/sdk/conversation/remote/test_remote_conversation.py

git diff --check
```

Result: all formatter, lint, type, import, registration, and whitespace checks passed.

### End-to-end transport verification

The patched SDK was also exercised from an external OpenLoop integration harness against the exact OpenHands 1.36 agent-server Docker image and a real HAProxy relay.

The controller had `--network none` and communicated with the relay only over a Unix-domain socket. The test:

1. constructed `RemoteConversation` using the injected factory;
2. established REST and WebSocket traffic through the UDS;
3. authenticated every WebSocket connection using the first message;
4. removed and replaced only the HAProxy relay;
5. observed the callback client reconnecting without replacing the agent;
6. verified `on_reconnect` reconciliation completed before the replacement connection’s state event was delivered;
7. verified REST remained usable after reconnection; and
8. validated checkpoint restrictions, archive streaming, no published ports, credential redaction, and resource cleanup.

Command run from the OpenLoop repository:

```bash
env \
  OPENHANDS_RELAY_LIVE=1 \
  OPENHANDS_RELAY_SDK_SOURCE=/private/tmp/openloop-software-agent-sdk-1.36.0/openhands-sdk \
  OPENHANDS_SUPPRESS_BANNER=1 \
  PYTHONPATH=/private/tmp/openloop-software-agent-sdk-1.36.0/openhands-sdk \
  .venv/bin/python -m pytest \
  tests/integration/test_openhands_relay_live.py \
  -q -s --tb=short
```

Result:

```text
3 passed in 84.94s
```

Post-test cleanup reported zero labeled containers, networks, and volumes.

A wider external regression run also completed with:

```text
681 passed, 10 skipped, 9 warnings in 7.24s
```

No model-provider request was made during the end-to-end test.

## Video/Screenshots

N/A — this is a backend SDK construction seam with no visual interface. Reproduction steps and test results are included above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This is backward compatible: omitting `websocket_client_factory` preserves the existing `WebSocketCallbackClient` path.
- The factory is selected only at the existing callback-client construction point.
- The existing client still owns startup, readiness waiting, initial reconciliation, failure cleanup, and shutdown.
- The change avoids module-global replacement and allows multiple conversations to use independently bound transports.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.54s · commit 264b028  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 8/8 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 5.0% | No direct hunk selected |
| Weakened authorization | 6.0% | No direct hunk selected |
| Contract regression | 8.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 7.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 93.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 337d9abc04841f8ed3665bd641517d24eee4ce6441dd405debb9539bd557149e -->
<!-- jev-fast-audit:end -->
