### PR TITLE
fix(llm): resolve chat-option capabilities from the canonical model name

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -20,6 +20,14 @@ def select_chat_options(
 
     This keeps the exact provider-aware mappings and precedence.
     """
+    # Capability detection must use the canonical model name — e.g. when a
+    # `litellm_proxy/<alias>` model is configured with `model_canonical_name`,
+    # the alias itself carries no feature info. This matches every other
+    # capability lookup in the SDK (responses_options, caching, responses API,
+    # inline-image). The raw `llm.model` is still used below for provider-routing
+    # string checks (azure/gemini prefixes), which key off the real routed model.
+    model_for_caps = llm._model_name_for_capabilities()
+
     # First pass: apply simple defaults without touching user-supplied values
     max_output_tokens = llm.effective_max_output_tokens
     defaults: dict[str, Any] = {
@@ -49,7 +57,7 @@ def select_chat_options(
         out["extra_headers"] = {**openrouter_headers, **existing}
 
     # Reasoning-model quirks
-    supports_reasoning_effort = get_features(llm.model).supports_reasoning_effort
+    supports_reasoning_effort = get_features(model_for_caps).supports_reasoning_effort
     if supports_reasoning_effort:
         # LiteLLM automatically handles reasoning_effort for all models, including
         # Claude Opus 4.5 (maps to output_config and adds beta header automatically)
@@ -62,7 +70,7 @@ def select_chat_options(
             out.pop("top_p", None)
 
     # Extended thinking models
-    if get_features(llm.model).supports_extended_thinking:
+    if get_features(model_for_caps).supports_extended_thinking:
         if llm.extended_thinking_budget and max_output_tokens:
             # Anthropic throws errors if thinking budget equals or exceeds max output
             # tokens -- force the thinking budget lower if there's a conflict
@@ -94,7 +102,7 @@ def select_chat_options(
 
     # Send prompt_cache_retention only if model supports it
     if (
-        get_features(llm.model).supports_prompt_cache_retention
+        get_features(model_for_caps).supports_prompt_cache_retention
         and llm.prompt_cache_retention
     ):
         out["prompt_cache_retention"] = llm.prompt_cache_retention

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -9,6 +9,7 @@ from openhands.sdk.llm.options.chat_options import select_chat_options
 @dataclass
 class DummyLLM:
     model: str
+    model_canonical_name: str | None = None
     top_k: int | None = None
     top_p: float | None = 1.0
     temperature: float | None = 0.0
@@ -34,6 +35,9 @@ class DummyLLM:
     @property
     def effective_max_output_tokens(self) -> int:
         return self.max_output_tokens
+
+    def _model_name_for_capabilities(self) -> str:
+        return self.model_canonical_name or self.model
 
 
 def test_opus_4_5_uses_reasoning_effort_and_strips_temp_top_p():
@@ -146,6 +150,33 @@ def test_claude_sonnet_4_6_strips_temp_and_top_p():
     # Extended thinking models should strip temperature/top_p to avoid API errors
     assert "temperature" not in out
     assert "top_p" not in out
+
+
+def test_canonical_name_drives_capability_detection_for_proxied_model():
+    """A litellm_proxy alias with model_canonical_name must resolve capabilities
+    from the canonical name, like every other capability lookup in the SDK.
+
+    The raw alias carries no feature info, so before this fix the chat options
+    left temperature/top_p in the request and never enabled extended thinking for
+    a proxied thinking model — the direct model stripped them.
+    """
+    proxied = DummyLLM(
+        model="litellm_proxy/my-claude",
+        model_canonical_name="claude-sonnet-4-6",
+        top_p=1.0,
+        temperature=0.5,
+    )
+    out = select_chat_options(proxied, user_kwargs={}, has_tools=True)
+
+    # Same posture as the direct model (test_claude_sonnet_4_6_strips_temp_and_top_p).
+    assert "temperature" not in out
+    assert "top_p" not in out
+
+    # Sanity: the raw alias alone is not detected as a thinking model, so without
+    # the canonical resolution temperature would have survived.
+    raw = DummyLLM(model="litellm_proxy/my-claude", top_p=1.0, temperature=0.5)
+    raw_out = select_chat_options(raw, user_kwargs={}, has_tools=True)
+    assert raw_out.get("temperature") == 0.5
 
 
 def test_bedrock_opus_4_8_strips_temp_top_p_without_thinking_block():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Chat options ignored model_canonical_name when detecting capabilities, so a proxied thinking model kept temperature and never enabled thinking. I verified the canonical model now strips temperature/top_p correctly and added a regression test.

---

AGENT:

## Why

`select_chat_options` looked up model features with the raw `llm.model`, while every other capability lookup in the SDK (`responses_options`, `is_caching_prompt_active`, `uses_responses_api`, `_to_chat_dicts`, `_inline_required`) uses `_model_name_for_capabilities()` (= `model_canonical_name or model`). For a `litellm_proxy/<alias>` model with `model_canonical_name` set to the real model, the alias carries no feature info, so the chat path never detected reasoning-effort / extended-thinking / prompt-cache-retention support: it left `temperature`/`top_p` in the request (which Anthropic reasoning models reject) and never enabled thinking.

## Summary

- Resolve the three `get_features(...)` calls in chat options from the canonical model name. The raw `llm.model` is still used for provider-routing string checks (azure/gemini prefixes).
- Add a regression test; give the chat-options test double a `_model_name_for_capabilities()` mirroring the real LLM.

## Issue Number

N/A — found via code review; no pre-existing issue.

## How to Test

Reproduced before/after with `LLM(model="litellm_proxy/my-claude", model_canonical_name="claude-sonnet-4-5", temperature=0.5)`:

```
get_features("litellm_proxy/my-claude").supports_extended_thinking == False
get_features("claude-sonnet-4-5").supports_extended_thinking       == True
```
BEFORE: `temperature` survived in the request; thinking not enabled. AFTER: `temperature`/`top_p` stripped, same posture as the direct model.

Tests: `.venv/bin/python -m pytest tests/sdk/llm/test_chat_options.py tests/sdk/llm/test_model_canonical_name_resolution.py -q` — 19 passed. `ruff` clean.

## Type

- [x] Bug fix

## Notes

Found via code review; no pre-existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
