### PR TITLE
feat(agent-server): add GET /api/llm/balance endpoint (OpenRouter credit balance)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 import asyncio
 import secrets
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import BaseModel, Field
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field, SecretStr
 
+from openhands.agent_server._secrets_exposure import get_cipher, get_config
+from openhands.agent_server.persistence import (
+    PersistedSettings,
+    get_llm_profile_store,
+    get_settings_store,
+)
+from openhands.sdk.llm import LLM
 from openhands.sdk.llm.auth.openai import (
     DEVICE_CODE_TIMEOUT_SECONDS,
     OPENAI_CODEX_MODELS,
@@ -58,6 +67,19 @@ class VerifiedModelsResponse(BaseModel):
     """Response containing verified LLM models organized by provider."""
 
     models: dict[str, list[str]]
+
+
+class BalanceResponse(BaseModel):
+    """Credit balance information for the resolved LLM's provider."""
+
+    provider: str
+    limit: float | None = None
+    limit_remaining: float | None = None
+    usage: float
+    usage_daily: float | None = None
+    usage_weekly: float | None = None
+    usage_monthly: float | None = None
+    is_free_tier: bool = False
 
 
 class SubscriptionStatusResponse(BaseModel):
@@ -156,6 +178,141 @@ async def list_verified_models() -> VerifiedModelsResponse:
     with OpenHands.
     """
     return VerifiedModelsResponse(models=VERIFIED_MODELS)
+
+
+OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
+BALANCE_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+def _extract_api_key(llm: LLM) -> str | None:
+    """Return the LLM's API key as plaintext, or ``None`` if unset."""
+    key = llm.api_key
+    if isinstance(key, SecretStr):
+        key = key.get_secret_value()
+    if key is None:
+        return None
+    key = str(key).strip()
+    return key or None
+
+
+async def _fetch_openrouter_balance(api_key: str) -> BalanceResponse:
+    """Query OpenRouter's key endpoint for credit limit and usage information.
+
+    See https://openrouter.ai/docs/api-reference/limits for the response shape.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=BALANCE_HTTP_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                OPENROUTER_KEY_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"OpenRouter balance lookup failed with status {e.response.status_code}"
+            ),
+        )
+    except httpx.HTTPError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"OpenRouter balance lookup failed: {e}",
+        )
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="OpenRouter balance lookup returned an unexpected response",
+        )
+
+    return BalanceResponse(
+        provider="openrouter",
+        limit=data.get("limit"),
+        limit_remaining=data.get("limit_remaining"),
+        usage=data.get("usage", 0.0),
+        usage_daily=data.get("usage_daily"),
+        usage_weekly=data.get("usage_weekly"),
+        usage_monthly=data.get("usage_monthly"),
+        is_free_tier=bool(data.get("is_free_tier", False)),
+    )
+
+
+# Provider name -> balance fetcher taking the plaintext API key. Add new
+# providers here as they gain balance/credits endpoints.
+_BALANCE_FETCHERS: dict[str, Callable[[str], Awaitable[BalanceResponse]]] = {
+    "openrouter": _fetch_openrouter_balance,
+}
+
+
+def _resolve_balance_provider(llm: LLM) -> str | None:
+    """Map an LLM config to a provider supported by ``_BALANCE_FETCHERS``."""
+    base_url = llm.base_url or ""
+    if "openrouter.ai" in base_url or llm.model.startswith("openrouter/"):
+        return "openrouter"
+    return None
+
+
+def _resolve_llm_for_balance(request: Request, profile: str | None) -> LLM:
+    """Load the named profile's LLM, or the active agent settings LLM."""
+    if profile is not None:
+        store = get_llm_profile_store()
+        try:
+            return store.load(profile, cipher=get_cipher(request))
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Profile '{profile}' not found",
+            )
+
+    config = get_config(request)
+    settings = get_settings_store(config).load() or PersistedSettings()
+    return settings.agent_settings.llm
+
+
+@llm_router.get("/balance", response_model=BalanceResponse)
+async def get_balance(
+    request: Request,
+    profile: str | None = Query(
+        default=None,
+        description=(
+            "LLM profile name to check. Defaults to the currently active LLM settings."
+        ),
+    ),
+) -> BalanceResponse:
+    """Get the credit balance for the resolved LLM's provider.
+
+    Currently only OpenRouter is supported (detected via an ``openrouter.ai``
+    base URL or an ``openrouter/`` model prefix). The provider is queried
+    server-side with the stored API key; the key itself is never returned.
+
+    Returns 404 if the provider does not support balance lookup or no API key
+    is configured, and 502 if the upstream provider call fails.
+    """
+    llm = _resolve_llm_for_balance(request, profile)
+    provider = _resolve_balance_provider(llm)
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Balance lookup is not supported for model '{llm.model}'. "
+                "Supported providers: " + ", ".join(sorted(_BALANCE_FETCHERS))
+            ),
+        )
+
+    api_key = _extract_api_key(llm)
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No API key is configured for the resolved '{provider}' LLM; "
+                "cannot look up balance"
+            ),
+        )
+
+    return await _BALANCE_FETCHERS[provider](api_key)
 
 
 @llm_router.get(

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -324,6 +324,229 @@ async def test_openai_subscription_device_poll_failure_keeps_pending_login(
     assert "opaque-token" not in llm_router._IN_FLIGHT_OPENAI_DEVICE_LOGINS
 
 
+OPENROUTER_KEY_PAYLOAD = {
+    "data": {
+        "label": "sk-or-v1-abc...def",
+        "limit": 25.0,
+        "limit_remaining": 18.5,
+        "limit_reset": None,
+        "usage": 6.5,
+        "usage_daily": 0.5,
+        "usage_weekly": 2.0,
+        "usage_monthly": 6.5,
+        "is_free_tier": False,
+    }
+}
+
+
+@pytest.fixture
+def openrouter_settings(monkeypatch):
+    """Point the router's settings store at an in-memory OpenRouter config."""
+    import httpx
+
+    from openhands.agent_server import llm_router
+    from openhands.agent_server.persistence import PersistedSettings
+    from openhands.sdk.llm import LLM
+
+    def set_llm(llm: LLM) -> None:
+        settings = PersistedSettings()
+        settings.agent_settings = settings.agent_settings.model_copy(
+            update={"llm": llm}
+        )
+
+        class FakeSettingsStore:
+            def load(self):
+                return settings
+
+        monkeypatch.setattr(
+            llm_router, "get_settings_store", lambda config: FakeSettingsStore()
+        )
+
+    def set_upstream(handler) -> None:
+        real_async_client = httpx.AsyncClient
+
+        def fake_async_client(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return real_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", fake_async_client)
+
+    return set_llm, set_upstream
+
+
+def test_balance_endpoint_openrouter_success(client, openrouter_settings):
+    """Balance endpoint returns OpenRouter credit info without leaking the key."""
+    import httpx
+
+    from openhands.sdk.llm import LLM
+
+    set_llm, set_upstream = openrouter_settings
+    set_llm(LLM(model="openrouter/moonshotai/kimi-k3", api_key="sk-or-test-key"))
+
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, json=OPENROUTER_KEY_PAYLOAD)
+
+    set_upstream(handler)
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "provider": "openrouter",
+        "limit": 25.0,
+        "limit_remaining": 18.5,
+        "usage": 6.5,
+        "usage_daily": 0.5,
+        "usage_weekly": 2.0,
+        "usage_monthly": 6.5,
+        "is_free_tier": False,
+    }
+    assert "sk-or-test-key" not in response.text
+    assert len(seen_requests) == 1
+    assert str(seen_requests[0].url) == "https://openrouter.ai/api/v1/key"
+    assert seen_requests[0].headers["Authorization"] == "Bearer sk-or-test-key"
+
+
+def test_balance_endpoint_detects_openrouter_by_base_url(client, openrouter_settings):
+    """OpenRouter is detected from base_url even without a model prefix."""
+    import httpx
+
+    from openhands.sdk.llm import LLM
+
+    set_llm, set_upstream = openrouter_settings
+    set_llm(
+        LLM(
+            model="moonshotai/kimi-k3",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test-key",
+        )
+    )
+    set_upstream(lambda request: httpx.Response(200, json=OPENROUTER_KEY_PAYLOAD))
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 200
+    assert response.json()["provider"] == "openrouter"
+
+
+def test_balance_endpoint_unsupported_provider(client, openrouter_settings):
+    """Non-OpenRouter providers return 404 with a clear message."""
+    from openhands.sdk.llm import LLM
+
+    set_llm, _ = openrouter_settings
+    set_llm(LLM(model="gpt-4o", api_key="sk-test"))
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 404
+    assert "not supported" in response.json()["detail"]
+
+
+def test_balance_endpoint_missing_api_key(client, openrouter_settings):
+    """An OpenRouter config without an API key returns 404."""
+    from openhands.sdk.llm import LLM
+
+    set_llm, _ = openrouter_settings
+    set_llm(LLM(model="openrouter/moonshotai/kimi-k3"))
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 404
+    assert "No API key" in response.json()["detail"]
+
+
+def test_balance_endpoint_upstream_error(client, openrouter_settings):
+    """Upstream OpenRouter failures surface as 502."""
+    import httpx
+
+    from openhands.sdk.llm import LLM
+
+    set_llm, set_upstream = openrouter_settings
+    set_llm(LLM(model="openrouter/moonshotai/kimi-k3", api_key="sk-or-test-key"))
+    set_upstream(lambda request: httpx.Response(401, json={"error": "bad key"}))
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 502
+    # 5xx details are masked by the app-level handler; the raised exception
+    # string still carries the upstream status.
+    assert "401" in response.json()["exception"]
+
+
+def test_balance_endpoint_upstream_network_error(client, openrouter_settings):
+    """Network-level failures (e.g. timeouts) surface as 502."""
+    import httpx
+
+    from openhands.sdk.llm import LLM
+
+    set_llm, set_upstream = openrouter_settings
+    set_llm(LLM(model="openrouter/moonshotai/kimi-k3", api_key="sk-or-test-key"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("connection timed out")
+
+    set_upstream(handler)
+
+    response = client.get("/api/llm/balance")
+
+    assert response.status_code == 502
+    assert "failed" in response.json()["exception"]
+
+
+def test_balance_endpoint_with_profile(client, monkeypatch, openrouter_settings):
+    """The profile query param loads the named profile's LLM."""
+    import tempfile
+    from pathlib import Path
+
+    import httpx
+
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm import LLM
+    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+
+    _, set_upstream = openrouter_settings
+    set_upstream(lambda request: httpx.Response(200, json=OPENROUTER_KEY_PAYLOAD))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = LLMProfileStore(base_dir=Path(tmpdir))
+        store.save(
+            "my-openrouter",
+            LLM(model="openrouter/moonshotai/kimi-k3", api_key="sk-or-test-key"),
+            include_secrets=True,
+        )
+        monkeypatch.setattr(llm_router, "get_llm_profile_store", lambda: store)
+
+        response = client.get("/api/llm/balance?profile=my-openrouter")
+
+    assert response.status_code == 200
+    assert response.json()["provider"] == "openrouter"
+    assert "sk-or-test-key" not in response.text
+
+
+def test_balance_endpoint_profile_not_found(client, monkeypatch):
+    """An unknown profile name returns 404."""
+    import tempfile
+    from pathlib import Path
+
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setattr(
+            llm_router,
+            "get_llm_profile_store",
+            lambda: LLMProfileStore(base_dir=Path(tmpdir)),
+        )
+
+        response = client.get("/api/llm/balance?profile=nope")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
 def test_openai_subscription_logout_endpoint(client, monkeypatch):
     """Logout removes credentials and returns disconnected status."""
     from openhands.agent_server import llm_router


### PR DESCRIPTION
## Motivation

Users running OpenHands against OpenRouter want to see their remaining credits in the UI without leaving the app. The agent-server already stores the (encrypted) API key for the active LLM and for saved profiles, so it can query the provider's balance endpoint server-side and expose a safe, key-free summary. A companion agent-canvas UI PR that consumes this endpoint is coming.

## API contract

`GET /api/llm/balance?profile=<name>`

- `profile` (optional): LLM profile name to check. When omitted, the endpoint uses the currently active agent settings LLM (the same config the server resolves for conversations).
- The provider is detected as OpenRouter when the resolved LLM has a `base_url` containing `openrouter.ai` or a model prefixed with `openrouter/`. The server then calls `GET https://openrouter.ai/api/v1/key` with the stored API key (decrypted server-side, 10s timeout). The key is never returned to the client.

**200 response:**

```json
{
  "provider": "openrouter",
  "limit": 25.0,
  "limit_remaining": 18.5,
  "usage": 6.5,
  "usage_daily": 0.5,
  "usage_weekly": 2.0,
  "usage_monthly": 6.5,
  "is_free_tier": false
}
```

`limit`, `limit_remaining`, and the `usage_*` fields are nullable floats.

**Errors:**

- `404` — the named profile does not exist, the resolved provider does not support balance lookup, or no API key is configured for it (clear `detail` message in each case).
- `502` — the upstream OpenRouter call failed (HTTP error, timeout, or unexpected response shape).

## Implementation notes

- Lives in `llm_router.py` next to the other `/api/llm` endpoints, following the surrounding conventions (pydantic response model, `httpx.AsyncClient`, `HTTPException` with `status` constants).
- A small provider -> fetcher mapping (`_BALANCE_FETCHERS`) makes it easy to add other providers with balance/credits endpoints later without changing the route.
- Tests mock the OpenRouter HTTP call via `httpx.MockTransport` and cover: success (including no-key-leak assertion), base_url-based detection, unsupported provider, missing API key, upstream HTTP/network failures, `profile` lookup, and unknown profile.

## Testing

- `uv run pytest tests/agent_server/test_llm_router.py` — 24 passed.
- Full `tests/agent_server/` suite passes except a pre-existing, unrelated `test_terminal_service` failure that also fails on a clean `main` checkout in my environment.
- `pre-commit` (ruff format/lint, pycodestyle, pyright, import rules) passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)