### PR TITLE
fix(llm): clamp thinking budget and sibling key in joint-budget clamp

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2342,7 +2342,34 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 input_tokens,
                 context_window,
             )
-        return {**call_kwargs, budget_key: clamped}
+
+        updated = {**call_kwargs, budget_key: clamped}
+
+        # The extended-thinking path in chat_options sets ``max_tokens`` without
+        # popping the default ``max_completion_tokens``, so both budget keys can
+        # be present. Clamp the sibling too (only when already present) so a stale
+        # full-size copy can't defeat the clamp downstream.
+        sibling_key = (
+            "max_completion_tokens" if budget_key == "max_tokens" else "max_tokens"
+        )
+        sibling = updated.get(sibling_key)
+        if isinstance(sibling, int) and sibling > clamped:
+            updated[sibling_key] = clamped
+
+        # Preserve the extended-thinking invariant ``budget_tokens < max_tokens``
+        # (Anthropic/Bedrock reject a thinking budget that meets or exceeds
+        # max_tokens). chat_options applied this against the original
+        # max_output_tokens; re-apply it against the clamped budget so lowering
+        # max_tokens for a large input can't invert it into an invalid request.
+        thinking = updated.get("thinking")
+        if (
+            isinstance(thinking, dict)
+            and isinstance(thinking.get("budget_tokens"), int)
+            and thinking["budget_tokens"] >= clamped
+        ):
+            updated["thinking"] = {**thinking, "budget_tokens": max(clamped - 1, 1)}
+
+        return updated
 
     def _init_model_info_and_caps(self) -> None:
         self._model_info = get_litellm_model_info(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -160,6 +160,10 @@ DEFAULT_MAX_OUTPUT_TOKENS_CAP: Final[int] = 16384
 # default change that made this manifest.
 JOINT_BUDGET_SAFETY_MARGIN_TOKENS: Final[int] = 256
 JOINT_BUDGET_MIN_OUTPUT_TOKENS: Final[int] = 1024
+# Anthropic rejects ``thinking.budget_tokens`` below this minimum, so a clamped
+# ``max_tokens`` that cannot fit ``budget_tokens >= 1024`` while keeping
+# ``budget_tokens < max_tokens`` leaves no legal thinking budget at all.
+ANTHROPIC_MIN_THINKING_BUDGET_TOKENS: Final[int] = 1024
 # Provider name prefixes known to enforce a joint input/output token budget.
 # Kept as a narrow allowlist so direct providers (Anthropic, OpenAI, etc.) --
 # which have independent input/output windows -- are not affected. We match by
@@ -2361,13 +2365,28 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # max_tokens). chat_options applied this against the original
         # max_output_tokens; re-apply it against the clamped budget so lowering
         # max_tokens for a large input can't invert it into an invalid request.
+        # Anthropic also enforces ``budget_tokens >= 1024``, so when the clamped
+        # budget leaves no room for both constraints there is no legal thinking
+        # budget at all -- degrade the call to non-thinking instead of sending a
+        # request the provider must reject.
         thinking = updated.get("thinking")
         if (
             isinstance(thinking, dict)
             and isinstance(thinking.get("budget_tokens"), int)
             and thinking["budget_tokens"] >= clamped
         ):
-            updated["thinking"] = {**thinking, "budget_tokens": max(clamped - 1, 1)}
+            fitted_budget = clamped - 1
+            if fitted_budget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS:
+                logger.warning(
+                    "Clamped output budget of %s cannot fit a legal thinking "
+                    "budget (provider minimum %s); disabling extended thinking "
+                    "for this request.",
+                    clamped,
+                    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+                )
+                updated.pop("thinking")
+            else:
+                updated["thinking"] = {**thinking, "budget_tokens": fitted_budget}
 
         return updated
 

--- a/tests/sdk/llm/test_joint_budget_clamp.py
+++ b/tests/sdk/llm/test_joint_budget_clamp.py
@@ -184,3 +184,49 @@ def test_no_clamp_when_context_window_unknown():
         out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
 
     assert out["max_completion_tokens"] == 64_000
+
+
+def test_thinking_budget_clamped_below_clamped_max_tokens():
+    """On the extended-thinking path, lowering max_tokens must also lower the
+    thinking budget so it stays strictly below max_tokens.
+
+    chat_options sets ``max_tokens`` (without popping the default
+    ``max_completion_tokens``) plus a ``thinking.budget_tokens`` just under the
+    full output budget. Clamping only ``max_tokens`` for a large input would
+    leave ``budget_tokens >= max_tokens``, which Bedrock/Anthropic reject.
+    """
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {
+        "max_tokens": 64_000,
+        "max_completion_tokens": 64_000,
+        "thinking": {"type": "enabled", "budget_tokens": 63_999},
+    }
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=180_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    clamped = 200_000 - 180_000 - JOINT_BUDGET_SAFETY_MARGIN_TOKENS
+    assert out["max_tokens"] == clamped
+    # The sibling budget key is clamped too, so a stale full-size copy cannot
+    # defeat the clamp downstream.
+    assert out["max_completion_tokens"] == clamped
+    # Thinking budget stays strictly below the clamped max_tokens.
+    assert out["thinking"]["budget_tokens"] < out["max_tokens"]
+    assert out["thinking"]["budget_tokens"] == clamped - 1
+    # The caller's nested thinking dict must not be mutated in place.
+    assert call_kwargs["thinking"]["budget_tokens"] == 63_999
+
+
+def test_thinking_budget_preserved_when_no_clamp_needed():
+    """Small input: nothing is clamped and the thinking budget is preserved."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {
+        "max_tokens": 64_000,
+        "thinking": {"type": "enabled", "budget_tokens": 63_999},
+    }
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=50_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_tokens"] == 64_000
+    assert out["thinking"]["budget_tokens"] == 63_999

--- a/tests/sdk/llm/test_joint_budget_clamp.py
+++ b/tests/sdk/llm/test_joint_budget_clamp.py
@@ -230,3 +230,44 @@ def test_thinking_budget_preserved_when_no_clamp_needed():
 
     assert out["max_tokens"] == 64_000
     assert out["thinking"]["budget_tokens"] == 63_999
+
+
+def test_thinking_dropped_when_no_legal_budget_fits():
+    """Near-exhausted window: the clamped budget cannot fit any legal thinking
+    budget (Anthropic requires ``1024 <= budget_tokens < max_tokens``), so the
+    thinking block must be dropped rather than sent one token short.
+
+    With 199.5k input the clamp lands on the floor of 1024, and
+    ``budget_tokens = 1023`` would swap the "budget >= max_tokens" 400 for a
+    "budget < 1024" 400.
+    """
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {
+        "max_tokens": 64_000,
+        "thinking": {"type": "enabled", "budget_tokens": 63_999},
+    }
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=199_500):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_tokens"] == JOINT_BUDGET_MIN_OUTPUT_TOKENS
+    assert "thinking" not in out
+    # The caller's kwargs must not be mutated.
+    assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 63_999}
+
+
+def test_thinking_kept_at_smallest_legal_budget():
+    """Boundary: a clamped budget of 1025 still fits the minimum legal
+    thinking budget of exactly 1024, so thinking survives."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {
+        "max_tokens": 64_000,
+        "thinking": {"type": "enabled", "budget_tokens": 63_999},
+    }
+
+    # headroom = 200_000 - 198_719 - 256 = 1_025 -> clamped = 1_025
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=198_719):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_tokens"] == 1_025
+    assert out["thinking"]["budget_tokens"] == 1_024


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

On Bedrock the joint-budget clamp lowered max_tokens but left thinking.budget_tokens above it, producing a request the provider rejects. I reproduced the scenario and added regression tests for the thinking-budget and both-keys cases.

---

AGENT:

## Why

`_clamp_max_tokens_for_joint_budget` lowers the per-request output budget for joint-window providers (Bedrock-Anthropic) when the input is large, but only rewrote the single budget key it found. On the extended-thinking path this caused two follow-on defects: (1) `thinking.budget_tokens` was left just under the full 64k output, so once `max_tokens` is clamped below it, `budget_tokens >= max_tokens`, which Bedrock/Anthropic reject; (2) chat_options sets `max_tokens` without popping the default `max_completion_tokens`, so a stale full-size sibling key could defeat the clamp downstream.

## Summary

- Re-apply the `budget_tokens < max_tokens` invariant against the clamped value.
- Clamp the sibling budget key too (only when already present, so no new key is introduced).
- Rebuild (not mutate) the nested `thinking` dict so caller kwargs are untouched.
- Add regression tests.

## Issue Number

N/A — found via code review; no pre-existing issue.

## How to Test

Reproduced against the clamp with a Bedrock thinking request (200k window, 180k input):

```
call_kwargs = {"max_tokens": 64000, "max_completion_tokens": 64000,
               "thinking": {"type": "enabled", "budget_tokens": 63999}}
# AFTER: max_tokens=19744, max_completion_tokens=19744, thinking.budget_tokens=19743  (< max_tokens)
# BEFORE: budget_tokens stayed 63999 >= clamped max_tokens 19744 -> provider rejects
```
Tests: `.venv/bin/python -m pytest tests/sdk/llm/test_joint_budget_clamp.py -q` — 12 passed. `ruff` clean.

## Type

- [x] Bug fix

## Notes

Found via code review; no pre-existing issue. Triggers on Bedrock Claude thinking models with large inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
