### PR TITLE
fix: decrypt LLM profiles for subagents

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -452,6 +452,7 @@ def _register_agent_definitions(
     agent_defs: list["AgentDefinition"],
     *,
     context: str,
+    cipher: Cipher | None = None,
 ) -> None:
     """Register agent definitions into the subagent registry.
 
@@ -466,7 +467,7 @@ def _register_agent_definitions(
     registered = 0
     for agent_def in agent_defs:
         try:
-            factory = agent_definition_to_factory(agent_def)
+            factory = agent_definition_to_factory(agent_def, cipher=cipher)
             register_agent_if_absent(
                 name=agent_def.name,
                 factory_func=factory,
@@ -643,6 +644,7 @@ class ConversationService:
             _register_agent_definitions(
                 stored.agent_definitions,
                 context=f"resuming conversation {stored.id}",
+                cipher=self.cipher,
             )
 
     async def _get_or_load_event_service(
@@ -992,6 +994,7 @@ class ConversationService:
             _register_agent_definitions(
                 request.agent_definitions,
                 context=f"conversation {conversation_id}",
+                cipher=self.cipher,
             )
 
         # Plugin loading is now handled lazily by LocalConversation.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1071,6 +1071,7 @@ class LocalConversation(BaseConversation):
             register_plugin_agents(
                 agents=all_plugin_agents,
                 work_dir=self.workspace.working_dir,
+                cipher=self._cipher,
             )
 
         # Combine explicit hook_config with plugin hooks
@@ -1282,6 +1283,7 @@ class LocalConversation(BaseConversation):
                 register_plugin_agents(
                     agents=plugin.agents,
                     work_dir=self.workspace.working_dir,
+                    cipher=self._cipher,
                 )
             if plugin.hooks and not plugin.hooks.is_empty():
                 self._merge_runtime_plugin_hooks(plugin.hooks)
@@ -1320,7 +1322,10 @@ class LocalConversation(BaseConversation):
                 then `~/.openhands/agents/*.md`)
         """
         # register project-level and then user-level file-based agents
-        register_file_agents(self.workspace.working_dir)
+        register_file_agents(
+            self.workspace.working_dir,
+            cipher=self._cipher,
+        )
 
     def _ensure_agent_ready(self) -> None:
         """Ensure the agent is fully initialized with plugins and agents loaded.

--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -42,6 +42,7 @@ from openhands.sdk.utils.deprecation import warn_deprecated
 if TYPE_CHECKING:
     from openhands.sdk.agent.agent import Agent
     from openhands.sdk.llm.llm import LLM
+    from openhands.sdk.utils.cipher import Cipher
 
 logger = get_logger(__name__)
 
@@ -160,6 +161,8 @@ def _get_profile_store(profile_store_dir: str | None) -> LLMProfileStore:
 def agent_definition_to_factory(
     agent_def: AgentDefinition,
     work_dir: str | Path | None = None,
+    *,
+    cipher: "Cipher | None" = None,
 ) -> Callable[["LLM"], "Agent"]:
     """Create an agent factory closure from an `AgentDefinition`.
 
@@ -181,6 +184,7 @@ def agent_definition_to_factory(
         agent_def: The agent definition to convert.
         work_dir: Project directory for resolving skill names. If None,
             only user-level skills are searched.
+        cipher: Optional cipher for decrypting secrets in LLM profiles.
 
     Raises:
         ValueError: If a tool or skill is not found.
@@ -225,7 +229,7 @@ def agent_definition_to_factory(
                     f"Available profiles: {available_profiles}"
                 )
 
-            llm = store.load(profile_name)
+            llm = store.load(profile_name, cipher=cipher)
 
         # the system prompt of the subagent is added as a suffix of the
         # main system prompt
@@ -285,7 +289,11 @@ def agent_definition_to_factory(
     return _factory
 
 
-def register_file_agents(work_dir: str | Path) -> list[str]:
+def register_file_agents(
+    work_dir: str | Path,
+    *,
+    cipher: "Cipher | None" = None,
+) -> list[str]:
     """Load and register file-based agents from project-level `.agents/agents` and
     `.openhands/agents`, and user-level `~/.agents/agents` and `~/.openhands/agents`
     directories.
@@ -294,6 +302,10 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
     each level `.agents/` takes priority over `.openhands/`.
 
     Does not overwrite agents already registered programmatically or by plugins.
+
+    Args:
+        work_dir: Project directory containing file-based agent definitions.
+        cipher: Optional cipher for decrypting secrets in LLM profiles.
 
     Returns:
         List of agent names that were actually registered.
@@ -317,7 +329,11 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
 
     registered: list[str] = []
     for agent_def in deduplicated:
-        factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
+        factory = agent_definition_to_factory(
+            agent_def,
+            work_dir=work_dir,
+            cipher=cipher,
+        )
         was_registered = register_agent_if_absent(
             name=agent_def.name,
             factory_func=factory,
@@ -336,6 +352,8 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
 def register_plugin_agents(
     agents: list[AgentDefinition],
     work_dir: str | Path | None = None,
+    *,
+    cipher: "Cipher | None" = None,
 ) -> list[str]:
     """Register plugin-provided agent definitions into the delegate registry.
 
@@ -348,13 +366,18 @@ def register_plugin_agents(
         agents: Agent definitions collected from loaded plugins.
         work_dir: Project directory for resolving skill names in agent
             definitions. If None, only user-level skills are searched.
+        cipher: Optional cipher for decrypting secrets in LLM profiles.
 
     Returns:
         List of agent names that were actually registered.
     """
     registered: list[str] = []
     for agent_def in agents:
-        factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
+        factory = agent_definition_to_factory(
+            agent_def,
+            work_dir=work_dir,
+            cipher=cipher,
+        )
         was_registered = register_agent_if_absent(
             name=agent_def.name,
             factory_func=factory,

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -49,6 +49,7 @@ from openhands.sdk.mcp.config import dump_mcp_config
 from openhands.sdk.secret import SecretSource, StaticSecret
 from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 from openhands.tools.terminal.definition import TerminalAction, TerminalObservation
@@ -215,6 +216,71 @@ async def test_start_conversation_registers_and_injects_client_tools(
     from openhands.sdk.tool.registry import list_registered_tools
 
     assert "srv_show_dialog" in list_registered_tools()
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_passes_cipher_to_subagent_factory(
+    conversation_service, tmp_path
+):
+    cipher = Cipher("subagent-profile-test-key")
+    conversation_service.cipher = cipher
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    agent_def = AgentDefinition(name="profile-subagent")
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+        agent_definitions=[agent_def],
+    )
+
+    async def fake_start_event_service(stored: StoredConversation):
+        service = AsyncMock(spec=EventService)
+        service.stored = stored
+        service.get_state.return_value = ConversationState(
+            id=stored.id,
+            agent=stored.agent,
+            workspace=stored.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=stored.confirmation_policy,
+        )
+        return service
+
+    with (
+        patch.object(
+            conversation_service,
+            "_start_event_service",
+            side_effect=fake_start_event_service,
+        ),
+        patch(
+            "openhands.sdk.subagent.registry.agent_definition_to_factory"
+        ) as mock_factory,
+        patch("openhands.sdk.subagent.registry.register_agent_if_absent"),
+    ):
+        await conversation_service.start_conversation(request)
+
+    mock_factory.assert_called_once_with(agent_def, cipher=cipher)
+
+
+def test_prepare_persisted_runtime_passes_cipher_to_subagent_factory(
+    conversation_service, sample_stored_conversation
+):
+    cipher = Cipher("subagent-profile-test-key")
+    conversation_service.cipher = cipher
+    agent_def = AgentDefinition(name="profile-subagent")
+    stored = sample_stored_conversation.model_copy(
+        update={"agent_definitions": [agent_def]}
+    )
+
+    with (
+        patch(
+            "openhands.sdk.subagent.registry.agent_definition_to_factory"
+        ) as mock_factory,
+        patch("openhands.sdk.subagent.registry.register_agent_if_absent"),
+    ):
+        conversation_service._prepare_persisted_runtime(stored)
+
+    mock_factory.assert_called_once_with(agent_def, cipher=cipher)
 
 
 @pytest.mark.asyncio

--- a/tests/sdk/subagent/test_subagent_registry.py
+++ b/tests/sdk/subagent/test_subagent_registry.py
@@ -21,6 +21,7 @@ from openhands.sdk.subagent.registry import (
     register_plugin_agents,
 )
 from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.utils.cipher import Cipher
 
 
 def setup_function() -> None:
@@ -503,6 +504,42 @@ def test_agent_definition_to_factory_model_profile(tmp_path: Path) -> None:
     assert agent.llm.stream is False
     # Metrics must be independent from the parent LLM
     assert agent.llm.metrics is not parent_llm.metrics
+
+
+def test_agent_definition_to_factory_model_profile_decrypts_with_cipher(
+    tmp_path: Path,
+) -> None:
+    """Encrypted profile secrets are decrypted before the subagent uses them."""
+    store = LLMProfileStore(base_dir=tmp_path)
+    cipher = Cipher("subagent-profile-test-key")
+    api_key = "sk-subagent-secret"
+    store.save(
+        "encrypted-profile",
+        LLM(
+            model="gpt-4o",
+            api_key=SecretStr(api_key),
+            usage_id="encrypted-profile-llm",
+        ),
+        include_secrets=True,
+        cipher=cipher,
+    )
+
+    serialized_profile = (tmp_path / "encrypted-profile.json").read_text()
+    assert api_key not in serialized_profile
+    assert "gAAAAA" in serialized_profile
+
+    factory = agent_definition_to_factory(
+        AgentDefinition(
+            name="encrypted-profile-agent",
+            model="encrypted-profile",
+            profile_store_dir=str(tmp_path),
+        ),
+        cipher=cipher,
+    )
+    agent = factory(_make_test_llm())
+
+    assert isinstance(agent.llm.api_key, SecretStr)
+    assert agent.llm.api_key.get_secret_value() == api_key
 
 
 def test_agent_definition_to_factory_model_profile_with_json_suffix(


### PR DESCRIPTION
HUMAN:

我已阅读并确认本次修改内容，测试结果符合预期，可以进入正式代码审查。

<!--
Human author: ...
-->
---

AGENT:

## Why

Encrypted LLM profiles were loaded by subagents without the server cipher, causing Fernet ciphertext to be used as the provider API key.

## Summary

- Pass the cipher through all subagent registration paths.
- Decrypt encrypted LLM profiles when creating subagents.
- Add regression tests for new and resumed conversations.

## Issue Number

Addresses OpenHands/software-agent-sdk#4270.

## How to Test

Ran the targeted regression tests, related test suites, pre-commit, Ruff, and Pyright successfully.

## Type

- [x] Bug fix

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.66s · commit cf08530  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 20/20 hunks, 5/5 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 5.0% | No direct hunk selected |
| Weakened authorization | 9.0% | No direct hunk selected |
| Contract regression | 12.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 7.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 10.0% | No direct hunk selected |
| Untrusted instruction authority | 5.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 4.0% | No direct hunk selected |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 89.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 23fd3ee52572881816635b9ef891df9f5bd050f97d03daac8cb9ae03bf2910b0 -->
<!-- jev-fast-audit:end -->
