### PR TITLE
Trace LLM endpoint alongside model

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/openhands_provider.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/openhands_provider.py
@@ -14,6 +14,7 @@ OPENHANDS_LLM_PROXY_BASE_URL: Final[str] = "https://llm-proxy.app.all-hands.dev"
 class LiteLLMCallKwargs(TypedDict):
     model: str
     api_base: str | None
+    base_url: str | None
 
 
 _OPENHANDS_PROXY_BASE_URLS: Final[frozenset[str]] = frozenset(
@@ -54,8 +55,9 @@ def litellm_call_kwargs(model: str, base_url: str | None) -> LiteLLMCallKwargs:
         return {
             "model": f"{LITELLM_PROXY_PREFIX}{model_name}",
             "api_base": base_url or OPENHANDS_LLM_PROXY_BASE_URL,
+            "base_url": base_url or OPENHANDS_LLM_PROXY_BASE_URL,
         }
-    return {"model": model, "api_base": base_url}
+    return {"model": model, "api_base": base_url, "base_url": base_url}
 
 
 def canonicalize_openhands_llm_payload(payload: dict[str, Any]) -> dict[str, Any]:

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -100,6 +100,7 @@ def test_openhands_provider_translates_only_for_litellm(mock_completion, mock_ge
     _, kwargs = mock_completion.call_args
     assert kwargs["model"] == "litellm_proxy/claude-haiku-4-5-20251001"
     assert kwargs["api_base"] == "https://llm-proxy.app.all-hands.dev"
+    assert kwargs["base_url"] == "https://llm-proxy.app.all-hands.dev"
     persisted = llm.to_persisted()
     assert persisted["model"] == "openhands/claude-haiku-4-5-20251001"
     assert "base_url" not in persisted
@@ -147,6 +148,28 @@ def test_base_url_for_openhands_provider_with_custom_url(mock_get):
     assert llm.base_url == custom_url
     # Should call with custom URL
     mock_get.assert_called_once()
+
+
+@patch("openhands.sdk.llm.utils.model_info.httpx.get")
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_litellm_transport_includes_base_url_for_tracing(mock_completion, mock_get):
+    mock_get.return_value = Mock(json=lambda: {"data": []})
+    mock_completion.return_value = create_mock_litellm_response("ok")
+
+    llm = LLM(
+        model="openai/gpt-4o",
+        api_key=SecretStr("test-key"),
+        usage_id="test-base-url-tracing",
+        base_url="https://proxy.example.com/v1",
+        num_retries=0,
+    )
+
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    llm.completion(messages=messages)
+
+    _, kwargs = mock_completion.call_args
+    assert kwargs["api_base"] == "https://proxy.example.com/v1"
+    assert kwargs["base_url"] == "https://proxy.example.com/v1"
 
 
 def test_token_usage_add():


### PR DESCRIPTION
## Summary
- include the resolved LiteLLM endpoint as `base_url` alongside existing `api_base` transport kwargs
- keep the API key untouched and avoid persisting the endpoint in the public OpenHands model config
- add focused tests for the OpenHands proxy and a custom endpoint

## Test
- `uv run pytest tests/sdk/llm/test_llm.py`
- `uv run ruff check openhands-sdk/openhands/sdk/llm/utils/openhands_provider.py tests/sdk/llm/test_llm.py`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3cfb685-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3cfb685-python \
  ghcr.io/openhands/agent-server:3cfb685-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3cfb685-golang-amd64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-golang-amd64
ghcr.io/openhands/agent-server:trace-llm-endpoint-golang-amd64
ghcr.io/openhands/agent-server:3cfb685-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3cfb685-golang-arm64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-golang-arm64
ghcr.io/openhands/agent-server:trace-llm-endpoint-golang-arm64
ghcr.io/openhands/agent-server:3cfb685-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3cfb685-java-amd64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-java-amd64
ghcr.io/openhands/agent-server:trace-llm-endpoint-java-amd64
ghcr.io/openhands/agent-server:3cfb685-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3cfb685-java-arm64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-java-arm64
ghcr.io/openhands/agent-server:trace-llm-endpoint-java-arm64
ghcr.io/openhands/agent-server:3cfb685-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3cfb685-python-amd64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-python-amd64
ghcr.io/openhands/agent-server:trace-llm-endpoint-python-amd64
ghcr.io/openhands/agent-server:3cfb685-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3cfb685-python-arm64
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-python-arm64
ghcr.io/openhands/agent-server:trace-llm-endpoint-python-arm64
ghcr.io/openhands/agent-server:3cfb685-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3cfb685-golang
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-golang
ghcr.io/openhands/agent-server:trace-llm-endpoint-golang
ghcr.io/openhands/agent-server:3cfb685-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3cfb685-java
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-java
ghcr.io/openhands/agent-server:trace-llm-endpoint-java
ghcr.io/openhands/agent-server:3cfb685-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3cfb685-python
ghcr.io/openhands/agent-server:3cfb68577d1a299fe05162f7b47e4b8c81447142-python
ghcr.io/openhands/agent-server:trace-llm-endpoint-python
ghcr.io/openhands/agent-server:3cfb685-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3cfb685-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3cfb685-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->