### PR TITLE
chore(deps): validate uv lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,6 @@
 # Dependabot configuration for automated dependency updates
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Note: Python (pip) ecosystem is not configured here because Dependabot does not
-# fully support uv workspaces yet. See issue #2510 for tracking.
-
 version: 2
 
 updates:
@@ -13,5 +10,19 @@ updates:
       directory: /
       schedule:
           interval: weekly
+      commit-message:
+          prefix: chore(deps)
+
+    - package-ecosystem: uv
+      directory: /
+      schedule:
+          interval: weekly
+      cooldown:
+          default-days: 7
+      groups:
+          security:
+              applies-to: security-updates
+              patterns:
+                  - '*'
       commit-message:
           prefix: chore(deps)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,5 @@ updates:
           interval: weekly
       cooldown:
           default-days: 7
-      groups:
-          security:
-              applies-to: security-updates
-              patterns:
-                  - '*'
       commit-message:
           prefix: chore(deps)

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,35 @@
+---
+name: Lockfile validation
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: ['**']
+
+permissions:
+    contents: read
+
+jobs:
+    lockfile:
+        runs-on: ubuntu-24.04
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v7
+
+            - name: Set up Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.13'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  version: 0.11.29
+
+            - name: Check lockfile
+              run: uv lock --check
+
+            - name: Sync locked dependencies
+              run: uv sync --locked --group dev

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ RESET := \033[0m
 UNDERLINE := \033[4m
 
 # Required uv version
-REQUIRED_UV_VERSION := 0.8.13
+REQUIRED_UV_VERSION := 0.11.29
 PKGS ?= openhands-sdk openhands-tools openhands-workspace openhands-agent-server
 
 .PHONY: build format lint clean help check-uv-version


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

AGENT:

## Why

The documented minimum `uv` version accepted 0.8.15, which cannot parse the relative `exclude-newer` setting. It discards the existing lockfile and re-resolves dependencies instead.

## Summary

- enable Dependabot's native `uv` ecosystem at the workspace root
- match Dependabot's cooldown to the project’s seven-day `exclude-newer` window
- remove security-update grouping because Dependabot's current grouped Python path can silently skip CVEs ([dependabot/dependabot-core#14665](https://github.com/dependabot/dependabot-core/issues/14665))
- validate the lockfile and locked dev sync in CI with `uv` 0.11.29
- raise the documented local `uv` minimum to 0.11.29

## Tests

- `uvx uv@0.11.29 lock --check`
- `uvx uv@0.11.29 sync --locked --group dev`
- `uvx uv@0.11.29 run --locked pre-commit run --files Makefile .github/dependabot.yml .github/workflows/lockfile.yml`
- `actionlint .github/workflows/lockfile.yml`
- `git diff --check`

## Notes

A project-wide `[tool.uv].required-version` is deliberately not set: Dependabot uses a service-managed `uv` binary, so an exact requirement can prevent it from generating security updates. The CI validation pins its own compatible version instead.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f1f5d6f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f1f5d6f-python \
  ghcr.io/openhands/agent-server:f1f5d6f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f1f5d6f-golang-amd64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-golang-amd64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-golang-amd64
ghcr.io/openhands/agent-server:f1f5d6f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f1f5d6f-golang-arm64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-golang-arm64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-golang-arm64
ghcr.io/openhands/agent-server:f1f5d6f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f1f5d6f-java-amd64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-java-amd64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-java-amd64
ghcr.io/openhands/agent-server:f1f5d6f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f1f5d6f-java-arm64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-java-arm64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-java-arm64
ghcr.io/openhands/agent-server:f1f5d6f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f1f5d6f-python-amd64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-python-amd64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-python-amd64
ghcr.io/openhands/agent-server:f1f5d6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f1f5d6f-python-arm64
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-python-arm64
ghcr.io/openhands/agent-server:harden-uv-lock-generation-python-arm64
ghcr.io/openhands/agent-server:f1f5d6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f1f5d6f-golang
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-golang
ghcr.io/openhands/agent-server:harden-uv-lock-generation-golang
ghcr.io/openhands/agent-server:f1f5d6f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f1f5d6f-java
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-java
ghcr.io/openhands/agent-server:harden-uv-lock-generation-java
ghcr.io/openhands/agent-server:f1f5d6f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f1f5d6f-python
ghcr.io/openhands/agent-server:f1f5d6f3f28d080aaf806fb86c0c235967c4b387-python
ghcr.io/openhands/agent-server:harden-uv-lock-generation-python
ghcr.io/openhands/agent-server:f1f5d6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f1f5d6f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f1f5d6f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->