### PR TITLE
fix(grep): honor brace alternation in the include filter

### DIFF
--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -25,6 +25,62 @@ from openhands.tools.utils import (
 logger = get_logger(__name__)
 
 
+def _expand_brace_pattern(pattern: str) -> list[str]:
+    """Expand shell-style brace alternation into concrete glob patterns.
+
+    ``fnmatch`` treats ``{``, ``}`` and ``,`` literally, but the tool documents
+    ``*.{ts,tsx}`` as a supported ``include`` example and ripgrep's ``-g`` flag
+    honors it, so the post-filter must understand it too or brace includes
+    silently match nothing. ``"*.{ts,tsx}"`` expands to ``["*.ts", "*.tsx"]``.
+
+    Handles multiple and nested groups via recursion. Returns ``[pattern]``
+    unchanged when there is no balanced, comma-bearing brace group (mirroring
+    the shell, which leaves ``{abc}`` literal).
+    """
+    start = pattern.find("{")
+    if start == -1:
+        return [pattern]
+
+    depth = 0
+    end = -1
+    for i in range(start, len(pattern)):
+        if pattern[i] == "{":
+            depth += 1
+        elif pattern[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    if end == -1:  # unbalanced "{": treat literally
+        return [pattern]
+
+    # Split the group body on top-level commas (commas inside nested braces
+    # belong to the inner group, not this one).
+    options: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for ch in pattern[start + 1 : end]:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            options.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    options.append("".join(current))
+
+    if len(options) == 1:  # no alternation, e.g. "{abc}" — leave literal
+        return [pattern]
+
+    prefix, suffix = pattern[:start], pattern[end + 1 :]
+    expanded: list[str] = []
+    for option in options:
+        expanded.extend(_expand_brace_pattern(prefix + option + suffix))
+    return expanded
+
+
 class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
     """Executor for grep content search operations.
 
@@ -161,7 +217,10 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
 
         filename = relative_parts[-1] if relative_parts else path.name
         if include_pattern:
-            return fnmatch.fnmatch(filename, include_pattern)
+            return any(
+                fnmatch.fnmatch(filename, pat)
+                for pat in _expand_brace_pattern(include_pattern)
+            )
         return not filename.startswith(".")
 
     def _match_mtime(self, path: Path) -> float:

--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -47,14 +47,43 @@ def _split_first_brace_group(pattern: str) -> tuple[str, list[str], str] | None:
     """Return ``(prefix, options, suffix)`` for the leftmost expandable group.
 
     A balanced group without a top-level comma stays literal but does not hide
-    an expandable nested or later group. An unmatched opening leaves the rest
-    of the pattern unchanged.
+    an expandable nested or later group. Glob character classes and escaped
+    characters are opaque to brace parsing. An unmatched opening leaves the
+    rest of the pattern unchanged.
     """
     stack: list[tuple[int, list[int], int]] = []
     first_group: tuple[int, int, list[int], int] | None = None
+    in_character_class = False
+    character_class_has_member = False
+    character_class_can_negate = False
+    escaped = False
 
     for i, ch in enumerate(pattern):
-        if ch == "{":
+        if escaped:
+            escaped = False
+            if in_character_class:
+                character_class_has_member = True
+                character_class_can_negate = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if in_character_class:
+            # A leading ']' is a literal class member (for example ``[]a]``),
+            # as is one immediately after the optional negation marker.
+            if ch == "]" and character_class_has_member:
+                in_character_class = False
+            elif character_class_can_negate and ch == "!":
+                character_class_can_negate = False
+            else:
+                character_class_has_member = True
+                character_class_can_negate = False
+            continue
+        if ch == "[":
+            in_character_class = True
+            character_class_has_member = False
+            character_class_can_negate = True
+        elif ch == "{":
             stack.append((i, [], 0))
         elif ch == "," and stack:
             # A comma belongs to the innermost open group, so commas in nested
@@ -349,15 +378,37 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
             action.pattern,
             str(search_path),
             "--sortr=modified",
+            "--no-config",
         ]
         if action.include:
-            # Use the same bounded expansion as the post-filter. Any braces
-            # left afterward are literal and must be escaped for rg's globset.
-            for include_pattern in _expand_brace_pattern(action.include):
-                rg_pattern = include_pattern.replace("{", r"\{").replace("}", r"\}")
-                if rg_pattern.startswith("!"):
-                    rg_pattern = "\\" + rg_pattern
-                cmd.extend(["-g", rg_pattern])
+            expanded_includes = _expand_brace_pattern(action.include)
+            # Python's fnmatch is the canonical post-filter. Its backslash and
+            # globset differ for escapes, classes, Unicode '?', comments,
+            # whitespace, and Windows case normalization. For those patterns,
+            # let rg perform only the linear-time content search, then apply
+            # the canonical filename filter below.
+            requires_unfiltered_search = os.name == "nt" or any(
+                (
+                    any(ch in include_pattern for ch in "\\[]?")
+                    or include_pattern.startswith("#")
+                    or any(ch.isspace() for ch in include_pattern)
+                    or any(not ch.isprintable() for ch in include_pattern)
+                )
+                for include_pattern in expanded_includes
+            )
+            if requires_unfiltered_search:
+                # Include hidden/ignored paths before the canonical post-filter.
+                cmd.extend(["--hidden", "--no-ignore"])
+            else:
+                # Any braces left after expansion are literal and must be
+                # escaped for rg's globset. Ignore repository excludes because
+                # the other backends search all visible directories.
+                cmd.append("--no-ignore")
+                for include_pattern in expanded_includes:
+                    rg_pattern = include_pattern.replace("{", r"\{").replace("}", r"\}")
+                    if rg_pattern.startswith("!"):
+                        rg_pattern = "\\" + rg_pattern
+                    cmd.extend(["-g", rg_pattern])
 
         result = subprocess.run(
             cmd,
@@ -367,6 +418,18 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
             check=False,
             env=sanitized_env(),
         )
+
+        if result.returncode not in (0, 1):
+            detail = result.stderr.strip() or f"exit code {result.returncode}"
+            logger.warning("ripgrep backend failed: %s", detail)
+            return GrepObservation.from_text(
+                text=f"ripgrep search failed: {detail}",
+                matches=[],
+                pattern=action.pattern,
+                search_path=str(search_path),
+                include_pattern=action.include,
+                is_error=True,
+            )
 
         matches = []
         if result.stdout:

--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -44,46 +44,46 @@ class BraceExpansionBudgetError(ValueError):
 
 
 def _split_first_brace_group(pattern: str) -> tuple[str, list[str], str] | None:
-    """Return ``(prefix, options, suffix)`` for the first balanced,
-    comma-bearing brace group, or ``None`` when the pattern has no such group
-    (mirroring the shell, which leaves ``{abc}`` and unbalanced ``{`` literal).
+    """Return ``(prefix, options, suffix)`` for the leftmost expandable group.
+
+    A balanced group without a top-level comma stays literal but does not hide
+    an expandable nested or later group. An unmatched opening leaves the rest
+    of the pattern unchanged.
     """
-    start = pattern.find("{")
-    if start == -1:
-        return None
+    stack: list[tuple[int, list[int], int]] = []
+    first_group: tuple[int, int, list[int], int] | None = None
 
-    depth = 0
-    end = -1
-    for i in range(start, len(pattern)):
-        if pattern[i] == "{":
-            depth += 1
-        elif pattern[i] == "}":
-            depth -= 1
-            if depth == 0:
-                end = i
-                break
-    if end == -1:  # unbalanced "{": treat literally
-        return None
-
-    # Split the group body on top-level commas (commas inside nested braces
-    # belong to the inner group, not this one).
-    options: list[str] = []
-    current: list[str] = []
-    depth = 0
-    for ch in pattern[start + 1 : end]:
+    for i, ch in enumerate(pattern):
         if ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-        if ch == "," and depth == 0:
-            options.append("".join(current))
-            current = []
-        else:
-            current.append(ch)
-    options.append("".join(current))
+            stack.append((i, [], 0))
+        elif ch == "," and stack:
+            # A comma belongs to the innermost open group, so commas in nested
+            # groups are not mistaken for top-level separators of their parent.
+            start, comma_positions, comma_count = stack[-1]
+            if comma_count < MAX_BRACE_EXPANSIONS - 1:
+                comma_positions.append(i)
+            stack[-1] = (start, comma_positions, comma_count + 1)
+        elif ch == "}" and stack:
+            start, commas, comma_count = stack.pop()
+            if comma_count and (first_group is None or start < first_group[0]):
+                first_group = (start, i, commas, comma_count)
 
-    if len(options) == 1:  # no alternation, e.g. "{abc}" — leave literal
+    if first_group is None:
         return None
+    if stack and stack[0][0] < first_group[0]:
+        # Preserve the existing literal treatment: once an unmatched opening
+        # appears, following text is not parsed as a separate group.
+        return None
+
+    start, end, commas, comma_count = first_group
+    if comma_count >= MAX_BRACE_EXPANSIONS:
+        raise BraceExpansionBudgetError(pattern)
+    options: list[str] = []
+    option_start = start + 1
+    for comma in commas:
+        options.append(pattern[option_start:comma])
+        option_start = comma + 1
+    options.append(pattern[option_start:end])
 
     return pattern[:start], options, pattern[end + 1 :]
 
@@ -113,10 +113,11 @@ def _expand_brace_pattern(pattern: str) -> list[str]:
             expanded.append(candidate)
         else:
             prefix, options, suffix = group
+            projected_count = len(expanded) + len(pending) + len(options)
+            if projected_count > MAX_BRACE_EXPANSIONS:
+                raise BraceExpansionBudgetError(pattern)
             # Prepend to preserve depth-first (shell) expansion order.
             pending = [prefix + opt + suffix for opt in options] + pending
-        if len(expanded) + len(pending) > MAX_BRACE_EXPANSIONS:
-            raise BraceExpansionBudgetError(pattern)
     return expanded
 
 
@@ -350,7 +351,13 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
             "--sortr=modified",
         ]
         if action.include:
-            cmd.extend(["-g", action.include])
+            # Use the same bounded expansion as the post-filter. Any braces
+            # left afterward are literal and must be escaped for rg's globset.
+            for include_pattern in _expand_brace_pattern(action.include):
+                rg_pattern = include_pattern.replace("{", r"\{").replace("}", r"\}")
+                if rg_pattern.startswith("!"):
+                    rg_pattern = "\\" + rg_pattern
+                cmd.extend(["-g", rg_pattern])
 
         result = subprocess.run(
             cmd,

--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -25,21 +25,32 @@ from openhands.tools.utils import (
 logger = get_logger(__name__)
 
 
-def _expand_brace_pattern(pattern: str) -> list[str]:
-    """Expand shell-style brace alternation into concrete glob patterns.
+# Brace groups multiply: sixteen ``{a,b}`` groups already expand to 65,536
+# patterns, and ``include`` is agent/user-controlled tool input. Cap the number
+# of generated patterns so a malformed or adversarial filter fails cleanly
+# instead of exhausting the process. Legitimate filters are tiny (``*.{ts,tsx}``
+# is 2; three 4-way groups are 64).
+MAX_BRACE_EXPANSIONS = 64
 
-    ``fnmatch`` treats ``{``, ``}`` and ``,`` literally, but the tool documents
-    ``*.{ts,tsx}`` as a supported ``include`` example and ripgrep's ``-g`` flag
-    honors it, so the post-filter must understand it too or brace includes
-    silently match nothing. ``"*.{ts,tsx}"`` expands to ``["*.ts", "*.tsx"]``.
 
-    Handles multiple and nested groups via recursion. Returns ``[pattern]``
-    unchanged when there is no balanced, comma-bearing brace group (mirroring
-    the shell, which leaves ``{abc}`` literal).
+class BraceExpansionBudgetError(ValueError):
+    """Raised when brace alternation would expand past ``MAX_BRACE_EXPANSIONS``."""
+
+    def __init__(self, pattern: str) -> None:
+        super().__init__(
+            f"Include pattern '{pattern}' expands to more than "
+            f"{MAX_BRACE_EXPANSIONS} glob patterns; simplify the brace groups."
+        )
+
+
+def _split_first_brace_group(pattern: str) -> tuple[str, list[str], str] | None:
+    """Return ``(prefix, options, suffix)`` for the first balanced,
+    comma-bearing brace group, or ``None`` when the pattern has no such group
+    (mirroring the shell, which leaves ``{abc}`` and unbalanced ``{`` literal).
     """
     start = pattern.find("{")
     if start == -1:
-        return [pattern]
+        return None
 
     depth = 0
     end = -1
@@ -52,7 +63,7 @@ def _expand_brace_pattern(pattern: str) -> list[str]:
                 end = i
                 break
     if end == -1:  # unbalanced "{": treat literally
-        return [pattern]
+        return None
 
     # Split the group body on top-level commas (commas inside nested braces
     # belong to the inner group, not this one).
@@ -72,12 +83,40 @@ def _expand_brace_pattern(pattern: str) -> list[str]:
     options.append("".join(current))
 
     if len(options) == 1:  # no alternation, e.g. "{abc}" — leave literal
-        return [pattern]
+        return None
 
-    prefix, suffix = pattern[:start], pattern[end + 1 :]
+    return pattern[:start], options, pattern[end + 1 :]
+
+
+def _expand_brace_pattern(pattern: str) -> list[str]:
+    """Expand shell-style brace alternation into concrete glob patterns.
+
+    ``fnmatch`` treats ``{``, ``}`` and ``,`` literally, but the tool documents
+    ``*.{ts,tsx}`` as a supported ``include`` example and ripgrep's ``-g`` flag
+    honors it, so the post-filter must understand it too or brace includes
+    silently match nothing. ``"*.{ts,tsx}"`` expands to ``["*.ts", "*.tsx"]``.
+
+    Handles multiple and nested groups. Returns ``[pattern]`` unchanged when
+    there is no balanced, comma-bearing brace group.
+
+    Raises:
+        BraceExpansionBudgetError: if the pattern would expand to more than
+            ``MAX_BRACE_EXPANSIONS`` patterns. The bound is enforced while
+            expanding, before the full product is ever materialized.
+    """
     expanded: list[str] = []
-    for option in options:
-        expanded.extend(_expand_brace_pattern(prefix + option + suffix))
+    pending: list[str] = [pattern]
+    while pending:
+        candidate = pending.pop(0)
+        group = _split_first_brace_group(candidate)
+        if group is None:
+            expanded.append(candidate)
+        else:
+            prefix, options, suffix = group
+            # Prepend to preserve depth-first (shell) expansion order.
+            pending = [prefix + opt + suffix for opt in options] + pending
+        if len(expanded) + len(pending) > MAX_BRACE_EXPANSIONS:
+            raise BraceExpansionBudgetError(pattern)
     return expanded
 
 
@@ -144,6 +183,22 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
                     include_pattern=action.include,
                     is_error=True,
                 )
+
+            # Validate the include filter's expansion budget up front so an
+            # oversized brace product fails cleanly before any search work
+            # (the post-filter re-expands it per matched file).
+            if action.include:
+                try:
+                    _expand_brace_pattern(action.include)
+                except BraceExpansionBudgetError as e:
+                    return GrepObservation.from_text(
+                        text=str(e),
+                        matches=[],
+                        pattern=action.pattern,
+                        search_path=str(search_path),
+                        include_pattern=action.include,
+                        is_error=True,
+                    )
 
             if self._search_backend == "ripgrep":
                 return self._execute_with_ripgrep(action, search_path)

--- a/tests/tools/grep/test_grep_executor.py
+++ b/tests/tools/grep/test_grep_executor.py
@@ -14,7 +14,7 @@ import pytest
 
 import openhands.tools.grep.impl as grep_impl
 from openhands.tools.grep import GrepAction
-from openhands.tools.grep.impl import GrepExecutor
+from openhands.tools.grep.impl import GrepExecutor, _expand_brace_pattern
 from openhands.tools.utils import _check_grep_available
 
 
@@ -109,6 +109,50 @@ def test_grep_executor_include_filter():
         assert observation.is_error is False
         assert len(observation.matches) == 1
         assert observation.matches[0].endswith(".py")
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        ("*.py", ["*.py"]),
+        ("*.{ts,tsx}", ["*.ts", "*.tsx"]),
+        ("{a,b}.{js,ts}", ["a.js", "a.ts", "b.js", "b.ts"]),
+        ("a{,_test}.py", ["a.py", "a_test.py"]),
+        ("{abc}", ["{abc}"]),  # no comma: left literal, like the shell
+        ("*.{ts", ["*.{ts"]),  # unbalanced brace: left literal
+    ],
+)
+def test_expand_brace_pattern(pattern, expected):
+    assert _expand_brace_pattern(pattern) == expected
+
+
+def test_grep_executor_include_brace_expansion():
+    """`include` honors brace alternation like the documented "*.{ts,tsx}"."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "a.ts").write_text("logError('x')")
+        (Path(temp_dir) / "b.tsx").write_text("logError('y')")
+        (Path(temp_dir) / "c.py").write_text("logError('z')")
+
+        executor = GrepExecutor(working_dir=temp_dir)
+        observation = executor(GrepAction(pattern="logError", include="*.{ts,tsx}"))
+
+        assert observation.is_error is False
+        assert sorted(Path(m).name for m in observation.matches) == ["a.ts", "b.tsx"]
+
+
+def test_grep_executor_include_brace_expansion_python_backend():
+    """Brace expansion also works on the Python fallback backend."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "a.ts").write_text("logError('x')")
+        (Path(temp_dir) / "b.tsx").write_text("logError('y')")
+        (Path(temp_dir) / "c.py").write_text("logError('z')")
+
+        executor = GrepExecutor(working_dir=temp_dir)
+        executor._search_backend = "python"
+        observation = executor(GrepAction(pattern="logError", include="*.{ts,tsx}"))
+
+        assert observation.is_error is False
+        assert sorted(Path(m).name for m in observation.matches) == ["a.ts", "b.tsx"]
 
 
 def test_grep_executor_custom_path():

--- a/tests/tools/grep/test_grep_executor.py
+++ b/tests/tools/grep/test_grep_executor.py
@@ -123,6 +123,16 @@ def test_grep_executor_include_filter():
         ("*.{ts,tsx}", ["*.ts", "*.tsx"]),
         ("{a,b}.{js,ts}", ["a.js", "a.ts", "b.js", "b.ts"]),
         ("a{,_test}.py", ["a.py", "a_test.py"]),
+        (
+            "x{literal}*.{ts,tsx}",
+            ["x{literal}*.ts", "x{literal}*.tsx"],
+        ),
+        (
+            "x*.{ts,tsx}{literal}",
+            ["x*.ts{literal}", "x*.tsx{literal}"],
+        ),
+        ("x{{a,b}}", ["x{a}", "x{b}"]),
+        ("{a,{b,c}}", ["a", "b", "c"]),
         ("{abc}", ["{abc}"]),  # no comma: left literal, like the shell
         ("*.{ts", ["*.{ts"]),  # unbalanced brace: left literal
     ],
@@ -137,6 +147,43 @@ def test_expand_brace_pattern_budget_enforced_before_materialization():
     pattern = "{a,b}" * 16
     with pytest.raises(BraceExpansionBudgetError):
         _expand_brace_pattern(pattern)
+
+
+def test_expand_brace_pattern_rejects_single_wide_group():
+    options = [f"option{i}" for i in range(MAX_BRACE_EXPANSIONS + 1)]
+    pattern = "{" + ",".join(options) + "}"
+
+    with pytest.raises(BraceExpansionBudgetError):
+        _expand_brace_pattern(pattern)
+
+
+def test_expand_brace_pattern_leaves_wide_unmatched_group_literal():
+    unmatched_suffix = "x{" + "," * MAX_BRACE_EXPANSIONS
+
+    assert _expand_brace_pattern(unmatched_suffix) == [unmatched_suffix]
+    assert _expand_brace_pattern("{a,b}" + unmatched_suffix) == [
+        "a" + unmatched_suffix,
+        "b" + unmatched_suffix,
+    ]
+
+
+def test_expand_brace_pattern_checks_budget_before_candidate_build(monkeypatch):
+    class CandidateBuildGuard(str):
+        def __add__(self, other):
+            raise AssertionError("candidate strings were built before the budget check")
+
+    monkeypatch.setattr(
+        grep_impl,
+        "_split_first_brace_group",
+        lambda _pattern: (
+            CandidateBuildGuard(""),
+            ["option"] * (MAX_BRACE_EXPANSIONS + 1),
+            "",
+        ),
+    )
+
+    with pytest.raises(BraceExpansionBudgetError):
+        _expand_brace_pattern("{oversized}")
 
 
 def test_expand_brace_pattern_budget_boundary():
@@ -193,6 +240,52 @@ def test_grep_executor_include_brace_expansion_python_backend():
 
         assert observation.is_error is False
         assert sorted(Path(m).name for m in observation.matches) == ["a.ts", "b.tsx"]
+
+
+@pytest.mark.parametrize("backend", ["ripgrep", "grep", "python"])
+@pytest.mark.parametrize(
+    "include_pattern,expected_names",
+    [
+        (
+            "x{literal}*.{ts,tsx}",
+            ["x{literal}a.ts", "x{literal}b.tsx"],
+        ),
+        (
+            "x*.{ts,tsx}{literal}",
+            ["xa.ts{literal}", "xb.tsx{literal}"],
+        ),
+        ("{!foo,bar}", ["!foo", "bar"]),
+    ],
+)
+def test_grep_executor_brace_expansion_consistent_across_backends(
+    backend, include_pattern, expected_names
+):
+    if backend == "ripgrep" and not grep_impl._check_ripgrep_available():
+        pytest.skip("ripgrep is not available")
+    if backend == "grep" and not _check_grep_available():
+        pytest.skip("system grep is not available")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for filename in [
+            "x{literal}a.ts",
+            "x{literal}b.tsx",
+            "xa.ts{literal}",
+            "xb.tsx{literal}",
+            "!foo",
+            "bar",
+            "foo",
+            "noise.py",
+        ]:
+            (Path(temp_dir) / filename).write_text("findMe")
+
+        executor = GrepExecutor(working_dir=temp_dir)
+        executor._search_backend = backend
+        observation = executor(GrepAction(pattern="findMe", include=include_pattern))
+
+        assert observation.is_error is False
+        assert (
+            sorted(Path(match).name for match in observation.matches) == expected_names
+        )
 
 
 def test_grep_executor_custom_path():

--- a/tests/tools/grep/test_grep_executor.py
+++ b/tests/tools/grep/test_grep_executor.py
@@ -14,7 +14,12 @@ import pytest
 
 import openhands.tools.grep.impl as grep_impl
 from openhands.tools.grep import GrepAction
-from openhands.tools.grep.impl import GrepExecutor, _expand_brace_pattern
+from openhands.tools.grep.impl import (
+    MAX_BRACE_EXPANSIONS,
+    BraceExpansionBudgetError,
+    GrepExecutor,
+    _expand_brace_pattern,
+)
 from openhands.tools.utils import _check_grep_available
 
 
@@ -124,6 +129,41 @@ def test_grep_executor_include_filter():
 )
 def test_expand_brace_pattern(pattern, expected):
     assert _expand_brace_pattern(pattern) == expected
+
+
+def test_expand_brace_pattern_budget_enforced_before_materialization():
+    """Sixteen 2-way groups would be 65,536 patterns; the expander must fail
+    fast instead of allocating the Cartesian product."""
+    pattern = "{a,b}" * 16
+    with pytest.raises(BraceExpansionBudgetError):
+        _expand_brace_pattern(pattern)
+
+
+def test_expand_brace_pattern_budget_boundary():
+    """Exactly MAX_BRACE_EXPANSIONS patterns is allowed; one more group over
+    the budget is rejected."""
+    at_budget = "{a,b,c,d}" * 3  # 4^3 = 64 == MAX_BRACE_EXPANSIONS
+    assert len(_expand_brace_pattern(at_budget)) == MAX_BRACE_EXPANSIONS
+
+    over_budget = "{a,b}" + at_budget  # 128
+    with pytest.raises(BraceExpansionBudgetError):
+        _expand_brace_pattern(over_budget)
+
+
+def test_grep_executor_rejects_oversized_include_expansion():
+    """An over-budget include filter returns a clean error observation instead
+    of hanging the executor on an exponential expansion."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "a.ts").write_text("logError('x')")
+
+        executor = GrepExecutor(working_dir=temp_dir)
+        observation = executor(
+            GrepAction(pattern="logError", include="{a,b}" * 16 + "*.ts")
+        )
+
+        assert observation.is_error is True
+        assert "simplify the brace groups" in observation.text
+        assert observation.matches == []
 
 
 def test_grep_executor_include_brace_expansion():

--- a/tests/tools/grep/test_grep_executor.py
+++ b/tests/tools/grep/test_grep_executor.py
@@ -6,6 +6,7 @@ These tests verify that grep behaves like OpenHands:
 - Sorted by modification time (--sortr=modified)
 """
 
+import os
 import tempfile
 import time
 from pathlib import Path
@@ -21,6 +22,11 @@ from openhands.tools.grep.impl import (
     _expand_brace_pattern,
 )
 from openhands.tools.utils import _check_grep_available
+
+
+POSIX_FILENAME_CASE = pytest.mark.skipif(
+    os.name == "nt", reason="requires a filename with POSIX-only characters"
+)
 
 
 def test_grep_executor_initialization():
@@ -133,6 +139,13 @@ def test_grep_executor_include_filter():
         ),
         ("x{{a,b}}", ["x{a}", "x{b}"]),
         ("{a,{b,c}}", ["a", "b", "c"]),
+        ("[{,}]", ["[{,}]"]),
+        ("[]{,}]", ["[]{,}]"]),
+        ("{[a,b],c}", ["[a,b]", "c"]),
+        ("[!!]{a,b}", ["[!!]a", "[!!]b"]),
+        ("[!]]{a,b}", ["[!]]a", "[!]]b"]),
+        (r"\{a,b\}", [r"\{a,b\}"]),
+        (r"{a\,b,c}", [r"a\,b", "c"]),
         ("{abc}", ["{abc}"]),  # no comma: left literal, like the shell
         ("*.{ts", ["*.{ts"]),  # unbalanced brace: left literal
     ],
@@ -255,6 +268,20 @@ def test_grep_executor_include_brace_expansion_python_backend():
             ["xa.ts{literal}", "xb.tsx{literal}"],
         ),
         ("{!foo,bar}", ["!foo", "bar"]),
+        ("[{,}]", [",", "{", "}"]),
+        ("[]{,}]", [",", "]", "{", "}"]),
+        ("{[a,b],c}", [",", "a", "b", "c"]),
+        pytest.param(r"\{a,b\}", [r"\{a,b\}"], marks=POSIX_FILENAME_CASE),
+        pytest.param(r"{a\,b,c}", [r"a\,b", "c"], marks=POSIX_FILENAME_CASE),
+        ("{[^a],c}", ["^", "a", "c"]),
+        ("[^]]{a,b}", ["^]a", "^]b"]),
+        ("[a{x,y}", ["[a{x,y}"]),
+        ("[!]{a,b}", ["[!]{a,b}"]),
+        ("[]{a,b}", ["[]{a,b}"]),
+        ("[{,}", ["[{,}"]),
+        ("{#foo,bar}", ["#foo", "bar"]),
+        pytest.param("foo ", ["foo "], marks=POSIX_FILENAME_CASE),
+        pytest.param("foo\t", ["foo\t"], marks=POSIX_FILENAME_CASE),
     ],
 )
 def test_grep_executor_brace_expansion_consistent_across_backends(
@@ -266,7 +293,7 @@ def test_grep_executor_brace_expansion_consistent_across_backends(
         pytest.skip("system grep is not available")
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        for filename in [
+        filenames = [
             "x{literal}a.ts",
             "x{literal}b.tsx",
             "xa.ts{literal}",
@@ -274,8 +301,27 @@ def test_grep_executor_brace_expansion_consistent_across_backends(
             "!foo",
             "bar",
             "foo",
+            ",",
+            "{",
+            "}",
+            "]",
+            "a",
+            "b",
+            "c",
+            "^",
+            "^]a",
+            "^]b",
+            "[a{x,y}",
+            "[!]{a,b}",
+            "[]{a,b}",
+            "[{,}",
+            "#foo",
             "noise.py",
-        ]:
+        ]
+        if os.name != "nt":
+            filenames.extend([r"\{a,b\}", r"a\,b", "foo ", "foo\t"])
+
+        for filename in filenames:
             (Path(temp_dir) / filename).write_text("findMe")
 
         executor = GrepExecutor(working_dir=temp_dir)
@@ -286,6 +332,106 @@ def test_grep_executor_brace_expansion_consistent_across_backends(
         assert (
             sorted(Path(match).name for match in observation.matches) == expected_names
         )
+
+
+@pytest.mark.parametrize("backend", ["ripgrep", "grep", "python"])
+def test_grep_executor_question_mark_matches_unicode_character(backend, tmp_path):
+    if backend == "ripgrep" and not grep_impl._check_ripgrep_available():
+        pytest.skip("ripgrep is not available")
+    if backend == "grep" and not _check_grep_available():
+        pytest.skip("system grep is not available")
+
+    for filename in ["a", "é", "中"]:
+        (tmp_path / filename).write_text("findMe")
+
+    executor = GrepExecutor(working_dir=tmp_path)
+    executor._search_backend = backend
+    observation = executor(GrepAction(pattern="findMe", include="?"))
+
+    assert observation.is_error is False
+    assert sorted(Path(match).name for match in observation.matches) == ["a", "é", "中"]
+
+
+def test_ripgrep_escaped_braces_do_not_bypass_expansion_budget(monkeypatch, tmp_path):
+    captured_cmd = []
+    executor = GrepExecutor(working_dir=tmp_path)
+
+    def fake_run(cmd, **_kwargs):
+        captured_cmd.extend(cmd)
+        return grep_impl.subprocess.CompletedProcess(cmd, 1, "", "")
+
+    monkeypatch.setattr(grep_impl.subprocess, "run", fake_run)
+    escaped_groups = r"\{a,b\}" * 16
+
+    observation = executor._execute_with_ripgrep(
+        GrepAction(pattern="findMe", include=escaped_groups), tmp_path
+    )
+
+    assert observation.is_error is False
+    assert "-g" not in captured_cmd
+    assert "--hidden" in captured_cmd
+    assert "--no-ignore" in captured_cmd
+    assert "--no-config" in captured_cmd
+
+
+def test_ripgrep_non_match_error_returns_error_observation(monkeypatch, tmp_path):
+    def fake_run(cmd, **_kwargs):
+        return grep_impl.subprocess.CompletedProcess(cmd, 2, "", "invalid glob")
+
+    monkeypatch.setattr(grep_impl.subprocess, "run", fake_run)
+    executor = GrepExecutor(working_dir=tmp_path)
+    observation = executor._execute_with_ripgrep(
+        GrepAction(pattern="findMe", include="*.py"), tmp_path
+    )
+
+    assert observation.is_error is True
+    assert observation.matches == []
+    assert "invalid glob" in observation.text
+
+
+@pytest.mark.skipif(
+    not grep_impl._check_ripgrep_available(), reason="ripgrep is not available"
+)
+def test_ripgrep_complex_include_keeps_hidden_ignored_files(tmp_path):
+    search_root = tmp_path / ".root"
+    search_root.mkdir()
+    hidden_file = search_root / ".env"
+    hidden_file.write_text("findMe")
+    (search_root / ".ignore").write_text(".env\n")
+    hidden_dir = search_root / ".hidden"
+    hidden_dir.mkdir()
+    (hidden_dir / ".env").write_text("findMe")
+
+    executor = GrepExecutor(working_dir=search_root)
+    action = GrepAction(pattern="findMe", include="[.]env")
+    observation = executor._execute_with_ripgrep(action, search_root)
+
+    assert observation.is_error is False
+    assert observation.matches == [str(hidden_file.resolve())]
+
+
+@pytest.mark.skipif(
+    not grep_impl._check_ripgrep_available(), reason="ripgrep is not available"
+)
+def test_ripgrep_simple_include_ignores_repo_and_user_excludes(monkeypatch, tmp_path):
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "a.txt").write_text("findMe")
+    (tmp_path / "configured.txt").write_text("findMe")
+    (tmp_path / ".ignore").write_text("ignored/\n")
+    rg_config = tmp_path / "rg.conf"
+    rg_config.write_text("--glob=!configured.txt\n")
+    monkeypatch.setenv("RIPGREP_CONFIG_PATH", str(rg_config))
+
+    executor = GrepExecutor(working_dir=tmp_path)
+    action = GrepAction(pattern="findMe", include="*.txt")
+    observation = executor._execute_with_ripgrep(action, tmp_path)
+
+    assert observation.is_error is False
+    assert sorted(Path(match).name for match in observation.matches) == [
+        "a.txt",
+        "configured.txt",
+    ]
 
 
 def test_grep_executor_custom_path():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Brace `include` patterns like `*.{ts,tsx}` (a documented example) silently matched nothing. I reproduced this on both the ripgrep and Python backends and added unit and executor tests for the fix.

---

AGENT:

## Why

`grep` advertises `*.{ts,tsx}` as a supported `include` example (in both the `GrepAction.include` field description and the tool description), and ripgrep's `-g` honors it. But every backend's results are post-filtered through `_path_matches_filters`, which used `fnmatch`. `fnmatch` treats `{`, `}` and `,` literally, so any brace `include` silently matched nothing — the ripgrep backend even found the files with `-g` and then dropped them in the post-filter.

## Summary

- Add a small recursive brace expander (`*.{ts,tsx}` → `["*.ts", "*.tsx"]`, nested/multiple groups supported; malformed/comma-less braces left literal like the shell).
- Use it in `_path_matches_filters`, fixing all three backends at once (they share the post-filter).
- Add unit tests for the expander and executor tests for the documented example.

## Issue Number

N/A — found via code review; no pre-existing issue.

## How to Test

Reproduced against the executor before/after:

```python
# dir with a.ts, b.tsx, c.py all containing "logError"
GrepExecutor(working_dir=d)(GrepAction(pattern="logError", include="*.{ts,tsx}"))
# BEFORE: matches == []   AFTER: matches == [a.ts, b.tsx]
```
Verified on both the ripgrep and Python backends. `include="*.ts"` still returns only `a.ts`.

Tests: `.venv/bin/python -m pytest tests/tools/grep/ -q` — 56 passed. `ruff` clean.

## Type

- [x] Bug fix

## Notes

Found via code review; no pre-existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
