### PR TITLE
feat(llm): verify kimi-for-coding (Kimi Code membership)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -74,6 +74,7 @@ VERIFIED_MOONSHOT_MODELS = [
     "kimi-k2-thinking",
     "kimi-k2.5",
     "kimi-k2.6",
+    "kimi-for-coding",
 ]
 
 VERIFIED_MINIMAX_MODELS = [


### PR DESCRIPTION
HUMAN:

this adds Kimi's coding plan

---

AGENT:

> **Companion PR (canvas half): OpenHands/agent-canvas#1844.** This is one of two PRs that together make Moonshot's Kimi Code membership a first-class LLM option in agent-canvas. The membership is reachable via a Console API key against `https://api.kimi.com/coding/v1` (model `kimi-for-coding`), distinct from the Moonshot OpenPlatform. **This SDK PR** verifies the model id so it earns the "Verified" badge in the canvas model picker; **OpenHands/agent-canvas#1844** surfaces the endpoint as a first-class provider (provider label + default base_url). Either PR can be read standalone for the full picture.

`kimi-for-coding` is a valid, live model id on the Kimi Code membership endpoint. Verified directly: `POST https://api.kimi.com/coding/v1/chat/completions` with model `kimi-for-coding` and a Kimi Code membership key returned **200** with a valid OpenAI `chat.completion` (model id accepted; `cached_tokens` and `reasoning_content` present). End-to-end through OpenHands confirmed in OpenHands/agent-canvas#1844 (a conversation against `moonshot/kimi-for-coding` + `api.kimi.com/coding/v1` replied). `python -m py_compile openhands/sdk/llm/utils/verified_models.py` clean; the verified-models list is a static dict with no per-entry tests.

## Why

`kimi-for-coding` (Moonshot's Kimi Code membership coding model, served at `https://api.kimi.com/coding/v1`) is absent from `VERIFIED_MOONSHOT_MODELS`, so it doesn't appear in agent-canvas's "Verified" model list and users have to free-type the id. Adding it makes the model discoverable with the Verified badge.

## Summary

- Append `"kimi-for-coding"` to `VERIFIED_MOONSHOT_MODELS` in `openhands/sdk/llm/utils/verified_models.py`.

## Issue Number

N/A — no open issue.

## How to Test

`python -m py_compile openhands/sdk/llm/utils/verified_models.py`. For the live model: `POST https://api.kimi.com/coding/v1/chat/completions` with model `kimi-for-coding` + a Kimi Code membership key -> expect a 200 chat completion.

## Video/Screenshots

None; the change is one line in a static list. Live request/result captured in the AGENT section above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion to OpenHands/agent-canvas#1844. `kimi-for-coding` sits under the existing `moonshot` provider key (Moonshot AI operates both the OpenPlatform `api.moonshot.ai/v1` and the Kimi Code membership `api.kimi.com/coding/v1` endpoints); verification is endpoint-agnostic in the data model, so no provider-block change is needed.
