### PR TITLE
refactor(acp): isolate brokered file credential lifecycles

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -127,6 +127,8 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
     os.environ.get("ACP_CANCEL_DRAIN_TIMEOUT", "2.0")
 )
 
+_ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
+
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
 _CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
 _CODEX_AUTH_HTTP_TIMEOUT = 5.0
@@ -2972,7 +2974,20 @@ class ACPAgent(AgentBase):
                             if base_url:
                                 auth_kwargs["gateway"] = {"baseUrl": base_url}
                     try:
-                        await conn.authenticate(method_id=method_id, **auth_kwargs)
+                        await asyncio.wait_for(
+                            conn.authenticate(method_id=method_id, **auth_kwargs),
+                            timeout=_ACP_AUTH_TIMEOUT,
+                        )
+                    except TimeoutError as exc:
+                        if method_id == "chat-gpt":
+                            raise _ACPFileCredentialNeedsReauthError(
+                                "ChatGPT authentication did not complete in time. "
+                                "Please sign in again."
+                            ) from exc
+                        raise TimeoutError(
+                            f"ACP authentication with {method_id!r} timed out after "
+                            f"{_ACP_AUTH_TIMEOUT:g}s."
+                        ) from exc
                     except ACPRequestError as exc:
                         if method_id != "chat-gpt" or not _acp_error_indicates_auth(
                             exc

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -28,7 +28,7 @@ import uuid
 from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol
 
 import httpx
 from acp.client.connection import ClientSideConnection
@@ -960,12 +960,17 @@ _ACP_AUTH_ERROR_MARKERS: tuple[str, ...] = (
 )
 
 
-class _CodexNeedsReauthError(RuntimeError):
+class _ACPFileCredentialNeedsReauthError(RuntimeError):
     pass
 
 
-class _CodexCredentialSyncError(RuntimeError):
+class _ACPFileCredentialSyncError(RuntimeError):
     pass
+
+
+# Compatibility aliases for the current Codex-specific error classification.
+_CodexNeedsReauthError = _ACPFileCredentialNeedsReauthError
+_CodexCredentialSyncError = _ACPFileCredentialSyncError
 
 
 def _update_codex_auth_source(
@@ -1039,6 +1044,249 @@ def _is_valid_codex_auth_value(value: object) -> bool:
     except (TypeError, ValueError):
         return False
     return isinstance(payload, dict) and bool(payload)
+
+
+class _ACPFileCredentialLifecycle(Protocol):
+    """Lifecycle boundary for a brokered ACP file credential."""
+
+    secret_name: str
+    path: Path | None
+    authenticated: bool
+
+    def load(self) -> str | None: ...
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None: ...
+
+    def should_preserve_existing(self, path: Path) -> bool: ...
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
+
+    def sync(self) -> None: ...
+
+    def release(self) -> None: ...
+
+
+class _CodexAuthLifecycle:
+    """Brokered lifecycle implementation for Codex subscription auth."""
+
+    secret_name = _CODEX_AUTH_SECRET_NAME
+
+    def __init__(self, source: LookupSecret, refresh_url: str):
+        self.source = source
+        self.refresh_url = refresh_url
+        self.path: Path | None = None
+        self.expected_digest: str | None = None
+        self.last_remote_check = 0.0
+        self.registry: SecretRegistry | None = None
+        self.authenticated = False
+
+    def load(self) -> str | None:
+        try:
+            return self.source.get_value()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (404, 422):
+                detail = (
+                    "ChatGPT authentication was not found in Cloud."
+                    if exc.response.status_code == 404
+                    else "ChatGPT authentication needs to be refreshed."
+                )
+                raise _ACPFileCredentialNeedsReauthError(detail) from exc
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+        except Exception as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None:
+        if not _is_valid_codex_auth_value(remote_value):
+            raise _ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials."
+            )
+        self.path = path
+        self.registry = registry
+        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
+        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
+        self._track_transport()
+
+    def should_preserve_existing(self, path: Path) -> bool:
+        return _read_codex_auth_ancestor(path) == self.expected_digest
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        assert path is not None
+        assert expected_digest is not None
+        _write_codex_auth_ancestor(path, expected_digest)
+        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
+        self.last_remote_check = (
+            time.monotonic() if local_digest == expected_digest else 0.0
+        )
+        self._track_values(remote_value)
+        if local_digest != expected_digest:
+            self._track_values(local_value)
+
+    def _track_values(self, value: str) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {self.secret_name: value}
+        try:
+            tokens = json.loads(value).get("tokens", {})
+        except (AttributeError, TypeError, ValueError):
+            tokens = None
+        if isinstance(tokens, dict):
+            for name, token in tokens.items():
+                if isinstance(token, str) and token:
+                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
+        registry.track_exported_values(exported_values)
+
+    def _track_transport(self) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {
+            f"{self.secret_name}.refresh_url": self.refresh_url,
+        }
+        for name, value in self.source.headers.items():
+            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
+        registry.track_exported_values(exported_values)
+
+    def sync(self) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        if path is None or expected_digest is None:
+            return
+        try:
+            value = path.read_bytes()
+            text_value = value.decode()
+        except (OSError, UnicodeError) as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be saved to Cloud."
+            ) from exc
+        digest = hashlib.sha256(value).hexdigest()
+        changed = digest != expected_digest
+        now = time.monotonic()
+        if (
+            not changed
+            and self.last_remote_check > 0
+            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
+        ):
+            return
+        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                if changed:
+                    _update_codex_auth_source(self.source, text_value, expected_digest)
+                else:
+                    remote_digest = _touch_codex_auth_source(self.source)
+                    if (
+                        isinstance(remote_digest, str)
+                        and remote_digest != expected_digest
+                    ):
+                        self._adopt(_get_codex_auth_source(self.source))
+                        return
+            except httpx.HTTPStatusError as exc:
+                if changed and exc.response.status_code == 409:
+                    try:
+                        self._adopt(_get_codex_auth_source(self.source))
+                    except Exception as remote_exc:
+                        if attempt == attempts - 1:
+                            raise _ACPFileCredentialSyncError(
+                                "Codex credentials could not be reconciled with Cloud."
+                            ) from remote_exc
+                    else:
+                        return
+                if attempt == attempts - 1:
+                    raise _ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            except Exception as exc:
+                if attempt == attempts - 1:
+                    raise _ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            else:
+                break
+            if attempt < attempts - 1:
+                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
+        if changed:
+            try:
+                _write_codex_auth_ancestor(path, digest)
+            except OSError as exc:
+                raise _ACPFileCredentialSyncError(
+                    "Codex credentials could not be saved to Cloud."
+                ) from exc
+            self._track_values(text_value)
+            self.expected_digest = digest
+        self.last_remote_check = now
+
+    def _adopt(self, value: str) -> None:
+        path = self.path
+        assert path is not None
+        if not _is_valid_codex_auth_value(value):
+            raise _ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials; "
+                "the local copy was preserved."
+            )
+        digest = hashlib.sha256(value.encode()).hexdigest()
+        try:
+            _write_secret_file(path, value)
+            _write_codex_auth_ancestor(path, digest)
+        except OSError as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credentials could not be reconciled with Cloud."
+            ) from exc
+        self._track_values(value)
+        self.expected_digest = digest
+        self.last_remote_check = time.monotonic()
+
+    def release(self) -> None:
+        _release_codex_auth_source(self.source)
+        self.clear()
+
+    def clear(self) -> None:
+        self.path = None
+        self.expected_digest = None
+        self.last_remote_check = 0.0
+        self.registry = None
+        self.authenticated = False
+
+
+def _create_codex_auth_lifecycle(
+    source: LookupSecret,
+) -> _ACPFileCredentialLifecycle | None:
+    refresh_url = _codex_auth_refresh_url(source)
+    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
+
+
+_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
+    str, Callable[[LookupSecret], _ACPFileCredentialLifecycle | None]
+] = {
+    _CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
+}
+
+
+def _create_file_credential_lifecycle(
+    secret_name: str, source: object
+) -> _ACPFileCredentialLifecycle | None:
+    if not isinstance(source, LookupSecret):
+        return None
+    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
+    return factory(source) if factory is not None else None
 
 
 def _stringify_acp_error_data(data: Any) -> str:
@@ -1822,13 +2070,10 @@ class ACPAgent(AgentBase):
     _installed_suffix: str | None = PrivateAttr(default=None)
     _restart_session_on_next_turn: bool = PrivateAttr(default=False)
     _resumed_existing_session: bool = PrivateAttr(default=False)
-    _codex_auth_path: Path | None = PrivateAttr(default=None)
-    _codex_auth_source: LookupSecret | None = PrivateAttr(default=None)
-    _codex_auth_expected_digest: str | None = PrivateAttr(default=None)
-    _codex_auth_last_remote_check: float = PrivateAttr(default=0.0)
-    _codex_auth_registry: SecretRegistry | None = PrivateAttr(default=None)
-    _codex_auth_authenticated: bool = PrivateAttr(default=False)
-    _codex_auth_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _file_credential_lifecycles: dict[str, _ACPFileCredentialLifecycle] = PrivateAttr(
+        default_factory=dict
+    )
+    _file_credential_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     # -- Helpers -----------------------------------------------------------
 
@@ -2100,21 +2345,24 @@ class ACPAgent(AgentBase):
             self._start_acp_server(state)
         except Exception as e:
             logger.error("Failed to start ACP server: %s", e)
-            release_codex_auth = True
-            if self._codex_auth_authenticated:
+            release_file_credentials = True
+            if any(
+                lifecycle.authenticated
+                for lifecycle in self._file_credential_lifecycles.values()
+            ):
                 try:
-                    self._sync_codex_auth()
+                    self._sync_file_credentials()
                 except Exception:
-                    release_codex_auth = False
+                    release_file_credentials = False
                     logger.warning(
-                        "Failed to sync Codex credentials during cleanup",
+                        "Failed to sync ACP file credentials during cleanup",
                         exc_info=True,
                     )
-            if release_codex_auth:
+            if release_file_credentials:
                 try:
-                    self._release_codex_auth()
-                except _CodexCredentialSyncError:
-                    logger.warning("Failed to release Codex credential source")
+                    self._release_file_credentials()
+                except _ACPFileCredentialSyncError:
+                    logger.warning("Failed to release ACP file credential source")
             self._cleanup()
             # init_state runs *outside* run()/arun()'s try-block (it is reached
             # via _ensure_agent_ready() before the loop starts), so a cold-start
@@ -2370,7 +2618,7 @@ class ACPAgent(AgentBase):
         self, state: ConversationState, env: dict[str, str]
     ) -> None:
         """Materialize reserved file credentials and configure their paths."""
-        with self._codex_auth_lock:
+        with self._file_credential_lock:
             self._materialise_file_secrets_locked(state, env)
 
     def _materialise_file_secrets_locked(
@@ -2381,49 +2629,17 @@ class ACPAgent(AgentBase):
             source = state.secret_registry.secret_sources.get(name)
             directory = self._acp_file_secret_dir(state, spec.subdir)
             target = directory / spec.filename
-            refresh_url: str | None = None
-            brokered_source: LookupSecret | None = None
-            remote_digest: str | None = None
-            if name == _CODEX_AUTH_SECRET_NAME and isinstance(source, LookupSecret):
-                refresh_url = _codex_auth_refresh_url(source)
-                if refresh_url is not None:
-                    brokered_source = source
-            if brokered_source is not None:
-                assert refresh_url is not None
-                try:
-                    value = brokered_source.get_value()
-                except httpx.HTTPStatusError as exc:
-                    if exc.response.status_code in (404, 422):
-                        detail = (
-                            "ChatGPT authentication was not found in Cloud."
-                            if exc.response.status_code == 404
-                            else "ChatGPT authentication needs to be refreshed."
-                        )
-                        raise _CodexNeedsReauthError(detail) from exc
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be loaded from Cloud."
-                    ) from exc
-                except Exception as exc:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be loaded from Cloud."
-                    ) from exc
-            else:
-                value = state.secret_registry.get_secret_value(name)
+            lifecycle = _create_file_credential_lifecycle(name, source)
+            value = (
+                lifecycle.load()
+                if lifecycle is not None
+                else state.secret_registry.get_secret_value(name)
+            )
             if not value:
                 continue
-            if brokered_source is not None:
-                if not _is_valid_codex_auth_value(value):
-                    raise _CodexCredentialSyncError(
-                        "Cloud returned invalid Codex credentials."
-                    )
-                self._codex_auth_registry = state.secret_registry
-                self._codex_auth_path = target
-                self._codex_auth_source = brokered_source
-                remote_digest = hashlib.sha256(value.encode()).hexdigest()
-                self._codex_auth_expected_digest = remote_digest
-                assert refresh_url is not None
-                env[_CODEX_REFRESH_TOKEN_URL_ENV] = refresh_url
-                self._track_codex_auth_transport(brokered_source, refresh_url)
+            if lifecycle is not None:
+                lifecycle.bind(target, state.secret_registry, value, env)
+                self._file_credential_lifecycles[name] = lifecycle
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
                 # Tighten the SDK-owned per-conversation dir in case it
@@ -2435,11 +2651,9 @@ class ACPAgent(AgentBase):
                 # Stop at `acp/` — its parent is the persistence layer's.
                 directory.parent.chmod(0o700)
                 preserve_existing = target.is_file() and target.stat().st_size > 0
-                if brokered_source is not None:
-                    assert remote_digest is not None
-                    ancestor_digest = _read_codex_auth_ancestor(target)
+                if lifecycle is not None:
                     preserve_existing = (
-                        preserve_existing and ancestor_digest == remote_digest
+                        preserve_existing and lifecycle.should_preserve_existing(target)
                     )
                 if preserve_existing:
                     # Seed-if-absent: keep the (possibly CLI-refreshed) contents,
@@ -2455,12 +2669,9 @@ class ACPAgent(AgentBase):
                 else:
                     _write_secret_file(target, value)
                     logger.info("Materialised ACP file-secret %r -> %s", name, target)
-                if brokered_source is not None:
-                    assert remote_digest is not None
-                    _write_codex_auth_ancestor(target, remote_digest)
                 local_value = (
                     target.read_text(encoding="utf-8")
-                    if brokered_source is not None
+                    if lifecycle is not None
                     else None
                 )
             except (OSError, UnicodeError):
@@ -2479,17 +2690,9 @@ class ACPAgent(AgentBase):
             env[spec.env_var] = str(
                 directory if spec.env_points_to == "dir" else target
             )
-            if brokered_source is not None:
+            if lifecycle is not None:
                 assert local_value is not None
-                assert remote_digest is not None
-                local_digest = hashlib.sha256(local_value.encode()).hexdigest()
-                if local_digest == remote_digest:
-                    self._codex_auth_last_remote_check = time.monotonic()
-                else:
-                    self._codex_auth_last_remote_check = 0.0
-                self._track_codex_auth_values(value)
-                if local_digest != remote_digest:
-                    self._track_codex_auth_values(local_value)
+                lifecycle.record_materialized(value, local_value)
             for companion in spec.warn_if_unset:
                 if not env.get(companion):
                     logger.warning(
@@ -2499,167 +2702,43 @@ class ACPAgent(AgentBase):
                         companion,
                     )
 
-    def _track_codex_auth_values(self, value: str) -> None:
-        """Track Codex token values for event masking."""
-        registry = self._codex_auth_registry
-        if registry is None:
+    def _sync_file_credentials(self) -> None:
+        """Persist changed brokered ACP file credentials."""
+        with self._file_credential_lock:
+            for lifecycle in self._file_credential_lifecycles.values():
+                lifecycle.sync()
+
+    async def _sync_file_credentials_best_effort(self) -> None:
+        if not self._file_credential_lifecycles:
             return
-        mask_name = _CODEX_AUTH_SECRET_NAME
-        exported_values = {mask_name: value}
+        await asyncio.to_thread(self._sync_file_credentials_best_effort_blocking)
+
+    def _sync_file_credentials_best_effort_blocking(self) -> None:
         try:
-            tokens = json.loads(value).get("tokens", {})
-        except (AttributeError, TypeError, ValueError):
-            tokens = None
-        if isinstance(tokens, dict):
-            for name, token in tokens.items():
-                if isinstance(token, str) and token:
-                    exported_values[f"{mask_name}.tokens.{name}"] = token
-        registry.track_exported_values(exported_values)
-
-    def _track_codex_auth_transport(
-        self, source: LookupSecret, refresh_url: str
-    ) -> None:
-        registry = self._codex_auth_registry
-        if registry is None:
-            return
-        exported_values = {
-            f"{_CODEX_AUTH_SECRET_NAME}.refresh_url": refresh_url,
-        }
-        for name, value in source.headers.items():
-            exported_values[f"{_CODEX_AUTH_SECRET_NAME}.header.{name.lower()}"] = value
-        registry.track_exported_values(exported_values)
-
-    def _sync_codex_auth(self) -> None:
-        """Persist a changed Codex credential working copy."""
-        with self._codex_auth_lock:
-            self._sync_codex_auth_locked()
-
-    async def _sync_codex_auth_best_effort(self) -> None:
-        if self._codex_auth_path is None:
-            return
-        await asyncio.to_thread(self._sync_codex_auth_best_effort_blocking)
-
-    def _sync_codex_auth_best_effort_blocking(self) -> None:
-        try:
-            self._sync_codex_auth()
+            self._sync_file_credentials()
         except Exception:
-            logger.warning("Failed to sync Codex credentials", exc_info=True)
+            logger.warning("Failed to sync ACP file credentials", exc_info=True)
 
-    def _sync_codex_auth_locked(self) -> None:
-        path = self._codex_auth_path
-        source = self._codex_auth_source
-        expected_digest = self._codex_auth_expected_digest
-        if path is None or source is None or expected_digest is None:
-            return
-        try:
-            value = path.read_bytes()
-            text_value = value.decode()
-        except (OSError, UnicodeError) as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credentials could not be saved to Cloud."
-            ) from exc
-        digest = hashlib.sha256(value).hexdigest()
-        changed = digest != expected_digest
-        now = time.monotonic()
-        if (
-            not changed
-            and self._codex_auth_last_remote_check > 0
-            and now - self._codex_auth_last_remote_check
-            < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
-        ):
-            return
-        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
-        for attempt in range(attempts):
-            try:
-                if changed:
-                    _update_codex_auth_source(source, text_value, expected_digest)
+    def _release_file_credentials(self) -> None:
+        """Release scoped ACP file credential sources."""
+        with self._file_credential_lock:
+            first_error: Exception | None = None
+            for name, lifecycle in list(self._file_credential_lifecycles.items()):
+                try:
+                    lifecycle.release()
+                except Exception as exc:
+                    if first_error is None:
+                        first_error = exc
                 else:
-                    remote_digest = _touch_codex_auth_source(source)
-                    if (
-                        isinstance(remote_digest, str)
-                        and remote_digest != expected_digest
-                    ):
-                        remote_value = _get_codex_auth_source(source)
-                        self._adopt_codex_auth_value(path, remote_value)
-                        return
-            except httpx.HTTPStatusError as exc:
-                if changed and exc.response.status_code == 409:
-                    try:
-                        remote_value = _get_codex_auth_source(source)
-                        self._adopt_codex_auth_value(path, remote_value)
-                    except Exception as remote_exc:
-                        if attempt == attempts - 1:
-                            raise _CodexCredentialSyncError(
-                                "Codex credentials could not be reconciled with Cloud."
-                            ) from remote_exc
-                    else:
-                        return
-                if attempt == attempts - 1:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            except Exception as exc:
-                if attempt == attempts - 1:
-                    raise _CodexCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            else:
-                break
-            if attempt < attempts - 1:
-                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
-        if changed:
-            try:
-                _write_codex_auth_ancestor(path, digest)
-            except OSError as exc:
-                raise _CodexCredentialSyncError(
-                    "Codex credentials could not be saved to Cloud."
-                ) from exc
-            self._track_codex_auth_values(text_value)
-            self._codex_auth_expected_digest = digest
-        self._codex_auth_last_remote_check = now
+                    self._file_credential_lifecycles.pop(name, None)
+            if first_error is not None:
+                raise _ACPFileCredentialSyncError(
+                    "ACP file credential source could not be released."
+                ) from first_error
 
-    def _adopt_codex_auth_value(self, path: Path, value: str) -> None:
-        if not _is_valid_codex_auth_value(value):
-            raise _CodexCredentialSyncError(
-                "Cloud returned invalid Codex credentials; "
-                "the local copy was preserved."
-            )
-        digest = hashlib.sha256(value.encode()).hexdigest()
-        try:
-            _write_secret_file(path, value)
-            _write_codex_auth_ancestor(path, digest)
-        except OSError as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credentials could not be reconciled with Cloud."
-            ) from exc
-        self._track_codex_auth_values(value)
-        self._codex_auth_expected_digest = digest
-        self._codex_auth_last_remote_check = time.monotonic()
-
-    def _release_codex_auth(self) -> None:
-        """Release the scoped Codex credential source."""
-        with self._codex_auth_lock:
-            self._release_codex_auth_locked()
-
-    def _release_codex_auth_locked(self) -> None:
-        source = self._codex_auth_source
-        if source is None:
-            return
-        try:
-            _release_codex_auth_source(source)
-        except Exception as exc:
-            raise _CodexCredentialSyncError(
-                "Codex credential source could not be released."
-            ) from exc
-        self._clear_codex_auth_state()
-
-    def _clear_codex_auth_state(self) -> None:
-        self._codex_auth_path = None
-        self._codex_auth_source = None
-        self._codex_auth_expected_digest = None
-        self._codex_auth_last_remote_check = 0.0
-        self._codex_auth_registry = None
-        self._codex_auth_authenticated = False
+    def _mark_file_credentials_authenticated(self) -> None:
+        for lifecycle in self._file_credential_lifecycles.values():
+            lifecycle.authenticated = True
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -2891,8 +2970,8 @@ class ACPAgent(AgentBase):
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
                     if method_id == "chat-gpt":
-                        self._codex_auth_authenticated = True
-                        await self._sync_codex_auth_best_effort()
+                        self._mark_file_credentials_authenticated()
+                        await self._sync_file_credentials_best_effort()
                 else:
                     logger.warning(
                         "ACP server offers auth methods %s but no matching "
@@ -3047,8 +3126,8 @@ class ACPAgent(AgentBase):
             self._model_override_applied,
         ) = self._executor.run_async(_init)
         self._working_dir = working_dir
-        if self._codex_auth_source is not None:
-            self._codex_auth_authenticated = True
+        if self._file_credential_lifecycles:
+            self._mark_file_credentials_authenticated()
 
     def _reset_client_for_turn(
         self,
@@ -3720,7 +3799,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            self._sync_codex_auth_best_effort_blocking()
+            self._sync_file_credentials_best_effort_blocking()
 
     @observe(name="acp_agent.astep", ignore_inputs=["conversation", "on_event"])
     async def astep(
@@ -3936,7 +4015,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            await self._sync_codex_auth_best_effort()
+            await self._sync_file_credentials_best_effort()
 
     def ask_agent(self, question: str) -> str | None:
         """Fork the ACP session, prompt the fork, and return the response."""
@@ -3994,7 +4073,7 @@ class ACPAgent(AgentBase):
                 return result
             finally:
                 try:
-                    await self._sync_codex_auth_best_effort()
+                    await self._sync_file_credentials_best_effort()
                 finally:
                     client._fork_session_id = None
                     client._fork_accumulated_text.clear()
@@ -4140,11 +4219,11 @@ class ACPAgent(AgentBase):
         self._closed = True
         error: Exception | None = None
         try:
-            self._sync_codex_auth()
+            self._sync_file_credentials()
         except Exception as exc:
             error = exc
         try:
-            self._release_codex_auth()
+            self._release_file_credentials()
         except Exception as exc:
             if error is None:
                 error = exc
@@ -4203,8 +4282,8 @@ class ACPAgent(AgentBase):
 
         See :meth:`LocalConversation.switch_acp_model`.
         """
-        with self._codex_auth_lock:
-            self._clear_codex_auth_state()
+        with self._file_credential_lock:
+            self._file_credential_lifecycles = {}
         self._closed = True
 
     def __del__(self) -> None:
@@ -4212,11 +4291,16 @@ class ACPAgent(AgentBase):
             if self._closed:
                 return
             self._closed = True
-            if self._codex_auth_path is not None:
+            credential_paths = [
+                lifecycle.path
+                for lifecycle in self._file_credential_lifecycles.values()
+                if lifecycle.path is not None
+            ]
+            if credential_paths:
                 logger.warning(
-                    "Skipping Codex credential sync during ACPAgent finalization; "
-                    "the durable working copy remains at %s",
-                    self._codex_auth_path,
+                    "Skipping ACP file credential sync during finalization; "
+                    "durable working copies remain at %s",
+                    credential_paths,
                 )
             self._cleanup()
         except Exception:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -968,11 +968,6 @@ class _ACPFileCredentialSyncError(RuntimeError):
     pass
 
 
-# Compatibility aliases for the current Codex-specific error classification.
-_CodexNeedsReauthError = _ACPFileCredentialNeedsReauthError
-_CodexCredentialSyncError = _ACPFileCredentialSyncError
-
-
 def _update_codex_auth_source(
     source: LookupSecret, value: str, expected_digest: str
 ) -> None:
@@ -1047,7 +1042,12 @@ def _is_valid_codex_auth_value(value: object) -> bool:
 
 
 class _ACPFileCredentialLifecycle(Protocol):
-    """Lifecycle boundary for a brokered ACP file credential."""
+    """Lifecycle boundary for a brokered ACP file credential.
+
+    Implementations translate expected I/O and broker failures into the
+    provider-neutral credential errors above. Unexpected exceptions are treated
+    as implementation defects and intentionally propagate through orchestration.
+    """
 
     secret_name: str
     path: Path | None
@@ -1100,7 +1100,7 @@ class _CodexAuthLifecycle:
             raise _ACPFileCredentialSyncError(
                 "Codex credentials could not be loaded from Cloud."
             ) from exc
-        except Exception as exc:
+        except httpx.RequestError as exc:
             raise _ACPFileCredentialSyncError(
                 "Codex credentials could not be loaded from Cloud."
             ) from exc
@@ -1203,7 +1203,10 @@ class _CodexAuthLifecycle:
                 if changed and exc.response.status_code == 409:
                     try:
                         self._adopt(_get_codex_auth_source(self.source))
-                    except Exception as remote_exc:
+                    except (
+                        httpx.HTTPError,
+                        _ACPFileCredentialSyncError,
+                    ) as remote_exc:
                         if attempt == attempts - 1:
                             raise _ACPFileCredentialSyncError(
                                 "Codex credentials could not be reconciled with Cloud."
@@ -1214,7 +1217,7 @@ class _CodexAuthLifecycle:
                     raise _ACPFileCredentialSyncError(
                         "Codex credentials could not be saved to Cloud."
                     ) from exc
-            except Exception as exc:
+            except httpx.RequestError as exc:
                 if attempt == attempts - 1:
                     raise _ACPFileCredentialSyncError(
                         "Codex credentials could not be saved to Cloud."
@@ -1255,7 +1258,12 @@ class _CodexAuthLifecycle:
         self.last_remote_check = time.monotonic()
 
     def release(self) -> None:
-        _release_codex_auth_source(self.source)
+        try:
+            _release_codex_auth_source(self.source)
+        except httpx.HTTPError as exc:
+            raise _ACPFileCredentialSyncError(
+                "Codex credential source could not be released."
+            ) from exc
         self.clear()
 
     def clear(self) -> None:
@@ -1383,7 +1391,9 @@ def _classify_acp_init_error(exc: BaseException) -> str:
       creation (timeouts, transport drops, unexpected protocol errors, cwd
       mismatch surfaced by the server).
     """
-    if isinstance(exc, (_CodexNeedsReauthError, _CodexCredentialSyncError)):
+    if isinstance(
+        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
+    ):
         return "ACPAuthRequired"
     if _acp_error_indicates_auth(exc):
         return "ACPAuthRequired"
@@ -1399,7 +1409,9 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
     policy refusals get their own code, credential failures map to ``ACPAuthRequired``
     (so the client can offer re-auth), everything else is a generic ``ACPPromptError``.
     """
-    if isinstance(exc, (_CodexNeedsReauthError, _CodexCredentialSyncError)):
+    if isinstance(
+        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
+    ):
         return "ACPAuthRequired"
     text = _acp_error_text(exc)
     if "usage policy" in text or "content policy" in text:
@@ -2352,7 +2364,7 @@ class ACPAgent(AgentBase):
             ):
                 try:
                     self._sync_file_credentials()
-                except Exception:
+                except _ACPFileCredentialSyncError:
                     release_file_credentials = False
                     logger.warning(
                         "Failed to sync ACP file credentials during cleanup",
@@ -2716,7 +2728,7 @@ class ACPAgent(AgentBase):
     def _sync_file_credentials_best_effort_blocking(self) -> None:
         try:
             self._sync_file_credentials()
-        except Exception:
+        except _ACPFileCredentialSyncError:
             logger.warning("Failed to sync ACP file credentials", exc_info=True)
 
     def _release_file_credentials(self) -> None:
@@ -2726,7 +2738,7 @@ class ACPAgent(AgentBase):
             for name, lifecycle in list(self._file_credential_lifecycles.items()):
                 try:
                     lifecycle.release()
-                except Exception as exc:
+                except _ACPFileCredentialSyncError as exc:
                     if first_error is None:
                         first_error = exc
                 else:
@@ -2961,12 +2973,12 @@ class ACPAgent(AgentBase):
                                 auth_kwargs["gateway"] = {"baseUrl": base_url}
                     try:
                         await conn.authenticate(method_id=method_id, **auth_kwargs)
-                    except Exception as exc:
+                    except ACPRequestError as exc:
                         if method_id != "chat-gpt" or not _acp_error_indicates_auth(
                             exc
                         ):
                             raise
-                        raise _CodexNeedsReauthError(
+                        raise _ACPFileCredentialNeedsReauthError(
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
                     if method_id == "chat-gpt":

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -17,7 +17,6 @@ See https://agentclientprotocol.com/protocol/overview
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import inspect
 import json
 import os
@@ -28,9 +27,8 @@ import uuid
 from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
-import httpx
 from acp.client.connection import ClientSideConnection
 from acp.exceptions import RequestError as ACPRequestError
 from acp.helpers import image_block, text_block
@@ -61,6 +59,14 @@ from pydantic import (
     field_validator,
 )
 
+from openhands.sdk.agent.acp_file_credentials import (
+    ACPFileCredentialLifecycle,
+    ACPFileCredentialNeedsReauthError,
+    ACPFileCredentialSyncError,
+    codex_auth_file_is_chatgpt,
+    create_file_credential_lifecycle,
+    write_secret_file,
+)
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context import AgentContext
@@ -77,7 +83,6 @@ from openhands.sdk.llm import LLM, ImageContent, Message, MessageToolCall, TextC
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
-from openhands.sdk.secret import LookupSecret
 from openhands.sdk.settings.acp_providers import (
     ACPFileSecretSpec,
     build_session_model_meta,
@@ -107,8 +112,6 @@ if TYPE_CHECKING:
         LocalConversation,
     )
     from openhands.sdk.conversation.secret_registry import SecretRegistry
-
-
 # Maximum seconds to wait for a UsageUpdate notification after prompt()
 # returns. The ACP server writes UsageUpdate to the wire before the
 # PromptResponse, so under normal conditions the notification handler
@@ -130,13 +133,6 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
 _ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
 
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
-_CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
-_CODEX_AUTH_HTTP_TIMEOUT = 5.0
-_CODEX_AUTH_REMOTE_CHECK_INTERVAL = 60.0
-_CODEX_AUTH_DIGEST_HEADER = "X-Codex-Auth-Digest"
-_CODEX_AUTH_SANDBOX_HEADER = "X-OH-Sandbox"
-_CODEX_AUTH_SCOPE_HEADER = "X-OH-Codex"
-_CODEX_REFRESH_TOKEN_URL_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
 
 # Exception types that indicate transient connection issues worth retrying
 _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFError)
@@ -274,48 +270,10 @@ def _make_dummy_llm() -> LLM:
 _AUTH_METHOD_ENV_MAP: dict[str, str] = {
     "gemini-api-key": "GEMINI_API_KEY",
 }
-_CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
-_CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 # Gemini CLI personal (Google OAuth) login, cached by ``gemini login`` /
 # ``gemini --acp``. Its presence lets us select the server's ``oauth-personal``
 # auth method without an API key (mirrors the ChatGPT subscription path).
 _GEMINI_OAUTH_PATH = Path(".gemini") / "oauth_creds.json"
-
-
-def _codex_auth_file(env: dict[str, str]) -> Path:
-    """Path to Codex's ChatGPT-subscription ``auth.json``, honoring ``CODEX_HOME``.
-
-    Codex reads ``$CODEX_HOME/auth.json`` when ``CODEX_HOME`` is set — which the
-    SDK does after materialising a relocated, per-conversation ``auth.json``
-    (see :meth:`ACPAgent._materialise_file_secrets`) — and ``~/.codex/auth.json``
-    otherwise. Detection must follow the same relocation or a materialised
-    subscription token is never recognised (issue #1020).
-    """
-    codex_home = env.get("CODEX_HOME")
-    if codex_home:
-        return Path(codex_home) / "auth.json"
-    return Path.home() / _CHATGPT_AUTH_PATH
-
-
-def _codex_auth_file_is_chatgpt(env: dict[str, str]) -> bool:
-    """Return True only if ``auth.json`` is in ChatGPT-subscription format.
-
-    Codex itself rewrites ``$CODEX_HOME/auth.json`` during apikey-mode sessions
-    with ``{"auth_mode": "apikey", "OPENAI_API_KEY": "..."}``. That file's mere
-    presence used to make :func:`_select_auth_method` prefer ``chat-gpt`` on a
-    restart, after which ``conn.authenticate("chat-gpt")`` hung indefinitely
-    waiting for browser-based OAuth (issue #3627). The ChatGPT token blob is
-    keyed by ``tokens``; require that key before claiming the file is usable
-    for the ``chat-gpt`` auth method.
-    """
-    path = _codex_auth_file(env)
-    if not path.is_file():
-        return False
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and "tokens" in data
 
 
 def _select_auth_method(
@@ -343,7 +301,7 @@ def _select_auth_method(
     method_ids = {m.id for m in auth_methods}
     # Prefer file-backed subscription / service-account logins when their
     # credential file is present.
-    if "chat-gpt" in method_ids and _codex_auth_file_is_chatgpt(env):
+    if "chat-gpt" in method_ids and codex_auth_file_is_chatgpt(env):
         return "chat-gpt"
     gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
     if "vertex-ai" in method_ids and gac and Path(gac).is_file():
@@ -410,36 +368,6 @@ def _with_codex_base_url(
     config["openai_base_url"] = base_url
     configured_env["CODEX_CONFIG"] = json.dumps(config, separators=(",", ":"))
     return configured_env
-
-
-def _write_secret_file(path: Path, value: str) -> None:
-    """Write ``value`` to ``path`` as a ``0600`` file.
-
-    ``os.open`` creates a *new* file at ``0600``, but ``O_CREAT`` does not
-    narrow an existing file's mode. So ``fchmod`` the raw fd to ``0600`` before
-    any bytes land — clamping the mode while we still hold the fd guarantees the
-    secret content never exists with wider permissions even when the file
-    pre-existed (e.g. a ``0644`` empty file from another tool).
-    """
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(value)
-
-
-def _codex_auth_ancestor_file(path: Path) -> Path:
-    return path.with_name(f".{path.name}.cloud-digest")
-
-
-def _read_codex_auth_ancestor(path: Path) -> str | None:
-    try:
-        return _codex_auth_ancestor_file(path).read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        return None
-
-
-def _write_codex_auth_ancestor(path: Path, digest: str) -> None:
-    _write_secret_file(_codex_auth_ancestor_file(path), digest)
 
 
 # Session config-option id that selects the model on ACP servers that drive
@@ -962,343 +890,6 @@ _ACP_AUTH_ERROR_MARKERS: tuple[str, ...] = (
 )
 
 
-class _ACPFileCredentialNeedsReauthError(RuntimeError):
-    pass
-
-
-class _ACPFileCredentialSyncError(RuntimeError):
-    pass
-
-
-def _update_codex_auth_source(
-    source: LookupSecret, value: str, expected_digest: str
-) -> None:
-    response = httpx.put(
-        source.url,
-        headers=source.headers,
-        json={"expected_digest": expected_digest, "value": value},
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-
-
-def _get_codex_auth_source(source: LookupSecret) -> str:
-    response = httpx.get(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-    return response.text
-
-
-def _touch_codex_auth_source(source: LookupSecret) -> str | None:
-    response = httpx.head(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-    digest = response.headers.get(_CODEX_AUTH_DIGEST_HEADER)
-    return (
-        digest
-        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest)
-        else None
-    )
-
-
-def _release_codex_auth_source(source: LookupSecret) -> None:
-    response = httpx.delete(
-        source.url,
-        headers=source.headers,
-        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
-    )
-    response.raise_for_status()
-
-
-def _codex_auth_refresh_url(source: LookupSecret) -> str | None:
-    headers = {name.lower(): value for name, value in source.headers.items()}
-    session_api_key = headers.get(_CODEX_AUTH_SANDBOX_HEADER.lower())
-    codex_auth_token = headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
-    if not session_api_key or not codex_auth_token:
-        return None
-    url = httpx.URL(source.url)
-    refresh_path = f"{url.path.rstrip('/')}/refresh"
-    return str(
-        url.copy_with(
-            path=refresh_path,
-            username=session_api_key,
-            password=codex_auth_token,
-        )
-    )
-
-
-def _is_valid_codex_auth_value(value: object) -> bool:
-    if not isinstance(value, str) or not value.strip():
-        return False
-    try:
-        payload = json.loads(value)
-    except (TypeError, ValueError):
-        return False
-    return isinstance(payload, dict) and bool(payload)
-
-
-class _ACPFileCredentialLifecycle(Protocol):
-    """Lifecycle boundary for a brokered ACP file credential.
-
-    Implementations translate expected I/O and broker failures into the
-    provider-neutral credential errors above. Unexpected exceptions are treated
-    as implementation defects and intentionally propagate through orchestration.
-    """
-
-    secret_name: str
-    path: Path | None
-    authenticated: bool
-
-    def load(self) -> str | None: ...
-
-    def bind(
-        self,
-        path: Path,
-        registry: SecretRegistry,
-        remote_value: str,
-        env: dict[str, str],
-    ) -> None: ...
-
-    def should_preserve_existing(self, path: Path) -> bool: ...
-
-    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
-
-    def sync(self) -> None: ...
-
-    def release(self) -> None: ...
-
-
-class _CodexAuthLifecycle:
-    """Brokered lifecycle implementation for Codex subscription auth."""
-
-    secret_name = _CODEX_AUTH_SECRET_NAME
-
-    def __init__(self, source: LookupSecret, refresh_url: str):
-        self.source = source
-        self.refresh_url = refresh_url
-        self.path: Path | None = None
-        self.expected_digest: str | None = None
-        self.last_remote_check = 0.0
-        self.registry: SecretRegistry | None = None
-        self.authenticated = False
-
-    def load(self) -> str | None:
-        try:
-            return self.source.get_value()
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code in (404, 422):
-                detail = (
-                    "ChatGPT authentication was not found in Cloud."
-                    if exc.response.status_code == 404
-                    else "ChatGPT authentication needs to be refreshed."
-                )
-                raise _ACPFileCredentialNeedsReauthError(detail) from exc
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be loaded from Cloud."
-            ) from exc
-        except httpx.RequestError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be loaded from Cloud."
-            ) from exc
-
-    def bind(
-        self,
-        path: Path,
-        registry: SecretRegistry,
-        remote_value: str,
-        env: dict[str, str],
-    ) -> None:
-        if not _is_valid_codex_auth_value(remote_value):
-            raise _ACPFileCredentialSyncError(
-                "Cloud returned invalid Codex credentials."
-            )
-        self.path = path
-        self.registry = registry
-        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
-        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
-        self._track_transport()
-
-    def should_preserve_existing(self, path: Path) -> bool:
-        return _read_codex_auth_ancestor(path) == self.expected_digest
-
-    def record_materialized(self, remote_value: str, local_value: str) -> None:
-        path = self.path
-        expected_digest = self.expected_digest
-        assert path is not None
-        assert expected_digest is not None
-        _write_codex_auth_ancestor(path, expected_digest)
-        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
-        self.last_remote_check = (
-            time.monotonic() if local_digest == expected_digest else 0.0
-        )
-        self._track_values(remote_value)
-        if local_digest != expected_digest:
-            self._track_values(local_value)
-
-    def _track_values(self, value: str) -> None:
-        registry = self.registry
-        if registry is None:
-            return
-        exported_values = {self.secret_name: value}
-        try:
-            tokens = json.loads(value).get("tokens", {})
-        except (AttributeError, TypeError, ValueError):
-            tokens = None
-        if isinstance(tokens, dict):
-            for name, token in tokens.items():
-                if isinstance(token, str) and token:
-                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
-        registry.track_exported_values(exported_values)
-
-    def _track_transport(self) -> None:
-        registry = self.registry
-        if registry is None:
-            return
-        exported_values = {
-            f"{self.secret_name}.refresh_url": self.refresh_url,
-        }
-        for name, value in self.source.headers.items():
-            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
-        registry.track_exported_values(exported_values)
-
-    def sync(self) -> None:
-        path = self.path
-        expected_digest = self.expected_digest
-        if path is None or expected_digest is None:
-            return
-        try:
-            value = path.read_bytes()
-            text_value = value.decode()
-        except (OSError, UnicodeError) as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be saved to Cloud."
-            ) from exc
-        digest = hashlib.sha256(value).hexdigest()
-        changed = digest != expected_digest
-        now = time.monotonic()
-        if (
-            not changed
-            and self.last_remote_check > 0
-            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
-        ):
-            return
-        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
-        for attempt in range(attempts):
-            try:
-                if changed:
-                    _update_codex_auth_source(self.source, text_value, expected_digest)
-                else:
-                    remote_digest = _touch_codex_auth_source(self.source)
-                    if (
-                        isinstance(remote_digest, str)
-                        and remote_digest != expected_digest
-                    ):
-                        self._adopt(_get_codex_auth_source(self.source))
-                        return
-            except httpx.HTTPStatusError as exc:
-                if changed and exc.response.status_code == 409:
-                    try:
-                        self._adopt(_get_codex_auth_source(self.source))
-                    except (
-                        httpx.HTTPError,
-                        _ACPFileCredentialSyncError,
-                    ) as remote_exc:
-                        if attempt == attempts - 1:
-                            raise _ACPFileCredentialSyncError(
-                                "Codex credentials could not be reconciled with Cloud."
-                            ) from remote_exc
-                    else:
-                        return
-                if attempt == attempts - 1:
-                    raise _ACPFileCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            except httpx.RequestError as exc:
-                if attempt == attempts - 1:
-                    raise _ACPFileCredentialSyncError(
-                        "Codex credentials could not be saved to Cloud."
-                    ) from exc
-            else:
-                break
-            if attempt < attempts - 1:
-                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
-        if changed:
-            try:
-                _write_codex_auth_ancestor(path, digest)
-            except OSError as exc:
-                raise _ACPFileCredentialSyncError(
-                    "Codex credentials could not be saved to Cloud."
-                ) from exc
-            self._track_values(text_value)
-            self.expected_digest = digest
-        self.last_remote_check = now
-
-    def _adopt(self, value: str) -> None:
-        path = self.path
-        assert path is not None
-        if not _is_valid_codex_auth_value(value):
-            raise _ACPFileCredentialSyncError(
-                "Cloud returned invalid Codex credentials; "
-                "the local copy was preserved."
-            )
-        digest = hashlib.sha256(value.encode()).hexdigest()
-        try:
-            _write_secret_file(path, value)
-            _write_codex_auth_ancestor(path, digest)
-        except OSError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credentials could not be reconciled with Cloud."
-            ) from exc
-        self._track_values(value)
-        self.expected_digest = digest
-        self.last_remote_check = time.monotonic()
-
-    def release(self) -> None:
-        try:
-            _release_codex_auth_source(self.source)
-        except httpx.HTTPError as exc:
-            raise _ACPFileCredentialSyncError(
-                "Codex credential source could not be released."
-            ) from exc
-        self.clear()
-
-    def clear(self) -> None:
-        self.path = None
-        self.expected_digest = None
-        self.last_remote_check = 0.0
-        self.registry = None
-        self.authenticated = False
-
-
-def _create_codex_auth_lifecycle(
-    source: LookupSecret,
-) -> _ACPFileCredentialLifecycle | None:
-    refresh_url = _codex_auth_refresh_url(source)
-    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
-
-
-_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
-    str, Callable[[LookupSecret], _ACPFileCredentialLifecycle | None]
-] = {
-    _CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
-}
-
-
-def _create_file_credential_lifecycle(
-    secret_name: str, source: object
-) -> _ACPFileCredentialLifecycle | None:
-    if not isinstance(source, LookupSecret):
-        return None
-    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
-    return factory(source) if factory is not None else None
-
-
 def _stringify_acp_error_data(data: Any) -> str:
     """Render an ACP ``RequestError.data`` payload as a compact string.
 
@@ -1393,9 +984,7 @@ def _classify_acp_init_error(exc: BaseException) -> str:
       creation (timeouts, transport drops, unexpected protocol errors, cwd
       mismatch surfaced by the server).
     """
-    if isinstance(
-        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
-    ):
+    if isinstance(exc, (ACPFileCredentialNeedsReauthError, ACPFileCredentialSyncError)):
         return "ACPAuthRequired"
     if _acp_error_indicates_auth(exc):
         return "ACPAuthRequired"
@@ -1411,9 +1000,7 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
     policy refusals get their own code, credential failures map to ``ACPAuthRequired``
     (so the client can offer re-auth), everything else is a generic ``ACPPromptError``.
     """
-    if isinstance(
-        exc, (_ACPFileCredentialNeedsReauthError, _ACPFileCredentialSyncError)
-    ):
+    if isinstance(exc, (ACPFileCredentialNeedsReauthError, ACPFileCredentialSyncError)):
         return "ACPAuthRequired"
     text = _acp_error_text(exc)
     if "usage policy" in text or "content policy" in text:
@@ -2084,10 +1671,13 @@ class ACPAgent(AgentBase):
     _installed_suffix: str | None = PrivateAttr(default=None)
     _restart_session_on_next_turn: bool = PrivateAttr(default=False)
     _resumed_existing_session: bool = PrivateAttr(default=False)
-    _file_credential_lifecycles: dict[str, _ACPFileCredentialLifecycle] = PrivateAttr(
+    _file_credential_lifecycles: dict[str, ACPFileCredentialLifecycle] = PrivateAttr(
         default_factory=dict
     )
     _file_credential_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _file_credential_close_lock: threading.Lock = PrivateAttr(
+        default_factory=threading.Lock
+    )
 
     # -- Helpers -----------------------------------------------------------
 
@@ -2359,25 +1949,16 @@ class ACPAgent(AgentBase):
             self._start_acp_server(state)
         except Exception as e:
             logger.error("Failed to start ACP server: %s", e)
-            release_file_credentials = True
-            if any(
-                lifecycle.authenticated
-                for lifecycle in self._file_credential_lifecycles.values()
-            ):
-                try:
-                    self._sync_file_credentials()
-                except _ACPFileCredentialSyncError:
-                    release_file_credentials = False
-                    logger.warning(
-                        "Failed to sync ACP file credentials during cleanup",
-                        exc_info=True,
-                    )
-            if release_file_credentials:
-                try:
-                    self._release_file_credentials()
-                except _ACPFileCredentialSyncError:
-                    logger.warning("Failed to release ACP file credential source")
-            self._cleanup()
+            sync_failures = self._sync_file_credentials_collect(changed_only=True)
+            self._log_file_credential_failures("sync", sync_failures)
+            release_failures = self._release_file_credentials_collect(
+                exclude=set(sync_failures)
+            )
+            self._log_file_credential_failures("release", release_failures)
+            try:
+                self._cleanup()
+            except Exception:
+                logger.warning("Failed to clean up ACP resources", exc_info=True)
             # init_state runs *outside* run()/arun()'s try-block (it is reached
             # via _ensure_agent_ready() before the loop starts), so a cold-start
             # failure — bad/expired auth, missing CLI binary, cwd mismatch — would
@@ -2643,17 +2224,19 @@ class ACPAgent(AgentBase):
             source = state.secret_registry.secret_sources.get(name)
             directory = self._acp_file_secret_dir(state, spec.subdir)
             target = directory / spec.filename
-            lifecycle = _create_file_credential_lifecycle(name, source)
-            value = (
-                lifecycle.load()
-                if lifecycle is not None
-                else state.secret_registry.get_secret_value(name)
-            )
+            lifecycle = create_file_credential_lifecycle(name, source)
+            if lifecycle is not None:
+                self._file_credential_lifecycles[name] = lifecycle
+                value = lifecycle.load()
+            else:
+                value = state.secret_registry.get_secret_value(name)
             if not value:
+                if lifecycle is not None:
+                    lifecycle.release()
+                    self._file_credential_lifecycles.pop(name, None)
                 continue
             if lifecycle is not None:
                 lifecycle.bind(target, state.secret_registry, value, env)
-                self._file_credential_lifecycles[name] = lifecycle
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
                 # Tighten the SDK-owned per-conversation dir in case it
@@ -2681,7 +2264,7 @@ class ACPAgent(AgentBase):
                         target,
                     )
                 else:
-                    _write_secret_file(target, value)
+                    write_secret_file(target, value)
                     logger.info("Materialised ACP file-secret %r -> %s", name, target)
                 local_value = (
                     target.read_text(encoding="utf-8")
@@ -2716,43 +2299,110 @@ class ACPAgent(AgentBase):
                         companion,
                     )
 
-    def _sync_file_credentials(self) -> None:
-        """Persist changed brokered ACP file credentials."""
-        with self._file_credential_lock:
-            for lifecycle in self._file_credential_lifecycles.values():
-                lifecycle.sync()
+    @staticmethod
+    def _log_file_credential_failures(
+        operation: str, failures: dict[str, Exception]
+    ) -> None:
+        for name, error in failures.items():
+            logger.warning(
+                "Failed to %s ACP file credential %r",
+                operation,
+                name,
+                exc_info=(type(error), error, error.__traceback__),
+            )
 
-    async def _sync_file_credentials_best_effort(self) -> None:
-        if not self._file_credential_lifecycles:
+    @staticmethod
+    def _raise_first_file_credential_failure(
+        operation: str, failures: dict[str, Exception]
+    ) -> None:
+        if not failures:
             return
-        await asyncio.to_thread(self._sync_file_credentials_best_effort_blocking)
+        first_name = next(iter(failures))
+        remaining = dict(failures)
+        first_error = remaining.pop(first_name)
+        ACPAgent._log_file_credential_failures(operation, remaining)
+        raise first_error
 
-    def _sync_file_credentials_best_effort_blocking(self) -> None:
+    def _sync_file_credentials_collect(
+        self, *, changed_only: bool = False
+    ) -> dict[str, Exception]:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    if changed_only and not lifecycle.may_have_changed:
+                        continue
+                    lifecycle.sync()
+                except Exception as error:
+                    failures[name] = error
+        return failures
+
+    def _sync_file_credentials(self) -> None:
+        """Persist brokered ACP file credentials."""
+        failures = self._sync_file_credentials_collect()
+        self._raise_first_file_credential_failure("sync", failures)
+
+    async def _sync_file_credentials_best_effort(
+        self, *, changed_only: bool = False
+    ) -> None:
+        with self._file_credential_lock:
+            if not self._file_credential_lifecycles:
+                return
         try:
-            self._sync_file_credentials()
-        except _ACPFileCredentialSyncError:
+            await asyncio.to_thread(
+                self._sync_file_credentials_best_effort_blocking,
+                changed_only=changed_only,
+            )
+        except Exception:
             logger.warning("Failed to sync ACP file credentials", exc_info=True)
+
+    def _sync_file_credentials_best_effort_blocking(
+        self, *, changed_only: bool = False
+    ) -> None:
+        failures = self._sync_file_credentials_collect(changed_only=changed_only)
+        self._log_file_credential_failures("sync", failures)
+
+    def _release_file_credentials_collect(
+        self, *, exclude: set[str] | None = None
+    ) -> dict[str, Exception]:
+        failures: dict[str, Exception] = {}
+        excluded = exclude or set()
+        with self._file_credential_lock:
+            for name, lifecycle in list(self._file_credential_lifecycles.items()):
+                if name in excluded:
+                    continue
+                try:
+                    lifecycle.release()
+                except Exception as error:
+                    failures[name] = error
+                else:
+                    self._file_credential_lifecycles.pop(name, None)
+        return failures
 
     def _release_file_credentials(self) -> None:
         """Release scoped ACP file credential sources."""
-        with self._file_credential_lock:
-            first_error: Exception | None = None
-            for name, lifecycle in list(self._file_credential_lifecycles.items()):
-                try:
-                    lifecycle.release()
-                except _ACPFileCredentialSyncError as exc:
-                    if first_error is None:
-                        first_error = exc
-                else:
-                    self._file_credential_lifecycles.pop(name, None)
-            if first_error is not None:
-                raise _ACPFileCredentialSyncError(
-                    "ACP file credential source could not be released."
-                ) from first_error
+        failures = self._release_file_credentials_collect()
+        self._raise_first_file_credential_failure("release", failures)
 
-    def _mark_file_credentials_authenticated(self) -> None:
-        for lifecycle in self._file_credential_lifecycles.values():
-            lifecycle.authenticated = True
+    def _notify_file_credentials_auth_succeeded(self, method_id: str) -> None:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    lifecycle.on_auth_succeeded(method_id)
+                except Exception as error:
+                    failures[name] = error
+        self._raise_first_file_credential_failure("update", failures)
+
+    def _notify_file_credentials_session_started(self) -> None:
+        failures: dict[str, Exception] = {}
+        with self._file_credential_lock:
+            for name, lifecycle in self._file_credential_lifecycles.items():
+                try:
+                    lifecycle.on_session_started()
+                except Exception as error:
+                    failures[name] = error
+        self._raise_first_file_credential_failure("update", failures)
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -2980,7 +2630,7 @@ class ACPAgent(AgentBase):
                         )
                     except TimeoutError as exc:
                         if method_id == "chat-gpt":
-                            raise _ACPFileCredentialNeedsReauthError(
+                            raise ACPFileCredentialNeedsReauthError(
                                 "ChatGPT authentication did not complete in time. "
                                 "Please sign in again."
                             ) from exc
@@ -2993,12 +2643,11 @@ class ACPAgent(AgentBase):
                             exc
                         ):
                             raise
-                        raise _ACPFileCredentialNeedsReauthError(
+                        raise ACPFileCredentialNeedsReauthError(
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
-                    if method_id == "chat-gpt":
-                        self._mark_file_credentials_authenticated()
-                        await self._sync_file_credentials_best_effort()
+                    self._notify_file_credentials_auth_succeeded(method_id)
+                    await self._sync_file_credentials_best_effort(changed_only=True)
                 else:
                     logger.warning(
                         "ACP server offers auth methods %s but no matching "
@@ -3153,8 +2802,7 @@ class ACPAgent(AgentBase):
             self._model_override_applied,
         ) = self._executor.run_async(_init)
         self._working_dir = working_dir
-        if self._file_credential_lifecycles:
-            self._mark_file_credentials_authenticated()
+        self._notify_file_credentials_session_started()
 
     def _reset_client_for_turn(
         self,
@@ -3826,7 +3474,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            self._sync_file_credentials_best_effort_blocking()
+            self._sync_file_credentials_best_effort_blocking(changed_only=True)
 
     @observe(name="acp_agent.astep", ignore_inputs=["conversation", "on_event"])
     async def astep(
@@ -4042,7 +3690,7 @@ class ACPAgent(AgentBase):
             raise
         finally:
             self._clear_turn_callbacks()
-            await self._sync_file_credentials_best_effort()
+            await self._sync_file_credentials_best_effort(changed_only=True)
 
     def ask_agent(self, question: str) -> str | None:
         """Fork the ACP session, prompt the fork, and return the response."""
@@ -4100,7 +3748,7 @@ class ACPAgent(AgentBase):
                 return result
             finally:
                 try:
-                    await self._sync_file_credentials_best_effort()
+                    await self._sync_file_credentials_best_effort(changed_only=True)
                 finally:
                     client._fork_session_id = None
                     client._fork_accumulated_text.clear()
@@ -4241,26 +3889,21 @@ class ACPAgent(AgentBase):
 
     def close(self) -> None:
         """Terminate the ACP subprocess and clean up resources."""
-        if self._closed:
-            return
-        self._closed = True
-        error: Exception | None = None
-        try:
-            self._sync_file_credentials()
-        except Exception as exc:
-            error = exc
-        try:
-            self._release_file_credentials()
-        except Exception as exc:
-            if error is None:
-                error = exc
-        try:
-            self._cleanup()
-        except Exception as exc:
-            if error is None:
-                error = exc
-        if error is not None:
-            raise error
+        with self._file_credential_close_lock:
+            with self._file_credential_lock:
+                if self._closed and not self._file_credential_lifecycles:
+                    return
+            self._closed = True
+            sync_failures = self._sync_file_credentials_collect()
+            release_failures = self._release_file_credentials_collect(
+                exclude=set(sync_failures)
+            )
+            failures = {**sync_failures, **release_failures}
+            try:
+                self._cleanup()
+            except Exception as exc:
+                failures["ACP runtime"] = exc
+            self._raise_first_file_credential_failure("close", failures)
 
     def _cleanup(self) -> None:
         """Internal cleanup of ACP resources."""
@@ -4309,26 +3952,38 @@ class ACPAgent(AgentBase):
 
         See :meth:`LocalConversation.switch_acp_model`.
         """
-        with self._file_credential_lock:
-            self._file_credential_lifecycles = {}
-        self._closed = True
+        with self._file_credential_close_lock:
+            with self._file_credential_lock:
+                self._file_credential_lifecycles = {}
+            self._closed = True
 
     def __del__(self) -> None:
         try:
-            if self._closed:
-                return
-            self._closed = True
-            credential_paths = [
-                lifecycle.path
-                for lifecycle in self._file_credential_lifecycles.values()
-                if lifecycle.path is not None
-            ]
-            if credential_paths:
-                logger.warning(
-                    "Skipping ACP file credential sync during finalization; "
-                    "durable working copies remain at %s",
-                    credential_paths,
-                )
-            self._cleanup()
+            with self._file_credential_close_lock:
+                credential_paths: list[Path] = []
+                with self._file_credential_lock:
+                    for name, lifecycle in self._file_credential_lifecycles.items():
+                        try:
+                            path = lifecycle.path
+                        except Exception:
+                            logger.warning(
+                                "Failed to inspect ACP file credential %r",
+                                name,
+                                exc_info=True,
+                            )
+                        else:
+                            if path is not None:
+                                credential_paths.append(path)
+                    already_closed = self._closed
+                    self._closed = True
+                if credential_paths:
+                    logger.warning(
+                        "Skipping ACP file credential sync during finalization; "
+                        "durable working copies remain at %s",
+                        credential_paths,
+                    )
+                if already_closed:
+                    return
+                self._cleanup()
         except Exception:
             logger.warning("Failed to finalize ACPAgent resources", exc_info=True)

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -1,0 +1,443 @@
+"""Manage brokered ACP file credentials."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+import httpx
+
+from openhands.sdk.secret import LookupSecret
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.secret_registry import SecretRegistry
+
+
+CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
+
+_CODEX_AUTH_SYNC_DELAYS: tuple[float, ...] = (0.1, 0.5)
+_CODEX_AUTH_HTTP_TIMEOUT = 5.0
+_CODEX_AUTH_REMOTE_CHECK_INTERVAL = 60.0
+_CODEX_AUTH_DIGEST_HEADER = "X-Codex-Auth-Digest"
+_CODEX_AUTH_SANDBOX_HEADER = "X-OH-Sandbox"
+_CODEX_AUTH_SCOPE_HEADER = "X-OH-Codex"
+_CODEX_REFRESH_TOKEN_URL_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
+_CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
+
+
+class ACPFileCredentialNeedsReauthError(RuntimeError):
+    pass
+
+
+class ACPFileCredentialSyncError(RuntimeError):
+    pass
+
+
+class ACPFileCredentialLifecycle(Protocol):
+    """Define a brokered ACP file credential lifecycle."""
+
+    secret_name: str
+    path: Path | None
+
+    @property
+    def may_have_changed(self) -> bool: ...
+
+    def load(self) -> str | None: ...
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None: ...
+
+    def should_preserve_existing(self, path: Path) -> bool: ...
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None: ...
+
+    def on_auth_succeeded(self, method_id: str) -> None: ...
+
+    def on_session_started(self) -> None: ...
+
+    def sync(self) -> None: ...
+
+    def release(self) -> None: ...
+
+
+def codex_auth_file(env: dict[str, str]) -> Path:
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home) / "auth.json"
+    return Path.home() / _CHATGPT_AUTH_PATH
+
+
+def codex_auth_file_is_chatgpt(env: dict[str, str]) -> bool:
+    path = codex_auth_file(env)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and "tokens" in data
+
+
+def write_secret_file(path: Path, value: str) -> None:
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(fd, 0o600)
+        file = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with file:
+            file.write(value)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _codex_auth_ancestor_file(path: Path) -> Path:
+    return path.with_name(f".{path.name}.cloud-digest")
+
+
+def _read_codex_auth_ancestor(path: Path) -> str | None:
+    try:
+        return _codex_auth_ancestor_file(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _write_codex_auth_ancestor(path: Path, digest: str) -> None:
+    write_secret_file(_codex_auth_ancestor_file(path), digest)
+
+
+def _update_codex_auth_source(
+    source: LookupSecret, value: str, expected_digest: str
+) -> None:
+    response = httpx.put(
+        source.url,
+        headers=source.headers,
+        json={"expected_digest": expected_digest, "value": value},
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def _get_codex_auth_source(source: LookupSecret) -> str:
+    response = httpx.get(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def _touch_codex_auth_source(source: LookupSecret) -> str | None:
+    response = httpx.head(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+    digest = response.headers.get(_CODEX_AUTH_DIGEST_HEADER)
+    return (
+        digest
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest)
+        else None
+    )
+
+
+def _release_codex_auth_source(source: LookupSecret) -> None:
+    response = httpx.delete(
+        source.url,
+        headers=source.headers,
+        timeout=_CODEX_AUTH_HTTP_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def _codex_auth_refresh_url(source: LookupSecret) -> str | None:
+    headers = {name.lower(): value for name, value in source.headers.items()}
+    session_api_key = headers.get(_CODEX_AUTH_SANDBOX_HEADER.lower())
+    codex_auth_token = headers.get(_CODEX_AUTH_SCOPE_HEADER.lower())
+    if not session_api_key or not codex_auth_token:
+        return None
+    url = httpx.URL(source.url)
+    refresh_path = f"{url.path.rstrip('/')}/refresh"
+    return str(
+        url.copy_with(
+            path=refresh_path,
+            username=session_api_key,
+            password=codex_auth_token,
+        )
+    )
+
+
+def _is_valid_codex_auth_value(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(payload, dict) and bool(payload)
+
+
+class _CodexAuthLifecycle:
+    """Manage brokered Codex subscription auth."""
+
+    secret_name = CODEX_AUTH_SECRET_NAME
+
+    def __init__(self, source: LookupSecret, refresh_url: str):
+        self.source = source
+        self.refresh_url = refresh_url
+        self.path: Path | None = None
+        self.expected_digest: str | None = None
+        self.last_remote_check = 0.0
+        self.registry: SecretRegistry | None = None
+        self._may_have_changed = False
+
+    @property
+    def may_have_changed(self) -> bool:
+        return self._may_have_changed
+
+    def load(self) -> str | None:
+        try:
+            return self.source.get_value()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (404, 422):
+                detail = (
+                    "ChatGPT authentication was not found in Cloud."
+                    if exc.response.status_code == 404
+                    else "ChatGPT authentication needs to be refreshed."
+                )
+                raise ACPFileCredentialNeedsReauthError(detail) from exc
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be loaded from Cloud."
+            ) from exc
+
+    def bind(
+        self,
+        path: Path,
+        registry: SecretRegistry,
+        remote_value: str,
+        env: dict[str, str],
+    ) -> None:
+        if not _is_valid_codex_auth_value(remote_value):
+            raise ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials."
+            )
+        self.path = path
+        self.registry = registry
+        self.expected_digest = hashlib.sha256(remote_value.encode()).hexdigest()
+        env[_CODEX_REFRESH_TOKEN_URL_ENV] = self.refresh_url
+        self._track_transport()
+
+    def should_preserve_existing(self, path: Path) -> bool:
+        return _read_codex_auth_ancestor(path) == self.expected_digest
+
+    def record_materialized(self, remote_value: str, local_value: str) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        assert path is not None
+        assert expected_digest is not None
+        _write_codex_auth_ancestor(path, expected_digest)
+        local_digest = hashlib.sha256(local_value.encode()).hexdigest()
+        self.last_remote_check = (
+            time.monotonic() if local_digest == expected_digest else 0.0
+        )
+        if local_digest != expected_digest:
+            self._may_have_changed = True
+        self._track_values(remote_value)
+        if local_digest != expected_digest:
+            self._track_values(local_value)
+
+    def on_auth_succeeded(self, method_id: str) -> None:
+        if method_id == "chat-gpt":
+            self._may_have_changed = True
+
+    def on_session_started(self) -> None:
+        self._may_have_changed = True
+
+    def _track_values(self, value: str) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {self.secret_name: value}
+        try:
+            tokens = json.loads(value).get("tokens", {})
+        except (AttributeError, TypeError, ValueError):
+            tokens = None
+        if isinstance(tokens, dict):
+            for name, token in tokens.items():
+                if isinstance(token, str) and token:
+                    exported_values[f"{self.secret_name}.tokens.{name}"] = token
+        registry.track_exported_values(exported_values)
+
+    def _track_transport(self) -> None:
+        registry = self.registry
+        if registry is None:
+            return
+        exported_values = {
+            f"{self.secret_name}.refresh_url": self.refresh_url,
+        }
+        for name, value in self.source.headers.items():
+            exported_values[f"{self.secret_name}.header.{name.lower()}"] = value
+        registry.track_exported_values(exported_values)
+
+    def sync(self) -> None:
+        path = self.path
+        expected_digest = self.expected_digest
+        if path is None or expected_digest is None:
+            return
+        try:
+            value = path.read_bytes()
+            text_value = value.decode()
+        except (OSError, UnicodeError) as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be saved to Cloud."
+            ) from exc
+        if not _is_valid_codex_auth_value(text_value):
+            raise ACPFileCredentialSyncError(
+                "Local Codex credentials are invalid; the Cloud copy was preserved."
+            )
+        digest = hashlib.sha256(value).hexdigest()
+        changed = digest != expected_digest
+        now = time.monotonic()
+        if (
+            not changed
+            and self.last_remote_check > 0
+            and now - self.last_remote_check < _CODEX_AUTH_REMOTE_CHECK_INTERVAL
+        ):
+            return
+        attempts = len(_CODEX_AUTH_SYNC_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                if changed:
+                    _update_codex_auth_source(self.source, text_value, expected_digest)
+                else:
+                    remote_digest = _touch_codex_auth_source(self.source)
+                    if (
+                        isinstance(remote_digest, str)
+                        and remote_digest != expected_digest
+                    ):
+                        self._adopt(_get_codex_auth_source(self.source))
+                        return
+            except httpx.HTTPStatusError as exc:
+                if changed and exc.response.status_code == 409:
+                    try:
+                        self._adopt(_get_codex_auth_source(self.source))
+                    except (httpx.HTTPError, ACPFileCredentialSyncError) as remote_exc:
+                        if attempt == attempts - 1:
+                            raise ACPFileCredentialSyncError(
+                                "Codex credentials could not be reconciled with Cloud."
+                            ) from remote_exc
+                    else:
+                        return
+                if attempt == attempts - 1:
+                    raise ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            except httpx.RequestError as exc:
+                if attempt == attempts - 1:
+                    raise ACPFileCredentialSyncError(
+                        "Codex credentials could not be saved to Cloud."
+                    ) from exc
+            else:
+                break
+            if attempt < attempts - 1:
+                time.sleep(_CODEX_AUTH_SYNC_DELAYS[attempt])
+        if changed:
+            try:
+                _write_codex_auth_ancestor(path, digest)
+            except OSError as exc:
+                raise ACPFileCredentialSyncError(
+                    "Codex credentials could not be saved to Cloud."
+                ) from exc
+            self._track_values(text_value)
+            self.expected_digest = digest
+        self.last_remote_check = now
+
+    def _adopt(self, value: str) -> None:
+        path = self.path
+        assert path is not None
+        if not _is_valid_codex_auth_value(value):
+            raise ACPFileCredentialSyncError(
+                "Cloud returned invalid Codex credentials; "
+                "the local copy was preserved."
+            )
+        digest = hashlib.sha256(value.encode()).hexdigest()
+        try:
+            write_secret_file(path, value)
+            _write_codex_auth_ancestor(path, digest)
+        except OSError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credentials could not be reconciled with Cloud."
+            ) from exc
+        self._track_values(value)
+        self.expected_digest = digest
+        self.last_remote_check = time.monotonic()
+
+    def release(self) -> None:
+        try:
+            _release_codex_auth_source(self.source)
+        except httpx.HTTPError as exc:
+            raise ACPFileCredentialSyncError(
+                "Codex credential source could not be released."
+            ) from exc
+        self.clear()
+
+    def clear(self) -> None:
+        self.path = None
+        self.expected_digest = None
+        self.last_remote_check = 0.0
+        self.registry = None
+        self._may_have_changed = False
+
+
+def _create_codex_auth_lifecycle(
+    source: LookupSecret,
+) -> ACPFileCredentialLifecycle | None:
+    refresh_url = _codex_auth_refresh_url(source)
+    return _CodexAuthLifecycle(source, refresh_url) if refresh_url is not None else None
+
+
+_ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES: dict[
+    str, Callable[[LookupSecret], ACPFileCredentialLifecycle | None]
+] = {
+    CODEX_AUTH_SECRET_NAME: _create_codex_auth_lifecycle,
+}
+
+
+def create_file_credential_lifecycle(
+    secret_name: str, source: object
+) -> ACPFileCredentialLifecycle | None:
+    if not isinstance(source, LookupSecret):
+        return None
+    factory = _ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES.get(secret_name)
+    return factory(source) if factory is not None else None

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8684,6 +8684,40 @@ class TestACPFileSecretMaterialisation:
             touch_source.assert_not_called()
             agent.close()
 
+    def test_chatgpt_auth_timeout_becomes_auth_required(self, tmp_path):
+        credential = '{"tokens":{"refresh_token":"never-log-this"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+        conn = self._make_conn(auth_method="chat-gpt")
+        cancelled = threading.Event()
+
+        async def hang_until_cancelled(*_args, **_kwargs):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        conn.authenticate.side_effect = hang_until_cancelled
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=credential),
+            patch.object(acp_agent_module, "_ACP_AUTH_TIMEOUT", 0.01),
+            pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info,
+        ):
+            self._run_start(agent, state, conn=conn)
+
+        assert cancelled.is_set()
+        assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
+        assert "did not complete in time" in str(exc_info.value)
+        assert credential not in _acp_error_detail(
+            exc_info.value, state.secret_registry
+        )
+        agent._cleanup()
+
     def test_chatgpt_auth_programming_error_is_not_reclassified(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"r0"}}'
         agent = _make_agent()

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -26,13 +26,13 @@ from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _acp_error_detail,
     _acp_error_indicates_auth,
+    _ACPFileCredentialNeedsReauthError,
+    _ACPFileCredentialSyncError,
     _apply_acp_model,
     _classify_acp_init_error,
     _classify_acp_turn_error,
     _codex_auth_file,
     _codex_model_config_options,
-    _CodexCredentialSyncError,
-    _CodexNeedsReauthError,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -8310,11 +8310,30 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", side_effect=missing),
-            pytest.raises(_CodexNeedsReauthError, match="not found") as exc_info,
+            pytest.raises(
+                _ACPFileCredentialNeedsReauthError, match="not found"
+            ) as exc_info,
         ):
             agent._materialise_file_secrets(state, {})
 
         assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
+
+    def test_broker_load_programming_error_propagates(self, tmp_path):
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(
+                LookupSecret,
+                "get_value",
+                side_effect=RuntimeError("credential loader bug"),
+            ),
+            pytest.raises(RuntimeError, match="credential loader bug"),
+        ):
+            agent._materialise_file_secrets(state, {})
 
     def test_generic_lookup_secret_remains_get_only(self, tmp_path):
         remote = '{"tokens":{"refresh_token":"remote"}}'
@@ -8576,7 +8595,9 @@ class TestACPFileSecretMaterialisation:
         )
         lifecycle.path = auth_path
 
-        with pytest.raises(_CodexCredentialSyncError, match="local copy was preserved"):
+        with pytest.raises(
+            _ACPFileCredentialSyncError, match="local copy was preserved"
+        ):
             lifecycle._adopt("")
 
         assert auth_path.read_text() == local
@@ -8654,7 +8675,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(acp_agent_module, "_touch_codex_auth_source") as touch_source,
             patch.object(acp_agent_module, "_release_codex_auth_source"),
         ):
-            with pytest.raises(_CodexNeedsReauthError) as exc_info:
+            with pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info:
                 self._run_start(agent, state, conn=conn)
             assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
             assert credential not in _acp_error_detail(
@@ -8662,6 +8683,24 @@ class TestACPFileSecretMaterialisation:
             )
             touch_source.assert_not_called()
             agent.close()
+
+    def test_chatgpt_auth_programming_error_is_not_reclassified(self, tmp_path):
+        credential = '{"tokens":{"refresh_token":"r0"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+        conn = self._make_conn(auth_method="chat-gpt")
+        conn.authenticate.side_effect = RuntimeError("credential parser bug")
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=credential),
+            pytest.raises(RuntimeError, match="credential parser bug"),
+        ):
+            self._run_start(agent, state, conn=conn)
+
+        agent._cleanup()
 
     def test_post_auth_sync_failure_does_not_abort_session_start(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"r0"}}'
@@ -8677,7 +8716,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_CodexCredentialSyncError("unavailable"),
+                side_effect=_ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8733,13 +8772,40 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            with pytest.raises(_CodexCredentialSyncError) as exc_info:
+            with pytest.raises(_ACPFileCredentialSyncError) as exc_info:
                 agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
             agent._release_file_credentials()
 
         assert update_value.call_count == 3
+
+    def test_sync_programming_error_is_not_retried_or_wrapped(self, tmp_path):
+        original = '{"tokens":{"refresh_token":"r0"}}'
+        rotated = '{"tokens":{"refresh_token":"r1"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=original),
+            patch.object(
+                acp_agent_module,
+                "_update_codex_auth_source",
+                side_effect=RuntimeError("credential sync bug"),
+            ) as update_value,
+            patch.object(acp_agent_module, "_release_codex_auth_source"),
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
+            with pytest.raises(RuntimeError, match="credential sync bug"):
+                agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        update_value.assert_called_once()
 
     def test_turn_and_shutdown_sync_rotated_credentials(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8814,10 +8880,36 @@ class TestACPFileSecretMaterialisation:
         with patch.object(
             ACPAgent,
             "_sync_file_credentials",
-            side_effect=_CodexCredentialSyncError("unavailable"),
+            side_effect=_ACPFileCredentialSyncError("unavailable"),
         ):
             agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
+
+    def test_best_effort_sync_propagates_programming_error(self, tmp_path):
+        agent = _make_agent()
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+
+        with (
+            patch.object(
+                ACPAgent,
+                "_sync_file_credentials",
+                side_effect=RuntimeError("credential sync bug"),
+            ),
+            pytest.raises(RuntimeError, match="credential sync bug"),
+        ):
+            agent._sync_file_credentials_best_effort_blocking()
+
+        agent.release_runtime()
+
+    def test_release_propagates_lifecycle_programming_error(self, tmp_path):
+        agent = _make_agent()
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.release.side_effect = RuntimeError("credential release bug")
+
+        with pytest.raises(RuntimeError, match="credential release bug"):
+            agent._release_file_credentials()
+
+        assert agent._file_credential_lifecycles == {"TEST_AUTH_JSON": lifecycle}
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
         from openhands.sdk.utils.async_executor import AsyncExecutor
@@ -8852,7 +8944,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_CodexCredentialSyncError("unavailable"),
+                side_effect=_ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             result = agent.ask_agent("question")
@@ -8875,7 +8967,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 acp_agent_module,
                 "_update_codex_auth_source",
-                side_effect=[OSError("offline")] * 3,
+                side_effect=[httpx.ReadTimeout("offline")] * 3,
             ),
             patch.object(acp_agent_module, "_release_codex_auth_source") as release,
         ):
@@ -8883,7 +8975,7 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
 
-            with pytest.raises(_CodexCredentialSyncError):
+            with pytest.raises(_ACPFileCredentialSyncError):
                 agent.close()
             release.assert_called_once()
             assert agent._closed is True

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2496,7 +2496,7 @@ class TestACPAgentAstep:
         mock_client.get_turn_usage_update = MagicMock(return_value=object())
         agent._client = mock_client
         agent._conn = MagicMock()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         executor = AsyncExecutor()
 
@@ -2531,7 +2531,7 @@ class TestACPAgentAstep:
             with (
                 patch.object(
                     ACPAgent,
-                    "_sync_codex_auth",
+                    "_sync_file_credentials",
                     autospec=True,
                     side_effect=lambda _agent: threading.Event().wait(0.05),
                 ),
@@ -7993,6 +7993,21 @@ def _brokered_codex_source() -> LookupSecret:
     )
 
 
+def _codex_lifecycle(agent: ACPAgent) -> acp_agent_module._CodexAuthLifecycle:
+    return cast(
+        acp_agent_module._CodexAuthLifecycle,
+        agent._file_credential_lifecycles["CODEX_AUTH_JSON"],
+    )
+
+
+def _attach_file_credential_lifecycle(agent: ACPAgent, path: Path) -> MagicMock:
+    lifecycle = MagicMock()
+    lifecycle.path = path
+    lifecycle.authenticated = False
+    agent._file_credential_lifecycles["TEST_AUTH_JSON"] = lifecycle
+    return lifecycle
+
+
 class TestACPFileSecretMaterialisation:
     """Codex auth.json / Gemini Vertex SA JSON materialise to the durable
     per-conversation root, with the right data-dir env var, seed-if-absent.
@@ -8264,7 +8279,7 @@ class TestACPFileSecretMaterialisation:
                 )
                 == "<secret-hidden> <secret-hidden>"
             )
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_empty_broker_value_does_not_commit_sync_state(self, tmp_path):
         agent = _make_agent()
@@ -8278,9 +8293,7 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
 
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
-        assert agent._codex_auth_path is None
-        assert agent._codex_auth_source is None
-        assert agent._codex_auth_expected_digest is None
+        assert agent._file_credential_lifecycles == {}
 
     def test_missing_broker_value_requests_reauthentication(self, tmp_path):
         agent = _make_agent()
@@ -8326,8 +8339,8 @@ class TestACPFileSecretMaterialisation:
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         assert auth_path.read_text() == local
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
@@ -8353,13 +8366,13 @@ class TestACPFileSecretMaterialisation:
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
             auth_path.write_text(local)
-            first_agent._release_codex_auth()
+            first_agent._release_file_credentials()
 
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == local
-            resumed_agent._sync_codex_auth()
-            resumed_agent._release_codex_auth()
+            resumed_agent._sync_file_credentials()
+            resumed_agent._release_file_credentials()
 
         assert update_value.call_args.args[1:] == (
             local,
@@ -8388,8 +8401,8 @@ class TestACPFileSecretMaterialisation:
         ):
             agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == remote
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         update.assert_not_called()
 
@@ -8415,13 +8428,13 @@ class TestACPFileSecretMaterialisation:
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
-            first_agent._release_codex_auth()
+            first_agent._release_file_credentials()
 
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == authoritative
-            resumed_agent._sync_codex_auth()
-            resumed_agent._release_codex_auth()
+            resumed_agent._sync_file_credentials()
+            resumed_agent._release_file_credentials()
 
         update_value.assert_not_called()
 
@@ -8456,7 +8469,7 @@ class TestACPFileSecretMaterialisation:
                 auth_path,
                 ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
             )
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             assert (
                 state.secret_registry.mask_secrets_in_output("access-r1 refresh-r1")
                 == "<secret-hidden> <secret-hidden>"
@@ -8477,7 +8490,7 @@ class TestACPFileSecretMaterialisation:
                 "CODEX_AUTH_JSON.header.x-oh-sandbox",
                 "CODEX_AUTH_JSON.header.x-oh-codex",
             }
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_lost_update_response_reconciles_matching_remote_value(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8509,8 +8522,8 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            agent._sync_codex_auth()
-            agent._release_codex_auth()
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
 
         assert update_value.call_count == 2
 
@@ -8546,21 +8559,25 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             auth_path = Path(env["CODEX_HOME"]) / "auth.json"
             auth_path.write_text(rotated)
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             assert auth_path.read_text() == authoritative
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
         update_value.assert_called_once()
         release.assert_called_once()
 
     def test_empty_conflict_value_preserves_working_copy(self, tmp_path):
         local = '{"tokens":{"refresh_token":"local"}}'
-        agent = _make_agent()
         auth_path = tmp_path / "auth.json"
         auth_path.write_text(local)
+        lifecycle = acp_agent_module._CodexAuthLifecycle(
+            _brokered_codex_source(),
+            "https://session-a:scoped.jwt.token@cloud/codex-auth/refresh",
+        )
+        lifecycle.path = auth_path
 
         with pytest.raises(_CodexCredentialSyncError, match="local copy was preserved"):
-            agent._adopt_codex_auth_value(auth_path, "")
+            lifecycle._adopt("")
 
         assert auth_path.read_text() == local
 
@@ -8592,10 +8609,10 @@ class TestACPFileSecretMaterialisation:
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             auth_path = Path(env["CODEX_HOME"]) / "auth.json"
-            agent._codex_auth_last_remote_check = 0.0
-            agent._sync_codex_auth()
+            _codex_lifecycle(agent).last_remote_check = 0.0
+            agent._sync_file_credentials()
             assert auth_path.read_text() == authoritative
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_unchanged_auth_checks_remote_periodically(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8612,13 +8629,13 @@ class TestACPFileSecretMaterialisation:
             patch.object(acp_agent_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
-            agent._sync_codex_auth()
+            agent._sync_file_credentials()
             touch.assert_not_called()
 
-            agent._codex_auth_last_remote_check = 0.0
-            agent._sync_codex_auth()
+            _codex_lifecycle(agent).last_remote_check = 0.0
+            agent._sync_file_credentials()
             touch.assert_called_once()
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
     def test_chatgpt_auth_failure_becomes_auth_required(self, tmp_path):
         credential = '{"tokens":{"refresh_token":"never-log-this"}}'
@@ -8659,7 +8676,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(LookupSecret, "get_value", return_value=credential),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 side_effect=_CodexCredentialSyncError("unavailable"),
             ),
         ):
@@ -8717,10 +8734,10 @@ class TestACPFileSecretMaterialisation:
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
             with pytest.raises(_CodexCredentialSyncError) as exc_info:
-                agent._sync_codex_auth()
+                agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
-            agent._release_codex_auth()
+            agent._release_file_credentials()
 
         assert update_value.call_count == 3
 
@@ -8756,7 +8773,7 @@ class TestACPFileSecretMaterialisation:
 
             conn.prompt = AsyncMock(side_effect=rotate_during_turn)
             asyncio.run(agent._do_acp_prompt([]))
-            agent._sync_codex_auth_best_effort_blocking()
+            agent._sync_file_credentials_best_effort_blocking()
             assert update_value.call_args.args[1:] == (
                 after_turn,
                 hashlib.sha256(original.encode()).hexdigest(),
@@ -8774,11 +8791,13 @@ class TestACPFileSecretMaterialisation:
 
     def test_finalizer_skips_network_sync(self, tmp_path):
         agent = _make_agent()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         with (
-            patch.object(ACPAgent, "_sync_codex_auth", autospec=True) as sync,
-            patch.object(ACPAgent, "_release_codex_auth", autospec=True) as release,
+            patch.object(ACPAgent, "_sync_file_credentials", autospec=True) as sync,
+            patch.object(
+                ACPAgent, "_release_file_credentials", autospec=True
+            ) as release,
             patch.object(ACPAgent, "_cleanup", autospec=True) as cleanup,
         ):
             agent.__del__()
@@ -8790,14 +8809,14 @@ class TestACPFileSecretMaterialisation:
 
     def test_best_effort_sync_survives_failure(self, tmp_path):
         agent = _make_agent()
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
 
         with patch.object(
             ACPAgent,
-            "_sync_codex_auth",
+            "_sync_file_credentials",
             side_effect=_CodexCredentialSyncError("unavailable"),
         ):
-            agent._sync_codex_auth_best_effort_blocking()
+            agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
@@ -8813,7 +8832,7 @@ class TestACPFileSecretMaterialisation:
         agent._client = client
         agent._session_id = "session"
         agent._working_dir = str(tmp_path)
-        agent._codex_auth_path = tmp_path / "auth.json"
+        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
         agent._executor = AsyncExecutor()
         conn = MagicMock()
         conn.fork_session = AsyncMock(
@@ -8832,7 +8851,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(ACPAgent, "_record_usage"),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 side_effect=_CodexCredentialSyncError("unavailable"),
             ),
         ):
@@ -8869,7 +8888,7 @@ class TestACPFileSecretMaterialisation:
             release.assert_called_once()
             assert agent._closed is True
 
-        assert agent._codex_auth_source is None
+        assert agent._file_credential_lifecycles == {}
 
     def test_materialisation_failure_releases_brokered_source(self, tmp_path):
         agent = _make_agent()
@@ -8906,9 +8925,10 @@ class TestACPFileSecretMaterialisation:
         order: list[str] = []
 
         def fail_after_authentication(current_agent, _state):
-            current_agent._codex_auth_authenticated = True
-            current_agent._codex_auth_path = tmp_path / "auth.json"
-            current_agent._codex_auth_source = _brokered_codex_source()
+            lifecycle = _attach_file_credential_lifecycle(
+                current_agent, tmp_path / "auth.json"
+            )
+            lifecycle.authenticated = True
             raise RuntimeError("session creation failed")
 
         def record_sync(current_agent):
@@ -8928,13 +8948,13 @@ class TestACPFileSecretMaterialisation:
             ),
             patch.object(
                 ACPAgent,
-                "_sync_codex_auth",
+                "_sync_file_credentials",
                 autospec=True,
                 side_effect=record_sync,
             ),
             patch.object(
                 ACPAgent,
-                "_release_codex_auth",
+                "_release_file_credentials",
                 autospec=True,
                 side_effect=record_release,
             ),
@@ -9150,6 +9170,50 @@ class TestACPFileSecretMaterialisation:
         # The built-in Codex/Gemini specs were replaced, so their secrets would
         # NOT be materialised by this agent.
         assert agent._present_file_secret_names(state) == {"MYCLI_TOKEN_JSON"}
+
+    def test_registered_custom_file_credential_lifecycle_is_used(self, tmp_path):
+        from openhands.sdk import ACPFileSecretSpec
+
+        custom = ACPFileSecretSpec(
+            secret_name="MYCLI_TOKEN_JSON",
+            filename="token.json",
+            env_var="MYCLI_HOME",
+            subdir="mycli",
+            env_points_to="dir",
+        )
+        source = LookupSecret(url="https://broker.example/mycli")
+        lifecycle = MagicMock()
+        lifecycle.load.return_value = '{"token":"current"}'
+        lifecycle.should_preserve_existing.return_value = False
+        lifecycle.authenticated = False
+        factory = MagicMock(return_value=lifecycle)
+        agent = _make_agent(acp_file_secrets=[custom])
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets({"MYCLI_TOKEN_JSON": source})
+
+        with patch.dict(
+            acp_agent_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
+            {"MYCLI_TOKEN_JSON": factory},
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        target = Path(env["MYCLI_HOME"]) / "token.json"
+        factory.assert_called_once_with(source)
+        lifecycle.bind.assert_called_once_with(
+            target,
+            state.secret_registry,
+            '{"token":"current"}',
+            env,
+        )
+        lifecycle.record_materialized.assert_called_once_with(
+            '{"token":"current"}', '{"token":"current"}'
+        )
+        lifecycle.sync.assert_called_once_with()
+        lifecycle.release.assert_called_once_with()
+        assert agent._file_credential_lifecycles == {}
 
     def test_empty_specs_disables_materialisation(self, tmp_path):
         """With acp_file_secrets=[], a CODEX_AUTH_JSON secret is treated as an

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -22,16 +22,14 @@ from acp.schema import NewSessionResponse, PromptResponse
 from pydantic import SecretStr
 
 import openhands.sdk.agent.acp_agent as acp_agent_module
+import openhands.sdk.agent.acp_file_credentials as acp_file_credentials_module
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _acp_error_detail,
     _acp_error_indicates_auth,
-    _ACPFileCredentialNeedsReauthError,
-    _ACPFileCredentialSyncError,
     _apply_acp_model,
     _classify_acp_init_error,
     _classify_acp_turn_error,
-    _codex_auth_file,
     _codex_model_config_options,
     _estimate_cost_from_tokens,
     _extract_session_models,
@@ -47,6 +45,11 @@ from openhands.sdk.agent.acp_agent import (
     _stringify_acp_error_data,
     _strip_inherited_npm_env,
     _with_codex_base_url,
+)
+from openhands.sdk.agent.acp_file_credentials import (
+    ACPFileCredentialNeedsReauthError,
+    ACPFileCredentialSyncError,
+    codex_auth_file,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
@@ -4442,14 +4445,14 @@ class TestSelectAuthMethod:
             assert _select_auth_method(methods, env) == "api-key"
 
     def test_codex_auth_file_honors_codex_home(self, tmp_path):
-        """_codex_auth_file points at $CODEX_HOME/auth.json when set, else
+        """codex_auth_file points at $CODEX_HOME/auth.json when set, else
         ~/.codex/auth.json."""
         home = tmp_path / "home"
         home.mkdir()
-        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=home):
-            assert _codex_auth_file({}) == home / ".codex" / "auth.json"
+        with patch.object(acp_file_credentials_module.Path, "home", return_value=home):
+            assert codex_auth_file({}) == home / ".codex" / "auth.json"
         ch = tmp_path / "ch"
-        assert _codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
+        assert codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
 
     # -- apikey-format auth.json must not be treated as chatgpt (#3627) -----
 
@@ -7993,18 +7996,26 @@ def _brokered_codex_source() -> LookupSecret:
     )
 
 
-def _codex_lifecycle(agent: ACPAgent) -> acp_agent_module._CodexAuthLifecycle:
+def _codex_lifecycle(
+    agent: ACPAgent,
+) -> acp_file_credentials_module._CodexAuthLifecycle:
     return cast(
-        acp_agent_module._CodexAuthLifecycle,
+        acp_file_credentials_module._CodexAuthLifecycle,
         agent._file_credential_lifecycles["CODEX_AUTH_JSON"],
     )
 
 
-def _attach_file_credential_lifecycle(agent: ACPAgent, path: Path) -> MagicMock:
+def _attach_file_credential_lifecycle(
+    agent: ACPAgent,
+    path: Path,
+    *,
+    may_have_changed: bool = True,
+    name: str = "TEST_AUTH_JSON",
+) -> MagicMock:
     lifecycle = MagicMock()
     lifecycle.path = path
-    lifecycle.authenticated = False
-    agent._file_credential_lifecycles["TEST_AUTH_JSON"] = lifecycle
+    lifecycle.may_have_changed = may_have_changed
+    agent._file_credential_lifecycles[name] = lifecycle
     return lifecycle
 
 
@@ -8126,6 +8137,23 @@ class TestACPFileSecretMaterialisation:
         # The blob is not exported as an env var.
         assert "CODEX_AUTH_JSON" not in env
 
+    def test_secret_file_replace_failure_preserves_existing_value(self, tmp_path):
+        path = tmp_path / "auth.json"
+        path.write_text("original")
+
+        with (
+            patch.object(
+                acp_file_credentials_module.os,
+                "replace",
+                side_effect=OSError("disk full"),
+            ),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            acp_file_credentials_module.write_secret_file(path, "replacement")
+
+        assert path.read_text() == "original"
+        assert list(tmp_path.iterdir()) == [path]
+
     def test_rotated_lookup_secret_is_available_to_next_conversation(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
         rotated = '{"tokens":{"refresh_token":"r1"}}'
@@ -8145,16 +8173,16 @@ class TestACPFileSecretMaterialisation:
                 side_effect=lambda _source: cloud["value"],
             ) as get_value,
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 autospec=True,
                 side_effect=update,
             ) as update_value,
             patch.object(
-                acp_agent_module, "_touch_codex_auth_source", autospec=True
+                acp_file_credentials_module, "_touch_codex_auth_source", autospec=True
             ) as touch,
             patch.object(
-                acp_agent_module, "_release_codex_auth_source", autospec=True
+                acp_file_credentials_module, "_release_codex_auth_source", autospec=True
             ) as release,
         ):
             first_root = tmp_path / "first"
@@ -8207,45 +8235,45 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(
-                acp_agent_module.httpx, "put", return_value=response
+                acp_file_credentials_module.httpx, "put", return_value=response
             ) as mock_put,
             patch.object(
-                acp_agent_module.httpx, "get", return_value=response
+                acp_file_credentials_module.httpx, "get", return_value=response
             ) as mock_get,
             patch.object(
-                acp_agent_module.httpx, "head", return_value=response
+                acp_file_credentials_module.httpx, "head", return_value=response
             ) as mock_head,
             patch.object(
-                acp_agent_module.httpx, "delete", return_value=response
+                acp_file_credentials_module.httpx, "delete", return_value=response
             ) as mock_delete,
         ):
-            acp_agent_module._update_codex_auth_source(
+            acp_file_credentials_module._update_codex_auth_source(
                 source, "rotated", "original-digest"
             )
-            acp_agent_module._get_codex_auth_source(source)
-            acp_agent_module._touch_codex_auth_source(source)
-            acp_agent_module._release_codex_auth_source(source)
+            acp_file_credentials_module._get_codex_auth_source(source)
+            acp_file_credentials_module._touch_codex_auth_source(source)
+            acp_file_credentials_module._release_codex_auth_source(source)
 
         mock_put.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
             json={"expected_digest": "original-digest", "value": "rotated"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_get.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_head.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         mock_delete.assert_called_once_with(
             "https://cloud/codex-auth",
             headers={"Authorization": "Bearer scoped"},
-            timeout=acp_agent_module._CODEX_AUTH_HTTP_TIMEOUT,
+            timeout=acp_file_credentials_module._CODEX_AUTH_HTTP_TIMEOUT,
         )
         assert response.raise_for_status.call_count == 4
 
@@ -8264,7 +8292,7 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8288,12 +8316,18 @@ class TestACPFileSecretMaterialisation:
             {"CODEX_AUTH_JSON": _brokered_codex_source()}
         )
 
-        with patch.object(LookupSecret, "get_value", return_value=""):
+        with (
+            patch.object(LookupSecret, "get_value", return_value=""),
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
+        ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
 
         assert "CODEX_REFRESH_TOKEN_URL_OVERRIDE" not in env
         assert agent._file_credential_lifecycles == {}
+        release.assert_called_once()
 
     def test_missing_broker_value_requests_reauthentication(self, tmp_path):
         agent = _make_agent()
@@ -8311,7 +8345,7 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", side_effect=missing),
             pytest.raises(
-                _ACPFileCredentialNeedsReauthError, match="not found"
+                ACPFileCredentialNeedsReauthError, match="not found"
             ) as exc_info,
         ):
             agent._materialise_file_secrets(state, {})
@@ -8352,9 +8386,15 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8379,8 +8419,10 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
@@ -8390,6 +8432,7 @@ class TestACPFileSecretMaterialisation:
             resumed_agent = _make_agent()
             resumed_agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == local
+            assert _codex_lifecycle(resumed_agent).may_have_changed is True
             resumed_agent._sync_file_credentials()
             resumed_agent._release_file_credentials()
 
@@ -8415,8 +8458,10 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=remote),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
             assert auth_path.read_text() == remote
@@ -8437,13 +8482,15 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", side_effect=[stale, authoritative]),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module,
                 "_touch_codex_auth_source",
                 return_value=hashlib.sha256(authoritative.encode()).hexdigest(),
             ),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             first_agent = _make_agent()
             first_agent._materialise_file_secrets(state, {})
@@ -8470,8 +8517,8 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_update_codex_auth_source"),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_update_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8529,14 +8576,16 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module, "_get_codex_auth_source", return_value=rotated
+                acp_file_credentials_module,
+                "_get_codex_auth_source",
+                return_value=rotated,
             ),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=[httpx.ReadTimeout("response lost"), conflict],
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8565,14 +8614,18 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_get_codex_auth_source",
                 return_value=authoritative,
             ),
             patch.object(
-                acp_agent_module, "_update_codex_auth_source", side_effect=conflict
+                acp_file_credentials_module,
+                "_update_codex_auth_source",
+                side_effect=conflict,
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8589,18 +8642,52 @@ class TestACPFileSecretMaterialisation:
         local = '{"tokens":{"refresh_token":"local"}}'
         auth_path = tmp_path / "auth.json"
         auth_path.write_text(local)
-        lifecycle = acp_agent_module._CodexAuthLifecycle(
+        lifecycle = acp_file_credentials_module._CodexAuthLifecycle(
             _brokered_codex_source(),
             "https://session-a:scoped.jwt.token@cloud/codex-auth/refresh",
         )
         lifecycle.path = auth_path
 
         with pytest.raises(
-            _ACPFileCredentialSyncError, match="local copy was preserved"
+            ACPFileCredentialSyncError, match="local copy was preserved"
         ):
             lifecycle._adopt("")
 
         assert auth_path.read_text() == local
+
+    def test_invalid_local_value_never_overwrites_cloud(self, tmp_path):
+        original = '{"tokens":{"refresh_token":"r0"}}'
+        rotated = '{"tokens":{"refresh_token":"r1"}}'
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": _brokered_codex_source()}
+        )
+
+        with (
+            patch.object(LookupSecret, "get_value", return_value=original),
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
+        ):
+            env: dict[str, str] = {}
+            agent._materialise_file_secrets(state, env)
+            auth_path = Path(env["CODEX_HOME"]) / "auth.json"
+            auth_path.write_text("truncated")
+
+            with pytest.raises(
+                ACPFileCredentialSyncError, match="Cloud copy was preserved"
+            ):
+                agent._sync_file_credentials()
+
+            update.assert_not_called()
+            auth_path.write_text(rotated)
+            agent._sync_file_credentials()
+            agent._release_file_credentials()
+
+        update.assert_called_once()
+        assert update.call_args.args[1] == rotated
 
     def test_remote_digest_change_updates_unchanged_working_copy(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
@@ -8615,17 +8702,19 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_get_codex_auth_source",
                 return_value=authoritative,
             ),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_touch_codex_auth_source",
                 return_value=remote_digest,
             ),
-            patch.object(acp_agent_module.time, "monotonic", return_value=1.0),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module.time, "monotonic", return_value=1.0
+            ),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8645,9 +8734,13 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch,
-            patch.object(acp_agent_module.time, "monotonic", return_value=1.0),
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch,
+            patch.object(
+                acp_file_credentials_module.time, "monotonic", return_value=1.0
+            ),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             agent._materialise_file_secrets(state, {})
             agent._sync_file_credentials()
@@ -8672,10 +8765,12 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_touch_codex_auth_source") as touch_source,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(
+                acp_file_credentials_module, "_touch_codex_auth_source"
+            ) as touch_source,
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
-            with pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info:
+            with pytest.raises(ACPFileCredentialNeedsReauthError) as exc_info:
                 self._run_start(agent, state, conn=conn)
             assert _classify_acp_init_error(exc_info.value) == "ACPAuthRequired"
             assert credential not in _acp_error_detail(
@@ -8706,7 +8801,7 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
             patch.object(acp_agent_module, "_ACP_AUTH_TIMEOUT", 0.01),
-            pytest.raises(_ACPFileCredentialNeedsReauthError) as exc_info,
+            pytest.raises(ACPFileCredentialNeedsReauthError) as exc_info,
         ):
             self._run_start(agent, state, conn=conn)
 
@@ -8750,7 +8845,7 @@ class TestACPFileSecretMaterialisation:
             patch.object(
                 ACPAgent,
                 "_sync_file_credentials",
-                side_effect=_ACPFileCredentialSyncError("unavailable"),
+                side_effect=ACPFileCredentialSyncError("unavailable"),
             ),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8771,7 +8866,9 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=credential),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update,
             pytest.raises(BrokenPipeError, match="connection closed"),
         ):
             self._run_start(agent, state, conn=conn)
@@ -8797,16 +8894,16 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=unavailable,
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
-            with pytest.raises(_ACPFileCredentialSyncError) as exc_info:
+            with pytest.raises(ACPFileCredentialSyncError) as exc_info:
                 agent._sync_file_credentials()
             assert _classify_acp_turn_error(exc_info.value) == "ACPAuthRequired"
             assert rotated not in str(exc_info.value)
@@ -8826,11 +8923,11 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=RuntimeError("credential sync bug"),
             ) as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source"),
+            patch.object(acp_file_credentials_module, "_release_codex_auth_source"),
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8860,8 +8957,12 @@ class TestACPFileSecretMaterialisation:
 
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
-            patch.object(acp_agent_module, "_update_codex_auth_source") as update_value,
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_update_codex_auth_source"
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
@@ -8909,41 +9010,101 @@ class TestACPFileSecretMaterialisation:
 
     def test_best_effort_sync_survives_failure(self, tmp_path):
         agent = _make_agent()
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.sync.side_effect = ACPFileCredentialSyncError("unavailable")
 
-        with patch.object(
-            ACPAgent,
-            "_sync_file_credentials",
-            side_effect=_ACPFileCredentialSyncError("unavailable"),
-        ):
-            agent._sync_file_credentials_best_effort_blocking()
+        agent._sync_file_credentials_best_effort_blocking()
         agent.release_runtime()
 
-    def test_best_effort_sync_propagates_programming_error(self, tmp_path):
+    def test_best_effort_sync_survives_programming_error(self, tmp_path):
         agent = _make_agent()
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        failing = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
+        failing.sync.side_effect = RuntimeError("credential sync bug")
 
-        with (
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                side_effect=RuntimeError("credential sync bug"),
-            ),
-            pytest.raises(RuntimeError, match="credential sync bug"),
-        ):
-            agent._sync_file_credentials_best_effort_blocking()
+        agent._sync_file_credentials_best_effort_blocking()
 
+        failing.sync.assert_called_once_with()
+        succeeding.sync.assert_called_once_with()
+        agent.release_runtime()
+
+    def test_sync_attempts_every_lifecycle_before_raising(self, tmp_path):
+        agent = _make_agent()
+        failing = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
+        failing.sync.side_effect = RuntimeError("first sync failed")
+
+        with pytest.raises(RuntimeError, match="first sync failed"):
+            agent._sync_file_credentials()
+
+        failing.sync.assert_called_once_with()
+        succeeding.sync.assert_called_once_with()
+        agent.release_runtime()
+
+    @pytest.mark.parametrize(
+        ("method_id", "expected_name"),
+        [("chat-gpt", "CODEX_AUTH_JSON"), ("custom-oauth", "OTHER_AUTH_JSON")],
+    )
+    def test_auth_method_sync_is_owned_by_each_lifecycle(
+        self, tmp_path, method_id, expected_name
+    ):
+        agent = _make_agent()
+        codex = _attach_file_credential_lifecycle(
+            agent,
+            tmp_path / "codex.json",
+            may_have_changed=False,
+            name="CODEX_AUTH_JSON",
+        )
+        other = _attach_file_credential_lifecycle(
+            agent,
+            tmp_path / "other.json",
+            may_have_changed=False,
+            name="OTHER_AUTH_JSON",
+        )
+
+        def mark_codex(current_method):
+            codex.may_have_changed = current_method == "chat-gpt"
+
+        def mark_other(current_method):
+            other.may_have_changed = current_method == "custom-oauth"
+
+        codex.on_auth_succeeded.side_effect = mark_codex
+        other.on_auth_succeeded.side_effect = mark_other
+
+        agent._notify_file_credentials_auth_succeeded(method_id)
+        agent._sync_file_credentials_best_effort_blocking(changed_only=True)
+
+        expected = codex if expected_name == "CODEX_AUTH_JSON" else other
+        skipped = other if expected is codex else codex
+        expected.sync.assert_called_once_with()
+        skipped.sync.assert_not_called()
         agent.release_runtime()
 
     def test_release_propagates_lifecycle_programming_error(self, tmp_path):
         agent = _make_agent()
-        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(
+            agent, tmp_path / "first.json", name="FIRST_AUTH_JSON"
+        )
+        succeeding = _attach_file_credential_lifecycle(
+            agent, tmp_path / "second.json", name="SECOND_AUTH_JSON"
+        )
         lifecycle.release.side_effect = RuntimeError("credential release bug")
 
         with pytest.raises(RuntimeError, match="credential release bug"):
             agent._release_file_credentials()
 
-        assert agent._file_credential_lifecycles == {"TEST_AUTH_JSON": lifecycle}
+        lifecycle.release.assert_called_once_with()
+        succeeding.release.assert_called_once_with()
+        assert agent._file_credential_lifecycles == {"FIRST_AUTH_JSON": lifecycle}
+        agent.release_runtime()
 
     def test_successful_fork_survives_sync_failure(self, tmp_path):
         from openhands.sdk.utils.async_executor import AsyncExecutor
@@ -8958,7 +9119,8 @@ class TestACPFileSecretMaterialisation:
         agent._client = client
         agent._session_id = "session"
         agent._working_dir = str(tmp_path)
-        _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle = _attach_file_credential_lifecycle(agent, tmp_path / "auth.json")
+        lifecycle.sync.side_effect = ACPFileCredentialSyncError("unavailable")
         agent._executor = AsyncExecutor()
         conn = MagicMock()
         conn.fork_session = AsyncMock(
@@ -8973,21 +9135,14 @@ class TestACPFileSecretMaterialisation:
         conn.close = AsyncMock()
         agent._conn = conn
 
-        with (
-            patch.object(ACPAgent, "_record_usage"),
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                side_effect=_ACPFileCredentialSyncError("unavailable"),
-            ),
-        ):
+        with patch.object(ACPAgent, "_record_usage"):
             result = agent.ask_agent("question")
 
         assert result == "answer"
         agent._cleanup()
         agent.release_runtime()
 
-    def test_close_releases_source_and_stays_closed_when_sync_fails(self, tmp_path):
+    def test_close_retains_source_until_failed_sync_can_retry(self, tmp_path):
         original = '{"tokens":{"refresh_token":"r0"}}'
         rotated = '{"tokens":{"refresh_token":"r1"}}'
         agent = _make_agent()
@@ -8999,20 +9154,27 @@ class TestACPFileSecretMaterialisation:
         with (
             patch.object(LookupSecret, "get_value", return_value=original),
             patch.object(
-                acp_agent_module,
+                acp_file_credentials_module,
                 "_update_codex_auth_source",
                 side_effect=[httpx.ReadTimeout("offline")] * 3,
-            ),
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            ) as update_value,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
         ):
             env: dict[str, str] = {}
             agent._materialise_file_secrets(state, env)
             (Path(env["CODEX_HOME"]) / "auth.json").write_text(rotated)
 
-            with pytest.raises(_ACPFileCredentialSyncError):
+            with pytest.raises(ACPFileCredentialSyncError):
                 agent.close()
-            release.assert_called_once()
+            release.assert_not_called()
             assert agent._closed is True
+            assert agent._file_credential_lifecycles
+
+            update_value.side_effect = None
+            agent.close()
+            release.assert_called_once()
 
         assert agent._file_credential_lifecycles == {}
 
@@ -9034,36 +9196,45 @@ class TestACPFileSecretMaterialisation:
                 side_effect=materialise,
             ),
             patch.object(
-                acp_agent_module,
-                "_write_secret_file",
+                acp_file_credentials_module,
+                "write_secret_file",
                 side_effect=OSError("disk full"),
             ),
-            patch.object(acp_agent_module, "_release_codex_auth_source") as release,
+            patch.object(
+                acp_file_credentials_module, "_release_codex_auth_source"
+            ) as release,
             pytest.raises(OSError, match="disk full"),
         ):
             agent.init_state(state, lambda _event: None)
 
         release.assert_called_once_with(source)
 
-    def test_init_failure_syncs_before_releasing_authenticated_source(self, tmp_path):
+    def test_init_failure_isolates_sync_and_release_failures(self, tmp_path):
         agent = _make_agent()
         state = self._state(tmp_path)
         order: list[str] = []
 
         def fail_after_authentication(current_agent, _state):
-            lifecycle = _attach_file_credential_lifecycle(
-                current_agent, tmp_path / "auth.json"
+            failing = _attach_file_credential_lifecycle(
+                current_agent,
+                tmp_path / "first.json",
+                name="FIRST_AUTH_JSON",
             )
-            lifecycle.authenticated = True
+            succeeding = _attach_file_credential_lifecycle(
+                current_agent,
+                tmp_path / "second.json",
+                name="SECOND_AUTH_JSON",
+            )
+
+            def fail_sync():
+                order.append("sync first")
+                raise ACPFileCredentialSyncError("offline")
+
+            failing.sync.side_effect = fail_sync
+            failing.release.side_effect = lambda: order.append("release first")
+            succeeding.sync.side_effect = lambda: order.append("sync second")
+            succeeding.release.side_effect = lambda: order.append("release second")
             raise RuntimeError("session creation failed")
-
-        def record_sync(current_agent):
-            if current_agent is agent:
-                order.append("sync")
-
-        def record_release(current_agent):
-            if current_agent is agent:
-                order.append("release")
 
         with (
             patch.object(
@@ -9072,23 +9243,13 @@ class TestACPFileSecretMaterialisation:
                 autospec=True,
                 side_effect=fail_after_authentication,
             ),
-            patch.object(
-                ACPAgent,
-                "_sync_file_credentials",
-                autospec=True,
-                side_effect=record_sync,
-            ),
-            patch.object(
-                ACPAgent,
-                "_release_file_credentials",
-                autospec=True,
-                side_effect=record_release,
-            ),
             pytest.raises(RuntimeError, match="session creation failed"),
         ):
             agent.init_state(state, lambda _event: None)
 
-        assert order == ["sync", "release"]
+        assert order == ["sync first", "sync second", "release second"]
+        assert set(agent._file_credential_lifecycles) == {"FIRST_AUTH_JSON"}
+        agent.release_runtime()
 
     def test_gemini_vertex_sa_materialises_and_points_at_file(self, tmp_path):
         from openhands.sdk.secret import StaticSecret
@@ -9210,7 +9371,7 @@ class TestACPFileSecretMaterialisation:
             {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
         )
         with patch(
-            "openhands.sdk.agent.acp_agent._write_secret_file",
+            "openhands.sdk.agent.acp_agent.write_secret_file",
             side_effect=OSError("[Errno 30] Read-only file system"),
         ):
             with pytest.raises(OSError, match="Read-only file system"):
@@ -9311,14 +9472,14 @@ class TestACPFileSecretMaterialisation:
         lifecycle = MagicMock()
         lifecycle.load.return_value = '{"token":"current"}'
         lifecycle.should_preserve_existing.return_value = False
-        lifecycle.authenticated = False
+        lifecycle.may_have_changed = False
         factory = MagicMock(return_value=lifecycle)
         agent = _make_agent(acp_file_secrets=[custom])
         state = self._state(tmp_path)
         state.secret_registry.update_secrets({"MYCLI_TOKEN_JSON": source})
 
         with patch.dict(
-            acp_agent_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
+            acp_file_credentials_module._ACP_FILE_CREDENTIAL_LIFECYCLE_FACTORIES,
             {"MYCLI_TOKEN_JSON": factory},
         ):
             env: dict[str, str] = {}

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -19,7 +19,6 @@ from openhands.sdk.conversation.state import (
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import Message, MessageToolCall, TextContent, llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.sdk.secret import LookupSecret
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.utils.cipher import Cipher
 from tests.conftest import create_mock_litellm_response
@@ -214,14 +213,11 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     conv, old_agent = _make_acp_conversation(tmp_path)
     live_conn = old_agent._conn
     live_executor = old_agent._executor
-    source = LookupSecret(url="https://cloud/codex-auth", headers={})
-    old_agent._codex_auth_path = tmp_path / "auth.json"
-    old_agent._codex_auth_source = source
-    old_agent._codex_auth_expected_digest = "expected"
-    old_agent._codex_auth_last_remote_check = 42.0
-    old_agent._codex_auth_registry = conv.state.secret_registry
-    old_agent._codex_auth_authenticated = True
-    codex_auth_lock = old_agent._codex_auth_lock
+    lifecycle = MagicMock()
+    lifecycle.path = tmp_path / "auth.json"
+    lifecycle.authenticated = True
+    old_agent._file_credential_lifecycles["CODEX_AUTH_JSON"] = lifecycle
+    credential_lock = old_agent._file_credential_lock
 
     conv.switch_acp_model("model-b")
 
@@ -230,13 +226,8 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     assert isinstance(switched, ACPAgent)
     assert switched._conn is live_conn
     assert switched._executor is live_executor
-    assert switched._codex_auth_path == tmp_path / "auth.json"
-    assert switched._codex_auth_source is source
-    assert switched._codex_auth_expected_digest == "expected"
-    assert switched._codex_auth_last_remote_check == 42.0
-    assert switched._codex_auth_registry is conv.state.secret_registry
-    assert switched._codex_auth_authenticated is True
-    assert switched._codex_auth_lock is codex_auth_lock
+    assert switched._file_credential_lifecycles == {"CODEX_AUTH_JSON": lifecycle}
+    assert switched._file_credential_lock is credential_lock
 
     # ...and the discarded agent's finalizer was disarmed (marked closed)
     # WITHOUT clearing its runtime references — an in-flight ask_agent()/fork
@@ -244,12 +235,7 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     assert old_agent._closed is True
     assert old_agent._conn is live_conn
     assert old_agent._executor is live_executor
-    assert old_agent._codex_auth_path is None
-    assert old_agent._codex_auth_source is None
-    assert old_agent._codex_auth_expected_digest is None
-    assert old_agent._codex_auth_last_remote_check == 0.0
-    assert old_agent._codex_auth_registry is None
-    assert old_agent._codex_auth_authenticated is False
+    assert old_agent._file_credential_lifecycles == {}
 
     # Simulating GC (__del__ -> close()) on the disarmed old agent is a no-op:
     # the copy's shared connection/executor are left intact.

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -215,7 +215,7 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     live_executor = old_agent._executor
     lifecycle = MagicMock()
     lifecycle.path = tmp_path / "auth.json"
-    lifecycle.authenticated = True
+    lifecycle.may_have_changed = True
     old_agent._file_credential_lifecycles["CODEX_AUTH_JSON"] = lifecycle
     credential_lock = old_agent._file_credential_lock
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

PR #4124 adds the first writable, brokered ACP file credential, but its materialization, synchronization, masking, authentication, and release state lived directly on the generic `ACPAgent`. Adding another ACP provider with rotating file credentials would require another set of provider branches in that class.

## Summary

- Add a provider-neutral internal file-credential lifecycle protocol and factory registry, with Codex registered as the first implementation.
- Move Codex broker state and reconciliation behind that lifecycle while keeping `ACPAgent` responsible only for orchestration across registered lifecycles.
- Preserve GET-only behavior for ordinary `LookupSecret` values and preserve credential lifecycle ownership across shallow ACP model switches.
- Add coverage proving a custom provider lifecycle can materialize, sync, and release without modifying `ACPAgent`.

## Issue Number

Follow-up refactor for #4124.

## How to Test

```bash
make build
uv run pytest -q tests/sdk/agent/test_acp_agent.py tests/sdk/conversation/test_switch_model.py
# 458 passed, 2 unrelated LiteLLM pricing warnings

uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/agent/acp_agent.py \
  tests/sdk/agent/test_acp_agent.py \
  tests/sdk/conversation/test_switch_model.py
# Ruff format/lint, pycodestyle, Pyright, import rules, and tool registration passed
```

The custom-provider regression test drives the real file materialization path through a registered lifecycle, then exercises sync and release. Existing tests continue to exercise Codex broker GET/HEAD/PUT/DELETE, CAS reconciliation, masking, generic GET-only lookups, turn sync, shutdown, and error handling. This refactor does not alter the broker wire protocol, so the concurrent Codex E2E evidence on the base PR remains applicable.

## Live Evidence (agent-authored)

_This Live Evidence update was generated by an AI agent (OpenHands) on behalf of the user._

Date: 2026-07-19 UTC  
Environment: OpenHands runtime Linux container on branch `agent/acp-credential-lifecycle-adapter`, head `b5e8ee4ee268e363469ad50da347b8055bd9be0b`; `make build` completed with `uv 0.11.24`; tests ran under Python 3.13.14 against the workspace SDK (`OpenHands SDK v1.36.1`).

Live ACP credential lifecycle validation:

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run python - <<'PY'
# Inline harness started a real loopback ThreadingHTTPServer credential broker,
# wrote a temporary ACP server process using acp.run_agent(...), launched it
# through ACPAgent(acp_command=[.venv/bin/python, <temp live_acp_process.py>]),
# passed CODEX_AUTH_JSON as a LookupSecret with X-OH-Sandbox/X-OH-Codex broker
# headers, sent one Conversation message, then closed the conversation.
PY
```

Observed output:

```text
LIVE_ACP_CREDENTIAL_LIFECYCLE_OK
date_utc=2026-07-19
workspace=/tmp/pr4148-live-acp-efwba6c7
broker_url=http://127.0.0.1:33865/codex/auth
broker_methods=GET,PUT,DELETE
broker_final_digest=5b9e9e57ca1b1ddf5a2f151df2f53720af889ad66d6250a08ce75fd4d86ac648
child_events=initialize,authenticate,new_session,set_session_mode,prompt
observed=GET materialized broker credential; ACP subprocess authenticated from CODEX_HOME/auth.json and rewrote it; SDK synced rotated file with CAS PUT; close released broker source with DELETE
limitations=local loopback broker and purpose-built ACP subprocess; no real ChatGPT/Codex external account was used
```

Observed behavior details:

- The broker received `GET` with the expected scoped broker headers, and `ACPAgent` materialized `CODEX_AUTH_JSON` into the per-conversation `acp/codex/auth.json` file.
- The ACP subprocess was a separate real process speaking ACP over stdio via `acp.run_agent(...)`; it completed `initialize`, selected `chat-gpt` auth from the materialized Codex auth file, verified `CODEX_REFRESH_TOKEN_URL_OVERRIDE` contained broker userinfo, rewrote `auth.json`, completed `session/new`, accepted `agent-full-access`, and handled a real prompt.
- `ACPAgent` synced the subprocess-rotated file back to the broker with CAS `PUT` using the original digest, then `Conversation.close()` released the brokered credential with `DELETE`.
- Limitation: this validates the broker/file lifecycle and ACP protocol boundary locally without mocks, but it does not use a real external ChatGPT/Codex account or the published Codex CLI.

Focused tests:

```bash
env -u CODEX_AUTH_JSON uv run pytest -q   tests/sdk/agent/test_acp_agent.py   tests/sdk/conversation/test_switch_model.py
# 464 passed, 7 warnings in 11.03s
```

Note: the `env -u CODEX_AUTH_JSON` wrapper prevents the OpenHands runtime's registered `CODEX_AUTH_JSON` secret from being injected into the pytest subprocess and contaminating assertions that reserved file secrets are not forwarded as plain env vars.

## Video/Screenshots

Not applicable; this is an internal backend refactor with no UI change.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally targets Simon's `fix-acp-codex-auth-sync` branch. The lifecycle registry is internal and introduces no serialized or public SDK API change. SDK #4137's local capability support remains localized to the Codex lifecycle factory when rebased.

Closes #4149