### PR TITLE
fix(security): redact git remote URL credentials in terminal output

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -10,6 +10,10 @@ from pydantic import Field, PrivateAttr, SecretStr
 from openhands.sdk.logger import get_logger
 from openhands.sdk.secret import SecretSource, SecretValue, StaticSecret
 from openhands.sdk.utils.models import OpenHandsModel
+from openhands.sdk.utils.redact import (
+    redact_api_key_literals,
+    redact_url_credentials_in_text,
+)
 
 
 logger = get_logger(__name__)
@@ -175,6 +179,12 @@ class SecretRegistry(OpenHandsModel):
         for value in exported_values:
             if value:
                 masked_text = masked_text.replace(value, "<secret-hidden>")
+
+        # Always scrub bare key literals and URL-embedded credentials (e.g.
+        # `git remote -v` showing https://ghu_...@github.com/...), even when the
+        # secret was not registered in this conversation.
+        masked_text = redact_api_key_literals(masked_text)
+        masked_text = redact_url_credentials_in_text(masked_text)
 
         return masked_text
 

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -340,6 +340,10 @@ def redact_text_secrets(text: str) -> str:
     # Bare API key literals (common provider formats)
     text = redact_api_key_literals(text)
 
+    # https://user:token@host (and bare-token@host) embedded in arbitrary text —
+    # e.g. `git remote -v` / clone errors. Covers GitHub ghu_/ghp_ URL userinfo.
+    text = redact_url_credentials_in_text(text)
+
     return text
 
 
@@ -354,6 +358,8 @@ _API_KEY_LITERAL_RE = re.compile(
     r"|hf_[A-Za-z0-9]{20,}"  # HuggingFace
     r"|tgp_v1_[A-Za-z0-9_-]{20,}"  # Together AI
     r"|ghp_[A-Za-z0-9]{20,}"  # GitHub PAT (classic)
+    r"|ghu_[A-Za-z0-9]{20,}"  # GitHub user-to-server OAuth tokens
+    r"|gho_[A-Za-z0-9]{20,}"  # GitHub OAuth app tokens
     r"|github_pat_[A-Za-z0-9_]{20,}"  # GitHub PAT (fine-grained)
     r"|sk-oh-[A-Za-z0-9]{20,}"  # OpenHands session tokens
     r"|ctx7sk-[A-Za-z0-9_-]{10,}"  # Context7 MCP keys

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -174,7 +174,7 @@ def redact_url_credentials(url: str, *, preserve_placeholders: bool = False) -> 
 # larger string. The userinfo portion excludes ``/``, ``@``, and whitespace so
 # the match stops at the first credential boundary and never spans a path
 # segment or another token.
-_EMBEDDED_URL_CREDENTIALS_RE = re.compile(r"(https?://)[^/@\s]+@", re.IGNORECASE)
+_EMBEDDED_URL_CREDENTIALS_RE = re.compile(r"(https?://)([^/@\s]+)@", re.IGNORECASE)
 
 
 def redact_url_credentials_in_text(text: str) -> str:
@@ -201,10 +201,10 @@ def redact_url_credentials_in_text(text: str) -> str:
         'no credentials here'
     """
     return _EMBEDDED_URL_CREDENTIALS_RE.sub(
-        lambda m: (
-            m.group(0)
-            if "<secret-hidden>" in m.group(0) or "<redacted>" in m.group(0)
-            else f"{m.group(1)}****@"
+        lambda match: (
+            match.group(0)
+            if match.group(2) in {"<secret-hidden>", "<redacted>"}
+            else f"{match.group(1)}****@"
         ),
         text,
     )

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -200,7 +200,14 @@ def redact_url_credentials_in_text(text: str) -> str:
         >>> redact_url_credentials_in_text("no credentials here")
         'no credentials here'
     """
-    return _EMBEDDED_URL_CREDENTIALS_RE.sub(r"\g<1>****@", text)
+    return _EMBEDDED_URL_CREDENTIALS_RE.sub(
+        lambda m: (
+            m.group(0)
+            if "<secret-hidden>" in m.group(0) or "<redacted>" in m.group(0)
+            else f"{m.group(1)}****@"
+        ),
+        text,
+    )
 
 
 def redact_url_params(url: str) -> str:

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -8,6 +8,10 @@ from libtmux.exc import LibTmuxException, TmuxObjectDoesNotExist
 
 from openhands.sdk.llm import TextContent
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.redact import (
+    redact_api_key_literals,
+    redact_url_credentials_in_text,
+)
 from openhands.sdk.tool import ToolExecutor
 
 
@@ -362,24 +366,37 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         observation: TerminalObservation,
         conversation: "LocalConversation | None" = None,
     ) -> TerminalObservation:
-        """Apply automatic secrets masking to *observation*."""
-        content_text = observation.text
+        """Apply automatic secrets masking to *observation*.
 
-        if content_text and conversation is not None:
+        Always redacts URL-embedded credentials and bare API key literals so
+        outputs like ``git remote -v`` never leak GitHub tokens into the model
+        context (OpenHands#15338), even when no conversation secrets are set.
+        """
+        content_text = observation.text
+        if not content_text:
+            return observation
+
+        masked_content = content_text
+        if conversation is not None:
             try:
                 secret_registry = conversation.state.secret_registry
-                masked_content = secret_registry.mask_secrets_in_output(content_text)
-                if masked_content:
-                    data = observation.model_dump(
-                        exclude={"content", "full_output_save_dir"}
-                    )
-                    return TerminalObservation.from_text(
-                        text=masked_content,
-                        full_output_save_dir=self.full_output_save_dir,
-                        **data,
-                    )
+                masked_content = secret_registry.mask_secrets_in_output(masked_content)
             except Exception:
                 pass
+
+        # Generic redaction (idempotent if secret_registry already applied it).
+        masked_content = redact_api_key_literals(masked_content)
+        masked_content = redact_url_credentials_in_text(masked_content)
+
+        if masked_content != content_text:
+            data = observation.model_dump(
+                exclude={"content", "full_output_save_dir"}
+            )
+            return TerminalObservation.from_text(
+                text=masked_content,
+                full_output_save_dir=self.full_output_save_dir,
+                **data,
+            )
 
         return observation
 

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -377,11 +377,16 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         generic redactions (``redact_api_key_literals`` +
         ``redact_url_credentials_in_text``) are applied — enough to stop
         ``git remote -v`` from leaking a ``ghu_…`` token to the model.
+
+        Security redaction must fail closed: if the registry masker raises,
+        the generic literal/URL redactors still run so credential-bearing
+        output never reaches the model unmasked.
         """
         content_text = observation.text
         if not content_text:
             return observation
 
+        masked_content = content_text
         if conversation is not None:
             try:
                 masked_content = (
@@ -390,10 +395,15 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
                     )
                 )
             except Exception:
-                masked_content = content_text
-        else:
-            masked_content = redact_api_key_literals(content_text)
-            masked_content = redact_url_credentials_in_text(masked_content)
+                # Registry masking failed; fall through to deterministic
+                # generic redaction so the output is still scrubbed.
+                pass
+
+        # Always apply deterministic generic redaction as the last line of
+        # defence.  When the registry already applied it (success path) the
+        # redactors are idempotent no-ops on already-masked placeholders.
+        masked_content = redact_api_key_literals(masked_content)
+        masked_content = redact_url_credentials_in_text(masked_content)
 
         if masked_content != content_text:
             data = observation.model_dump(

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -368,25 +368,32 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
     ) -> TerminalObservation:
         """Apply automatic secrets masking to *observation*.
 
-        Always redacts URL-embedded credentials and bare API key literals so
-        outputs like ``git remote -v`` never leak GitHub tokens into the model
-        context (OpenHands#15338), even when no conversation secrets are set.
+        When a conversation is present, masking is fully delegated to its
+        ``SecretRegistry.mask_secrets_in_output``, which scrubs registered
+        secret values, bare API-key literals, and URL-embedded credentials
+        (OpenHands#15338) in one pass.
+
+        Without a conversation there is no registry to consult, so only the
+        generic redactions (``redact_api_key_literals`` +
+        ``redact_url_credentials_in_text``) are applied — enough to stop
+        ``git remote -v`` from leaking a ``ghu_…`` token to the model.
         """
         content_text = observation.text
         if not content_text:
             return observation
 
-        masked_content = content_text
         if conversation is not None:
             try:
-                secret_registry = conversation.state.secret_registry
-                masked_content = secret_registry.mask_secrets_in_output(masked_content)
+                masked_content = (
+                    conversation.state.secret_registry.mask_secrets_in_output(
+                        content_text
+                    )
+                )
             except Exception:
-                pass
-
-        # Generic redaction (idempotent if secret_registry already applied it).
-        masked_content = redact_api_key_literals(masked_content)
-        masked_content = redact_url_credentials_in_text(masked_content)
+                masked_content = content_text
+        else:
+            masked_content = redact_api_key_literals(content_text)
+            masked_content = redact_url_credentials_in_text(masked_content)
 
         if masked_content != content_text:
             data = observation.model_dump(

--- a/tests/sdk/utils/test_redact.py
+++ b/tests/sdk/utils/test_redact.py
@@ -1,6 +1,8 @@
 """Tests for redact utility functions."""
 
 from openhands.sdk.utils.redact import (
+    redact_api_key_literals,
+    redact_text_secrets,
     SENSITIVE_URL_PARAMS,
     redact_url_credentials,
     redact_url_credentials_in_text,
@@ -251,3 +253,34 @@ class TestRedactUrlCredentialsInText:
         """For a bare whole-URL string both helpers agree."""
         url = "https://oauth2:SECRET@gitlab.com/org/repo.git"
         assert redact_url_credentials_in_text(url) == redact_url_credentials(url)
+
+
+
+class TestGitHubUrlAndTokenRedaction:
+    """Coverage for OpenHands#15338 — git remote URL credential leakage."""
+
+    def test_redact_api_key_literals_ghu_token(self):
+        text = "https://ghu_abcdefghijklmnopqrstuvwxyz0123456789@github.com/owner/repo.git"
+        redacted = redact_api_key_literals(text)
+        assert "ghu_abcdefghijklmnopqrstuvwxyz0123456789" not in redacted
+        assert "<redacted>" in redacted
+
+    def test_redact_api_key_literals_gho_token(self):
+        text = "token gho_abcdefghijklmnopqrstuvwxyz0123456789 used"
+        redacted = redact_api_key_literals(text)
+        assert "gho_abcdefghijklmnopqrstuvwxyz0123456789" not in redacted
+
+    def test_redact_text_secrets_git_remote_v_output(self):
+        text = (
+            "origin\thttps://ghu_abcdefghijklmnopqrstuvwxyz0123456789@github.com/o/r.git (fetch)\n"
+            "origin\thttps://ghu_abcdefghijklmnopqrstuvwxyz0123456789@github.com/o/r.git (push)"
+        )
+        redacted = redact_text_secrets(text)
+        assert "ghu_abcdefghijklmnopqrstuvwxyz0123456789" not in redacted
+        assert "github.com/o/r.git" in redacted
+
+    def test_redact_url_credentials_in_text_ghu_userinfo(self):
+        text = "origin  https://ghu_abcdefghijklmnopqrstuvwxyz0123456789@github.com/owner/repo.git (fetch)"
+        redacted = redact_url_credentials_in_text(text)
+        assert "ghu_abcdefghijklmnopqrstuvwxyz0123456789" not in redacted
+        assert "https://****@github.com/owner/repo.git" in redacted

--- a/tests/sdk/utils/test_redact.py
+++ b/tests/sdk/utils/test_redact.py
@@ -198,6 +198,17 @@ class TestRedactUrlCredentialsInText:
             "fatal: unable to access 'https://****@github.com/o/r.git/': 403"
         )
 
+    def test_redacts_composite_userinfo_with_masked_component(self):
+        s = "url https://<redacted>:still-secret@example.com/repo.git"
+        result = redact_url_credentials_in_text(s)
+        assert "still-secret" not in result
+        assert result == "url https://****@example.com/repo.git"
+
+    def test_preserves_fully_masked_userinfo(self):
+        for userinfo in ("<redacted>", "<secret-hidden>"):
+            s = "url https://" + userinfo + "@example.com/repo.git"
+            assert redact_url_credentials_in_text(s) == s
+
     def test_redacts_token_only_credential(self):
         s = "Cloning https://ghp_supersecrettoken@github.com/o/r.git failed"
         result = redact_url_credentials_in_text(s)

--- a/tests/tools/terminal/test_secrets_masking.py
+++ b/tests/tools/terminal/test_secrets_masking.py
@@ -134,3 +134,33 @@ def test_terminal_executor_masks_secret_not_referenced_by_command():
         finally:
             executor.close()
             conversation.close()
+
+
+def test_terminal_masks_git_remote_credentials_without_registered_secrets():
+    """URL-embedded GitHub tokens must be redacted even with no conversation secrets.
+
+    Regression for OpenHands#15338: `git remote -v` can print
+    https://ghu_...@github.com/... and that used to reach the model unmasked.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executor = TerminalExecutor(working_dir=temp_dir, terminal_type="subprocess")
+        try:
+            mock_session = Mock()
+            token = "ghu_" + ("a" * 36)
+            remote_line = f"origin\thttps://{token}@github.com/owner/repo.git (fetch)"
+            mock_observation = TerminalObservation(
+                command="git remote -v",
+                exit_code=0,
+                content=[TextContent(text=remote_line)],
+            )
+            mock_session.execute.return_value = mock_observation
+            mock_session._closed = False
+            executor._session = mock_session
+
+            result = executor(TerminalAction(command="git remote -v"))
+            assert token not in result.text
+            assert "github.com/owner/repo.git" in result.text
+            assert "****@" in result.text or "<redacted>" in result.text
+        finally:
+            executor.close()
+

--- a/tests/tools/terminal/test_secrets_masking.py
+++ b/tests/tools/terminal/test_secrets_masking.py
@@ -164,3 +164,57 @@ def test_terminal_masks_git_remote_credentials_without_registered_secrets():
         finally:
             executor.close()
 
+
+
+def test_terminal_masks_credential_url_when_registry_masker_raises():
+    """Generic redaction must still run when SecretRegistry.mask_secrets_in_output raises.
+
+    Regression for the fail-open exception path identified in PR #4175 review:
+    a ``git remote -v`` line containing ``ghu_...@github.com`` must be redacted
+    even if the registry masker raises, so credential-bearing output never
+    reaches the model unmasked.
+    """
+    from unittest.mock import patch
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"
+        )
+        agent = Agent(llm=llm, tools=[])
+        conversation = Conversation(
+            agent=agent,
+            workspace=temp_dir,
+            persistence_dir=temp_dir,
+        )
+
+        executor = TerminalExecutor(working_dir=temp_dir, terminal_type="subprocess")
+        try:
+            token = "ghu_" + ("b" * 36)
+            remote_line = f"origin\thttps://{token}@github.com/owner/repo.git (fetch)"
+            mock_session = Mock()
+            mock_session.execute.return_value = TerminalObservation(
+                command="git remote -v",
+                exit_code=0,
+                content=[TextContent(text=remote_line)],
+            )
+            mock_session._closed = False
+            executor._session = mock_session
+
+            # Force the registry masker to raise — simulates state access failure.
+            with patch.object(
+                type(conversation.state.secret_registry),
+                "mask_secrets_in_output",
+                side_effect=RuntimeError("registry unavailable"),
+            ):
+                result = executor(
+                    TerminalAction(command="git remote -v"),
+                    conversation=conversation,
+                )
+
+                # The credential must still be redacted despite the registry failure.
+                assert token not in result.text
+                assert "github.com/owner/repo.git" in result.text
+                assert "****@" in result.text or "<redacted>" in result.text
+        finally:
+            executor.close()
+            conversation.close()


### PR DESCRIPTION
HUMAN:

Security fix for git remote credential leakage in terminal output (OpenHands#15338).

---

AGENT:

## Why

When OpenHands runs with a connected GitHub account, commands like `git remote -v` can print remote URLs containing user-to-server tokens (`ghu_...@github.com`). Those credentials were not redacted before terminal output entered the model context, so the model could repeat them. Documentation claims secrets are masked, so this is a redaction gap.

## Summary

- Match GitHub `ghu_` / `gho_` tokens in `redact_api_key_literals`
- Always scrub URL-embedded credentials in `SecretRegistry.mask_secrets_in_output` and `TerminalExecutor._mask_observation`, even without registered conversation secrets
- Unit coverage for git-remote-style output

## Issue Number

OpenHands/software-agent-sdk#4271

## How to Test

1. Logic checks (no full monorepo install required):
   - Load `openhands-sdk/openhands/sdk/utils/redact.py` and verify:
     - bare `ghu_`/`gho_` literals become `<redacted>`
     - `origin\thttps://ghu_...@github.com/owner/repo.git (fetch)` becomes `https://****@github.com/...`
     - `redact_text_secrets` and registry-style mask path also scrub the same string
2. Unit tests (when env deps available):
   - `pytest tests/sdk/utils/test_redact.py tests/tools/terminal/test_secrets_masking.py`
3. Manual:
   - Run a terminal action that prints `git remote -v` with a credential-bearing remote
   - Confirm the observation text no longer contains the raw token

## Video/Screenshots

N/A — security redaction of text output; no UI change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `software-agent-sdk` is the runtime path used by OpenHands Cloud for terminal observations.
- A comment linking this PR was left on OpenHands/software-agent-sdk#4271.
