### PR TITLE
fix(agent-server): broker local Codex auth refresh

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -20,6 +20,7 @@ from openhands.agent_server.agent_profiles_router import agent_profiles_router
 from openhands.agent_server.auth_router import auth_router
 from openhands.agent_server.bash_router import bash_router
 from openhands.agent_server.bash_service import get_default_bash_event_service
+from openhands.agent_server.codex_auth import router as codex_auth_router
 from openhands.agent_server.config import (
     Config,
     get_default_config,
@@ -327,6 +328,11 @@ def _add_api_routes(app: FastAPI) -> None:
     init_api_router = APIRouter(prefix="/api")
     init_api_router.include_router(init_router)
     app.include_router(init_api_router)
+
+    app.include_router(
+        codex_auth_router,
+        dependencies=[Depends(require_initialized)],
+    )
 
     # Header-only auth: applied to every /api/* route EXCEPT the workspace
     # static-file routes (handled separately below). Cookies are NOT honored

--- a/openhands-agent-server/openhands/agent_server/codex_auth.py
+++ b/openhands-agent-server/openhands/agent_server/codex_auth.py
@@ -1,0 +1,468 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import threading
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+
+from openhands.agent_server.persistence import FileSecretsStore
+from openhands.sdk.secret import LookupSecret
+
+
+CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
+CODEX_AUTH_ROUTE_PREFIX = "/api/conversations"
+CODEX_AUTH_ROUTE = "/{conversation_id}/codex-auth"
+
+_CODEX_AUTH_HEADER = "X-OH-Codex-Token"
+_CODEX_SANDBOX_HEADER = "X-OH-Sandbox"
+_LOCAL_SECRET_PATH = "/api/settings/secrets/CODEX_AUTH_JSON"
+_REFRESH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_REFRESH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+_REFRESH_USERNAME = "codex"
+_MAX_SECRET_VALUE_LENGTH = 64 * 1024
+_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_LOCAL_BROKER_PATH_PATTERN = re.compile(
+    r"/api/conversations/[0-9a-fA-F-]{36}/codex-auth$"
+)
+
+
+def codex_auth_path(conversation_id: UUID) -> str:
+    return (
+        f"{CODEX_AUTH_ROUTE_PREFIX}"
+        f"{CODEX_AUTH_ROUTE.format(conversation_id=conversation_id)}"
+    )
+
+
+def is_chatgpt_codex_auth(value: str) -> bool:
+    try:
+        document = json.loads(value)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(document, dict):
+        return False
+    if document.get("auth_mode") not in (None, "chatgpt"):
+        return False
+    tokens = document.get("tokens")
+    return (
+        isinstance(tokens, dict)
+        and isinstance(tokens.get("refresh_token"), str)
+        and bool(tokens["refresh_token"])
+    )
+
+
+@dataclass
+class CodexAuthBroker:
+    store: FileSecretsStore
+    _capability_digests: dict[UUID, bytes] = field(default_factory=dict, init=False)
+    _capability_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+
+    def ensure_brokered_source(
+        self, conversation_id: UUID, source: LookupSecret
+    ) -> LookupSecret:
+        headers = {name.lower(): value for name, value in source.headers.items()}
+        if headers.get(_CODEX_SANDBOX_HEADER.lower()):
+            return source
+
+        parsed_url = urlsplit(source.url)
+        path = parsed_url.path.rstrip("/")
+        broker_path = codex_auth_path(conversation_id)
+        is_local_secret = path.endswith(_LOCAL_SECRET_PATH)
+        is_local_broker = _LOCAL_BROKER_PATH_PATTERN.search(path) is not None
+        if not is_local_secret and not is_local_broker:
+            return source
+
+        token = headers.get(_CODEX_AUTH_HEADER.lower())
+        if (
+            path.endswith(broker_path)
+            and token
+            and self.is_authorized(conversation_id, token)
+        ):
+            return source
+
+        token = secrets.token_urlsafe(32)
+        token_digest = hashlib.sha256(token.encode()).digest()
+        with self._capability_lock:
+            self._capability_digests[conversation_id] = token_digest
+        return LookupSecret(
+            url=parsed_url._replace(path=broker_path, query="", fragment="").geturl(),
+            headers={_CODEX_AUTH_HEADER: token},
+            description=source.description,
+        )
+
+    def is_authorized(self, conversation_id: UUID, token: str) -> bool:
+        candidate = hashlib.sha256(token.encode()).digest()
+        with self._capability_lock:
+            expected = self._capability_digests.get(conversation_id)
+        return expected is not None and hmac.compare_digest(expected, candidate)
+
+    def revoke(self, conversation_id: UUID, token: str | None = None) -> bool:
+        with self._capability_lock:
+            expected = self._capability_digests.get(conversation_id)
+            if expected is None:
+                return False
+            if token is not None:
+                candidate = hashlib.sha256(token.encode()).digest()
+                if not hmac.compare_digest(expected, candidate):
+                    return False
+            del self._capability_digests[conversation_id]
+            return True
+
+    def clear(self) -> None:
+        with self._capability_lock:
+            self._capability_digests.clear()
+
+    def get_value(self) -> str | None:
+        return self.store.get_secret(CODEX_AUTH_SECRET_NAME)
+
+    def compare_and_swap(self, expected_digest: str, value: str) -> bool:
+        return self.store.compare_and_swap_secret(
+            CODEX_AUTH_SECRET_NAME, expected_digest, value
+        )
+
+    @asynccontextmanager
+    async def serialized_refresh(self) -> AsyncIterator[None]:
+        async with self._refresh_lock:
+            yield
+
+
+def _get_broker(request: Request) -> CodexAuthBroker:
+    service = getattr(request.app.state, "conversation_service", None)
+    broker = getattr(service, "codex_auth_broker", None)
+    if broker is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Codex credential broker is unavailable",
+        )
+    return broker
+
+
+def _authorize(
+    request: Request, conversation_id: UUID, token: str | None
+) -> CodexAuthBroker:
+    if not token:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail=f"{_CODEX_AUTH_HEADER} header is required",
+        )
+    broker = _get_broker(request)
+    if not broker.is_authorized(conversation_id, token):
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Codex auth token",
+        )
+    return broker
+
+
+async def _parse_update(request: Request) -> tuple[str, str]:
+    body = await request.body()
+    try:
+        payload = json.loads(body)
+        expected_digest = payload["expected_digest"]
+        value = payload["value"]
+    except (KeyError, TypeError, ValueError):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Codex credential update",
+        ) from None
+    try:
+        value_size = len(value.encode()) if isinstance(value, str) else None
+    except UnicodeError:
+        value_size = None
+    if not (
+        isinstance(expected_digest, str)
+        and _DIGEST_PATTERN.fullmatch(expected_digest) is not None
+        and isinstance(value, str)
+        and value_size is not None
+        and value_size <= _MAX_SECRET_VALUE_LENGTH
+        and is_chatgpt_codex_auth(value)
+    ):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Codex credential update",
+        )
+    return expected_digest, value
+
+
+def _decode_refresh_authorization(value: str | None) -> str:
+    try:
+        scheme, encoded = value.split(" ", 1) if value else ("", "")
+        decoded = base64.b64decode(encoded, validate=True).decode()
+        username, separator, token = decoded.partition(":")
+    except (UnicodeError, ValueError):
+        scheme = ""
+        username = ""
+        separator = ""
+        token = ""
+    if (
+        scheme.lower() != "basic"
+        or username != _REFRESH_USERNAME
+        or not separator
+        or not token
+    ):
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Codex refresh authorization",
+        )
+    return token
+
+
+async def _parse_refresh_request(request: Request) -> str:
+    body = await request.body()
+    try:
+        payload = json.loads(body)
+        client_id = payload["client_id"]
+        grant_type = payload["grant_type"]
+        refresh_token = payload["refresh_token"]
+    except (KeyError, TypeError, UnicodeError, ValueError):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Codex credential refresh",
+        ) from None
+    if (
+        client_id != _REFRESH_CLIENT_ID
+        or grant_type != "refresh_token"
+        or not isinstance(refresh_token, str)
+        or not refresh_token
+    ):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Codex credential refresh",
+        )
+    return refresh_token
+
+
+def _token_payload(value: str) -> dict[str, str]:
+    try:
+        tokens = json.loads(value)["tokens"]
+    except (KeyError, TypeError, ValueError):
+        tokens = None
+    if not isinstance(tokens, dict):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Stored Codex authentication needs to be refreshed",
+        )
+    payload = {
+        key: token
+        for key in ("id_token", "access_token", "refresh_token")
+        if isinstance((token := tokens.get(key)), str) and token
+    }
+    if "refresh_token" not in payload:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Stored Codex authentication needs to be refreshed",
+        )
+    return payload
+
+
+def _merge_refresh(value: str, refresh: dict[str, Any]) -> str:
+    if not isinstance(refresh.get("access_token"), str) or not refresh["access_token"]:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            detail="Codex credential refresh returned an invalid response",
+        )
+    document = json.loads(value)
+    tokens = document["tokens"]
+    for key in ("id_token", "access_token", "refresh_token"):
+        token = refresh.get(key)
+        if isinstance(token, str) and token:
+            tokens[key] = token
+    document["last_refresh"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    updated = json.dumps(document, separators=(",", ":"))
+    if not is_chatgpt_codex_auth(updated):
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            detail="Codex credential refresh returned invalid authentication",
+        )
+    return updated
+
+
+async def _request_token_refresh(refresh_token: str) -> httpx.Response:
+    url = os.getenv("OPENHANDS_CODEX_REFRESH_TOKEN_URL", _REFRESH_TOKEN_URL)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await client.post(
+            url,
+            json={
+                "client_id": _REFRESH_CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+            },
+        )
+
+
+def _refresh_error(response: httpx.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+        error = payload.get("error")
+        code = error.get("code") if isinstance(error, dict) else None
+    except (AttributeError, TypeError, ValueError):
+        code = None
+    return {"error": {"code": code or "credential_refresh_failed"}}
+
+
+router = APIRouter(prefix=CODEX_AUTH_ROUTE_PREFIX)
+
+
+@router.get(CODEX_AUTH_ROUTE, include_in_schema=False)
+async def get_codex_auth(
+    conversation_id: UUID,
+    request: Request,
+    x_oh_codex_token: str | None = Header(None),
+) -> Response:
+    broker = _authorize(request, conversation_id, x_oh_codex_token)
+    value = broker.get_value()
+    if value is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+        )
+    if not is_chatgpt_codex_auth(value):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Stored Codex authentication needs to be refreshed",
+        )
+    return Response(
+        content=value,
+        media_type="application/json",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.head(CODEX_AUTH_ROUTE, include_in_schema=False)
+async def touch_codex_auth(
+    conversation_id: UUID,
+    request: Request,
+    x_oh_codex_token: str | None = Header(None),
+) -> Response:
+    broker = _authorize(request, conversation_id, x_oh_codex_token)
+    value = broker.get_value()
+    if value is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+        )
+    digest = hashlib.sha256(value.encode()).hexdigest()
+    return Response(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"X-Codex-Auth-Digest": digest, "Cache-Control": "no-store"},
+    )
+
+
+@router.put(CODEX_AUTH_ROUTE, include_in_schema=False)
+async def update_codex_auth(
+    conversation_id: UUID,
+    request: Request,
+    x_oh_codex_token: str | None = Header(None),
+) -> Response:
+    broker = _authorize(request, conversation_id, x_oh_codex_token)
+    expected_digest, value = await _parse_update(request)
+    try:
+        updated = broker.compare_and_swap(expected_digest, value)
+    except KeyError as exc:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+        ) from exc
+    if not updated:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="Codex credentials changed in another session.",
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(f"{CODEX_AUTH_ROUTE}/refresh", include_in_schema=False)
+async def refresh_codex_auth(
+    conversation_id: UUID,
+    request: Request,
+    authorization: str | None = Header(None),
+) -> Response:
+    token = _decode_refresh_authorization(authorization)
+    broker = _authorize(request, conversation_id, token)
+    submitted_refresh_token = await _parse_refresh_request(request)
+    async with broker.serialized_refresh():
+        _authorize(request, conversation_id, token)
+        current = broker.get_value()
+        if current is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+            )
+        current_tokens = _token_payload(current)
+        current_refresh_token = current_tokens["refresh_token"]
+        if not hmac.compare_digest(
+            submitted_refresh_token.encode(errors="surrogatepass"),
+            current_refresh_token.encode(errors="surrogatepass"),
+        ):
+            return JSONResponse(
+                current_tokens,
+                headers={"Cache-Control": "no-store"},
+            )
+        try:
+            response = await _request_token_refresh(current_refresh_token)
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status.HTTP_502_BAD_GATEWAY,
+                detail="Codex credential refresh is unavailable",
+            ) from exc
+        if not response.is_success:
+            response_status = (
+                response.status_code
+                if 400 <= response.status_code < 500
+                else status.HTTP_502_BAD_GATEWAY
+            )
+            return JSONResponse(
+                _refresh_error(response),
+                status_code=response_status,
+                headers={"Cache-Control": "no-store"},
+            )
+        try:
+            refresh = response.json()
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_502_BAD_GATEWAY,
+                detail="Codex credential refresh returned an invalid response",
+            ) from exc
+        if not isinstance(refresh, dict):
+            raise HTTPException(
+                status.HTTP_502_BAD_GATEWAY,
+                detail="Codex credential refresh returned an invalid response",
+            )
+        updated_value = _merge_refresh(current, refresh)
+        current_digest = hashlib.sha256(current.encode()).hexdigest()
+        try:
+            updated = broker.compare_and_swap(current_digest, updated_value)
+        except KeyError as exc:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+            ) from exc
+        if not updated:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail="Codex credentials changed during refresh",
+            )
+        return JSONResponse(
+            _token_payload(updated_value),
+            headers={"Cache-Control": "no-store"},
+        )
+
+
+@router.delete(CODEX_AUTH_ROUTE, include_in_schema=False)
+async def release_codex_auth(
+    conversation_id: UUID,
+    request: Request,
+    x_oh_codex_token: str | None = Header(None),
+) -> Response:
+    broker = _authorize(request, conversation_id, x_oh_codex_token)
+    broker.revoke(conversation_id, x_oh_codex_token)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/openhands-agent-server/openhands/agent_server/codex_auth.py
+++ b/openhands-agent-server/openhands/agent_server/codex_auth.py
@@ -117,7 +117,7 @@ class CodexAuthBroker:
         )
 
     @asynccontextmanager
-    async def serialized_refresh(self) -> AsyncIterator[None]:
+    async def serialized_update(self) -> AsyncIterator[None]:
         async with self._refresh_lock:
             yield
 
@@ -350,12 +350,14 @@ async def update_codex_auth(
 ) -> Response:
     broker = _authorize(request, conversation_id, x_oh_codex_token)
     expected_digest, value = await _parse_update(request)
-    try:
-        updated = broker.compare_and_swap(expected_digest, value)
-    except KeyError as exc:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
-        ) from exc
+    async with broker.serialized_update():
+        _authorize(request, conversation_id, x_oh_codex_token)
+        try:
+            updated = broker.compare_and_swap(expected_digest, value)
+        except KeyError as exc:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
+            ) from exc
     if not updated:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
@@ -373,7 +375,7 @@ async def refresh_codex_auth(
     token = _decode_refresh_authorization(authorization)
     broker = _authorize(request, conversation_id, token)
     submitted_refresh_token = await _parse_refresh_request(request)
-    async with broker.serialized_refresh():
+    async with broker.serialized_update():
         _authorize(request, conversation_id, token)
         current = broker.get_value()
         if current is None:

--- a/openhands-agent-server/openhands/agent_server/codex_auth.py
+++ b/openhands-agent-server/openhands/agent_server/codex_auth.py
@@ -72,14 +72,21 @@ class CodexAuthBroker:
     ) -> LookupSecret:
         parsed_url = urlsplit(source.url)
         path = parsed_url.path.rstrip("/")
-        if path != _LOCAL_SECRET_PATH:
+        broker_path = codex_auth_path(conversation_id)
+        if path not in {_LOCAL_SECRET_PATH, broker_path}:
+            return source
+
+        if (
+            path == broker_path
+            and (token := source.headers.get(_CODEX_AUTH_HEADER))
+            and self.is_authorized(conversation_id, token)
+        ):
             return source
 
         token = secrets.token_urlsafe(32)
         token_digest = hashlib.sha256(token.encode()).digest()
         with self._capability_lock:
             self._capability_digests[conversation_id] = token_digest
-        broker_path = codex_auth_path(conversation_id)
         return LookupSecret(
             url=parsed_url._replace(path=broker_path, query="", fragment="").geturl(),
             headers={_CODEX_AUTH_HEADER: token},

--- a/openhands-agent-server/openhands/agent_server/codex_auth.py
+++ b/openhands-agent-server/openhands/agent_server/codex_auth.py
@@ -115,12 +115,18 @@ class CodexAuthBroker:
         with self._capability_lock:
             self._capability_digests.clear()
 
-    def get_value(self) -> str | None:
-        return self.store.get_secret(CODEX_AUTH_SECRET_NAME)
+    async def get_value(self) -> str | None:
+        return await asyncio.to_thread(
+            self.store.get_secret,
+            CODEX_AUTH_SECRET_NAME,
+        )
 
-    def compare_and_swap(self, expected_digest: str, value: str) -> bool:
-        return self.store.compare_and_swap_secret(
-            CODEX_AUTH_SECRET_NAME, expected_digest, value
+    async def compare_and_swap(self, expected_digest: str, value: str) -> bool:
+        return await asyncio.to_thread(
+            self.store.compare_and_swap_secret,
+            CODEX_AUTH_SECRET_NAME,
+            expected_digest,
+            value,
         )
 
     @asynccontextmanager
@@ -313,7 +319,7 @@ async def get_codex_auth(
     x_oh_codex_token: str | None = Header(None),
 ) -> Response:
     broker = _authorize(request, conversation_id, x_oh_codex_token)
-    value = broker.get_value()
+    value = await broker.get_value()
     if value is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
@@ -337,7 +343,7 @@ async def touch_codex_auth(
     x_oh_codex_token: str | None = Header(None),
 ) -> Response:
     broker = _authorize(request, conversation_id, x_oh_codex_token)
-    value = broker.get_value()
+    value = await broker.get_value()
     if value is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
@@ -360,7 +366,7 @@ async def update_codex_auth(
     async with broker.serialized_update():
         _authorize(request, conversation_id, x_oh_codex_token)
         try:
-            updated = broker.compare_and_swap(expected_digest, value)
+            updated = await broker.compare_and_swap(expected_digest, value)
         except KeyError as exc:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
@@ -384,7 +390,7 @@ async def refresh_codex_auth(
     submitted_refresh_token = await _parse_refresh_request(request)
     async with broker.serialized_update():
         _authorize(request, conversation_id, token)
-        current = broker.get_value()
+        current = await broker.get_value()
         if current is None:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"
@@ -432,7 +438,7 @@ async def refresh_codex_auth(
         updated_value = _merge_refresh(current, refresh)
         current_digest = hashlib.sha256(current.encode()).hexdigest()
         try:
-            updated = broker.compare_and_swap(current_digest, updated_value)
+            updated = await broker.compare_and_swap(current_digest, updated_value)
         except KeyError as exc:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, detail="Codex credentials were not found"

--- a/openhands-agent-server/openhands/agent_server/codex_auth.py
+++ b/openhands-agent-server/openhands/agent_server/codex_auth.py
@@ -28,16 +28,12 @@ CODEX_AUTH_ROUTE_PREFIX = "/api/conversations"
 CODEX_AUTH_ROUTE = "/{conversation_id}/codex-auth"
 
 _CODEX_AUTH_HEADER = "X-OH-Codex-Token"
-_CODEX_SANDBOX_HEADER = "X-OH-Sandbox"
 _LOCAL_SECRET_PATH = "/api/settings/secrets/CODEX_AUTH_JSON"
 _REFRESH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _REFRESH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _REFRESH_USERNAME = "codex"
 _MAX_SECRET_VALUE_LENGTH = 64 * 1024
 _DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
-_LOCAL_BROKER_PATH_PATTERN = re.compile(
-    r"/api/conversations/[0-9a-fA-F-]{36}/codex-auth$"
-)
 
 
 def codex_auth_path(conversation_id: UUID) -> str:
@@ -74,30 +70,16 @@ class CodexAuthBroker:
     def ensure_brokered_source(
         self, conversation_id: UUID, source: LookupSecret
     ) -> LookupSecret:
-        headers = {name.lower(): value for name, value in source.headers.items()}
-        if headers.get(_CODEX_SANDBOX_HEADER.lower()):
-            return source
-
         parsed_url = urlsplit(source.url)
         path = parsed_url.path.rstrip("/")
-        broker_path = codex_auth_path(conversation_id)
-        is_local_secret = path.endswith(_LOCAL_SECRET_PATH)
-        is_local_broker = _LOCAL_BROKER_PATH_PATTERN.search(path) is not None
-        if not is_local_secret and not is_local_broker:
-            return source
-
-        token = headers.get(_CODEX_AUTH_HEADER.lower())
-        if (
-            path.endswith(broker_path)
-            and token
-            and self.is_authorized(conversation_id, token)
-        ):
+        if path != _LOCAL_SECRET_PATH:
             return source
 
         token = secrets.token_urlsafe(32)
         token_digest = hashlib.sha256(token.encode()).digest()
         with self._capability_lock:
             self._capability_digests[conversation_id] = token_digest
+        broker_path = codex_auth_path(conversation_id)
         return LookupSecret(
             url=parsed_url._replace(path=broker_path, query="", fragment="").geturl(),
             headers={_CODEX_AUTH_HEADER: token},

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -13,6 +13,7 @@ from uuid import UUID, uuid4
 import httpx
 from pydantic import BaseModel
 
+from openhands.agent_server.codex_auth import CODEX_AUTH_SECRET_NAME, CodexAuthBroker
 from openhands.agent_server.config import Config, WebhookSpec
 from openhands.agent_server.conversation_lease import (
     DEFAULT_LEASE_TTL_SECONDS,
@@ -51,6 +52,7 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
+from openhands.sdk.secret import LookupSecret
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
@@ -502,6 +504,7 @@ class ConversationService:
     session_api_key: str | None = field(default=None)
     cipher: Cipher | None = None
     mcp_tool_provider: MCPToolProvider | None = None
+    codex_auth_broker: CodexAuthBroker | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
     lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
@@ -1126,6 +1129,8 @@ class ConversationService:
                     f"Failed to close event service for conversation "
                     f"{conversation_id}: {e}"
                 )
+            if self.codex_auth_broker is not None:
+                self.codex_auth_broker.revoke(conversation_id)
 
             # Safely remove only the conversation directory (workspace is preserved).
             # This operation may fail due to permission issues, but we don't want that
@@ -1408,19 +1413,25 @@ class ConversationService:
         async with self._lifecycle_lock:
             event_services = self._event_services
             if event_services is None:
+                if self.codex_auth_broker is not None:
+                    self.codex_auth_broker.clear()
                 return
             self._event_services = None
             self._conversation_records = {}
         # This stops conversations and saves meta
-        await asyncio.gather(
-            *[
-                event_service.__aexit__(exc_type, exc_value, traceback)
-                for event_service in event_services.values()
-            ]
-        )
-        if self._run_executor is not None:
-            self._run_executor.shutdown(wait=False)
-            self._run_executor = None
+        try:
+            await asyncio.gather(
+                *[
+                    event_service.__aexit__(exc_type, exc_value, traceback)
+                    for event_service in event_services.values()
+                ]
+            )
+        finally:
+            if self.codex_auth_broker is not None:
+                self.codex_auth_broker.clear()
+            if self._run_executor is not None:
+                self._run_executor.shutdown(wait=False)
+                self._run_executor = None
 
     @classmethod
     def get_instance(cls, config: Config) -> "ConversationService":
@@ -1429,9 +1440,13 @@ class ConversationService:
         from openhands.agent_server.mcp_oauth_store import (
             create_settings_backed_mcp_tool_provider,
         )
-        from openhands.agent_server.persistence import get_settings_store
+        from openhands.agent_server.persistence import (
+            get_secrets_store,
+            get_settings_store,
+        )
 
         get_settings_store(config)
+        codex_auth_broker = CodexAuthBroker(get_secrets_store(config))
         return ConversationService(
             conversations_dir=config.conversations_path,
             webhook_specs=config.webhooks,
@@ -1440,6 +1455,7 @@ class ConversationService:
             ),
             cipher=config.cipher,
             mcp_tool_provider=create_settings_backed_mcp_tool_provider(config),
+            codex_auth_broker=codex_auth_broker,
             max_concurrent_runs=config.max_concurrent_runs,
             lease_ttl_seconds=config.lease_ttl_seconds,
         )
@@ -1448,6 +1464,20 @@ class ConversationService:
         event_services = self._event_services
         if event_services is None:
             raise ValueError("inactive_service")
+
+        broker = self.codex_auth_broker
+        source = stored.secrets.get(CODEX_AUTH_SECRET_NAME)
+        if broker is not None and isinstance(source, LookupSecret):
+            brokered_source = broker.ensure_brokered_source(stored.id, source)
+            if brokered_source is not source:
+                stored = stored.model_copy(
+                    update={
+                        "secrets": {
+                            **stored.secrets,
+                            CODEX_AUTH_SECRET_NAME: brokered_source,
+                        }
+                    }
+                )
 
         event_service = EventService(
             stored=stored,
@@ -1494,7 +1524,11 @@ class ConversationService:
                 raise ValueError("inactive_service")
         except Exception:
             # Clean up the event service if startup fails
-            await event_service.close()
+            try:
+                await event_service.close()
+            finally:
+                if broker is not None:
+                    broker.revoke(stored.id)
             raise
 
         event_services[stored.id] = event_service

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -13,7 +13,7 @@ from uuid import UUID, uuid4
 import httpx
 from pydantic import BaseModel
 
-from openhands.agent_server.codex_auth import CODEX_AUTH_SECRET_NAME, CodexAuthBroker
+from openhands.agent_server.codex_auth import CodexAuthBroker
 from openhands.agent_server.config import Config, WebhookSpec
 from openhands.agent_server.conversation_lease import (
     DEFAULT_LEASE_TTL_SECONDS,
@@ -52,7 +52,6 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
-from openhands.sdk.secret import LookupSecret
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
@@ -1465,26 +1464,12 @@ class ConversationService:
         if event_services is None:
             raise ValueError("inactive_service")
 
-        broker = self.codex_auth_broker
-        runtime_stored = stored
-        source = stored.secrets.get(CODEX_AUTH_SECRET_NAME)
-        if broker is not None and isinstance(source, LookupSecret):
-            brokered_source = broker.ensure_brokered_source(stored.id, source)
-            if brokered_source is not source:
-                runtime_stored = stored.model_copy(
-                    update={
-                        "secrets": {
-                            **stored.secrets,
-                            CODEX_AUTH_SECRET_NAME: brokered_source,
-                        }
-                    }
-                )
-
         event_service = EventService(
-            stored=runtime_stored,
+            stored=stored,
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
             mcp_tool_provider=self.mcp_tool_provider,
+            codex_auth_broker=self.codex_auth_broker,
             owner_instance_id=self.owner_instance_id,
             lease_ttl_seconds=self.lease_ttl_seconds,
         )
@@ -1529,8 +1514,8 @@ class ConversationService:
             try:
                 await event_service.close()
             finally:
-                if broker is not None:
-                    broker.revoke(stored.id)
+                if self.codex_auth_broker is not None:
+                    self.codex_auth_broker.revoke(stored.id)
             raise
 
         event_services[stored.id] = event_service

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1429,9 +1429,9 @@ class ConversationService:
         finally:
             if self.codex_auth_broker is not None:
                 self.codex_auth_broker.clear()
-            if self._run_executor is not None:
-                self._run_executor.shutdown(wait=False)
-                self._run_executor = None
+        if self._run_executor is not None:
+            self._run_executor.shutdown(wait=False)
+            self._run_executor = None
 
     @classmethod
     def get_instance(cls, config: Config) -> "ConversationService":
@@ -1466,11 +1466,12 @@ class ConversationService:
             raise ValueError("inactive_service")
 
         broker = self.codex_auth_broker
+        runtime_stored = stored
         source = stored.secrets.get(CODEX_AUTH_SECRET_NAME)
         if broker is not None and isinstance(source, LookupSecret):
             brokered_source = broker.ensure_brokered_source(stored.id, source)
             if brokered_source is not source:
-                stored = stored.model_copy(
+                runtime_stored = stored.model_copy(
                     update={
                         "secrets": {
                             **stored.secrets,
@@ -1480,7 +1481,7 @@ class ConversationService:
                 )
 
         event_service = EventService(
-            stored=stored,
+            stored=runtime_stored,
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
             mcp_tool_provider=self.mcp_tool_provider,
@@ -1494,6 +1495,7 @@ class ConversationService:
 
         try:
             await event_service.start()
+            event_service.stored = stored
             # Register subscribers after start() so subscribe_to_events runs
             # its initial-state push synchronously and any failure surfaces to
             # the caller instead of being silently logged on a later publish.

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 from pydantic import ValidationError
 
+from openhands.agent_server.codex_auth import CODEX_AUTH_SECRET_NAME, CodexAuthBroker
 from openhands.agent_server.conversation_lease import (
     DEFAULT_LEASE_TTL_SECONDS,
     ConversationLease,
@@ -56,6 +57,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.llm.streaming import LLMStreamChunk
 from openhands.sdk.mcp.utils import MCPToolProvider
+from openhands.sdk.secret import LookupSecret
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
 from openhands.sdk.utils.async_utils import AsyncCallbackWrapper
@@ -83,6 +85,7 @@ class EventService:
     conversations_dir: Path
     cipher: Cipher | None = None
     mcp_tool_provider: MCPToolProvider | None = None
+    codex_auth_broker: CodexAuthBroker | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _conversation: LocalConversation | None = field(default=None, init=False)
@@ -116,6 +119,13 @@ class EventService:
     @property
     def conversation_dir(self):
         return self.conversations_dir / self.stored.id.hex
+
+    def _broker_codex_auth_source(
+        self, source: SecretValue | None
+    ) -> SecretValue | None:
+        if self.codex_auth_broker is None or not isinstance(source, LookupSecret):
+            return source
+        return self.codex_auth_broker.ensure_brokered_source(self.stored.id, source)
 
     async def load_meta(self):
         meta_file = self.conversation_dir / "meta.json"
@@ -845,6 +855,12 @@ class EventService:
         conversation.set_confirmation_policy(self.stored.confirmation_policy)
         conversation.set_security_analyzer(self.stored.security_analyzer)
         self._conversation = conversation
+        registry = self._conversation.state.secret_registry
+        source = registry.secret_sources.get(CODEX_AUTH_SECRET_NAME)
+        brokered_source = self._broker_codex_auth_source(source)
+        if brokered_source is not source:
+            assert brokered_source is not None
+            registry.update_secrets({CODEX_AUTH_SECRET_NAME: brokered_source})
         self._conversation._state.set_write_guard(self._write_guard)
         if not self._external_lease_renewal:
             self._lease_task = asyncio.create_task(self._renew_lease_loop())
@@ -1359,6 +1375,11 @@ class EventService:
         """Update secrets in the conversation."""
         if not self._conversation:
             raise ValueError("inactive_service")
+        source = secrets.get(CODEX_AUTH_SECRET_NAME)
+        brokered_source = self._broker_codex_auth_source(source)
+        if brokered_source is not source:
+            assert brokered_source is not None
+            secrets = {**secrets, CODEX_AUTH_SECRET_NAME: brokered_source}
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.update_secrets, secrets)
 

--- a/openhands-agent-server/openhands/agent_server/persistence/store.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/store.py
@@ -8,6 +8,8 @@ File locking uses fcntl on Unix and msvcrt on Windows.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import stat
@@ -596,6 +598,34 @@ class FileSecretsStore(SecretsStore):
                 return False
 
             new_secrets = {k: v for k, v in secrets.custom_secrets.items() if k != name}
+            self.save(Secrets(custom_secrets=new_secrets))
+            return True
+
+    def compare_and_swap_secret(
+        self, name: str, expected_digest: str, value: str
+    ) -> bool:
+        """Replace a secret when its digest matches."""
+        with _file_lock(self._lock_path):
+            secrets = self.load()
+            if secrets is None:
+                if self._path.exists():
+                    raise RuntimeError(
+                        f"Cannot load secrets from {self._path}. "
+                        "File may be corrupted or encrypted with a different key. "
+                        "Refusing to modify to prevent data loss."
+                    )
+                raise KeyError(name)
+
+            current = secrets.custom_secrets.get(name)
+            if current is None or current.secret is None:
+                raise KeyError(name)
+            current_value = current.secret.get_secret_value()
+            current_digest = hashlib.sha256(current_value.encode()).hexdigest()
+            if not hmac.compare_digest(current_digest, expected_digest):
+                return False
+
+            new_secrets = dict(secrets.custom_secrets)
+            new_secrets[name] = current.model_copy(update={"secret": SecretStr(value)})
             self.save(Secrets(custom_secrets=new_secrets))
             return True
 

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -127,6 +127,8 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
     os.environ.get("ACP_CANCEL_DRAIN_TIMEOUT", "2.0")
 )
 
+_ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
+
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
 _CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
 _CODEX_AUTH_HTTP_TIMEOUT = 5.0
@@ -2972,7 +2974,20 @@ class ACPAgent(AgentBase):
                             if base_url:
                                 auth_kwargs["gateway"] = {"baseUrl": base_url}
                     try:
-                        await conn.authenticate(method_id=method_id, **auth_kwargs)
+                        await asyncio.wait_for(
+                            conn.authenticate(method_id=method_id, **auth_kwargs),
+                            timeout=_ACP_AUTH_TIMEOUT,
+                        )
+                    except TimeoutError as exc:
+                        if method_id == "chat-gpt":
+                            raise _ACPFileCredentialNeedsReauthError(
+                                "ChatGPT authentication did not complete in time. "
+                                "Please sign in again."
+                            ) from exc
+                        raise TimeoutError(
+                            f"ACP authentication with {method_id!r} timed out after "
+                            f"{_ACP_AUTH_TIMEOUT:g}s."
+                        ) from exc
                     except ACPRequestError as exc:
                         if method_id != "chat-gpt" or not _acp_error_indicates_auth(
                             exc

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -28,7 +28,7 @@ import uuid
 from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol
 
 import httpx
 from acp.client.connection import ClientSideConnection
@@ -960,12 +960,17 @@ _ACP_AUTH_ERROR_MARKERS: tuple[str, ...] = (
 )
 
 
-class _CodexNeedsReauthError(RuntimeError):
+class _ACPFileCredentialNeedsReauthError(RuntimeError):
     pass
 
 
-class _CodexCredentialSyncError(RuntimeError):
+class _ACPFileCredentialSyncError(RuntimeError):
     pass
+
+
+# Compatibility aliases for the current Codex-specific error classification.
+_CodexNeedsReauthError = _ACPFileCredentialNeedsReauthError
+_CodexCredentialSyncError = _ACPFileCredentialSyncError
 
 
 def _update_codex_auth_source(
@@ -1039,6 +1044,249 @@ def _is_valid_codex_auth_value(value: object) -> bool:
     except (TypeError, ValueError):
         return False
     return isinstance(payload, dict) and bool(payload)
+
+
+class _ACPFileCredentialLifecycle(Protocol):
+    """Lifecycle boundary for a brokered ACP file credential."""
+
+    secret_name: str
+    path: Path | None
+    authenticated: bool
+
+    def load(self) -> str | None: ...
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None: ...
+
+    def should_preserve_existing(self, path: Path) -> bool: ...
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
+
+    def sync(self) -> None: ...
+
+    def release(self) -> None: ...
+
+
+class _CodexAuthLifecycle:
+    """Brokered lifecycle implementation for Codex subscription auth."""
+
+    secret_name = _CODEX_AUTH_SECRET_NAME
+
+    def __init__(self, source: LookupSecret, refresh_url: str):
+        self.source = source
+        self.refresh_url = refresh_url
+        self.path: Path | None = None
+        self.expected_digest: str | None = None
+        self.last_remote_check = 0.0
+        self.registry: SecretRegistry | None = None
+        self.authenticated = False
+
+    def load(self) -> str | None:
+        try:
+            return self.source.get_value()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (404, 422):
+                detail = (
+                    "ChatGPT authentication was not found in Cloud."
+                    if exc.response.status_code == 404
+                    else "ChatGPT authentication needs to be refreshed."
+                )
+                raise _ACPFileCredentialNeedsReauthError(detail) from exc
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+        except Exception as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None:
+        if not _is_valid_codex_auth_value(remote_value):
+            raise _ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials."
+            )
+        self.path = path
+        self.registry = registry
+        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
+        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
+        self._track_transport()
+
+    def should_preserve_existing(self, path: Path) -> bool:
+        return _read_codex_auth_ancestor(path) == self.expected_digest
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        assert path is not None
+        assert expected_digest is not None
+        _write_codex_auth_ancestor(path, expected_digest)
+        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
+        self.last_remote_check = (
+            time.monotonic() if local_digest == expected_digest else 0.0
+        )
+        self._track_values(remote_value)
+        if local_digest != expected_digest:
+            self._track_values(local_value)
+
+    def _track_values(self, value: str) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {self.secret_name: value}
+        try:
+            tokens = json.loads(value).get("tokens", {})
+        except (AttributeError, TypeError, ValueError):
+            tokens = None
+        if isinstance(tokens, dict):
+            for name, token in tokens.items():
+                if isinstance(token, str) and token:
+                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
+        registry.track_exported_values(exported_values)
+
+    def _track_transport(self) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {
+            f"{self.secret_name}.refresh_url": self.refresh_url,
+        }
+        for name, value in self.source.headers.items():
+            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
+        registry.track_exported_values(exported_values)
+
+    def sync(self) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        if path is None or expected_digest is None:
+            return
+        try:
+            value = path.read_bytes()
+            text_value = value.decode()
+        except (OSError, UnicodeError) as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be saved to Cloud."
+            ) from exc
+        digest = hashlib.sha256(value).hexdigest()
+        changed = digest != expected_digest
+        now = time.monotonic()
+        if (
+            not changed
+            and self.last_remote_check > 0
+            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
+        ):
+            return
+        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                if changed:
+                    _update_codex_auth_source(self.source, text_value, expected_digest)
+                else:
+                    remote_digest = _touch_codex_auth_source(self.source)
+                    if (
+                        isinstance(remote_digest, str)
+                        and remote_digest != expected_digest
+                    ):
+                        self._adopt(_get_codex_auth_source(self.source))
+                        return
+            except httpx.HTTPStatusError as exc:
+                if changed and exc.response.status_code == 409:
+                    try:
+                        self._adopt(_get_codex_auth_source(self.source))
+                    except Exception as remote_exc:
+                        if attempt == attempts - 1:
+                            raise _ACPFileCredentialSyncError(
+                                "Codex credentials could not be reconciled with Cloud."
+                            ) from remote_exc
+                    else:
+                        return
+                if attempt == attempts - 1:
+                    raise _ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            except Exception as exc:
+                if attempt == attempts - 1:
+                    raise _ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            else:
+                break
+            if attempt < attempts - 1:
+                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
+        if changed:
+            try:
+                _write_codex_auth_ancestor(path, digest)
+            except OSError as exc:
+                raise _ACPFileCredentialSyncError(
+                    "Codex credentials could not be saved to Cloud."
+                ) from exc
+            self._track_values(text_value)
+            self.expected_digest = digest
+        self.last_remote_check = now
+
+    def _adopt(self, value: str) -> None:
+        path = self.path
+        assert path is not None
+        if not _is_valid_codex_auth_value(value):
+            raise _ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials; "
+                "the local copy was preserved."
+            )
+        digest = hashlib.sha256(value.encode()).hexdigest()
+        try:
+            _write_secret_file(path, value)
+            _write_codex_auth_ancestor(path, digest)
+        except OSError as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be reconciled with Cloud."
+            ) from exc
+        self._track_values(value)
+        self.expected_digest = digest
+        self.last_remote_check = time.monotonic()
+
+    def release(self) -> None:
+        _release_codex_auth_source(self.source)
+        self.clear()
+
+    def clear(self) -> None:
+        self.path = None
+        self.expected_digest = None
+        self.last_remote_check = 0.0
+        self.registry = None
+        self.authenticated = False
+
+
+def _create_codex_auth_lifecycle(
+    source: LookupSecret,
+) -> _ACPFileCredentialLifecycle | None:
+    refresh_url = _codex_auth_refresh_url(source)
+    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
+
+
+_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
+    str, Callable[[LookupSecret], _ACPFileCredentialLifecycle | None]
+] = {
+    _CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
+}
+
+
+def _create_file_credential_lifecycle(
+    secret_name: str, source: object
+) -> _ACPFileCredentialLifecycle | None:
+    if not isinstance(source, LookupSecret):
+        return None
+    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
+    return factory(source) if factory is not None else None
 
 
 def _stringify_acp_error_data(data: Any) -> str:
@@ -1822,13 +2070,10 @@ class ACPAgent(AgentBase):
     _installed_suffix: str | None = PrivateAttr(default=None)
     _restart_session_on_next_turn: bool = PrivateAttr(default=False)
     _resumed_existing_session: bool = PrivateAttr(default=False)
-    _codex_auth_path: Path | None = PrivateAttr(default=None)
-    _codex_auth_source: LookupSecret | None = PrivateAttr(default=None)
-    _codex_auth_expected_digest: str | None = PrivateAttr(default=None)
-    _codex_auth_last_remote_check: float = PrivateAttr(default=0.0)
-    _codex_auth_registry: SecretRegistry | None = PrivateAttr(default=None)
-    _codex_auth_authenticated: bool = PrivateAttr(default=False)
-    _codex_auth_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _file_credential_lifecycles: dict[str, _ACPFileCredentialLifecycle] = PrivateAttr(
+        default_factory=dict
+    )
+    _file_credential_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     # -- Helpers -----------------------------------------------------------
 
@@ -2100,21 +2345,24 @@ class ACPAgent(AgentBase):
             self._start_acp_server(state)
         except Exception as e:
             logger.error("Failed to start ACP server: %s", e)
-            release_codex_auth = True
-            if self._codex_auth_authenticated:
+            release_file_credentials = True
+            if any(
+                lifecycle.authenticated
+                for lifecycle in self._file_credential_lifecycles.values()
+            ):
                 try:
-                    self._sync_codex_auth()
+                    self._sync_file_credentials()
                 except Exception:
-                    release_codex_auth = False
+                    release_file_credentials = False
                     logger.warning(
-                        "Failed to sync Codex credentials during cleanup",
+                        "Failed to sync ACP file credentials during cleanup",
                         exc_info=True,
                     )
-            if release_codex_auth:
+            if release_file_credentials:
                 try:
-                    self._release_codex_auth()
-                except _CodexCredentialSyncError:
-                    logger.warning("Failed to release Codex credential source")
+                    self._release_file_credentials()
+                except _ACPFileCredentialSyncError:
+                    logger.warning("Failed to release ACP file credential source")
             self._cleanup()
             # init_state runs *outside* run()/arun()'s try-block (it is reached
             # via _ensure_agent_ready() before the loop starts), so a cold-start
@@ -2370,7 +2618,7 @@ class ACPAgent(AgentBase):
         self, state: ConversationState, env: dict[str, str]
     ) -> None:
         """Materialize reserved file credentials and configure their paths."""
-        with self._codex_auth_lock:
+        with self._file_credential_lock:
             self._materialise_file_secrets_locked(state, env)
 
     def _materialise_file_secrets_locked(
@@ -2381,49 +2629,17 @@ class ACPAgent(AgentBase):
             source = state.secret_registry.secret_sources.get(name)
             directory = self._acp_file_secret_dir(state, spec.subdir)
             target = directory / spec.filename
-            refresh_url: str | None = None
-            brokered_source: LookupSecret | None = None
-            remote_digest: str | None = None
-            if name == _CODEX_AUTH_SECRET_NAME and isinstance(source, LookupSecret):
-                refresh_url = _codex_auth_refresh_url(source)
-                if refresh_url is not None:
-                    brokered_source = source
-            if brokered_source is not None:
-                assert refresh_url is not None
-                try:
-                    value = brokered_source.get_value()
-                except httpx.HTTPStatusError as exc:
-                    if exc.response.status_code in (404, 422):
-                        detail = (
-                            "ChatGPT authentication was not found in Cloud."
-                            if exc.response.status_code == 404
-                            else "ChatGPT authentication needs to be refreshed."
-                        )
-                        raise _CodexNeedsReauthError(detail) from exc
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be loaded from Cloud."
-                    ) from exc
-                except Exception as exc:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be loaded from Cloud."
-                    ) from exc
-            else:
-                value = state.secret_registry.get_secret_value(name)
+            lifecycle = _create_file_credential_lifecycle(name, source)
+            value = (
+                lifecycle.load()
+                if lifecycle is not None
+                else state.secret_registry.get_secret_value(name)
+            )
             if not value:
                 continue
-            if brokered_source is not None:
-                if not _is_valid_codex_auth_value(value):
-                    raise _CodexCredentialSyncError(
-                        "Cloud returned invalid Codex credentials."
-                    )
-                self._codex_auth_registry = state.secret_registry
-                self._codex_auth_path = target
-                self._codex_auth_source = brokered_source
-                remote_digest = hashlib.sha256(value.encode()).hexdigest()
-                self._codex_auth_expected_digest = remote_digest
-                assert refresh_url is not None
-                env[_CODEX_REFRESH_TOKEN_URL_ENV] = refresh_url
-                self._track_codex_auth_transport(brokered_source, refresh_url)
+            if lifecycle is not None:
+                lifecycle.bind(target, state.secret_registry, value, env)
+                self._file_credential_lifecycles[name] = lifecycle
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
                 # Tighten the SDK-owned per-conversation dir in case it
@@ -2435,11 +2651,9 @@ class ACPAgent(AgentBase):
                 # Stop at `acp/` — its parent is the persistence layer's.
                 directory.parent.chmod(0o700)
                 preserve_existing = target.is_file() and target.stat().st_size > 0
-                if brokered_source is not None:
-                    assert remote_digest is not None
-                    ancestor_digest = _read_codex_auth_ancestor(target)
+                if lifecycle is not None:
                     preserve_existing = (
-                        preserve_existing and ancestor_digest == remote_digest
+                        preserve_existing and lifecycle.should_preserve_existing(target)
                     )
                 if preserve_existing:
                     # Seed-if-absent: keep the (possibly CLI-refreshed) contents,
@@ -2455,12 +2669,9 @@ class ACPAgent(AgentBase):
                 else:
                     _write_secret_file(target, value)
                     logger.info("Materialised ACP file-secret %r -> %s", name, target)
-                if brokered_source is not None:
-                    assert remote_digest is not None
-                    _write_codex_auth_ancestor(target, remote_digest)
                 local_value = (
                     target.read_text(encoding="utf-8")
-                    if brokered_source is not None
+                    if lifecycle is not None
                     else None
                 )
             except (OSError, UnicodeError):
@@ -2479,17 +2690,9 @@ class ACPAgent(AgentBase):
             env[spec.env_var] = str(
                 directory if spec.env_points_to == "dir" else target
             )
-            if brokered_source is not None:
+            if lifecycle is not None:
                 assert local_value is not None
-                assert remote_digest is not None
-                local_digest = hashlib.sha256(local_value.encode()).hexdigest()
-                if local_digest == remote_digest:
-                    self._codex_auth_last_remote_check = time.monotonic()
-                else:
-                    self._codex_auth_last_remote_check = 0.0
-                self._track_codex_auth_values(value)
-                if local_digest != remote_digest:
-                    self._track_codex_auth_values(local_value)
+                lifecycle.record_materialized(value, local_value)
             for companion in spec.warn_if_unset:
                 if not env.get(companion):
                     logger.warning(
@@ -2499,167 +2702,43 @@ class ACPAgent(AgentBase):
                         companion,
                     )
 
-    def _track_codex_auth_values(self, value: str) -> None:
-        """Track Codex token values for event masking."""
-        registry = self._codex_auth_registry
-        if registry is None:
+    def _sync_file_credentials(self) -> None:
+        """Persist changed brokered ACP file credentials."""
+        with self._file_credential_lock:
+            for lifecycle in self._file_credential_lifecycles.values():
+                lifecycle.sync()
+
+    async def _sync_file_credentials_best_effort(self) -> None:
+        if not self._file_credential_lifecycles:
             return
-        mask_name = _CODEX_AUTH_SECRET_NAME
-        exported_values = {mask_name: value}
+        await asyncio.to_thread(self._sync_file_credentials_best_effort_blocking)
+
+    def _sync_file_credentials_best_effort_blocking(self) -> None:
         try:
-            tokens = json.loads(value).get("tokens", {})
-        except (AttributeError, TypeError, ValueError):
-            tokens = None
-        if isinstance(tokens, dict):
-            for name, token in tokens.items():
-                if isinstance(token, str) and token:
-                    exported_values[f"{mask_name}.tokens.{name}"] = token
-        registry.track_exported_values(exported_values)
-
-    def _track_codex_auth_transport(
-        self, source: LookupSecret, refresh_url: str
-    ) -> None:
-        registry = self._codex_auth_registry
-        if registry is None:
-            return
-        exported_values = {
-            f"{_CODEX_AUTH_SECRET_NAME}.refresh_url": refresh_url,
-        }
-        for name, value in source.headers.items():
-            exported_values[f"{_CODEX_AUTH_SECRET_NAME}.header.{name.lower()}"] = value
-        registry.track_exported_values(exported_values)
-
-    def _sync_codex_auth(self) -> None:
-        """Persist a changed Codex credential working copy."""
-        with self._codex_auth_lock:
-            self._sync_codex_auth_locked()
-
-    async def _sync_codex_auth_best_effort(self) -> None:
-        if self._codex_auth_path is None:
-            return
-        await asyncio.to_thread(self._sync_codex_auth_best_effort_blocking)
-
-    def _sync_codex_auth_best_effort_blocking(self) -> None:
-        try:
-            self._sync_codex_auth()
+            self._sync_file_credentials()
         except Exception:
-            logger.warning("Failed to sync Codex credentials", exc_info=True)
+            logger.warning("Failed to sync ACP file credentials", exc_info=True)
 
-    def _sync_codex_auth_locked(self) -> None:
-        path = self._codex_auth_path
-        source = self._codex_auth_source
-        expected_digest = self._codex_auth_expected_digest
-        if path is None or source is None or expected_digest is None:
-            return
-        try:
-            value = path.read_bytes()
-            text_value = value.decode()
-        except (OSError, UnicodeError) as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credentials could not be saved to Cloud."
-            ) from exc
-        digest = hashlib.sha256(value).hexdigest()
-        changed = digest != expected_digest
-        now = time.monotonic()
-        if (
-            not changed
-            and self._codex_auth_last_remote_check > 0
-            and now - self._codex_auth_last_remote_check
-            < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
-        ):
-            return
-        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
-        for attempt in range(attempts):
-            try:
-                if changed:
-                    _update_codex_auth_source(source, text_value, expected_digest)
+    def _release_file_credentials(self) -> None:
+        """Release scoped ACP file credential sources."""
+        with self._file_credential_lock:
+            first_error: Exception | None = None
+            for name, lifecycle in list(self._file_credential_lifecycles.items()):
+                try:
+                    lifecycle.release()
+                except Exception as exc:
+                    if first_error is None:
+                        first_error = exc
                 else:
-                    remote_digest = _touch_codex_auth_source(source)
-                    if (
-                        isinstance(remote_digest, str)
-                        and remote_digest != expected_digest
-                    ):
-                        remote_value = _get_codex_auth_source(source)
-                        self._adopt_codex_auth_value(path, remote_value)
-                        return
-            except httpx.HTTPStatusError as exc:
-                if changed and exc.response.status_code == 409:
-                    try:
-                        remote_value = _get_codex_auth_source(source)
-                        self._adopt_codex_auth_value(path, remote_value)
-                    except Exception as remote_exc:
-                        if attempt == attempts - 1:
-                            raise _CodexCredentialSyncError(
-                                "Codex credentials could not be reconciled with Cloud."
-                            ) from remote_exc
-                    else:
-                        return
-                if attempt == attempts - 1:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            except Exception as exc:
-                if attempt == attempts - 1:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            else:
-                break
-            if attempt < attempts - 1:
-                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
-        if changed:
-            try:
-                _write_codex_auth_ancestor(path, digest)
-            except OSError as exc:
-                raise _CodexCredentialSyncError(
-                    "Codex credentials could not be saved to Cloud."
-                ) from exc
-            self._track_codex_auth_values(text_value)
-            self._codex_auth_expected_digest = digest
-        self._codex_auth_last_remote_check = now
+                    self._file_credential_lifecycles.pop(name, None)
+            if first_error is not None:
+                raise _ACPFileCredentialSyncError(
+                    "ACP file credential source could not be released."
+                ) from first_error
 
-    def _adopt_codex_auth_value(self, path: Path, value: str) -> None:
-        if not _is_valid_codex_auth_value(value):
-            raise _CodexCredentialSyncError(
-                "Cloud returned invalid Codex credentials; "
-                "the local copy was preserved."
-            )
-        digest = hashlib.sha256(value.encode()).hexdigest()
-        try:
-            _write_secret_file(path, value)
-            _write_codex_auth_ancestor(path, digest)
-        except OSError as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credentials could not be reconciled with Cloud."
-            ) from exc
-        self._track_codex_auth_values(value)
-        self._codex_auth_expected_digest = digest
-        self._codex_auth_last_remote_check = time.monotonic()
-
-    def _release_codex_auth(self) -> None:
-        """Release the scoped Codex credential source."""
-        with self._codex_auth_lock:
-            self._release_codex_auth_locked()
-
-    def _release_codex_auth_locked(self) -> None:
-        source = self._codex_auth_source
-        if source is None:
-            return
-        try:
-            _release_codex_auth_source(source)
-        except Exception as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credential source could not be released."
-            ) from exc
-        self._clear_codex_auth_state()
-
-    def _clear_codex_auth_state(self) -> None:
-        self._codex_auth_path = None
-        self._codex_auth_source = None
-        self._codex_auth_expected_digest = None
-        self._codex_auth_last_remote_check = 0.0
-        self._codex_auth_registry = None
-        self._codex_auth_authenticated = False
+    def _mark_file_credentials_authenticated(self) -> None:
+        for lifecycle in self._file_credential_lifecycles.values():
+            lifecycle.authenticated = True
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -2891,8 +2970,8 @@ class ACPAgent(AgentBase):
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
                     if method_id == "chat-gpt":
-                        self._codex_auth_authenticated = True
-                        await self._sync_codex_auth_best_effort()
+                        self._mark_file_credentials_authenticated()
+                        await self._sync_file_credentials_best_effort()
                 else:
                     logger.warning(
                         "ACP server offers auth methods %s but no matching "
@@ -3047,8 +3126,8 @@ class ACPAgent(AgentBase):
             self._model_override_applied,
         ) = self._executor.run_async(_init)
         self._working_dir = working_dir
-        if self._codex_auth_source is not None:
-            self._codex_auth_authenticated = True
+        if self._file_credential_lifecycles:
+            self._mark_file_credentials_authenticated()
 
     def _reset_client_for_turn(
         self,
@@ -3720,7 +3799,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            self._sync_codex_auth_best_effort_blocking()
+            self._sync_file_credentials_best_effort_blocking()
 
     @observe(name="acp_agent.astep", ignore_inputs=["conversation", "on_event"])
     async def astep(
@@ -3936,7 +4015,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            await self._sync_codex_auth_best_effort()
+            await self._sync_file_credentials_best_effort()
 
     def ask_agent(self, question: str) -> str | None:
         """Fork the ACP session, prompt the fork, and return the response."""
@@ -3994,7 +4073,7 @@ class ACPAgent(AgentBase):
                 return result
             finally:
                 try:
-                    await self._sync_codex_auth_best_effort()
+                    await self._sync_file_credentials_best_effort()
                 finally:
                     client._fork_session_id = None
                     client._fork_accumulated_text.clear()
@@ -4140,11 +4219,11 @@ class ACPAgent(AgentBase):
         self._closed = True
         error: Exception | None = None
         try:
-            self._sync_codex_auth()
+            self._sync_file_credentials()
         except Exception as exc:
             error = exc
         try:
-            self._release_codex_auth()
+            self._release_file_credentials()
         except Exception as exc:
             if error is None:
                 error = exc
@@ -4203,8 +4282,8 @@ class ACPAgent(AgentBase):
 
         See :meth:`LocalConversation.switch_acp_model`.
         """
-        with self._codex_auth_lock:
-            self._clear_codex_auth_state()
+        with self._file_credential_lock:
+            self._file_credential_lifecycles = {}
         self._closed = True
 
     def __del__(self) -> None:
@@ -4212,11 +4291,16 @@ class ACPAgent(AgentBase):
             if self._closed:
                 return
             self._closed = True
-            if self._codex_auth_path is not None:
+            credential_paths = [
+                lifecycle.path
+                for lifecycle in self._file_credential_lifecycles.values()
+                if lifecycle.path is not None
+            ]
+            if credential_paths:
                 logger.warning(
-                    "Skipping Codex credential sync during ACPAgent finalization; "
-                    "the durable working copy remains at %s",
-                    self._codex_auth_path,
+                    "Skipping ACP file credential sync during finalization; "
+                    "durable working copies remain at %s",
+                    credential_paths,
                 )
             self._cleanup()
         except Exception:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -968,11 +968,6 @@ class _ACPFileCredentialSyncError(RuntimeError):
     pass
 
 
-# Compatibility aliases for the current Codex-specific error classification.
-_CodexNeedsReauthError = _ACPFileCredentialNeedsReauthError
-_CodexCredentialSyncError = _ACPFileCredentialSyncError
-
-
 def _update_codex_auth_source(
     source: LookupSecret, value: str, expected_digest: str
 ) -> None:
@@ -1047,7 +1042,12 @@ def _is_valid_codex_auth_value(value: object) -> bool:
 
 
 class _ACPFileCredentialLifecycle(Protocol):
-    """Lifecycle boundary for a brokered ACP file credential."""
+    """Lifecycle boundary for a brokered ACP file credential.
+
+    Implementations translate expected I/O and broker failures into the
+    provider-neutral credential errors above. Unexpected exceptions are treated
+    as implementation defects and intentionally propagate through orchestration.
+    """
 
     secret_name: str
     path: Path | None
@@ -1100,7 +1100,7 @@ class _CodexAuthLifecycle:
             raise _ACPFileCredentialSyncError(
                 "Codex credentials could not be loaded from Cloud."
             ) from exc
-        except Exception as exc:
+        except httpx.RequestError as exc:
             raise _ACPFileCredentialSyncError(
                 "Codex credentials could not be loaded from Cloud."
             ) from exc
@@ -1203,7 +1203,10 @@ class _CodexAuthLifecycle:
                 if changed and exc.response.status_code == 409:
                     try:
                         self._adopt(_get_codex_auth_source(self.source))
-                    except Exception as remote_exc:
+                    except (
+                        httpx.HTTPError,
+                        _ACPFileCredentialSyncError,
+                    ) as remote_exc:
                         if attempt == attempts - 1:
                             raise _ACPFileCredentialSyncError(
                                 "Codex credentials could not be reconciled with Cloud."
@@ -1214,7 +1217,7 @@ class _CodexAuthLifecycle:
                     raise _ACPFileCredentialSyncError(
                         "Codex credentials could not be saved to Cloud."
                     ) from exc
-            except Exception as exc:
+            except httpx.RequestError as exc:
                 if attempt == attempts - 1:
                     raise _ACPFileCredentialSyncError(
                         "Codex credentials could not be saved to Cloud."
@@ -1255,7 +1258,12 @@ class _CodexAuthLifecycle:
         self.last_remote_check = time.monotonic()
 
     def release(self) -> None:
-        _release_codex_auth_source(self.source)
+        try:
+            _release_codex_auth_source(self.source)
+        except httpx.HTTPError as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credential source could not be released."
+            ) from exc
         self.clear()
 
     def clear(self) -> None:
@@ -1383,7 +1391,9 @@ def _classify_acp_init_error(exc: BaseException) -> str:
       creation (timeouts, transport drops, unexpected protocol errors, cwd
       mismatch surfaced by the server).
     """
-    if isinstance(exc, (_CodexNeedsReauthError, _CodexCredentialSyncError)):
+    if isinstance(
+        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
+    ):
         return "ACPAuthRequired"
     if _acp_error_indicates_auth(exc):
         return "ACPAuthRequired"
@@ -1399,7 +1409,9 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
     policy refusals get their own code, credential failures map to ``ACPAuthRequired``
     (so the client can offer re-auth), everything else is a generic ``ACPPromptError``.
     """
-    if isinstance(exc, (_CodexNeedsReauthError, _CodexCredentialSyncError)):
+    if isinstance(
+        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
+    ):
         return "ACPAuthRequired"
     text = _acp_error_text(exc)
     if "usage policy" in text or "content policy" in text:
@@ -2352,7 +2364,7 @@ class ACPAgent(AgentBase):
             ):
                 try:
                     self._sync_file_credentials()
-                except Exception:
+                except _ACPFileCredentialSyncError:
                     release_file_credentials = False
                     logger.warning(
                         "Failed to sync ACP file credentials during cleanup",
@@ -2716,7 +2728,7 @@ class ACPAgent(AgentBase):
     def _sync_file_credentials_best_effort_blocking(self) -> None:
         try:
             self._sync_file_credentials()
-        except Exception:
+        except _ACPFileCredentialSyncError:
             logger.warning("Failed to sync ACP file credentials", exc_info=True)
 
     def _release_file_credentials(self) -> None:
@@ -2726,7 +2738,7 @@ class ACPAgent(AgentBase):
             for name, lifecycle in list(self._file_credential_lifecycles.items()):
                 try:
                     lifecycle.release()
-                except Exception as exc:
+                except _ACPFileCredentialSyncError as exc:
                     if first_error is None:
                         first_error = exc
                 else:
@@ -2961,12 +2973,12 @@ class ACPAgent(AgentBase):
                                 auth_kwargs["gateway"] = {"baseUrl": base_url}
                     try:
                         await conn.authenticate(method_id=method_id, **auth_kwargs)
-                    except Exception as exc:
+                    except ACPRequestError as exc:
                         if method_id != "chat-gpt" or not _acp_error_indicates_auth(
                             exc
                         ):
                             raise
-                        raise _CodexNeedsReauthError(
+                        raise _ACPFileCredentialNeedsReauthError(
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
                     if method_id == "chat-gpt":

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -17,7 +17,6 @@ See https://agentclientprotocol.com/protocol/overview
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import inspect
 import json
 import os
@@ -28,9 +27,8 @@ import uuid
 from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
-import httpx
 from acp.client.connection import ClientSideConnection
 from acp.exceptions import RequestError as ACPRequestError
 from acp.helpers import image_block, text_block
@@ -61,6 +59,14 @@ from pydantic import (
     field_validator,
 )
 
+from openhands.sdk.agent.acp_file_credentials import (
+    ACPFileCredentialLifecycle,
+    ACPFileCredentialNeedsReauthError,
+    ACPFileCredentialSyncError,
+    codex_auth_file_is_chatgpt,
+    create_file_credential_lifecycle,
+    write_secret_file,
+)
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context import AgentContext
@@ -77,7 +83,6 @@ from openhands.sdk.llm import LLM, ImageContent, Message, MessageToolCall, TextC
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
-from openhands.sdk.secret import LookupSecret
 from openhands.sdk.settings.acp_providers import (
     ACPFileSecretSpec,
     build_session_model_meta,
@@ -107,8 +112,6 @@ if TYPE_CHECKING:
         LocalConversation,
     )
     from openhands.sdk.conversation.secret_registry import SecretRegistry
-
-
 # Maximum seconds to wait for a UsageUpdate notification after prompt()
 # returns. The ACP server writes UsageUpdate to the wire before the
 # PromptResponse, so under normal conditions the notification handler
@@ -130,13 +133,6 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
 _ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
 
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
-_CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
-_CODEX_AUTH_HTTP_TIMEOUT = 5.0
-_CODEX_AUTH_REMOTE_CHECK_INTERVAL = 60.0
-_CODEX_AUTH_DIGEST_HEADER = "X-Codex-Auth-Digest"
-_CODEX_AUTH_SANDBOX_HEADER = "X-OH-Sandbox"
-_CODEX_AUTH_SCOPE_HEADER = "X-OH-Codex"
-_CODEX_REFRESH_TOKEN_URL_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
 
 # Exception types that indicate transient connection issues worth retrying
 _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFError)
@@ -274,48 +270,10 @@ def _make_dummy_llm() -> LLM:
 _AUTH_METHOD_ENV_MAP: dict[str, str] = {
     "gemini-api-key": "GEMINI_API_KEY",
 }
-_CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
-_CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 # Gemini CLI personal (Google OAuth) login, cached by ``gemini login`` /
 # ``gemini --acp``. Its presence lets us select the server's ``oauth-personal``
 # auth method without an API key (mirrors the ChatGPT subscription path).
 _GEMINI_OAUTH_PATH = Path(".gemini") / "oauth_creds.json"
-
-
-def _codex_auth_file(env: dict[str, str]) -> Path:
-    """Path to Codex's ChatGPT-subscription ``auth.json``, honoring ``CODEX_HOME``.
-
-    Codex reads ``$CODEX_HOME/auth.json`` when ``CODEX_HOME`` is set — which the
-    SDK does after materialising a relocated, per-conversation ``auth.json``
-    (see :meth:`ACPAgent._materialise_file_secrets`) — and ``~/.codex/auth.json``
-    otherwise. Detection must follow the same relocation or a materialised
-    subscription token is never recognised (issue #1020).
-    """
-    codex_home = env.get("CODEX_HOME")
-    if codex_home:
-        return Path(codex_home) / "auth.json"
-    return Path.home() / _CHATGPT_AUTH_PATH
-
-
-def _codex_auth_file_is_chatgpt(env: dict[str, str]) -> bool:
-    """Return True only if ``auth.json`` is in ChatGPT-subscription format.
-
-    Codex itself rewrites ``$CODEX_HOME/auth.json`` during apikey-mode sessions
-    with ``{"auth_mode": "apikey", "OPENAI_API_KEY": "..."}``. That file's mere
-    presence used to make :func:`_select_auth_method` prefer ``chat-gpt`` on a
-    restart, after which ``conn.authenticate("chat-gpt")`` hung indefinitely
-    waiting for browser-based OAuth (issue #3627). The ChatGPT token blob is
-    keyed by ``tokens``; require that key before claiming the file is usable
-    for the ``chat-gpt`` auth method.
-    """
-    path = _codex_auth_file(env)
-    if not path.is_file():
-        return False
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and "tokens" in data
 
 
 def _select_auth_method(
@@ -343,7 +301,7 @@ def _select_auth_method(
     method_ids = {m.id for m in auth_methods}
     # Prefer file-backed subscription / service-account logins when their
     # credential file is present.
-    if "chat-gpt" in method_ids and _codex_auth_file_is_chatgpt(env):
+    if "chat-gpt" in method_ids and codex_auth_file_is_chatgpt(env):
         return "chat-gpt"
     gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
     if "vertex-ai" in method_ids and gac and Path(gac).is_file():
@@ -410,36 +368,6 @@ def _with_codex_base_url(
     config["openai_base_url"] = base_url
     configured_env["CODEX_CONFIG"] = json.dumps(config, separators=(",", ":"))
     return configured_env
-
-
-def _write_secret_file(path: Path, value: str) -> None:
-    """Write ``value`` to ``path`` as a ``0600`` file.
-
-    ``os.open`` creates a *new* file at ``0600``, but ``O_CREAT`` does not
-    narrow an existing file's mode. So ``fchmod`` the raw fd to ``0600`` before
-    any bytes land — clamping the mode while we still hold the fd guarantees the
-    secret content never exists with wider permissions even when the file
-    pre-existed (e.g. a ``0644`` empty file from another tool).
-    """
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(value)
-
-
-def _codex_auth_ancestor_file(path: Path) -> Path:
-    return path.with_name(f".{path.name}.cloud-digest")
-
-
-def _read_codex_auth_ancestor(path: Path) -> str | None:
-    try:
-        return _codex_auth_ancestor_file(path).read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        return None
-
-
-def _write_codex_auth_ancestor(path: Path, digest: str) -> None:
-    _write_secret_file(_codex_auth_ancestor_file(path), digest)
 
 
 # Session config-option id that selects the model on ACP servers that drive
@@ -962,343 +890,6 @@ _ACP_AUTH_ERROR_MARKERS: tuple[str, ...] = (
 )
 
 
-class _ACPFileCredentialNeedsReauthError(RuntimeError):
-    pass
-
-
-class _ACPFileCredentialSyncError(RuntimeError):
-    pass
-
-
-def _update_codex_auth_source(
-    source: LookupSecret, value: str, expected_digest: str
-) -> None:
-    response = httpx.put(
-        source.url,
-        headers=source.headers,
-        json={"expected_digest": expected_digest, "value": value},
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-
-
-def _get_codex_auth_source(source: LookupSecret) -> str:
-    response = httpx.get(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-    return response.text
-
-
-def _touch_codex_auth_source(source: LookupSecret) -> str | None:
-    response = httpx.head(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-    digest = response.headers.get(_CODEX_AUTH_DIGEST_HEADER)
-    return (
-        digest
-        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest)
-        else None
-    )
-
-
-def _release_codex_auth_source(source: LookupSecret) -> None:
-    response = httpx.delete(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-
-
-def _codex_auth_refresh_url(source: LookupSecret) -> str | None:
-    headers = {name.lower(): value for name, value in source.headers.items()}
-    session_api_key = headers.get(_CODEX_AUTH_SANDBOX_HEADER.lower())
-    codex_auth_token = headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
-    if not session_api_key or not codex_auth_token:
-        return None
-    url = httpx.URL(source.url)
-    refresh_path = f"{url.path.rstrip('/')}/refresh"
-    return str(
-        url.copy_with(
-            path=refresh_path,
-            username=session_api_key,
-            password=codex_auth_token,
-        )
-    )
-
-
-def _is_valid_codex_auth_value(value: object) -> bool:
-    if not isinstance(value, str) or not value.strip():
-        return False
-    try:
-        payload = json.loads(value)
-    except (TypeError, ValueError):
-        return False
-    return isinstance(payload, dict) and bool(payload)
-
-
-class _ACPFileCredentialLifecycle(Protocol):
-    """Lifecycle boundary for a brokered ACP file credential.
-
-    Implementations translate expected I/O and broker failures into the
-    provider-neutral credential errors above. Unexpected exceptions are treated
-    as implementation defects and intentionally propagate through orchestration.
-    """
-
-    secret_name: str
-    path: Path | None
-    authenticated: bool
-
-    def load(self) -> str | None: ...
-
-    def bind(
-        self,
-        path: Path,
-        registry: SecretRegistry,
-        remote_value: str,
-        env: dict[str, str],
-    ) -> None: ...
-
-    def should_preserve_existing(self, path: Path) -> bool: ...
-
-    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
-
-    def sync(self) -> None: ...
-
-    def release(self) -> None: ...
-
-
-class _CodexAuthLifecycle:
-    """Brokered lifecycle implementation for Codex subscription auth."""
-
-    secret_name = _CODEX_AUTH_SECRET_NAME
-
-    def __init__(self, source: LookupSecret, refresh_url: str):
-        self.source = source
-        self.refresh_url = refresh_url
-        self.path: Path | None = None
-        self.expected_digest: str | None = None
-        self.last_remote_check = 0.0
-        self.registry: SecretRegistry | None = None
-        self.authenticated = False
-
-    def load(self) -> str | None:
-        try:
-            return self.source.get_value()
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code in (404, 422):
-                detail = (
-                    "ChatGPT authentication was not found in Cloud."
-                    if exc.response.status_code == 404
-                    else "ChatGPT authentication needs to be refreshed."
-                )
-                raise _ACPFileCredentialNeedsReauthError(detail) from exc
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be loaded from Cloud."
-            ) from exc
-        except httpx.RequestError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be loaded from Cloud."
-            ) from exc
-
-    def bind(
-        self,
-        path: Path,
-        registry: SecretRegistry,
-        remote_value: str,
-        env: dict[str, str],
-    ) -> None:
-        if not _is_valid_codex_auth_value(remote_value):
-            raise _ACPFileCredentialSyncError(
-                "Cloud returned invalid Codex credentials."
-            )
-        self.path = path
-        self.registry = registry
-        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
-        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
-        self._track_transport()
-
-    def should_preserve_existing(self, path: Path) -> bool:
-        return _read_codex_auth_ancestor(path) == self.expected_digest
-
-    def record_materialized(self, remote_value: str, local_value: str) -> None:
-        path = self.path
-        expected_digest = self.expected_digest
-        assert path is not None
-        assert expected_digest is not None
-        _write_codex_auth_ancestor(path, expected_digest)
-        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
-        self.last_remote_check = (
-            time.monotonic() if local_digest == expected_digest else 0.0
-        )
-        self._track_values(remote_value)
-        if local_digest != expected_digest:
-            self._track_values(local_value)
-
-    def _track_values(self, value: str) -> None:
-        registry = self.registry
-        if registry is None:
-            return
-        exported_values = {self.secret_name: value}
-        try:
-            tokens = json.loads(value).get("tokens", {})
-        except (AttributeError, TypeError, ValueError):
-            tokens = None
-        if isinstance(tokens, dict):
-            for name, token in tokens.items():
-                if isinstance(token, str) and token:
-                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
-        registry.track_exported_values(exported_values)
-
-    def _track_transport(self) -> None:
-        registry = self.registry
-        if registry is None:
-            return
-        exported_values = {
-            f"{self.secret_name}.refresh_url": self.refresh_url,
-        }
-        for name, value in self.source.headers.items():
-            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
-        registry.track_exported_values(exported_values)
-
-    def sync(self) -> None:
-        path = self.path
-        expected_digest = self.expected_digest
-        if path is None or expected_digest is None:
-            return
-        try:
-            value = path.read_bytes()
-            text_value = value.decode()
-        except (OSError, UnicodeError) as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be saved to Cloud."
-            ) from exc
-        digest = hashlib.sha256(value).hexdigest()
-        changed = digest != expected_digest
-        now = time.monotonic()
-        if (
-            not changed
-            and self.last_remote_check > 0
-            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
-        ):
-            return
-        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
-        for attempt in range(attempts):
-            try:
-                if changed:
-                    _update_codex_auth_source(self.source, text_value, expected_digest)
-                else:
-                    remote_digest = _touch_codex_auth_source(self.source)
-                    if (
-                        isinstance(remote_digest, str)
-                        and remote_digest != expected_digest
-                    ):
-                        self._adopt(_get_codex_auth_source(self.source))
-                        return
-            except httpx.HTTPStatusError as exc:
-                if changed and exc.response.status_code == 409:
-                    try:
-                        self._adopt(_get_codex_auth_source(self.source))
-                    except (
-                        httpx.HTTPError,
-                        _ACPFileCredentialSyncError,
-                    ) as remote_exc:
-                        if attempt == attempts - 1:
-                            raise _ACPFileCredentialSyncError(
-                                "Codex credentials could not be reconciled with Cloud."
-                            ) from remote_exc
-                    else:
-                        return
-                if attempt == attempts - 1:
-                    raise _ACPFileCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            except httpx.RequestError as exc:
-                if attempt == attempts - 1:
-                    raise _ACPFileCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            else:
-                break
-            if attempt < attempts - 1:
-                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
-        if changed:
-            try:
-                _write_codex_auth_ancestor(path, digest)
-            except OSError as exc:
-                raise _ACPFileCredentialSyncError(
-                    "Codex credentials could not be saved to Cloud."
-                ) from exc
-            self._track_values(text_value)
-            self.expected_digest = digest
-        self.last_remote_check = now
-
-    def _adopt(self, value: str) -> None:
-        path = self.path
-        assert path is not None
-        if not _is_valid_codex_auth_value(value):
-            raise _ACPFileCredentialSyncError(
-                "Cloud returned invalid Codex credentials; "
-                "the local copy was preserved."
-            )
-        digest = hashlib.sha256(value.encode()).hexdigest()
-        try:
-            _write_secret_file(path, value)
-            _write_codex_auth_ancestor(path, digest)
-        except OSError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be reconciled with Cloud."
-            ) from exc
-        self._track_values(value)
-        self.expected_digest = digest
-        self.last_remote_check = time.monotonic()
-
-    def release(self) -> None:
-        try:
-            _release_codex_auth_source(self.source)
-        except httpx.HTTPError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credential source could not be released."
-            ) from exc
-        self.clear()
-
-    def clear(self) -> None:
-        self.path = None
-        self.expected_digest = None
-        self.last_remote_check = 0.0
-        self.registry = None
-        self.authenticated = False
-
-
-def _create_codex_auth_lifecycle(
-    source: LookupSecret,
-) -> _ACPFileCredentialLifecycle | None:
-    refresh_url = _codex_auth_refresh_url(source)
-    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
-
-
-_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
-    str, Callable[[LookupSecret], _ACPFileCredentialLifecycle | None]
-] = {
-    _CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
-}
-
-
-def _create_file_credential_lifecycle(
-    secret_name: str, source: object
-) -> _ACPFileCredentialLifecycle | None:
-    if not isinstance(source, LookupSecret):
-        return None
-    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
-    return factory(source) if factory is not None else None
-
-
 def _stringify_acp_error_data(data: Any) -> str:
     """Render an ACP ``RequestError.data`` payload as a compact string.
 
@@ -1393,9 +984,7 @@ def _classify_acp_init_error(exc: BaseException) -> str:
       creation (timeouts, transport drops, unexpected protocol errors, cwd
       mismatch surfaced by the server).
     """
-    if isinstance(
-        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
-    ):
+    if isinstance(exc, (ACPFileCredentialNeedsReauthError, ACPFileCredentialSyncError)):
         return "ACPAuthRequired"
     if _acp_error_indicates_auth(exc):
         return "ACPAuthRequired"
@@ -1411,9 +1000,7 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
     policy refusals get their own code, credential failures map to ``ACPAuthRequired``
     (so the client can offer re-auth), everything else is a generic ``ACPPromptError``.
     """
-    if isinstance(
-        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
-    ):
+    if isinstance(exc, (ACPFileCredentialNeedsReauthError, ACPFileCredentialSyncError)):
         return "ACPAuthRequired"
     text = _acp_error_text(exc)
     if "usage policy" in text or "content policy" in text:
@@ -2084,10 +1671,13 @@ class ACPAgent(AgentBase):
     _installed_suffix: str | None = PrivateAttr(default=None)
     _restart_session_on_next_turn: bool = PrivateAttr(default=False)
     _resumed_existing_session: bool = PrivateAttr(default=False)
-    _file_credential_lifecycles: dict[str, _ACPFileCredentialLifecycle] = PrivateAttr(
+    _file_credential_lifecycles: dict[str, ACPFileCredentialLifecycle] = PrivateAttr(
         default_factory=dict
     )
     _file_credential_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _file_credential_close_lock: threading.Lock = PrivateAttr(
+        default_factory=threading.Lock
+    )
 
     # -- Helpers -----------------------------------------------------------
 
@@ -2359,25 +1949,16 @@ class ACPAgent(AgentBase):
             self._start_acp_server(state)
         except Exception as e:
             logger.error("Failed to start ACP server: %s", e)
-            release_file_credentials = True
-            if any(
-                lifecycle.authenticated
-                for lifecycle in self._file_credential_lifecycles.values()
-            ):
-                try:
-                    self._sync_file_credentials()
-                except _ACPFileCredentialSyncError:
-                    release_file_credentials = False
-                    logger.warning(
-                        "Failed to sync ACP file credentials during cleanup",
-                        exc_info=True,
-                    )
-            if release_file_credentials:
-                try:
-                    self._release_file_credentials()
-                except _ACPFileCredentialSyncError:
-                    logger.warning("Failed to release ACP file credential source")
-            self._cleanup()
+            sync_failures = self._sync_file_credentials_collect(changed_only=True)
+            self._log_file_credential_failures("sync", sync_failures)
+            release_failures = self._release_file_credentials_collect(
+                exclude=set(sync_failures)
+            )
+            self._log_file_credential_failures("release", release_failures)
+            try:
+                self._cleanup()
+            except Exception:
+                logger.warning("Failed to clean up ACP resources", exc_info=True)
             # init_state runs *outside* run()/arun()'s try-block (it is reached
             # via _ensure_agent_ready() before the loop starts), so a cold-start
             # failure — bad/expired auth, missing CLI binary, cwd mismatch — would
@@ -2643,17 +2224,19 @@ class ACPAgent(AgentBase):
             source = state.secret_registry.secret_sources.get(name)
             directory = self._acp_file_secret_dir(state, spec.subdir)
             target = directory / spec.filename
-            lifecycle = _create_file_credential_lifecycle(name, source)
-            value = (
-                lifecycle.load()
-                if lifecycle is not None
-                else state.secret_registry.get_secret_value(name)
-            )
+            lifecycle = create_file_credential_lifecycle(name, source)
+            if lifecycle is not None:
+                self._file_credential_lifecycles[name] = lifecycle
+                value = lifecycle.load()
+            else:
+                value = state.secret_registry.get_secret_value(name)
             if not value:
+                if lifecycle is not None:
+                    lifecycle.release()
+                    self._file_credential_lifecycles.pop(name, None)
                 continue
             if lifecycle is not None:
                 lifecycle.bind(target, state.secret_registry, value, env)
-                self._file_credential_lifecycles[name] = lifecycle
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
                 # Tighten the SDK-owned per-conversation dir in case it
@@ -2681,7 +2264,7 @@ class ACPAgent(AgentBase):
                         target,
                     )
                 else:
-                    _write_secret_file(target, value)
+                    write_secret_file(target, value)
                     logger.info("Materialised ACP file-secret %r -> %s", name, target)
                 local_value = (
                     target.read_text(encoding="utf-8")
@@ -2716,43 +2299,110 @@ class ACPAgent(AgentBase):
                         companion,
                     )
 
-    def _sync_file_credentials(self) -> None:
-        """Persist changed brokered ACP file credentials."""
-        with self._file_credential_lock:
-            for lifecycle in self._file_credential_lifecycles.values():
-                lifecycle.sync()
+    @staticmethod
+    def _log_file_credential_failures(
+        operation: str, failures: dict[str, Exception]
+    ) -> None:
+        for name, error in failures.items():
+            logger.warning(
+                "Failed to %s ACP file credential %r",
+                operation,
+                name,
+                exc_info=(type(error), error, error.__traceback__),
+            )
 
-    async def _sync_file_credentials_best_effort(self) -> None:
-        if not self._file_credential_lifecycles:
+    @staticmethod
+    def _raise_first_file_credential_failure(
+        operation: str, failures: dict[str, Exception]
+    ) -> None:
+        if not failures:
             return
-        await asyncio.to_thread(self._sync_file_credentials_best_effort_blocking)
+        first_name = next(iter(failures))
+        remaining = dict(failures)
+        first_error = remaining.pop(first_name)
+        ACPAgent._log_file_credential_failures(operation, remaining)
+        raise first_error
 
-    def _sync_file_credentials_best_effort_blocking(self) -> None:
+    def _sync_file_credentials_collect(
+        self, *, changed_only: bool = False
+    ) -> dict[str, Exception]:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    if changed_only and not lifecycle.may_have_changed:
+                        continue
+                    lifecycle.sync()
+                except Exception as error:
+                    failures[name] = error
+        return failures
+
+    def _sync_file_credentials(self) -> None:
+        """Persist brokered ACP file credentials."""
+        failures = self._sync_file_credentials_collect()
+        self._raise_first_file_credential_failure("sync", failures)
+
+    async def _sync_file_credentials_best_effort(
+        self, *, changed_only: bool = False
+    ) -> None:
+        with self._file_credential_lock:
+            if not self._file_credential_lifecycles:
+                return
         try:
-            self._sync_file_credentials()
-        except _ACPFileCredentialSyncError:
+            await asyncio.to_thread(
+                self._sync_file_credentials_best_effort_blocking,
+                changed_only=changed_only,
+            )
+        except Exception:
             logger.warning("Failed to sync ACP file credentials", exc_info=True)
+
+    def _sync_file_credentials_best_effort_blocking(
+        self, *, changed_only: bool = False
+    ) -> None:
+        failures = self._sync_file_credentials_collect(changed_only=changed_only)
+        self._log_file_credential_failures("sync", failures)
+
+    def _release_file_credentials_collect(
+        self, *, exclude: set[str] | None = None
+    ) -> dict[str, Exception]:
+        failures: dict[str, Exception] = {}
+        excluded = exclude or set()
+        with self._file_credential_lock:
+            for name, lifecycle in list(self._file_credential_lifecycles.items()):
+                if name in excluded:
+                    continue
+                try:
+                    lifecycle.release()
+                except Exception as error:
+                    failures[name] = error
+                else:
+                    self._file_credential_lifecycles.pop(name, None)
+        return failures
 
     def _release_file_credentials(self) -> None:
         """Release scoped ACP file credential sources."""
-        with self._file_credential_lock:
-            first_error: Exception | None = None
-            for name, lifecycle in list(self._file_credential_lifecycles.items()):
-                try:
-                    lifecycle.release()
-                except _ACPFileCredentialSyncError as exc:
-                    if first_error is None:
-                        first_error = exc
-                else:
-                    self._file_credential_lifecycles.pop(name, None)
-            if first_error is not None:
-                raise _ACPFileCredentialSyncError(
-                    "ACP file credential source could not be released."
-                ) from first_error
+        failures = self._release_file_credentials_collect()
+        self._raise_first_file_credential_failure("release", failures)
 
-    def _mark_file_credentials_authenticated(self) -> None:
-        for lifecycle in self._file_credential_lifecycles.values():
-            lifecycle.authenticated = True
+    def _notify_file_credentials_auth_succeeded(self, method_id: str) -> None:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    lifecycle.on_auth_succeeded(method_id)
+                except Exception as error:
+                    failures[name] = error
+        self._raise_first_file_credential_failure("update", failures)
+
+    def _notify_file_credentials_session_started(self) -> None:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    lifecycle.on_session_started()
+                except Exception as error:
+                    failures[name] = error
+        self._raise_first_file_credential_failure("update", failures)
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -2980,7 +2630,7 @@ class ACPAgent(AgentBase):
                         )
                     except TimeoutError as exc:
                         if method_id == "chat-gpt":
-                            raise _ACPFileCredentialNeedsReauthError(
+                            raise ACPFileCredentialNeedsReauthError(
                                 "ChatGPT authentication did not complete in time. "
                                 "Please sign in again."
                             ) from exc
@@ -2993,12 +2643,11 @@ class ACPAgent(AgentBase):
                             exc
                         ):
                             raise
-                        raise _ACPFileCredentialNeedsReauthError(
+                        raise ACPFileCredentialNeedsReauthError(
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
-                    if method_id == "chat-gpt":
-                        self._mark_file_credentials_authenticated()
-                        await self._sync_file_credentials_best_effort()
+                    self._notify_file_credentials_auth_succeeded(method_id)
+                    await self._sync_file_credentials_best_effort(changed_only=True)
                 else:
                     logger.warning(
                         "ACP server offers auth methods %s but no matching "
@@ -3153,8 +2802,7 @@ class ACPAgent(AgentBase):
             self._model_override_applied,
         ) = self._executor.run_async(_init)
         self._working_dir = working_dir
-        if self._file_credential_lifecycles:
-            self._mark_file_credentials_authenticated()
+        self._notify_file_credentials_session_started()
 
     def _reset_client_for_turn(
         self,
@@ -3826,7 +3474,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            self._sync_file_credentials_best_effort_blocking()
+            self._sync_file_credentials_best_effort_blocking(changed_only=True)
 
     @observe(name="acp_agent.astep", ignore_inputs=["conversation", "on_event"])
     async def astep(
@@ -4042,7 +3690,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            await self._sync_file_credentials_best_effort()
+            await self._sync_file_credentials_best_effort(changed_only=True)
 
     def ask_agent(self, question: str) -> str | None:
         """Fork the ACP session, prompt the fork, and return the response."""
@@ -4100,7 +3748,7 @@ class ACPAgent(AgentBase):
                 return result
             finally:
                 try:
-                    await self._sync_file_credentials_best_effort()
+                    await self._sync_file_credentials_best_effort(changed_only=True)
                 finally:
                     client._fork_session_id = None
                     client._fork_accumulated_text.clear()
@@ -4241,26 +3889,21 @@ class ACPAgent(AgentBase):
 
     def close(self) -> None:
         """Terminate the ACP subprocess and clean up resources."""
-        if self._closed:
-            return
-        self._closed = True
-        error: Exception | None = None
-        try:
-            self._sync_file_credentials()
-        except Exception as exc:
-            error = exc
-        try:
-            self._release_file_credentials()
-        except Exception as exc:
-            if error is None:
-                error = exc
-        try:
-            self._cleanup()
-        except Exception as exc:
-            if error is None:
-                error = exc
-        if error is not None:
-            raise error
+        with self._file_credential_close_lock:
+            with self._file_credential_lock:
+                if self._closed and not self._file_credential_lifecycles:
+                    return
+            self._closed = True
+            sync_failures = self._sync_file_credentials_collect()
+            release_failures = self._release_file_credentials_collect(
+                exclude=set(sync_failures)
+            )
+            failures = {**sync_failures, **release_failures}
+            try:
+                self._cleanup()
+            except Exception as exc:
+                failures["ACP runtime"] = exc
+            self._raise_first_file_credential_failure("close", failures)
 
     def _cleanup(self) -> None:
         """Internal cleanup of ACP resources."""
@@ -4309,26 +3952,38 @@ class ACPAgent(AgentBase):
 
         See :meth:`LocalConversation.switch_acp_model`.
         """
-        with self._file_credential_lock:
-            self._file_credential_lifecycles = {}
-        self._closed = True
+        with self._file_credential_close_lock:
+            with self._file_credential_lock:
+                self._file_credential_lifecycles = {}
+            self._closed = True
 
     def __del__(self) -> None:
         try:
-            if self._closed:
-                return
-            self._closed = True
-            credential_paths = [
-                lifecycle.path
-                for lifecycle in self._file_credential_lifecycles.values()
-                if lifecycle.path is not None
-            ]
-            if credential_paths:
-                logger.warning(
-                    "Skipping ACP file credential sync during finalization; "
-                    "durable working copies remain at %s",
-                    credential_paths,
-                )
-            self._cleanup()
+            with self._file_credential_close_lock:
+                credential_paths: list[Path] = []
+                with self._file_credential_lock:
+                    for name, lifecycle in self._file_credential_lifecycles.items():
+                        try:
+                            path = lifecycle.path
+                        except Exception:
+                            logger.warning(
+                                "Failed to inspect ACP file credential %r",
+                                name,
+                                exc_info=True,
+                            )
+                        else:
+                            if path is not None:
+                                credential_paths.append(path)
+                    already_closed = self._closed
+                    self._closed = True
+                if credential_paths:
+                    logger.warning(
+                        "Skipping ACP file credential sync during finalization; "
+                        "durable working copies remain at %s",
+                        credential_paths,
+                    )
+                if already_closed:
+                    return
+                self._cleanup()
         except Exception:
             logger.warning("Failed to finalize ACPAgent resources", exc_info=True)

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -29,6 +29,8 @@ _CODEX_AUTH_REMOTE_CHECK_INTERVAL = 60.0
 _CODEX_AUTH_DIGEST_HEADER = "X-Codex-Auth-Digest"
 _CODEX_AUTH_SANDBOX_HEADER = "X-OH-Sandbox"
 _CODEX_AUTH_SCOPE_HEADER = "X-OH-Codex"
+_CODEX_LOCAL_AUTH_SCOPE_HEADER = "X-OH-Codex-Token"
+_CODEX_LOCAL_REFRESH_USERNAME = "codex"
 _CODEX_REFRESH_TOKEN_URL_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
 _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 
@@ -180,15 +182,17 @@ def _release_codex_auth_source(source: LookupSecret) -> None:
 def _codex_auth_refresh_url(source: LookupSecret) -> str | None:
     headers = {name.lower(): value for name, value in source.headers.items()}
     session_api_key = headers.get(_CODEX_AUTH_SANDBOX_HEADER.lower())
-    codex_auth_token = headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
-    if not session_api_key or not codex_auth_token:
+    codex_auth_token = headers.get(
+        _CODEX_LOCAL_AUTH_SCOPE_HEADER.lower()
+    ) or headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
+    if not codex_auth_token:
         return None
     url = httpx.URL(source.url)
     refresh_path = f"{url.path.rstrip('/')}/refresh"
     return str(
         url.copy_with(
             path=refresh_path,
-            username=session_api_key,
+            username=session_api_key or _CODEX_LOCAL_REFRESH_USERNAME,
             password=codex_auth_token,
         )
     )

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -1,0 +1,443 @@
+"""Manage brokered ACP file credentials."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+import httpx
+
+from openhands.sdk.secret import LookupSecret
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.secret_registry import SecretRegistry
+
+
+CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
+
+_CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
+_CODEX_AUTH_HTTP_TIMEOUT = 5.0
+_CODEX_AUTH_REMOTE_CHECK_INTERVAL = 60.0
+_CODEX_AUTH_DIGEST_HEADER = "X-Codex-Auth-Digest"
+_CODEX_AUTH_SANDBOX_HEADER = "X-OH-Sandbox"
+_CODEX_AUTH_SCOPE_HEADER = "X-OH-Codex"
+_CODEX_REFRESH_TOKEN_URL_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
+_CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
+
+
+class ACPFileCredentialNeedsReauthError(RuntimeError):
+    pass
+
+
+class ACPFileCredentialSyncError(RuntimeError):
+    pass
+
+
+class ACPFileCredentialLifecycle(Protocol):
+    """Define a brokered ACP file credential lifecycle."""
+
+    secret_name: str
+    path: Path | None
+
+    @property
+    def may_have_changed(self) -> bool: ...
+
+    def load(self) -> str | None: ...
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None: ...
+
+    def should_preserve_existing(self, path: Path) -> bool: ...
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
+
+    def on_auth_succeeded(self, method_id: str) -> None: ...
+
+    def on_session_started(self) -> None: ...
+
+    def sync(self) -> None: ...
+
+    def release(self) -> None: ...
+
+
+def codex_auth_file(env: dict[str, str]) -> Path:
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home) / "auth.json"
+    return Path.home() / _CHATGPT_AUTH_PATH
+
+
+def codex_auth_file_is_chatgpt(env: dict[str, str]) -> bool:
+    path = codex_auth_file(env)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and "tokens" in data
+
+
+def write_secret_file(path: Path, value: str) -> None:
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(fd, 0o600)
+        file = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with file:
+            file.write(value)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _codex_auth_ancestor_file(path: Path) -> Path:
+    return path.with_name(f".{path.name}.cloud-digest")
+
+
+def _read_codex_auth_ancestor(path: Path) -> str | None:
+    try:
+        return _codex_auth_ancestor_file(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _write_codex_auth_ancestor(path: Path, digest: str) -> None:
+    write_secret_file(_codex_auth_ancestor_file(path), digest)
+
+
+def _update_codex_auth_source(
+    source: LookupSecret, value: str, expected_digest: str
+) -> None:
+    response = httpx.put(
+        source.url,
+        headers=source.headers,
+        json={"expected_digest": expected_digest, "value": value},
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def _get_codex_auth_source(source: LookupSecret) -> str:
+    response = httpx.get(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def _touch_codex_auth_source(source: LookupSecret) -> str | None:
+    response = httpx.head(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+    digest = response.headers.get(_CODEX_AUTH_DIGEST_HEADER)
+    return (
+        digest
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest)
+        else None
+    )
+
+
+def _release_codex_auth_source(source: LookupSecret) -> None:
+    response = httpx.delete(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def _codex_auth_refresh_url(source: LookupSecret) -> str | None:
+    headers = {name.lower(): value for name, value in source.headers.items()}
+    session_api_key = headers.get(_CODEX_AUTH_SANDBOX_HEADER.lower())
+    codex_auth_token = headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
+    if not session_api_key or not codex_auth_token:
+        return None
+    url = httpx.URL(source.url)
+    refresh_path = f"{url.path.rstrip('/')}/refresh"
+    return str(
+        url.copy_with(
+            path=refresh_path,
+            username=session_api_key,
+            password=codex_auth_token,
+        )
+    )
+
+
+def _is_valid_codex_auth_value(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(payload, dict) and bool(payload)
+
+
+class _CodexAuthLifecycle:
+    """Manage brokered Codex subscription auth."""
+
+    secret_name = CODEX_AUTH_SECRET_NAME
+
+    def __init__(self, source: LookupSecret, refresh_url: str):
+        self.source = source
+        self.refresh_url = refresh_url
+        self.path: Path | None = None
+        self.expected_digest: str | None = None
+        self.last_remote_check = 0.0
+        self.registry: SecretRegistry | None = None
+        self._may_have_changed = False
+
+    @property
+    def may_have_changed(self) -> bool:
+        return self._may_have_changed
+
+    def load(self) -> str | None:
+        try:
+            return self.source.get_value()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (404, 422):
+                detail = (
+                    "ChatGPT authentication was not found in Cloud."
+                    if exc.response.status_code == 404
+                    else "ChatGPT authentication needs to be refreshed."
+                )
+                raise ACPFileCredentialNeedsReauthError(detail) from exc
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None:
+        if not _is_valid_codex_auth_value(remote_value):
+            raise ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials."
+            )
+        self.path = path
+        self.registry = registry
+        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
+        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
+        self._track_transport()
+
+    def should_preserve_existing(self, path: Path) -> bool:
+        return _read_codex_auth_ancestor(path) == self.expected_digest
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        assert path is not None
+        assert expected_digest is not None
+        _write_codex_auth_ancestor(path, expected_digest)
+        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
+        self.last_remote_check = (
+            time.monotonic() if local_digest == expected_digest else 0.0
+        )
+        if local_digest != expected_digest:
+            self._may_have_changed = True
+        self._track_values(remote_value)
+        if local_digest != expected_digest:
+            self._track_values(local_value)
+
+    def on_auth_succeeded(self, method_id: str) -> None:
+        if method_id == "chat-gpt":
+            self._may_have_changed = True
+
+    def on_session_started(self) -> None:
+        self._may_have_changed = True
+
+    def _track_values(self, value: str) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {self.secret_name: value}
+        try:
+            tokens = json.loads(value).get("tokens", {})
+        except (AttributeError, TypeError, ValueError):
+            tokens = None
+        if isinstance(tokens, dict):
+            for name, token in tokens.items():
+                if isinstance(token, str) and token:
+                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
+        registry.track_exported_values(exported_values)
+
+    def _track_transport(self) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {
+            f"{self.secret_name}.refresh_url": self.refresh_url,
+        }
+        for name, value in self.source.headers.items():
+            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
+        registry.track_exported_values(exported_values)
+
+    def sync(self) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        if path is None or expected_digest is None:
+            return
+        try:
+            value = path.read_bytes()
+            text_value = value.decode()
+        except (OSError, UnicodeError) as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be saved to Cloud."
+            ) from exc
+        if not _is_valid_codex_auth_value(text_value):
+            raise ACPFileCredentialSyncError(
+                "Local Codex credentials are invalid; the Cloud copy was preserved."
+            )
+        digest = hashlib.sha256(value).hexdigest()
+        changed = digest != expected_digest
+        now = time.monotonic()
+        if (
+            not changed
+            and self.last_remote_check > 0
+            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
+        ):
+            return
+        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                if changed:
+                    _update_codex_auth_source(self.source, text_value, expected_digest)
+                else:
+                    remote_digest = _touch_codex_auth_source(self.source)
+                    if (
+                        isinstance(remote_digest, str)
+                        and remote_digest != expected_digest
+                    ):
+                        self._adopt(_get_codex_auth_source(self.source))
+                        return
+            except httpx.HTTPStatusError as exc:
+                if changed and exc.response.status_code == 409:
+                    try:
+                        self._adopt(_get_codex_auth_source(self.source))
+                    except (httpx.HTTPError, ACPFileCredentialSyncError) as remote_exc:
+                        if attempt == attempts - 1:
+                            raise ACPFileCredentialSyncError(
+                                "Codex credentials could not be reconciled with Cloud."
+                            ) from remote_exc
+                    else:
+                        return
+                if attempt == attempts - 1:
+                    raise ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            except httpx.RequestError as exc:
+                if attempt == attempts - 1:
+                    raise ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            else:
+                break
+            if attempt < attempts - 1:
+                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
+        if changed:
+            try:
+                _write_codex_auth_ancestor(path, digest)
+            except OSError as exc:
+                raise ACPFileCredentialSyncError(
+                    "Codex credentials could not be saved to Cloud."
+                ) from exc
+            self._track_values(text_value)
+            self.expected_digest = digest
+        self.last_remote_check = now
+
+    def _adopt(self, value: str) -> None:
+        path = self.path
+        assert path is not None
+        if not _is_valid_codex_auth_value(value):
+            raise ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials; "
+                "the local copy was preserved."
+            )
+        digest = hashlib.sha256(value.encode()).hexdigest()
+        try:
+            write_secret_file(path, value)
+            _write_codex_auth_ancestor(path, digest)
+        except OSError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be reconciled with Cloud."
+            ) from exc
+        self._track_values(value)
+        self.expected_digest = digest
+        self.last_remote_check = time.monotonic()
+
+    def release(self) -> None:
+        try:
+            _release_codex_auth_source(self.source)
+        except httpx.HTTPError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credential source could not be released."
+            ) from exc
+        self.clear()
+
+    def clear(self) -> None:
+        self.path = None
+        self.expected_digest = None
+        self.last_remote_check = 0.0
+        self.registry = None
+        self._may_have_changed = False
+
+
+def _create_codex_auth_lifecycle(
+    source: LookupSecret,
+) -> ACPFileCredentialLifecycle | None:
+    refresh_url = _codex_auth_refresh_url(source)
+    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
+
+
+_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
+    str, Callable[[LookupSecret], ACPFileCredentialLifecycle | None]
+] = {
+    CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
+}
+
+
+def create_file_credential_lifecycle(
+    secret_name: str, source: object
+) -> ACPFileCredentialLifecycle | None:
+    if not isinstance(source, LookupSecret):
+        return None
+    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
+    return factory(source) if factory is not None else None

--- a/tests/agent_server/test_codex_auth.py
+++ b/tests/agent_server/test_codex_auth.py
@@ -14,12 +14,16 @@ from fastapi.testclient import TestClient
 
 from openhands.agent_server import codex_auth as codex_auth_module
 from openhands.agent_server.api import create_app
-from openhands.agent_server.codex_auth import CodexAuthBroker, router
+from openhands.agent_server.codex_auth import (
+    CODEX_AUTH_SECRET_NAME,
+    CodexAuthBroker,
+    router,
+)
 from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.models import StartConversationRequest
 from openhands.agent_server.persistence import FileSecretsStore
-from openhands.sdk import LLM, Agent
+from openhands.sdk import LLM, Agent, AgentContext
 from openhands.sdk.secret import LookupSecret
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -425,6 +429,83 @@ async def test_restart_reissues_capability_and_keeps_it_out_of_meta(tmp_path):
         assert second_token != first_token
         assert second_broker.is_authorized(info.id, second_token)
         assert not second_broker.is_authorized(info.id, first_token)
+
+
+@pytest.mark.asyncio
+async def test_agent_context_secret_is_brokered_after_registry_initialization(tmp_path):
+    store = FileSecretsStore(tmp_path / "settings")
+    store.set_secret(CODEX_AUTH_SECRET_NAME, _auth_value())
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    request = StartConversationRequest(
+        agent=Agent(
+            llm=LLM(model="gpt-4o", usage_id="test"),
+            tools=[],
+            agent_context=AgentContext(
+                secrets={CODEX_AUTH_SECRET_NAME: _local_source()}
+            ),
+        ),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+    )
+    broker = CodexAuthBroker(store)
+
+    async with ConversationService(
+        conversations_dir=tmp_path / "conversations",
+        codex_auth_broker=broker,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        source = event_service.get_conversation().state.secret_registry.secret_sources[
+            CODEX_AUTH_SECRET_NAME
+        ]
+        assert isinstance(source, LookupSecret)
+        assert source != _local_source()
+        first_token = _token(source)
+        assert broker.is_authorized(info.id, first_token)
+
+    second_broker = CodexAuthBroker(store)
+    async with ConversationService(
+        conversations_dir=tmp_path / "conversations",
+        codex_auth_broker=second_broker,
+    ) as service:
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        source = event_service.get_conversation().state.secret_registry.secret_sources[
+            CODEX_AUTH_SECRET_NAME
+        ]
+        assert isinstance(source, LookupSecret)
+        second_token = _token(source)
+        assert second_token != first_token
+        assert second_broker.is_authorized(info.id, second_token)
+
+
+@pytest.mark.asyncio
+async def test_late_codex_auth_secret_update_is_brokered(tmp_path):
+    store = FileSecretsStore(tmp_path / "settings")
+    store.set_secret(CODEX_AUTH_SECRET_NAME, _auth_value())
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+    )
+    broker = CodexAuthBroker(store)
+
+    async with ConversationService(
+        conversations_dir=tmp_path / "conversations",
+        codex_auth_broker=broker,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        await event_service.update_secrets({CODEX_AUTH_SECRET_NAME: _local_source()})
+        source = event_service.get_conversation().state.secret_registry.secret_sources[
+            CODEX_AUTH_SECRET_NAME
+        ]
+        assert isinstance(source, LookupSecret)
+        assert source != _local_source()
+        assert broker.is_authorized(info.id, _token(source))
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_codex_auth.py
+++ b/tests/agent_server/test_codex_auth.py
@@ -278,6 +278,72 @@ def test_concurrent_refresh_rotates_upstream_once(broker_client, monkeypatch):
     assert calls == 1
 
 
+@pytest.mark.asyncio
+async def test_update_waits_for_in_flight_refresh(tmp_path, monkeypatch):
+    store = FileSecretsStore(tmp_path)
+    original = _auth_value()
+    store.set_secret("CODEX_AUTH_JSON", original)
+    broker = CodexAuthBroker(store)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.conversation_service = SimpleNamespace(codex_auth_broker=broker)
+    source = broker.ensure_brokered_source(uuid4(), _local_source())
+    refresh_started = asyncio.Event()
+    continue_refresh = asyncio.Event()
+
+    async def refresh(_refresh_token: str) -> httpx.Response:
+        refresh_started.set()
+        await continue_refresh.wait()
+        return httpx.Response(
+            200,
+            json={"access_token": "access-r1", "refresh_token": "refresh-r1"},
+            request=httpx.Request("POST", "https://auth.openai.com/oauth/token"),
+        )
+
+    monkeypatch.setattr(codex_auth_module, "_request_token_refresh", refresh)
+    path = urlsplit(source.url).path
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        refresh_task = asyncio.create_task(
+            client.post(
+                f"{path}/refresh",
+                headers={"Authorization": _refresh_authorization(source)},
+                json={
+                    "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+                    "grant_type": "refresh_token",
+                    "refresh_token": "refresh-r0",
+                },
+            )
+        )
+        await asyncio.wait_for(refresh_started.wait(), timeout=1)
+        update_task = asyncio.create_task(
+            client.put(
+                path,
+                headers=source.headers,
+                json={
+                    "expected_digest": hashlib.sha256(original.encode()).hexdigest(),
+                    "value": _auth_value(
+                        access_token="local", refresh_token="refresh-r0"
+                    ),
+                },
+            )
+        )
+        await asyncio.sleep(0.01)
+        assert not update_task.done()
+        continue_refresh.set()
+        refresh_response, update_response = await asyncio.gather(
+            refresh_task, update_task
+        )
+
+    assert refresh_response.status_code == 200
+    assert update_response.status_code == 409
+    assert json.loads(store.get_secret("CODEX_AUTH_JSON") or "{}")["tokens"] == {
+        "id_token": "id-r0",
+        "access_token": "access-r1",
+        "refresh_token": "refresh-r1",
+    }
+
+
 def test_failed_refresh_preserves_authoritative_secret(broker_client, monkeypatch):
     client, broker, store = broker_client
     conversation_id = uuid4()

--- a/tests/agent_server/test_codex_auth.py
+++ b/tests/agent_server/test_codex_auth.py
@@ -328,12 +328,17 @@ async def test_restart_reissues_capability_and_keeps_it_out_of_meta(tmp_path):
         info, _ = await service.start_conversation(request)
         event_service = await service.get_event_service(info.id)
         assert event_service is not None
-        first_source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        first_source = (
+            event_service.get_conversation().state.secret_registry.secret_sources[
+                "CODEX_AUTH_JSON"
+            ]
+        )
         assert isinstance(first_source, LookupSecret)
         first_token = _token(first_source)
+        assert event_service.stored.secrets["CODEX_AUTH_JSON"] == _local_source()
         meta = (conversations_dir / info.id.hex / "meta.json").read_text()
         assert first_token not in meta
-        assert "broad-session-key" not in meta
+        assert "/api/settings/secrets/CODEX_AUTH_JSON" in meta
 
     assert not first_broker.is_authorized(info.id, first_token)
 
@@ -344,7 +349,11 @@ async def test_restart_reissues_capability_and_keeps_it_out_of_meta(tmp_path):
     ) as service:
         event_service = await service.get_event_service(info.id)
         assert event_service is not None
-        second_source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        second_source = (
+            event_service.get_conversation().state.secret_registry.secret_sources[
+                "CODEX_AUTH_JSON"
+            ]
+        )
         assert isinstance(second_source, LookupSecret)
         second_token = _token(second_source)
         assert second_token != first_token
@@ -372,7 +381,9 @@ async def test_conversation_delete_revokes_unmaterialized_capability(tmp_path):
         info, _ = await service.start_conversation(request)
         event_service = await service.get_event_service(info.id)
         assert event_service is not None
-        source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        source = event_service.get_conversation().state.secret_registry.secret_sources[
+            "CODEX_AUTH_JSON"
+        ]
         assert isinstance(source, LookupSecret)
         token = _token(source)
         assert broker.is_authorized(info.id, token)

--- a/tests/agent_server/test_codex_auth.py
+++ b/tests/agent_server/test_codex_auth.py
@@ -1,0 +1,381 @@
+import asyncio
+import base64
+import hashlib
+import json
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openhands.agent_server import codex_auth as codex_auth_module
+from openhands.agent_server.api import create_app
+from openhands.agent_server.codex_auth import CodexAuthBroker, router
+from openhands.agent_server.config import Config
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.models import StartConversationRequest
+from openhands.agent_server.persistence import FileSecretsStore
+from openhands.sdk import LLM, Agent
+from openhands.sdk.secret import LookupSecret
+from openhands.sdk.workspace import LocalWorkspace
+
+
+def _auth_value(
+    *,
+    access_token: str = "access-r0",
+    refresh_token: str = "refresh-r0",
+) -> str:
+    return json.dumps(
+        {
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": "id-r0",
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            },
+        },
+        separators=(",", ":"),
+    )
+
+
+def _local_source() -> LookupSecret:
+    return LookupSecret(
+        url="http://agent/api/settings/secrets/CODEX_AUTH_JSON",
+        headers={"X-Session-API-Key": "broad-session-key"},
+    )
+
+
+def _token(source: LookupSecret) -> str:
+    return source.headers["X-OH-Codex-Token"]
+
+
+def _refresh_authorization(source: LookupSecret) -> str:
+    encoded = base64.b64encode(f"codex:{_token(source)}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+@pytest.fixture
+def broker_client(tmp_path):
+    store = FileSecretsStore(tmp_path)
+    store.set_secret("CODEX_AUTH_JSON", _auth_value())
+    broker = CodexAuthBroker(store)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.conversation_service = SimpleNamespace(codex_auth_broker=broker)
+    with TestClient(app) as client:
+        yield client, broker, store
+
+
+def test_local_lookup_uses_scoped_non_disclosing_capability(tmp_path):
+    store = FileSecretsStore(tmp_path)
+    broker = CodexAuthBroker(store)
+    conversation_id = uuid4()
+
+    source = broker.ensure_brokered_source(conversation_id, _local_source())
+    token = _token(source)
+
+    assert source.headers == {"X-OH-Codex-Token": token}
+    assert "broad-session-key" not in source.headers.values()
+    assert urlsplit(source.url).netloc == "agent"
+    assert urlsplit(source.url).path == (
+        f"/api/conversations/{conversation_id}/codex-auth"
+    )
+    assert broker.is_authorized(conversation_id, token)
+    assert token not in source.model_dump_json()
+
+
+def test_broker_leaves_saas_source_unchanged(tmp_path):
+    broker = CodexAuthBroker(FileSecretsStore(tmp_path))
+    source = LookupSecret(
+        url="https://cloud/api/internal/conversations/123/codex-auth",
+        headers={"X-OH-Sandbox": "sandbox-key", "X-OH-Codex": "cloud-token"},
+    )
+
+    assert broker.ensure_brokered_source(uuid4(), source) is source
+
+
+def test_file_store_compare_and_swap_rejects_concurrent_loser(tmp_path):
+    store = FileSecretsStore(tmp_path)
+    original = _auth_value()
+    store.set_secret("CODEX_AUTH_JSON", original, description="Codex auth")
+    digest = hashlib.sha256(original.encode()).hexdigest()
+    candidates = [
+        _auth_value(access_token="access-a", refresh_token="refresh-a"),
+        _auth_value(access_token="access-b", refresh_token="refresh-b"),
+    ]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda value: store.compare_and_swap_secret(
+                    "CODEX_AUTH_JSON", digest, value
+                ),
+                candidates,
+            )
+        )
+
+    assert sorted(results) == [False, True]
+    stored = store.load()
+    assert stored is not None
+    assert stored.custom_secrets["CODEX_AUTH_JSON"].description == "Codex auth"
+    assert store.get_secret("CODEX_AUTH_JSON") in candidates
+
+
+def test_broker_get_update_and_release_are_capability_scoped(broker_client):
+    client, broker, store = broker_client
+    conversation_id = uuid4()
+    source = broker.ensure_brokered_source(conversation_id, _local_source())
+    path = urlsplit(source.url).path
+    headers = source.headers
+    original = store.get_secret("CODEX_AUTH_JSON")
+    assert original is not None
+    original_digest = hashlib.sha256(original.encode()).hexdigest()
+
+    unauthorized = client.get(path, headers={"X-Session-API-Key": "broad-session-key"})
+    wrong_scope = client.get(
+        path.replace(str(conversation_id), str(uuid4())), headers=headers
+    )
+    fetched = client.get(path, headers=headers)
+    touched = client.head(path, headers=headers)
+
+    assert unauthorized.status_code == 401
+    assert wrong_scope.status_code == 401
+    assert fetched.status_code == 200
+    assert fetched.text == original
+    assert fetched.headers["Cache-Control"] == "no-store"
+    assert touched.status_code == 204
+    assert touched.headers["X-Codex-Auth-Digest"] == original_digest
+
+    updated = _auth_value(access_token="access-r1", refresh_token="refresh-r1")
+    winner = client.put(
+        path,
+        headers=headers,
+        json={"expected_digest": original_digest, "value": updated},
+    )
+    loser = client.put(
+        path,
+        headers=headers,
+        json={"expected_digest": original_digest, "value": original},
+    )
+
+    assert winner.status_code == 204
+    assert loser.status_code == 409
+    assert store.get_secret("CODEX_AUTH_JSON") == updated
+
+    released = client.delete(path, headers=headers)
+    revoked = client.get(path, headers=headers)
+
+    assert released.status_code == 204
+    assert revoked.status_code == 401
+
+
+def test_full_app_exempts_only_capability_broker_from_session_auth(tmp_path):
+    store = FileSecretsStore(tmp_path)
+    store.set_secret("CODEX_AUTH_JSON", _auth_value())
+    broker = CodexAuthBroker(store)
+    conversation_id = uuid4()
+    source = broker.ensure_brokered_source(conversation_id, _local_source())
+    app = create_app(Config(session_api_keys=["broad-session-key"]))
+    app.state.conversation_service = SimpleNamespace(codex_auth_broker=broker)
+    client = TestClient(app)
+
+    broker_response = client.get(urlsplit(source.url).path, headers=source.headers)
+    settings_response = client.get("/api/settings")
+
+    assert broker_response.status_code == 200
+    assert settings_response.status_code == 401
+
+
+def test_sequential_stale_refresh_converges_without_second_rotation(
+    broker_client, monkeypatch
+):
+    client, broker, store = broker_client
+    first_source = broker.ensure_brokered_source(uuid4(), _local_source())
+    calls = 0
+
+    async def refresh(refresh_token: str) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert refresh_token == "refresh-r0"
+        return httpx.Response(
+            200,
+            json={"access_token": "access-r1", "refresh_token": "refresh-r1"},
+            request=httpx.Request("POST", "https://auth.openai.com/oauth/token"),
+        )
+
+    monkeypatch.setattr(codex_auth_module, "_request_token_refresh", refresh)
+    payload = {
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-r0",
+    }
+
+    first = client.post(
+        f"{urlsplit(first_source.url).path}/refresh",
+        headers={"Authorization": _refresh_authorization(first_source)},
+        json=payload,
+    )
+    second_source = broker.ensure_brokered_source(uuid4(), _local_source())
+    second = client.post(
+        f"{urlsplit(second_source.url).path}/refresh",
+        headers={"Authorization": _refresh_authorization(second_source)},
+        json=payload,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert first.json()["refresh_token"] == "refresh-r1"
+    assert calls == 1
+    assert (
+        json.loads(store.get_secret("CODEX_AUTH_JSON") or "{}")["tokens"][
+            "refresh_token"
+        ]
+        == "refresh-r1"
+    )
+
+
+def test_concurrent_refresh_rotates_upstream_once(broker_client, monkeypatch):
+    client, broker, _store = broker_client
+    sources = [
+        broker.ensure_brokered_source(uuid4(), _local_source()) for _index in range(2)
+    ]
+    calls = 0
+
+    async def refresh(_refresh_token: str) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return httpx.Response(
+            200,
+            json={"access_token": "access-r1", "refresh_token": "refresh-r1"},
+            request=httpx.Request("POST", "https://auth.openai.com/oauth/token"),
+        )
+
+    monkeypatch.setattr(codex_auth_module, "_request_token_refresh", refresh)
+    payload = {
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-r0",
+    }
+
+    def submit(source: LookupSecret) -> httpx.Response:
+        return client.post(
+            f"{urlsplit(source.url).path}/refresh",
+            headers={"Authorization": _refresh_authorization(source)},
+            json=payload,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        responses = list(executor.map(submit, sources))
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert responses[0].json() == responses[1].json()
+    assert calls == 1
+
+
+def test_failed_refresh_preserves_authoritative_secret(broker_client, monkeypatch):
+    client, broker, store = broker_client
+    conversation_id = uuid4()
+    source = broker.ensure_brokered_source(conversation_id, _local_source())
+    path = f"{urlsplit(source.url).path}/refresh"
+    original = store.get_secret("CODEX_AUTH_JSON")
+
+    async def refresh(_refresh_token: str) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={"error": {"code": "upstream_failed"}},
+            request=httpx.Request("POST", "https://auth.openai.com/oauth/token"),
+        )
+
+    monkeypatch.setattr(codex_auth_module, "_request_token_refresh", refresh)
+    response = client.post(
+        path,
+        headers={"Authorization": _refresh_authorization(source)},
+        json={
+            "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-r0",
+        },
+    )
+
+    assert response.status_code == 502
+    assert store.get_secret("CODEX_AUTH_JSON") == original
+
+
+@pytest.mark.asyncio
+async def test_restart_reissues_capability_and_keeps_it_out_of_meta(tmp_path):
+    store = FileSecretsStore(tmp_path / "settings")
+    store.set_secret("CODEX_AUTH_JSON", _auth_value())
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        secrets={"CODEX_AUTH_JSON": _local_source()},
+    )
+    first_broker = CodexAuthBroker(store)
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        codex_auth_broker=first_broker,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        first_source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        assert isinstance(first_source, LookupSecret)
+        first_token = _token(first_source)
+        meta = (conversations_dir / info.id.hex / "meta.json").read_text()
+        assert first_token not in meta
+        assert "broad-session-key" not in meta
+
+    assert not first_broker.is_authorized(info.id, first_token)
+
+    second_broker = CodexAuthBroker(store)
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        codex_auth_broker=second_broker,
+    ) as service:
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        second_source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        assert isinstance(second_source, LookupSecret)
+        second_token = _token(second_source)
+        assert second_token != first_token
+        assert second_broker.is_authorized(info.id, second_token)
+        assert not second_broker.is_authorized(info.id, first_token)
+
+
+@pytest.mark.asyncio
+async def test_conversation_delete_revokes_unmaterialized_capability(tmp_path):
+    store = FileSecretsStore(tmp_path / "settings")
+    store.set_secret("CODEX_AUTH_JSON", _auth_value())
+    broker = CodexAuthBroker(store)
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        secrets={"CODEX_AUTH_JSON": _local_source()},
+    )
+
+    async with ConversationService(
+        conversations_dir=tmp_path / "conversations",
+        codex_auth_broker=broker,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        source = event_service.stored.secrets["CODEX_AUTH_JSON"]
+        assert isinstance(source, LookupSecret)
+        token = _token(source)
+        assert broker.is_authorized(info.id, token)
+
+        assert await service.delete_conversation(info.id)
+        assert not broker.is_authorized(info.id, token)

--- a/tests/agent_server/test_codex_auth.py
+++ b/tests/agent_server/test_codex_auth.py
@@ -2,6 +2,8 @@ import asyncio
 import base64
 import hashlib
 import json
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from urllib.parse import urlsplit
@@ -127,6 +129,49 @@ def test_file_store_compare_and_swap_rejects_concurrent_loser(tmp_path):
     assert stored is not None
     assert stored.custom_secrets["CODEX_AUTH_JSON"].description == "Codex auth"
     assert store.get_secret("CODEX_AUTH_JSON") in candidates
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["get", "compare_and_swap"])
+async def test_broker_store_io_does_not_block_event_loop(
+    tmp_path, monkeypatch, operation
+):
+    store = FileSecretsStore(tmp_path)
+    value = _auth_value()
+    store.set_secret(CODEX_AUTH_SECRET_NAME, value)
+    broker = CodexAuthBroker(store)
+    started = threading.Event()
+    release = threading.Event()
+
+    if operation == "get":
+
+        def blocking_get(_name):
+            started.set()
+            release.wait(2)
+            return value
+
+        monkeypatch.setattr(store, "get_secret", blocking_get)
+    else:
+
+        def blocking_compare(_name, _digest, _value):
+            started.set()
+            release.wait(2)
+            return True
+
+        monkeypatch.setattr(store, "compare_and_swap_secret", blocking_compare)
+
+    async def run_operation() -> object:
+        if operation == "get":
+            return await broker.get_value()
+        return await broker.compare_and_swap("digest", value)
+
+    task = asyncio.create_task(run_operation())
+    start = time.monotonic()
+    while not started.is_set():
+        await asyncio.sleep(0)
+    assert time.monotonic() - start < 1
+    release.set()
+    assert await asyncio.wait_for(task, timeout=1) in (value, True)
 
 
 def test_broker_get_update_and_release_are_capability_scoped(broker_client):

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -14,7 +14,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -24,6 +24,7 @@ from pydantic import SecretStr
 
 from openhands.agent_server.__main__ import preload_modules
 from openhands.agent_server.codex_auth import CODEX_AUTH_SECRET_NAME
+from openhands.agent_server.persistence import FileSecretsStore
 from openhands.sdk import LLM, Agent, AgentContext, Conversation
 from openhands.sdk.conversation import RemoteConversation
 from openhands.sdk.event import (
@@ -184,44 +185,19 @@ def test_local_codex_auth_broker_over_live_server(server_env):
             },
         }
     )
-    agent = Agent(
-        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")),
-        tools=[],
-        include_default_tools=[],
-    )
+    broker = server_env["conversation_service"].codex_auth_broker
+    assert broker is not None
+    broker.store = FileSecretsStore(server_env["workspace_path"] / "codex-auth")
+    broker.store.set_secret(CODEX_AUTH_SECRET_NAME, credential)
+    conversation_id = uuid4()
     source = LookupSecret(
         url=(f"{server_env['host']}/api/settings/secrets/{CODEX_AUTH_SECRET_NAME}"),
         headers={"X-Session-API-Key": "broad-key"},
     )
-    payload = {
-        "agent": agent.model_dump(mode="json", context={"expose_secrets": True}),
-        "workspace": {"working_dir": str(server_env["workspace_path"])},
-        "secrets": {
-            CODEX_AUTH_SECRET_NAME: source.model_dump(
-                mode="json", context={"expose_secrets": True}
-            )
-        },
-    }
+    brokered_source = broker.ensure_brokered_source(conversation_id, source)
+    token = brokered_source.headers["X-OH-Codex-Token"]
 
     with httpx.Client(base_url=server_env["host"], timeout=10.0) as client:
-        secret_response = client.put(
-            "/api/settings/secrets",
-            json={"name": CODEX_AUTH_SECRET_NAME, "value": credential},
-        )
-        assert secret_response.status_code == 200
-
-        create_response = client.post("/api/conversations", json=payload)
-        assert create_response.status_code == 201, create_response.text
-        conversation_id = UUID(create_response.json()["id"])
-        event_service = server_env["conversation_service"]._event_services[
-            conversation_id
-        ]
-        brokered_source = event_service.stored.secrets[CODEX_AUTH_SECRET_NAME]
-        assert isinstance(brokered_source, LookupSecret)
-        token = brokered_source.headers["X-OH-Codex-Token"]
-        assert "broad-key" not in brokered_source.headers.values()
-        assert token not in create_response.text
-
         broker_response = client.get(
             brokered_source.url,
             headers={"X-OH-Codex-Token": token},
@@ -230,8 +206,11 @@ def test_local_codex_auth_broker_over_live_server(server_env):
         assert broker_response.text == credential
         assert broker_response.headers["cache-control"] == "no-store"
 
-        delete_response = client.delete(f"/api/conversations/{conversation_id}")
-        assert delete_response.status_code == 200
+        delete_response = client.delete(
+            brokered_source.url,
+            headers={"X-OH-Codex-Token": token},
+        )
+        assert delete_response.status_code == 204
         revoked_response = client.get(
             brokered_source.url,
             headers={"X-OH-Codex-Token": token},

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -23,6 +23,7 @@ from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelRespons
 from pydantic import SecretStr
 
 from openhands.agent_server.__main__ import preload_modules
+from openhands.agent_server.codex_auth import CODEX_AUTH_SECRET_NAME
 from openhands.sdk import LLM, Agent, AgentContext, Conversation
 from openhands.sdk.conversation import RemoteConversation
 from openhands.sdk.event import (
@@ -39,6 +40,7 @@ from openhands.sdk.event import (
     SystemPromptEvent,
 )
 from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+from openhands.sdk.secret import LookupSecret
 from openhands.sdk.skills import Skill
 from openhands.sdk.subagent import AgentDefinition
 from openhands.sdk.subagent.registry import (
@@ -169,6 +171,72 @@ def test_health_endpoints_return_ok_json(server_env):
             response = client.get(f"{server_env['host']}{endpoint}", timeout=1.0)
             assert response.status_code == 200
             assert response.json() == {"status": "ok"}
+
+
+def test_local_codex_auth_broker_over_live_server(server_env):
+    credential = json.dumps(
+        {
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": "id-r0",
+                "access_token": "access-r0",
+                "refresh_token": "refresh-r0",
+            },
+        }
+    )
+    agent = Agent(
+        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")),
+        tools=[],
+        include_default_tools=[],
+    )
+    source = LookupSecret(
+        url=(f"{server_env['host']}/api/settings/secrets/{CODEX_AUTH_SECRET_NAME}"),
+        headers={"X-Session-API-Key": "broad-key"},
+    )
+    payload = {
+        "agent": agent.model_dump(mode="json", context={"expose_secrets": True}),
+        "workspace": {"working_dir": str(server_env["workspace_path"])},
+        "secrets": {
+            CODEX_AUTH_SECRET_NAME: source.model_dump(
+                mode="json", context={"expose_secrets": True}
+            )
+        },
+    }
+
+    with httpx.Client(base_url=server_env["host"], timeout=10.0) as client:
+        secret_response = client.put(
+            "/api/settings/secrets",
+            json={"name": CODEX_AUTH_SECRET_NAME, "value": credential},
+        )
+        assert secret_response.status_code == 200
+
+        create_response = client.post("/api/conversations", json=payload)
+        assert create_response.status_code == 201, create_response.text
+        conversation_id = UUID(create_response.json()["id"])
+        event_service = server_env["conversation_service"]._event_services[
+            conversation_id
+        ]
+        brokered_source = event_service.stored.secrets[CODEX_AUTH_SECRET_NAME]
+        assert isinstance(brokered_source, LookupSecret)
+        token = brokered_source.headers["X-OH-Codex-Token"]
+        assert "broad-key" not in brokered_source.headers.values()
+        assert token not in create_response.text
+
+        broker_response = client.get(
+            brokered_source.url,
+            headers={"X-OH-Codex-Token": token},
+        )
+        assert broker_response.status_code == 200
+        assert broker_response.text == credential
+        assert broker_response.headers["cache-control"] == "no-store"
+
+        delete_response = client.delete(f"/api/conversations/{conversation_id}")
+        assert delete_response.status_code == 200
+        revoked_response = client.get(
+            brokered_source.url,
+            headers={"X-OH-Codex-Token": token},
+        )
+        assert revoked_response.status_code == 401
 
 
 @pytest.fixture

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8684,6 +8684,40 @@ class TestACPFileSecretMaterialisation:
             touch_source.assert_not_called()
             agent.close()
 
+    def test_chatgpt_auth_timeout_becomes_auth_required(self, tmp_path):
+        credential = '{"tokens":{"refresh_token":"never-log-this"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+        conn = self._make_conn(auth_method="chat-gpt")
+        cancelled = threading.Event()
+
+        async def hang_until_cancelled(*_args, **_kwargs):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        conn.authenticate.side_effect = hang_until_cancelled
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=credential),
+            patch.object(acp_agent_module, "_ACP_AUTH_TIMEOUT", 0.01),
+            pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info,
+        ):
+            self._run_start(agent, state, conn=conn)
+
+        assert cancelled.is_set()
+        assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
+        assert "did not complete in time" in str(exc_info.value)
+        assert credential not in _acp_error_detail(
+            exc_info.value, state.secret_registry
+        )
+        agent._cleanup()
+
     def test_chatgpt_auth_programming_error_is_not_reclassified(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"r0"}}'
         agent = _make_agent()

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -26,13 +26,13 @@ from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _acp_error_detail,
     _acp_error_indicates_auth,
+    _ACPFileCredentialNeedsReauthError,
+    _ACPFileCredentialSyncError,
     _apply_acp_model,
     _classify_acp_init_error,
     _classify_acp_turn_error,
     _codex_auth_file,
     _codex_model_config_options,
-    _CodexCredentialSyncError,
-    _CodexNeedsReauthError,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -8310,11 +8310,30 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", side_effect=missing),
-            pytest.raises(_CodexNeedsReauthError, match="not found") as exc_info,
+            pytest.raises(
+                _ACPFileCredentialNeedsReauthError, match="not found"
+            ) as exc_info,
         ):
             agent._materialise_file_secrets(state, {})
 
         assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
+
+    def test_broker_load_programming_error_propagates(self, tmp_path):
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(
+                LookupSecret,
+                "get_value",
+                side_effect=RuntimeError("credential loader bug"),
+            ),
+            pytest.raises(RuntimeError, match="credential loader bug"),
+        ):
+            agent._materialise_file_secrets(state, {})
 
     def test_generic_lookup_secret_remains_get_only(self, tmp_path):
         remote = '{"tokens":{"refresh_token":"remote"}}'
@@ -8576,7 +8595,9 @@ class TestACPFileSecretMaterialisation:
         )
         lifecycle.path = auth_path
 
-        with pytest.raises(_CodexCredentialSyncError, match="local copy was preserved"):
+        with pytest.raises(
+            _ACPFileCredentialSyncError, match="local copy was preserved"
+        ):
             lifecycle._adopt("")
 
         assert auth_path.read_text() == local
@@ -8654,7 +8675,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(acp_agent_module, "_touch_codex_auth_source") as touch_source,
             patch.object(acp_agent_module, "_release_codex_auth_source"),
         ):
-            with pytest.raises(_CodexNeedsReauthError) as exc_info:
+            with pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info:
                 self._run_start(agent, state, conn=conn)
             assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
             assert credential not in _acp_error_detail(
@@ -8662,6 +8683,24 @@ class TestACPFileSecretMaterialisation:
             )
             touch_source.assert_not_called()
             agent.close()
+
+    def test_chatgpt_auth_programming_error_is_not_reclassified(self, tmp_path):
+        credential = '{"tokens":{"refresh_token":"r0"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+        conn = self._make_conn(auth_method="chat-gpt")
+        conn.authenticate.side_effect = RuntimeError("credential parser bug")
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=credential),
+            pytest.raises(RuntimeError, match="credential parser bug"),
+        ):
+            self._run_start(agent, state, conn=conn)
+
+        agent._cleanup()
 
     def test_post_auth_sync_failure_does_not_abort_session_start(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"r0"}}'
@@ -8677,7 +8716,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_CodexCredentialSyncError("unavailable"),
+                side_effect=_ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8733,13 +8772,40 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            with pytest.raises(_CodexCredentialSyncError) as exc_info:
+            with pytest.raises(_ACPFileCredentialSyncError) as exc_info:
                 agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
             agent._release_file_credentials()
 
         assert update_value.call_count == 3
+
+    def test_sync_programming_error_is_not_retried_or_wrapped(self, tmp_path):
+        original = '{"tokens":{"refresh_token":"r0"}}'
+        rotated = '{"tokens":{"refresh_token":"r1"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=original),
+            patch.object(
+                acp_agent_module,
+                "_update_codex_auth_source",
+                side_effect=RuntimeError("credential sync bug"),
+            ) as update_value,
+            patch.object(acp_agent_module, "_release_codex_auth_source"),
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
+            with pytest.raises(RuntimeError, match="credential sync bug"):
+                agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        update_value.assert_called_once()
 
     def test_turn_and_shutdown_sync_rotated_credentials(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8814,10 +8880,36 @@ class TestACPFileSecretMaterialisation:
         with patch.object(
             ACPAgent,
             "_sync_file_credentials",
-            side_effect=_CodexCredentialSyncError("unavailable"),
+            side_effect=_ACPFileCredentialSyncError("unavailable"),
         ):
             agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
+
+    def test_best_effort_sync_propagates_programming_error(self, tmp_path):
+        agent = _make_agent()
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+
+        with (
+            patch.object(
+                ACPAgent,
+                "_sync_file_credentials",
+                side_effect=RuntimeError("credential sync bug"),
+            ),
+            pytest.raises(RuntimeError, match="credential sync bug"),
+        ):
+            agent._sync_file_credentials_best_effort_blocking()
+
+        agent.release_runtime()
+
+    def test_release_propagates_lifecycle_programming_error(self, tmp_path):
+        agent = _make_agent()
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.release.side_effect = RuntimeError("credential release bug")
+
+        with pytest.raises(RuntimeError, match="credential release bug"):
+            agent._release_file_credentials()
+
+        assert agent._file_credential_lifecycles == {"TEST_AUTH_JSON": lifecycle}
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
         from openhands.sdk.utils.async_executor import AsyncExecutor
@@ -8852,7 +8944,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_CodexCredentialSyncError("unavailable"),
+                side_effect=_ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             result = agent.ask_agent("question")
@@ -8875,7 +8967,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 acp_agent_module,
                 "_update_codex_auth_source",
-                side_effect=[OSError("offline")] * 3,
+                side_effect=[httpx.ReadTimeout("offline")] * 3,
             ),
             patch.object(acp_agent_module, "_release_codex_auth_source") as release,
         ):
@@ -8883,7 +8975,7 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
 
-            with pytest.raises(_CodexCredentialSyncError):
+            with pytest.raises(_ACPFileCredentialSyncError):
                 agent.close()
             release.assert_called_once()
             assert agent._closed is True

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2496,7 +2496,7 @@ class TestACPAgentAstep:
         mock_client.get_turn_usage_update = MagicMock(return_value=object())
         agent._client = mock_client
         agent._conn = MagicMock()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         executor = AsyncExecutor()
 
@@ -2531,7 +2531,7 @@ class TestACPAgentAstep:
             with (
                 patch.object(
                     ACPAgent,
-                    "_sync_codex_auth",
+                    "_sync_file_credentials",
                     autospec=True,
                     side_effect=lambda _agent: threading.Event().wait(0.05),
                 ),
@@ -7993,6 +7993,21 @@ def _brokered_codex_source() -> LookupSecret:
     )
 
 
+def _codex_lifecycle(agent: ACPAgent) -> acp_agent_module._CodexAuthLifecycle:
+    return cast(
+        acp_agent_module._CodexAuthLifecycle,
+        agent._file_credential_lifecycles["CODEX_AUTH_JSON"],
+    )
+
+
+def _attach_file_credential_lifecycle(agent: ACPAgent, path: Path) -> MagicMock:
+    lifecycle = MagicMock()
+    lifecycle.path = path
+    lifecycle.authenticated = False
+    agent._file_credential_lifecycles["TEST_AUTH_JSON"] = lifecycle
+    return lifecycle
+
+
 class TestACPFileSecretMaterialisation:
     """Codex auth.json / Gemini Vertex SA JSON materialise to the durable
     per-conversation root, with the right data-dir env var, seed-if-absent.
@@ -8264,7 +8279,7 @@ class TestACPFileSecretMaterialisation:
                 )
                 == "<secret-hidden> <secret-hidden>"
             )
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_empty_broker_value_does_not_commit_sync_state(self, tmp_path):
         agent = _make_agent()
@@ -8278,9 +8293,7 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
 
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
-        assert agent._codex_auth_path is None
-        assert agent._codex_auth_source is None
-        assert agent._codex_auth_expected_digest is None
+        assert agent._file_credential_lifecycles == {}
 
     def test_missing_broker_value_requests_reauthentication(self, tmp_path):
         agent = _make_agent()
@@ -8326,8 +8339,8 @@ class TestACPFileSecretMaterialisation:
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         assert auth_path.read_text() == local
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
@@ -8353,13 +8366,13 @@ class TestACPFileSecretMaterialisation:
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
             auth_path.write_text(local)
-            first_agent._release_codex_auth()
+            first_agent._release_file_credentials()
 
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == local
-            resumed_agent._sync_codex_auth()
-            resumed_agent._release_codex_auth()
+            resumed_agent._sync_file_credentials()
+            resumed_agent._release_file_credentials()
 
         assert update_value.call_args.args[1:] == (
             local,
@@ -8388,8 +8401,8 @@ class TestACPFileSecretMaterialisation:
         ):
             agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == remote
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         update.assert_not_called()
 
@@ -8415,13 +8428,13 @@ class TestACPFileSecretMaterialisation:
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
-            first_agent._release_codex_auth()
+            first_agent._release_file_credentials()
 
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == authoritative
-            resumed_agent._sync_codex_auth()
-            resumed_agent._release_codex_auth()
+            resumed_agent._sync_file_credentials()
+            resumed_agent._release_file_credentials()
 
         update_value.assert_not_called()
 
@@ -8456,7 +8469,7 @@ class TestACPFileSecretMaterialisation:
                 auth_path,
                 ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
             )
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             assert (
                 state.secret_registry.mask_secrets_in_output("access-r1 refresh-r1")
                 == "<secret-hidden> <secret-hidden>"
@@ -8477,7 +8490,7 @@ class TestACPFileSecretMaterialisation:
                 "CODEX_AUTH_JSON.header.x-oh-sandbox",
                 "CODEX_AUTH_JSON.header.x-oh-codex",
             }
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_lost_update_response_reconciles_matching_remote_value(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8509,8 +8522,8 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         assert update_value.call_count == 2
 
@@ -8546,21 +8559,25 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             auth_path = Path(env["CODEX_HOME"]) / "auth.json"
             auth_path.write_text(rotated)
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             assert auth_path.read_text() == authoritative
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
         update_value.assert_called_once()
         release.assert_called_once()
 
     def test_empty_conflict_value_preserves_working_copy(self, tmp_path):
         local = '{"tokens":{"refresh_token":"local"}}'
-        agent = _make_agent()
         auth_path = tmp_path / "auth.json"
         auth_path.write_text(local)
+        lifecycle = acp_agent_module._CodexAuthLifecycle(
+            _brokered_codex_source(),
+            "https://session-a:scoped.jwt.token@cloud/codex-auth/refresh",
+        )
+        lifecycle.path = auth_path
 
         with pytest.raises(_CodexCredentialSyncError, match="local copy was preserved"):
-            agent._adopt_codex_auth_value(auth_path, "")
+            lifecycle._adopt("")
 
         assert auth_path.read_text() == local
 
@@ -8592,10 +8609,10 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             auth_path = Path(env["CODEX_HOME"]) / "auth.json"
-            agent._codex_auth_last_remote_check = 0.0
-            agent._sync_codex_auth()
+            _codex_lifecycle(agent).last_remote_check = 0.0
+            agent._sync_file_credentials()
             assert auth_path.read_text() == authoritative
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_unchanged_auth_checks_remote_periodically(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8612,13 +8629,13 @@ class TestACPFileSecretMaterialisation:
             patch.object(acp_agent_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             touch.assert_not_called()
 
-            agent._codex_auth_last_remote_check = 0.0
-            agent._sync_codex_auth()
+            _codex_lifecycle(agent).last_remote_check = 0.0
+            agent._sync_file_credentials()
             touch.assert_called_once()
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_chatgpt_auth_failure_becomes_auth_required(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"never-log-this"}}'
@@ -8659,7 +8676,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(LookupSecret, "get_value", return_value=credential),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 side_effect=_CodexCredentialSyncError("unavailable"),
             ),
         ):
@@ -8717,10 +8734,10 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
             with pytest.raises(_CodexCredentialSyncError) as exc_info:
-                agent._sync_codex_auth()
+                agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
         assert update_value.call_count == 3
 
@@ -8756,7 +8773,7 @@ class TestACPFileSecretMaterialisation:
 
             conn.prompt = AsyncMock(side_effect=rotate_during_turn)
             asyncio.run(agent._do_acp_prompt([]))
-            agent._sync_codex_auth_best_effort_blocking()
+            agent._sync_file_credentials_best_effort_blocking()
             assert update_value.call_args.args[1:] == (
                 after_turn,
                 hashlib.sha256(original.encode()).hexdigest(),
@@ -8774,11 +8791,13 @@ class TestACPFileSecretMaterialisation:
 
     def test_finalizer_skips_network_sync(self, tmp_path):
         agent = _make_agent()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         with (
-            patch.object(ACPAgent, "_sync_codex_auth", autospec=True) as sync,
-            patch.object(ACPAgent, "_release_codex_auth", autospec=True) as release,
+            patch.object(ACPAgent, "_sync_file_credentials", autospec=True) as sync,
+            patch.object(
+                ACPAgent, "_release_file_credentials", autospec=True
+            ) as release,
             patch.object(ACPAgent, "_cleanup", autospec=True) as cleanup,
         ):
             agent.__del__()
@@ -8790,14 +8809,14 @@ class TestACPFileSecretMaterialisation:
 
     def test_best_effort_sync_survives_failure(self, tmp_path):
         agent = _make_agent()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         with patch.object(
             ACPAgent,
-            "_sync_codex_auth",
+            "_sync_file_credentials",
             side_effect=_CodexCredentialSyncError("unavailable"),
         ):
-            agent._sync_codex_auth_best_effort_blocking()
+            agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
@@ -8813,7 +8832,7 @@ class TestACPFileSecretMaterialisation:
         agent._client = client
         agent._session_id = "session"
         agent._working_dir = str(tmp_path)
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
         agent._executor = AsyncExecutor()
         conn = MagicMock()
         conn.fork_session = AsyncMock(
@@ -8832,7 +8851,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(ACPAgent, "_record_usage"),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 side_effect=_CodexCredentialSyncError("unavailable"),
             ),
         ):
@@ -8869,7 +8888,7 @@ class TestACPFileSecretMaterialisation:
             release.assert_called_once()
             assert agent._closed is True
 
-        assert agent._codex_auth_source is None
+        assert agent._file_credential_lifecycles == {}
 
     def test_materialisation_failure_releases_brokered_source(self, tmp_path):
         agent = _make_agent()
@@ -8906,9 +8925,10 @@ class TestACPFileSecretMaterialisation:
         order: list[str] = []
 
         def fail_after_authentication(current_agent, _state):
-            current_agent._codex_auth_authenticated = True
-            current_agent._codex_auth_path = tmp_path / "auth.json"
-            current_agent._codex_auth_source = _brokered_codex_source()
+            lifecycle = _attach_file_credential_lifecycle(
+                current_agent, tmp_path / "auth.json"
+            )
+            lifecycle.authenticated = True
             raise RuntimeError("session creation failed")
 
         def record_sync(current_agent):
@@ -8928,13 +8948,13 @@ class TestACPFileSecretMaterialisation:
             ),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 autospec=True,
                 side_effect=record_sync,
             ),
             patch.object(
                 ACPAgent,
-                "_release_codex_auth",
+                "_release_file_credentials",
                 autospec=True,
                 side_effect=record_release,
             ),
@@ -9150,6 +9170,50 @@ class TestACPFileSecretMaterialisation:
         # The built-in Codex/Gemini specs were replaced, so their secrets would
         # NOT be materialised by this agent.
         assert agent._present_file_secret_names(state) == {"MYCLI_TOKEN_JSON"}
+
+    def test_registered_custom_file_credential_lifecycle_is_used(self, tmp_path):
+        from openhands.sdk import ACPFileSecretSpec
+
+        custom = ACPFileSecretSpec(
+            secret_name="MYCLI_TOKEN_JSON",
+            filename="token.json",
+            env_var="MYCLI_HOME",
+            subdir="mycli",
+            env_points_to="dir",
+        )
+        source = LookupSecret(url="https://broker.example/mycli")
+        lifecycle = MagicMock()
+        lifecycle.load.return_value = '{"token":"current"}'
+        lifecycle.should_preserve_existing.return_value = False
+        lifecycle.authenticated = False
+        factory = MagicMock(return_value=lifecycle)
+        agent = _make_agent(acp_file_secrets=[custom])
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets({"MYCLI_TOKEN_JSON": source})
+
+        with patch.dict(
+            acp_agent_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
+            {"MYCLI_TOKEN_JSON": factory},
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        target = Path(env["MYCLI_HOME"]) / "token.json"
+        factory.assert_called_once_with(source)
+        lifecycle.bind.assert_called_once_with(
+            target,
+            state.secret_registry,
+            '{"token":"current"}',
+            env,
+        )
+        lifecycle.record_materialized.assert_called_once_with(
+            '{"token":"current"}', '{"token":"current"}'
+        )
+        lifecycle.sync.assert_called_once_with()
+        lifecycle.release.assert_called_once_with()
+        assert agent._file_credential_lifecycles == {}
 
     def test_empty_specs_disables_materialisation(self, tmp_path):
         """With acp_file_secrets=[], a CODEX_AUTH_JSON secret is treated as an

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8309,6 +8309,32 @@ class TestACPFileSecretMaterialisation:
             )
             agent._release_file_credentials()
 
+    def test_local_lookup_source_configures_brokered_codex_refresh(self, tmp_path):
+        credential = '{"tokens":{"refresh_token":"refresh-r0"}}'
+        source = LookupSecret(
+            url="http://agent/api/conversations/123/codex-auth",
+            headers={"X-OH-Codex-Token": "local-capability"},
+        )
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets({"CODEX_AUTH_JSON": source})
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=credential),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            refresh_url = (
+                "http://codex:local-capability@agent/api/conversations/123/"
+                "codex-auth/refresh"
+            )
+            assert env["CODEX_REFRESH_TOKEN_URL_OVERRIDE"] == refresh_url
+            assert state.secret_registry.mask_secrets_in_output(refresh_url) == (
+                "<secret-hidden>"
+            )
+            agent._release_file_credentials()
+
     def test_empty_broker_value_does_not_commit_sync_state(self, tmp_path):
         agent = _make_agent()
         state = self._state(tmp_path)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -22,16 +22,14 @@ from acp.schema import NewSessionResponse, PromptResponse
 from pydantic import SecretStr
 
 import openhands.sdk.agent.acp_agent as acp_agent_module
+import openhands.sdk.agent.acp_file_credentials as acp_file_credentials_module
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _acp_error_detail,
     _acp_error_indicates_auth,
-    _ACPFileCredentialNeedsReauthError,
-    _ACPFileCredentialSyncError,
     _apply_acp_model,
     _classify_acp_init_error,
     _classify_acp_turn_error,
-    _codex_auth_file,
     _codex_model_config_options,
     _estimate_cost_from_tokens,
     _extract_session_models,
@@ -47,6 +45,11 @@ from openhands.sdk.agent.acp_agent import (
     _stringify_acp_error_data,
     _strip_inherited_npm_env,
     _with_codex_base_url,
+)
+from openhands.sdk.agent.acp_file_credentials import (
+    ACPFileCredentialNeedsReauthError,
+    ACPFileCredentialSyncError,
+    codex_auth_file,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
@@ -4442,14 +4445,14 @@ class TestSelectAuthMethod:
             assert _select_auth_method(methods, env) == "api-key"
 
     def test_codex_auth_file_honors_codex_home(self, tmp_path):
-        """_codex_auth_file points at $CODEX_HOME/auth.json when set, else
+        """codex_auth_file points at $CODEX_HOME/auth.json when set, else
         ~/.codex/auth.json."""
         home = tmp_path / "home"
         home.mkdir()
-        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=home):
-            assert _codex_auth_file({}) == home / ".codex" / "auth.json"
+        with patch.object(acp_file_credentials_module.Path, "home", return_value=home):
+            assert codex_auth_file({}) == home / ".codex" / "auth.json"
         ch = tmp_path / "ch"
-        assert _codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
+        assert codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
 
     # -- apikey-format auth.json must not be treated as chatgpt (#3627) -----
 
@@ -7993,18 +7996,26 @@ def _brokered_codex_source() -> LookupSecret:
     )
 
 
-def _codex_lifecycle(agent: ACPAgent) -> acp_agent_module._CodexAuthLifecycle:
+def _codex_lifecycle(
+    agent: ACPAgent,
+) -> acp_file_credentials_module._CodexAuthLifecycle:
     return cast(
-        acp_agent_module._CodexAuthLifecycle,
+        acp_file_credentials_module._CodexAuthLifecycle,
         agent._file_credential_lifecycles["CODEX_AUTH_JSON"],
     )
 
 
-def _attach_file_credential_lifecycle(agent: ACPAgent, path: Path) -> MagicMock:
+def _attach_file_credential_lifecycle(
+    agent: ACPAgent,
+    path: Path,
+    *,
+    may_have_changed: bool = True,
+    name: str = "TEST_AUTH_JSON",
+) -> MagicMock:
     lifecycle = MagicMock()
     lifecycle.path = path
-    lifecycle.authenticated = False
-    agent._file_credential_lifecycles["TEST_AUTH_JSON"] = lifecycle
+    lifecycle.may_have_changed = may_have_changed
+    agent._file_credential_lifecycles[name] = lifecycle
     return lifecycle
 
 
@@ -8126,6 +8137,23 @@ class TestACPFileSecretMaterialisation:
         # The blob is not exported as an env var.
         assert "CODEX_AUTH_JSON" not in env
 
+    def test_secret_file_replace_failure_preserves_existing_value(self, tmp_path):
+        path = tmp_path / "auth.json"
+        path.write_text("original")
+
+        with (
+            patch.object(
+                acp_file_credentials_module.os,
+                "replace",
+                side_effect=OSError("disk full"),
+            ),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            acp_file_credentials_module.write_secret_file(path, "replacement")
+
+        assert path.read_text() == "original"
+        assert list(tmp_path.iterdir()) == [path]
+
     def test_rotated_lookup_secret_is_available_to_next_conversation(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
         rotated = '{"tokens":{"refresh_token":"r1"}}'
@@ -8145,16 +8173,16 @@ class TestACPFileSecretMaterialisation:
                 side_effect=lambda _source: cloud["value"],
             ) as get_value,
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 autospec=True,
                 side_effect=update,
             ) as update_value,
             patch.object(
-                acp_agent_module, "_touch_codex_auth_source", autospec=True
+                acp_file_credentials_module, "_touch_codex_auth_source", autospec=True
             ) as touch,
             patch.object(
-                acp_agent_module, "_release_codex_auth_source", autospec=True
+                acp_file_credentials_module, "_release_codex_auth_source", autospec=True
             ) as release,
         ):
             first_root = tmp_path / "first"
@@ -8207,45 +8235,45 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(
-                acp_agent_module.httpx, "put", return_value=response
+                acp_file_credentials_module.httpx, "put", return_value=response
             ) as mock_put,
             patch.object(
-                acp_agent_module.httpx, "get", return_value=response
+                acp_file_credentials_module.httpx, "get", return_value=response
             ) as mock_get,
             patch.object(
-                acp_agent_module.httpx, "head", return_value=response
+                acp_file_credentials_module.httpx, "head", return_value=response
             ) as mock_head,
             patch.object(
-                acp_agent_module.httpx, "delete", return_value=response
+                acp_file_credentials_module.httpx, "delete", return_value=response
             ) as mock_delete,
         ):
-            acp_agent_module._update_codex_auth_source(
+            acp_file_credentials_module._update_codex_auth_source(
                 source, "rotated", "original-digest"
             )
-            acp_agent_module._get_codex_auth_source(source)
-            acp_agent_module._touch_codex_auth_source(source)
-            acp_agent_module._release_codex_auth_source(source)
+            acp_file_credentials_module._get_codex_auth_source(source)
+            acp_file_credentials_module._touch_codex_auth_source(source)
+            acp_file_credentials_module._release_codex_auth_source(source)
 
         mock_put.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
             json={"expected_digest": "original-digest", "value": "rotated"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_get.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_head.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_delete.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         assert response.raise_for_status.call_count == 4
 
@@ -8264,7 +8292,7 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8288,12 +8316,18 @@ class TestACPFileSecretMaterialisation:
             {"CODEX_AUTH_JSON": _brokered_codex_source()}
         )
 
-        with patch.object(LookupSecret, "get_value", return_value=""):
+        with (
+            patch.object(LookupSecret, "get_value", return_value=""),
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
+        ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
 
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
         assert agent._file_credential_lifecycles == {}
+        release.assert_called_once()
 
     def test_missing_broker_value_requests_reauthentication(self, tmp_path):
         agent = _make_agent()
@@ -8311,7 +8345,7 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", side_effect=missing),
             pytest.raises(
-                _ACPFileCredentialNeedsReauthError, match="not found"
+                ACPFileCredentialNeedsReauthError, match="not found"
             ) as exc_info,
         ):
             agent._materialise_file_secrets(state, {})
@@ -8352,9 +8386,15 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8379,8 +8419,10 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
@@ -8390,6 +8432,7 @@ class TestACPFileSecretMaterialisation:
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == local
+            assert _codex_lifecycle(resumed_agent).may_have_changed is True
             resumed_agent._sync_file_credentials()
             resumed_agent._release_file_credentials()
 
@@ -8415,8 +8458,10 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == remote
@@ -8437,13 +8482,15 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", side_effect=[stale, authoritative]),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module,
                 "_touch_codex_auth_source",
                 return_value=hashlib.sha256(authoritative.encode()).hexdigest(),
             ),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
@@ -8470,8 +8517,8 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_update_codex_auth_source"),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_update_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8529,14 +8576,16 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module, "_get_codex_auth_source", return_value=rotated
+                acp_file_credentials_module,
+                "_get_codex_auth_source",
+                return_value=rotated,
             ),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=[httpx.ReadTimeout("response lost"), conflict],
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8565,14 +8614,18 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_get_codex_auth_source",
                 return_value=authoritative,
             ),
             patch.object(
-                acp_agent_module, "_update_codex_auth_source", side_effect=conflict
+                acp_file_credentials_module,
+                "_update_codex_auth_source",
+                side_effect=conflict,
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8589,18 +8642,52 @@ class TestACPFileSecretMaterialisation:
         local = '{"tokens":{"refresh_token":"local"}}'
         auth_path = tmp_path / "auth.json"
         auth_path.write_text(local)
-        lifecycle = acp_agent_module._CodexAuthLifecycle(
+        lifecycle = acp_file_credentials_module._CodexAuthLifecycle(
             _brokered_codex_source(),
             "https://session-a:scoped.jwt.token@cloud/codex-auth/refresh",
         )
         lifecycle.path = auth_path
 
         with pytest.raises(
-            _ACPFileCredentialSyncError, match="local copy was preserved"
+            ACPFileCredentialSyncError, match="local copy was preserved"
         ):
             lifecycle._adopt("")
 
         assert auth_path.read_text() == local
+
+    def test_invalid_local_value_never_overwrites_cloud(self, tmp_path):
+        original = '{"tokens":{"refresh_token":"r0"}}'
+        rotated = '{"tokens":{"refresh_token":"r1"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=original),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            auth_path = Path(env["CODEX_HOME"]) / "auth.json"
+            auth_path.write_text("truncated")
+
+            with pytest.raises(
+                ACPFileCredentialSyncError, match="Cloud copy was preserved"
+            ):
+                agent._sync_file_credentials()
+
+            update.assert_not_called()
+            auth_path.write_text(rotated)
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        update.assert_called_once()
+        assert update.call_args.args[1] == rotated
 
     def test_remote_digest_change_updates_unchanged_working_copy(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8615,17 +8702,19 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_get_codex_auth_source",
                 return_value=authoritative,
             ),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_touch_codex_auth_source",
                 return_value=remote_digest,
             ),
-            patch.object(acp_agent_module.time, "monotonic", return_value=1.0),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module.time, "monotonic", return_value=1.0
+            ),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8645,9 +8734,13 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch,
-            patch.object(acp_agent_module.time, "monotonic", return_value=1.0),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch,
+            patch.object(
+                acp_file_credentials_module.time, "monotonic", return_value=1.0
+            ),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
             agent._sync_file_credentials()
@@ -8672,10 +8765,12 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch_source,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch_source,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
-            with pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info:
+            with pytest.raises(ACPFileCredentialNeedsReauthError) as exc_info:
                 self._run_start(agent, state, conn=conn)
             assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
             assert credential not in _acp_error_detail(
@@ -8706,7 +8801,7 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
             patch.object(acp_agent_module, "_ACP_AUTH_TIMEOUT", 0.01),
-            pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info,
+            pytest.raises(ACPFileCredentialNeedsReauthError) as exc_info,
         ):
             self._run_start(agent, state, conn=conn)
 
@@ -8750,7 +8845,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_ACPFileCredentialSyncError("unavailable"),
+                side_effect=ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8771,7 +8866,9 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
             pytest.raises(BrokenPipeError, match="connection closed"),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8797,16 +8894,16 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=unavailable,
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            with pytest.raises(_ACPFileCredentialSyncError) as exc_info:
+            with pytest.raises(ACPFileCredentialSyncError) as exc_info:
                 agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
@@ -8826,11 +8923,11 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=RuntimeError("credential sync bug"),
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8860,8 +8957,12 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8909,41 +9010,101 @@ class TestACPFileSecretMaterialisation:
 
     def test_best_effort_sync_survives_failure(self, tmp_path):
         agent = _make_agent()
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.sync.side_effect = ACPFileCredentialSyncError("unavailable")
 
-        with patch.object(
-            ACPAgent,
-            "_sync_file_credentials",
-            side_effect=_ACPFileCredentialSyncError("unavailable"),
-        ):
-            agent._sync_file_credentials_best_effort_blocking()
+        agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
 
-    def test_best_effort_sync_propagates_programming_error(self, tmp_path):
+    def test_best_effort_sync_survives_programming_error(self, tmp_path):
         agent = _make_agent()
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        failing = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
+        failing.sync.side_effect = RuntimeError("credential sync bug")
 
-        with (
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                side_effect=RuntimeError("credential sync bug"),
-            ),
-            pytest.raises(RuntimeError, match="credential sync bug"),
-        ):
-            agent._sync_file_credentials_best_effort_blocking()
+        agent._sync_file_credentials_best_effort_blocking()
 
+        failing.sync.assert_called_once_with()
+        succeeding.sync.assert_called_once_with()
+        agent.release_runtime()
+
+    def test_sync_attempts_every_lifecycle_before_raising(self, tmp_path):
+        agent = _make_agent()
+        failing = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
+        failing.sync.side_effect = RuntimeError("first sync failed")
+
+        with pytest.raises(RuntimeError, match="first sync failed"):
+            agent._sync_file_credentials()
+
+        failing.sync.assert_called_once_with()
+        succeeding.sync.assert_called_once_with()
+        agent.release_runtime()
+
+    @pytest.mark.parametrize(
+        ("method_id", "expected_name"),
+        [("chat-gpt", "CODEX_AUTH_JSON"), ("custom-oauth", "OTHER_AUTH_JSON")],
+    )
+    def test_auth_method_sync_is_owned_by_each_lifecycle(
+        self, tmp_path, method_id, expected_name
+    ):
+        agent = _make_agent()
+        codex = _attach_file_credential_lifecycle(
+            agent,
+            tmp_path / "codex.json",
+            may_have_changed=False,
+            name="CODEX_AUTH_JSON",
+        )
+        other = _attach_file_credential_lifecycle(
+            agent,
+            tmp_path / "other.json",
+            may_have_changed=False,
+            name="OTHER_AUTH_JSON",
+        )
+
+        def mark_codex(current_method):
+            codex.may_have_changed = current_method == "chat-gpt"
+
+        def mark_other(current_method):
+            other.may_have_changed = current_method == "custom-oauth"
+
+        codex.on_auth_succeeded.side_effect = mark_codex
+        other.on_auth_succeeded.side_effect = mark_other
+
+        agent._notify_file_credentials_auth_succeeded(method_id)
+        agent._sync_file_credentials_best_effort_blocking(changed_only=True)
+
+        expected = codex if expected_name == "CODEX_AUTH_JSON" else other
+        skipped = other if expected is codex else codex
+        expected.sync.assert_called_once_with()
+        skipped.sync.assert_not_called()
         agent.release_runtime()
 
     def test_release_propagates_lifecycle_programming_error(self, tmp_path):
         agent = _make_agent()
-        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
         lifecycle.release.side_effect = RuntimeError("credential release bug")
 
         with pytest.raises(RuntimeError, match="credential release bug"):
             agent._release_file_credentials()
 
-        assert agent._file_credential_lifecycles == {"TEST_AUTH_JSON": lifecycle}
+        lifecycle.release.assert_called_once_with()
+        succeeding.release.assert_called_once_with()
+        assert agent._file_credential_lifecycles == {"FIRST_AUTH_JSON": lifecycle}
+        agent.release_runtime()
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
         from openhands.sdk.utils.async_executor import AsyncExecutor
@@ -8958,7 +9119,8 @@ class TestACPFileSecretMaterialisation:
         agent._client = client
         agent._session_id = "session"
         agent._working_dir = str(tmp_path)
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.sync.side_effect = ACPFileCredentialSyncError("unavailable")
         agent._executor = AsyncExecutor()
         conn = MagicMock()
         conn.fork_session = AsyncMock(
@@ -8973,21 +9135,14 @@ class TestACPFileSecretMaterialisation:
         conn.close = AsyncMock()
         agent._conn = conn
 
-        with (
-            patch.object(ACPAgent, "_record_usage"),
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                side_effect=_ACPFileCredentialSyncError("unavailable"),
-            ),
-        ):
+        with patch.object(ACPAgent, "_record_usage"):
             result = agent.ask_agent("question")
 
         assert result == "answer"
         agent._cleanup()
         agent.release_runtime()
 
-    def test_close_releases_source_and_stays_closed_when_sync_fails(self, tmp_path):
+    def test_close_retains_source_until_failed_sync_can_retry(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
         rotated = '{"tokens":{"refresh_token":"r1"}}'
         agent = _make_agent()
@@ -8999,20 +9154,27 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=[httpx.ReadTimeout("offline")] * 3,
-            ),
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
 
-            with pytest.raises(_ACPFileCredentialSyncError):
+            with pytest.raises(ACPFileCredentialSyncError):
                 agent.close()
-            release.assert_called_once()
+            release.assert_not_called()
             assert agent._closed is True
+            assert agent._file_credential_lifecycles
+
+            update_value.side_effect = None
+            agent.close()
+            release.assert_called_once()
 
         assert agent._file_credential_lifecycles == {}
 
@@ -9034,36 +9196,45 @@ class TestACPFileSecretMaterialisation:
                 side_effect=materialise,
             ),
             patch.object(
-                acp_agent_module,
-                "_write_secret_file",
+                acp_file_credentials_module,
+                "write_secret_file",
                 side_effect=OSError("disk full"),
             ),
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
             pytest.raises(OSError, match="disk full"),
         ):
             agent.init_state(state, lambda _event: None)
 
         release.assert_called_once_with(source)
 
-    def test_init_failure_syncs_before_releasing_authenticated_source(self, tmp_path):
+    def test_init_failure_isolates_sync_and_release_failures(self, tmp_path):
         agent = _make_agent()
         state = self._state(tmp_path)
         order: list[str] = []
 
         def fail_after_authentication(current_agent, _state):
-            lifecycle = _attach_file_credential_lifecycle(
-                current_agent, tmp_path / "auth.json"
+            failing = _attach_file_credential_lifecycle(
+                current_agent,
+                tmp_path / "first.json",
+                name="FIRST_AUTH_JSON",
             )
-            lifecycle.authenticated = True
+            succeeding = _attach_file_credential_lifecycle(
+                current_agent,
+                tmp_path / "second.json",
+                name="SECOND_AUTH_JSON",
+            )
+
+            def fail_sync():
+                order.append("sync first")
+                raise ACPFileCredentialSyncError("offline")
+
+            failing.sync.side_effect = fail_sync
+            failing.release.side_effect = lambda: order.append("release first")
+            succeeding.sync.side_effect = lambda: order.append("sync second")
+            succeeding.release.side_effect = lambda: order.append("release second")
             raise RuntimeError("session creation failed")
-
-        def record_sync(current_agent):
-            if current_agent is agent:
-                order.append("sync")
-
-        def record_release(current_agent):
-            if current_agent is agent:
-                order.append("release")
 
         with (
             patch.object(
@@ -9072,23 +9243,13 @@ class TestACPFileSecretMaterialisation:
                 autospec=True,
                 side_effect=fail_after_authentication,
             ),
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                autospec=True,
-                side_effect=record_sync,
-            ),
-            patch.object(
-                ACPAgent,
-                "_release_file_credentials",
-                autospec=True,
-                side_effect=record_release,
-            ),
             pytest.raises(RuntimeError, match="session creation failed"),
         ):
             agent.init_state(state, lambda _event: None)
 
-        assert order == ["sync", "release"]
+        assert order == ["sync first", "sync second", "release second"]
+        assert set(agent._file_credential_lifecycles) == {"FIRST_AUTH_JSON"}
+        agent.release_runtime()
 
     def test_gemini_vertex_sa_materialises_and_points_at_file(self, tmp_path):
         from openhands.sdk.secret import StaticSecret
@@ -9210,7 +9371,7 @@ class TestACPFileSecretMaterialisation:
             {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
         )
         with patch(
-            "openhands.sdk.agent.acp_agent._write_secret_file",
+            "openhands.sdk.agent.acp_agent.write_secret_file",
             side_effect=OSError("[Errno 30] Read-only file system"),
         ):
             with pytest.raises(OSError, match="Read-only file system"):
@@ -9311,14 +9472,14 @@ class TestACPFileSecretMaterialisation:
         lifecycle = MagicMock()
         lifecycle.load.return_value = '{"token":"current"}'
         lifecycle.should_preserve_existing.return_value = False
-        lifecycle.authenticated = False
+        lifecycle.may_have_changed = False
         factory = MagicMock(return_value=lifecycle)
         agent = _make_agent(acp_file_secrets=[custom])
         state = self._state(tmp_path)
         state.secret_registry.update_secrets({"MYCLI_TOKEN_JSON": source})
 
         with patch.dict(
-            acp_agent_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
+            acp_file_credentials_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
             {"MYCLI_TOKEN_JSON": factory},
         ):
             env: dict[str, str] = {}

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -19,7 +19,6 @@ from openhands.sdk.conversation.state import (
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import Message, MessageToolCall, TextContent, llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.sdk.secret import LookupSecret
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.utils.cipher import Cipher
 from tests.conftest import create_mock_litellm_response
@@ -214,14 +213,11 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     conv, old_agent = _make_acp_conversation(tmp_path)
     live_conn = old_agent._conn
     live_executor = old_agent._executor
-    source = LookupSecret(url="https://cloud/codex-auth", headers={})
-    old_agent._codex_auth_path = tmp_path / "auth.json"
-    old_agent._codex_auth_source = source
-    old_agent._codex_auth_expected_digest = "expected"
-    old_agent._codex_auth_last_remote_check = 42.0
-    old_agent._codex_auth_registry = conv.state.secret_registry
-    old_agent._codex_auth_authenticated = True
-    codex_auth_lock = old_agent._codex_auth_lock
+    lifecycle = MagicMock()
+    lifecycle.path = tmp_path / "auth.json"
+    lifecycle.authenticated = True
+    old_agent._file_credential_lifecycles["CODEX_AUTH_JSON"] = lifecycle
+    credential_lock = old_agent._file_credential_lock
 
     conv.switch_acp_model("model-b")
 
@@ -230,13 +226,8 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     assert isinstance(switched, ACPAgent)
     assert switched._conn is live_conn
     assert switched._executor is live_executor
-    assert switched._codex_auth_path == tmp_path / "auth.json"
-    assert switched._codex_auth_source is source
-    assert switched._codex_auth_expected_digest == "expected"
-    assert switched._codex_auth_last_remote_check == 42.0
-    assert switched._codex_auth_registry is conv.state.secret_registry
-    assert switched._codex_auth_authenticated is True
-    assert switched._codex_auth_lock is codex_auth_lock
+    assert switched._file_credential_lifecycles == {"CODEX_AUTH_JSON": lifecycle}
+    assert switched._file_credential_lock is credential_lock
 
     # ...and the discarded agent's finalizer was disarmed (marked closed)
     # WITHOUT clearing its runtime references — an in-flight ask_agent()/fork
@@ -244,12 +235,7 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     assert old_agent._closed is True
     assert old_agent._conn is live_conn
     assert old_agent._executor is live_executor
-    assert old_agent._codex_auth_path is None
-    assert old_agent._codex_auth_source is None
-    assert old_agent._codex_auth_expected_digest is None
-    assert old_agent._codex_auth_last_remote_check == 0.0
-    assert old_agent._codex_auth_registry is None
-    assert old_agent._codex_auth_authenticated is False
+    assert old_agent._file_credential_lifecycles == {}
 
     # Simulating GC (__del__ -> close()) on the disarmed old agent is a no-op:
     # the copy's shared connection/executor are left intact.

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -215,7 +215,7 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     live_executor = old_agent._executor
     lifecycle = MagicMock()
     lifecycle.path = tmp_path / "auth.json"
-    lifecycle.authenticated = True
+    lifecycle.may_have_changed = True
     old_agent._file_credential_lifecycles["CODEX_AUTH_JSON"] = lifecycle
     credential_lock = old_agent._file_credential_lock
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Add a local Agent Server Codex credential broker with ephemeral conversation capabilities
---

AGENT:

## Why

Agent Canvas stores `CODEX_AUTH_JSON` in the local Agent Server, but the ACP lifecycle synchronization from OpenHands/OpenHands#4124 requires a concurrent-safe broker. Without a local broker, separate Docker conversations can start from stale credentials or submit the same rotating refresh token upstream.

## Summary

- Add a local Agent Server Codex credential broker with ephemeral conversation capabilities, one serialization boundary for refresh and lifecycle writes, stale-token convergence, and file-locked digest compare-and-swap.
- Transform only the exact local settings lookup at runtime. Stored conversation metadata retains the original lookup, and capabilities are revoked on release, deletion, failed startup, and shutdown.
- Extend OpenHands/OpenHands#4124 only for the local capability header and refresh username. Existing Cloud behavior and messages remain unchanged.
- Cover sequential and concurrent refresh, refresh-vs-write races, stale CAS, restart/failure behavior, capability scope/revocation, and a real HTTP broker lifecycle.

The HTTP broker remains intentionally similar to OpenHands#15287: GET seeds the working copy, HEAD reconciles idle sessions, PUT persists changed copies, DELETE releases capabilities, and POST serializes upstream refresh. Each operation is required by the OpenHands/OpenHands#4124 ACP lifecycle.

## Issue Number

Addresses OpenHands/software-agent-sdk#4268.

## How to Test

Focused broker and ACP integration:

```text
.venv/bin/pytest -q tests/agent_server/test_codex_auth.py tests/cross/test_remote_conversation_live_server.py::test_local_codex_auth_broker_over_live_server tests/sdk/agent/test_acp_agent.py::TestACPFileSecretMaterialisation::test_local_lookup_source_configures_brokered_codex_refresh
13 passed
```

Relevant regression suite:

```text
.venv/bin/pytest -q tests/agent_server/test_codex_auth.py tests/agent_server/test_conversation_service.py tests/agent_server/test_settings_router.py tests/agent_server/test_api_authentication.py tests/sdk/agent/test_acp_agent.py
622 passed, 8 warnings in 30.22s
```

The full local cross suite passed the two formerly failing tests in normal order. Its only failure was an unrelated macOS tmux socket path-length error; that test passed when rerun with `TMUX_TMPDIR=/tmp`. On the current SHA, GitHub `cross-tests`, `sdk-tests`, `agent-server-tests`, pre-commit, and all other required checks pass.

Static verification:

```text
.venv/bin/ruff check <changed files>
All checks passed!

.venv/bin/pyright <changed files>
0 errors, 0 warnings, 0 informations

.venv/bin/python scripts/check_import_rules.py <changed files>
All import dependency rules satisfied!

.venv/bin/python scripts/check_tool_registration.py <changed files>
All Tool subclasses are properly registered!
```

## Video/Screenshots

Not applicable; this is an Agent Server/SDK backend change. The live-server test exercises the capability over a real FastAPI/uvicorn HTTP server.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR is stacked only on OpenHands/OpenHands#4124 (`fix-acp-codex-auth-sync`).
- It is independent of OpenHands#15287, which provides the Cloud/SaaS broker.
- Retarget this PR to `main` after OpenHands/OpenHands#4124 merges.
- After release, OpenHands/Agent Canvas needs a separate PR only if its SDK pin or integration requires adjustment.
