### PR TITLE
fix(llm): don't crash prompt caching on an empty-content trailing message

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2579,7 +2579,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # extends every turn. Anthropic-only; Gemini is excluded from
         # PROMPT_CACHE_MODELS because its cache can't extend this way.
         for message in reversed(messages):
-            if message.role in ("user", "tool"):
+            # Skip empty-content user/tool messages (e.g. a tool observation that
+            # produced no text/image): there is no content block to mark, and
+            # indexing content[-1] on an empty list would raise IndexError. Fall
+            # through to the previous non-empty user/tool message instead.
+            if message.role in ("user", "tool") and message.content:
                 message.content[
                     -1
                 ].cache_prompt = True  # Last item inside the message content

--- a/tests/sdk/llm/test_prompt_caching_cross_conversation.py
+++ b/tests/sdk/llm/test_prompt_caching_cross_conversation.py
@@ -144,6 +144,35 @@ def test_end_to_end_caching_flow(tmp_path, dynamic_context, expect_dynamic):
     assert messages[1].content[-1].cache_prompt is True
 
 
+def test_apply_prompt_caching_skips_empty_content_trailing_message():
+    """REGRESSION: an empty-content trailing user/tool message (e.g. a tool
+    observation that produced no text/image) must not crash prompt caching.
+
+    Marking ``content[-1]`` on an empty content list raised IndexError and
+    aborted the whole completion. The breakpoint should instead fall through to
+    the previous non-empty user/tool message.
+    """
+    llm = LLM(
+        model="claude-sonnet-4-20250514",
+        api_key=SecretStr("fake-key"),
+        usage_id="test",
+    )
+
+    messages = [
+        Message(role="system", content=[TextContent(text="System prompt")]),
+        Message(role="user", content=[TextContent(text="Hello")]),
+        Message(role="tool", content=[]),  # empty tool observation
+    ]
+
+    # Must not raise IndexError.
+    llm._apply_prompt_caching(messages)
+
+    # The empty trailing message has no block to mark; the breakpoint falls back
+    # to the last non-empty user/tool message.
+    assert messages[1].content[-1].cache_prompt is True
+    assert messages[2].content == []
+
+
 def test_gemini_prompt_caching_emits_no_markers():
     """REGRESSION: Gemini must not emit explicit cache_control markers.
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

An empty-content trailing tool/user message crashed prompt caching with an IndexError that aborted the whole completion. I reproduced it and added a regression test covering the empty-message case.

---

AGENT:

## Why

`_apply_prompt_caching` marks the last user/tool message's final content block with `message.content[-1].cache_prompt = True`. When that message has empty content — e.g. a tool observation that produced no text or image, or an empty trailing user message — `content[-1]` raised `IndexError` and aborted the entire completion. The system-message branch above already length-checks its content; the user/tool loop did not.

## Summary

- Skip empty-content user/tool messages so the cache breakpoint falls through to the previous non-empty message instead of crashing.
- Add a regression test.

## Issue Number

N/A — found via code review; no pre-existing issue.

## How to Test

Reproduced before/after:

```python
llm._apply_prompt_caching([
    Message(role="system", content=[TextContent(text="sys")]),
    Message(role="user", content=[TextContent(text="hi")]),
    Message(role="tool", content=[]),   # empty tool observation
])
# BEFORE: IndexError: list index out of range
# AFTER: no error; breakpoint set on the previous non-empty message
```
Tests: `.venv/bin/python -m pytest tests/sdk/llm/test_prompt_caching_cross_conversation.py -q` — 7 passed. `ruff` clean.

## Type

- [x] Bug fix

## Notes

Found via code review; no pre-existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
