### PR TITLE
fix(sdk): accept boolean JSON Schema nodes in _process_schema_node

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/schema.py
+++ b/openhands-sdk/openhands/sdk/tool/schema.py
@@ -69,7 +69,7 @@ def _shallow_expand_circular_ref(ref_def: dict[str, Any]) -> dict[str, Any]:
 
 
 def _process_schema_node(
-    node: dict[str, Any],
+    node: dict[str, Any] | bool,
     defs: dict[str, Any],
     _visiting: frozenset[str] | None = None,
 ) -> dict[str, Any]:
@@ -104,6 +104,12 @@ def _process_schema_node(
     if _visiting is None:
         _visiting = frozenset()
 
+    # JSON Schema allows boolean sub-schemas: `true` accepts any value and
+    # `false` accepts none. Normalize them to their object equivalents so the
+    # rest of this function can assume a dict node.
+    if isinstance(node, bool):
+        return {} if node else {"not": {}}
+
     # Handle $ref references
     if "$ref" in node:
         ref_path = node["$ref"]
@@ -134,7 +140,11 @@ def _process_schema_node(
 
     # Handle anyOf (often used for optional fields with None)
     if "anyOf" in node:
-        non_null_types = [t for t in node["anyOf"] if t.get("type") != "null"]
+        non_null_types = [
+            t
+            for t in node["anyOf"]
+            if not isinstance(t, dict) or t.get("type") != "null"
+        ]
         if non_null_types:
             # Process the first non-null type
             processed = _process_schema_node(non_null_types[0], defs, _visiting)

--- a/openhands-sdk/openhands/sdk/tool/schema.py
+++ b/openhands-sdk/openhands/sdk/tool/schema.py
@@ -104,9 +104,7 @@ def _process_schema_node(
     if _visiting is None:
         _visiting = frozenset()
 
-    # JSON Schema allows boolean sub-schemas: `true` accepts any value and
-    # `false` accepts none. Normalize them to their object equivalents so the
-    # rest of this function can assume a dict node.
+    # JSON Schema booleans: `true` accepts any value, `false` accepts none.
     if isinstance(node, bool):
         return {} if node else {"not": {}}
 

--- a/tests/sdk/tool/test_mcp_schema.py
+++ b/tests/sdk/tool/test_mcp_schema.py
@@ -3,6 +3,7 @@
 import json
 from collections.abc import Sequence
 
+import pytest
 from pydantic import Field
 
 from openhands.sdk.llm import ImageContent, TextContent
@@ -388,67 +389,46 @@ class TestCircularSchemaHandling:
         json.dumps(result)
 
 
-class TestBooleanSchemaHandling:
-    """Tests for JSON Schema boolean sub-schemas.
-
-    JSON Schema allows ``true``/``false`` wherever a schema is expected:
-    ``true`` accepts any value, ``false`` accepts none. MCP servers emit
-    these (e.g. ``{"type": "array", "items": true}``), and the SDK used to
-    crash with ``TypeError: argument of type 'bool' is not iterable``.
-
-    Regression coverage for:
-        https://github.com/OpenHands/software-agent-sdk/issues/4182
-    """
-
-    def test_items_true_normalized_to_empty_schema(self):
-        """`items: true` becomes `items: {}` instead of raising TypeError."""
-        result = _process_schema_node({"type": "array", "items": True}, {})
-
-        assert result == {"type": "array", "items": {}}
-        json.dumps(result)
-
-    def test_items_false_normalized_to_never_schema(self):
-        """`items: false` becomes the equivalent 'accepts nothing' schema."""
-        result = _process_schema_node({"type": "array", "items": False}, {})
-
-        assert result == {"type": "array", "items": {"not": {}}}
-        json.dumps(result)
-
-    def test_boolean_inside_any_of(self):
-        """A boolean member of anyOf does not raise AttributeError."""
-        result = _process_schema_node({"anyOf": [True, {"type": "null"}]}, {})
-
-        assert result == {}
-        json.dumps(result)
-
-    def test_boolean_property_schema(self):
-        """A property whose whole schema is `true` is accepted."""
-        result = _process_schema_node(
-            {"type": "object", "properties": {"anything": True}}, {}
-        )
-
-        assert result["properties"]["anything"] == {}
-        json.dumps(result)
-
-    def test_issue_4182_reported_schema(self):
-        """The exact schema from the bug report converts successfully."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "description": "Pagination cursor",
-                    "anyOf": [
-                        {"type": "array", "items": True},
-                        {"type": "null"},
-                    ],
-                }
+@pytest.mark.parametrize(
+    ("node", "expected"),
+    [
+        ({"type": "array", "items": True}, {"type": "array", "items": {}}),
+        ({"type": "array", "items": False}, {"type": "array", "items": {"not": {}}}),
+        ({"anyOf": [True, {"type": "null"}]}, {}),
+        (
+            {"type": "object", "properties": {"anything": True}},
+            {"type": "object", "properties": {"anything": {}}},
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "cursor": {
+                        "description": "Pagination cursor",
+                        "anyOf": [{"type": "array", "items": True}, {"type": "null"}],
+                    }
+                },
             },
-        }
+            {
+                "type": "object",
+                "properties": {
+                    "cursor": {
+                        "type": "array",
+                        "items": {},
+                        "description": "Pagination cursor",
+                    }
+                },
+            },
+        ),
+    ],
+)
+def test_boolean_schema_nodes_are_normalized(node, expected):
+    """Boolean sub-schemas normalize to their object equivalents.
 
-        result = _process_schema_node(schema, {})
+    ``true`` accepts any value and ``false`` accepts none; both are valid
+    wherever a schema is expected.
+    """
+    result = _process_schema_node(node, {})
 
-        cursor = result["properties"]["cursor"]
-        assert cursor["type"] == "array"
-        assert cursor["items"] == {}
-        assert cursor["description"] == "Pagination cursor"
-        json.dumps(result)
+    assert result == expected
+    json.dumps(result)

--- a/tests/sdk/tool/test_mcp_schema.py
+++ b/tests/sdk/tool/test_mcp_schema.py
@@ -386,3 +386,69 @@ class TestCircularSchemaHandling:
         assert result["properties"]["next"]["type"] == "object"
 
         json.dumps(result)
+
+
+class TestBooleanSchemaHandling:
+    """Tests for JSON Schema boolean sub-schemas.
+
+    JSON Schema allows ``true``/``false`` wherever a schema is expected:
+    ``true`` accepts any value, ``false`` accepts none. MCP servers emit
+    these (e.g. ``{"type": "array", "items": true}``), and the SDK used to
+    crash with ``TypeError: argument of type 'bool' is not iterable``.
+
+    Regression coverage for:
+        https://github.com/OpenHands/software-agent-sdk/issues/4182
+    """
+
+    def test_items_true_normalized_to_empty_schema(self):
+        """`items: true` becomes `items: {}` instead of raising TypeError."""
+        result = _process_schema_node({"type": "array", "items": True}, {})
+
+        assert result == {"type": "array", "items": {}}
+        json.dumps(result)
+
+    def test_items_false_normalized_to_never_schema(self):
+        """`items: false` becomes the equivalent 'accepts nothing' schema."""
+        result = _process_schema_node({"type": "array", "items": False}, {})
+
+        assert result == {"type": "array", "items": {"not": {}}}
+        json.dumps(result)
+
+    def test_boolean_inside_any_of(self):
+        """A boolean member of anyOf does not raise AttributeError."""
+        result = _process_schema_node({"anyOf": [True, {"type": "null"}]}, {})
+
+        assert result == {}
+        json.dumps(result)
+
+    def test_boolean_property_schema(self):
+        """A property whose whole schema is `true` is accepted."""
+        result = _process_schema_node(
+            {"type": "object", "properties": {"anything": True}}, {}
+        )
+
+        assert result["properties"]["anything"] == {}
+        json.dumps(result)
+
+    def test_issue_4182_reported_schema(self):
+        """The exact schema from the bug report converts successfully."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "Pagination cursor",
+                    "anyOf": [
+                        {"type": "array", "items": True},
+                        {"type": "null"},
+                    ],
+                }
+            },
+        }
+
+        result = _process_schema_node(schema, {})
+
+        cursor = result["properties"]["cursor"]
+        assert cursor["type"] == "array"
+        assert cursor["items"] == {}
+        assert cursor["description"] == "Pagination cursor"
+        json.dumps(result)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix a small bug with MCP server and JSON schema

---

AGENT:

## Why

JSON Schema allows a boolean wherever a schema is expected: `true` accepts any
value, `false` accepts none. MCP servers emit these in practice, e.g.

```json
{"cursor": {"description": "Pagination cursor",
            "anyOf": [{"type": "array", "items": true}, {"type": "null"}]}}
```

`_process_schema_node` assumed every node was a dict, so `"$ref" in node`
raised `TypeError: argument of type 'bool' is not iterable`.

This is not confined to the private helper. `MCPToolDefinition._get_tool_schema`
feeds the **raw, server-provided** `inputSchema` straight into it
(`openhands-sdk/openhands/sdk/mcp/tool.py:374-377`), so a single MCP server
advertising `items: true` breaks the request before it is sent. The tool
conversion in `LLM.get_token_count` (`llm.py:2764`) sits *outside* the
`try/except` at `llm.py:2786`, so the `TypeError` propagates out of token
counting rather than being swallowed.

## Summary

- Normalize boolean schema nodes to their object equivalents (`true` → `{}`,
  `false` → `{"not": {}}`) at the top of `_process_schema_node`.
- Guard the `anyOf` member filter, which raised a *separate*
  `AttributeError: 'bool' object has no attribute 'get'` on the same input.
- Add `TestBooleanSchemaHandling` covering `items: true` / `items: false`,
  booleans inside `anyOf`, boolean property schemas, and the exact schema
  from the issue.

## Issue Number

Fixes #4182

## How to Test

**1. Unit tests**

```
uv run pytest tests/sdk/tool/test_mcp_schema.py -q
# 17 passed
```

Each new test was confirmed to fail on `main` before the fix (HEAD's function
loaded via `importlib`, working tree untouched):

```
FAILS on HEAD: test_items_true_normalized_to_empty_schema -> TypeError: argument of type 'bool' is not iterable
FAILS on HEAD: test_items_false_normalized_to_never_schema -> TypeError: argument of type 'bool' is not iterable
FAILS on HEAD: test_boolean_inside_any_of              -> AttributeError: 'bool' object has no attribute 'get'
FAILS on HEAD: test_boolean_property_schema            -> TypeError: argument of type 'bool' is not iterable
FAILS on HEAD: test_issue_4182_reported_schema         -> TypeError: argument of type 'bool' is not iterable
```

**2. End-to-end — real `MCPToolDefinition` through the LLM request path**

Unit tests alone are not sufficient here, so this drives an actual MCP tool
built from the issue's schema through the code that prepares the LLM request:

```python
tool = MCPToolDefinition(
    description="list items", action_type=MCPToolAction, observation_type=None,
    executor=DummyExecutor(),
    mcp_tool=mcp.types.Tool(name="list_items", description="d", inputSchema={
        "type": "object",
        "properties": {"cursor": {"description": "Pagination cursor",
            "anyOf": [{"type": "array", "items": True}, {"type": "null"}]}},
    }),
)
llm = LLM(model="gpt-4o", api_key=SecretStr("test"), service_id="t")
llm.get_token_count([Message(role="user", content=[TextContent(text="hello")])],
                    tools=[tool])
```

| Path | `main` | This PR |
|---|---|---|
| `to_openai_tool()` | `TypeError` | `{'type': 'array', 'items': {}, 'description': 'Pagination cursor'}` |
| `to_responses_tool()` | `TypeError` | same |
| `llm.get_token_count()` | `TypeError` | returns `84` |

The emitted schema matches what the issue asks for: `items: true` → `items: {}`.

**3. Normalization semantics verified against the `jsonschema` library**

Both rewrites are valid Draft 2020-12 and behaviourally identical to the
booleans they replace:

```
items:{}        accepts [1,"a"] -> True    (orig items:true  -> True)
items:{"not":{}} accepts [1]    -> False   (orig items:false -> False)
items:{"not":{}} accepts []     -> True
```

**4. Full suite + lint**

```
uv run pytest tests/sdk -q
# 5431 passed, 9 skipped, 13 xfailed

uv run pre-commit run --files openhands-sdk/openhands/sdk/tool/schema.py tests/sdk/tool/test_mcp_schema.py
# ruff format / ruff lint / pycodestyle / pyright / import rules / Tool registration -> all Passed
```

## Video/Screenshots

Not applicable — this is a library-internal schema conversion fix with no UI
surface. The reproduction and before/after output are in "How to Test" above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Deliberately scoped to `_process_schema_node`, per the issue. Three adjacent
problems were found and verified while investigating but are **not** fixed here:

1. `fn_call_converter.py:296` — `if "enum" in param_info:` is unguarded while
   line 292 immediately above already does `isinstance(param_info, dict)`.
   Raises the same `TypeError` on a boolean sub-schema.
2. `client_tool.py:291` — `ClientTool` copies `input_schema` verbatim, bypassing
   `_process_schema_node` entirely, which is what keeps (1) reachable.
3. Non-dict, non-bool nodes still crash: tuple-form `items` (draft-07,
   `{"items": [{...}]}`) raises `AttributeError: 'list' object has no attribute
   'get'`. Widening the guard to `not isinstance(node, dict)` would cover it.

Happy to fold any of these in if reviewers prefer a broader fix.

One judgment call: `false` is mapped to `{"not": {}}` (semantically correct)
rather than `{}`. If a provider is used in OpenAI **strict** function-calling
mode, `not` may be rejected — trading a `TypeError` for an API 400. `items:
false` is rare enough that correctness seemed the better default, but this is
easy to change.

Note that `_process_schema_node` is lossy by design (it keeps only the first
`anyOf` branch), so `anyOf: [false, {"type": "null"}]` normalizes to
`{"not": {}}` rather than "must be null". That is consistent with the existing
behaviour for `anyOf: [string, integer]` and is not addressed here.
