### PR TITLE
fix(agent): apply filter_tools_regex to runtime tools

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -823,20 +823,18 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         if self.filter_tools_regex:
             pattern = re.compile(self.filter_tools_regex)
             builtin_classes = tuple(BUILT_IN_TOOL_CLASSES.values())
-            kept = [
+            num_tools = len(tools)
+            tools = [
                 tool
                 for tool in tools
                 if isinstance(tool, builtin_classes) or pattern.match(tool.name)
             ]
-            if len(kept) != len(tools):
-                dropped = sorted(
-                    {tool.name for tool in tools} - {tool.name for tool in kept}
-                )
+            if len(tools) != num_tools:
                 logger.info(
-                    "Filtered out runtime tools not matching filter_tools_regex: %s",
-                    dropped,
+                    "Filtered runtime tools from %d to %d after applying regex filter",
+                    num_tools,
+                    len(tools),
                 )
-            tools = kept
 
         tool_names = [tool.name for tool in tools]
         if len(tool_names) != len(set(tool_names)):

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -802,6 +802,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             logger.warning("Error closing executor for tool '%s': %s", tool.name, exc)
 
     def add_runtime_tools(self, tools: Sequence[ToolDefinition]) -> None:
+        """Register tools materialized at runtime (e.g. MCP tools).
+
+        Tools are subject to `filter_tools_regex`; built-in default tools are
+        exempt, matching the behavior of `_initialize()`.
+        """
         if not self._initialized:
             logger.warning(
                 "add_runtime_tools called before agent initialization; "
@@ -814,6 +819,24 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
                     f"Tool {tool} is not an instance of 'ToolDefinition'. "
                     f"Got type: {type(tool)}"
                 )
+
+        if self.filter_tools_regex:
+            pattern = re.compile(self.filter_tools_regex)
+            builtin_classes = tuple(BUILT_IN_TOOL_CLASSES.values())
+            kept = [
+                tool
+                for tool in tools
+                if isinstance(tool, builtin_classes) or pattern.match(tool.name)
+            ]
+            if len(kept) != len(tools):
+                dropped = sorted(
+                    {tool.name for tool in tools} - {tool.name for tool in kept}
+                )
+                logger.info(
+                    "Filtered out runtime tools not matching filter_tools_regex: %s",
+                    dropped,
+                )
+            tools = kept
 
         tool_names = [tool.name for tool in tools]
         if len(tool_names) != len(set(tool_names)):

--- a/tests/sdk/agent/test_filter_tools_regex.py
+++ b/tests/sdk/agent/test_filter_tools_regex.py
@@ -1,0 +1,170 @@
+"""Tests for `Agent.filter_tools_regex`.
+
+The regex must apply both to statically configured tools resolved during
+`_initialize()` and to tools materialized at runtime (e.g. MCP tools) that are
+registered through `add_runtime_tools()`. Built-in default tools are exempt in
+both paths.
+
+Regression tests for https://github.com/OpenHands/software-agent-sdk/issues/4184
+"""
+
+import uuid
+from collections.abc import Sequence
+from typing import ClassVar, cast
+
+from openhands.sdk import LLM
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.llm.message import ImageContent, TextContent
+from openhands.sdk.mcp.client import MCPClient
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins import ThinkTool
+from openhands.sdk.tool.registry import register_tool
+from openhands.sdk.tool.spec import Tool
+from openhands.sdk.tool.tool import Action, Observation, ToolExecutor
+from openhands.sdk.workspace import LocalWorkspace
+
+
+class _FilterAction(Action):
+    text: str = ""
+
+
+class _FilterObs(Observation):
+    out: str = ""
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
+        return [TextContent(text=self.out)]
+
+
+class _NoopExec(ToolExecutor[_FilterAction, _FilterObs]):
+    def __call__(self, action: _FilterAction, conversation=None) -> _FilterObs:
+        return _FilterObs(out="ok")
+
+
+class _AllowedTool(ToolDefinition[_FilterAction, _FilterObs]):
+    name: ClassVar[str] = "allowed"
+
+    @classmethod
+    def create(cls, conv_state=None, **params) -> Sequence["_AllowedTool"]:
+        return [
+            cls(
+                description="allowed tool",
+                action_type=_FilterAction,
+                observation_type=_FilterObs,
+                executor=_NoopExec(),
+            )
+        ]
+
+
+class _BlockedTool(ToolDefinition[_FilterAction, _FilterObs]):
+    name: ClassVar[str] = "blocked"
+
+    @classmethod
+    def create(cls, conv_state=None, **params) -> Sequence["_BlockedTool"]:
+        return [
+            cls(
+                description="blocked tool",
+                action_type=_FilterAction,
+                observation_type=_FilterObs,
+                executor=_NoopExec(),
+            )
+        ]
+
+
+def _make_agent(**agent_kwargs) -> Agent:
+    return Agent(
+        llm=LLM(model="test-model", usage_id="test-llm"),
+        tools=[],
+        include_default_tools=[],
+        **agent_kwargs,
+    )
+
+
+def _initialize_agent(agent: Agent, tmp_path) -> None:
+    state = ConversationState.create(
+        id=uuid.uuid4(),
+        agent=agent,
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+    )
+    agent._initialize(state)
+
+
+def test_add_runtime_tools_applies_filter_tools_regex(tmp_path):
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    agent.add_runtime_tools([_AllowedTool.create()[0], _BlockedTool.create()[0]])
+
+    assert "allowed" in agent.tools_map
+    assert "blocked" not in agent.tools_map
+
+
+def test_add_runtime_tools_keeps_builtin_tools(tmp_path):
+    """Built-in default tools bypass the regex, matching `_initialize()`."""
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    think_tool = ThinkTool.create()[0]
+    agent.add_runtime_tools([think_tool])
+
+    assert think_tool.name in agent.tools_map
+
+
+def test_add_runtime_tools_without_filter_keeps_all(tmp_path):
+    agent = _make_agent()
+    _initialize_agent(agent, tmp_path)
+
+    agent.add_runtime_tools([_AllowedTool.create()[0], _BlockedTool.create()[0]])
+
+    assert "allowed" in agent.tools_map
+    assert "blocked" in agent.tools_map
+
+
+def test_static_tools_apply_filter_tools_regex(tmp_path):
+    register_tool("allowed", _AllowedTool)
+    register_tool("blocked", _BlockedTool)
+    agent = Agent(
+        llm=LLM(model="test-model", usage_id="test-llm"),
+        tools=[Tool(name="allowed"), Tool(name="blocked")],
+        include_default_tools=[],
+        filter_tools_regex=r"^allowed$",
+    )
+    _initialize_agent(agent, tmp_path)
+
+    assert "allowed" in agent.tools_map
+    assert "blocked" not in agent.tools_map
+
+
+class _StaticMCPClient:
+    def __init__(self, tools: list[ToolDefinition]):
+        self.tools = tools
+
+
+class _StaticMCPToolProvider:
+    """Stands in for a live MCP server advertising two tools."""
+
+    def create_tools(self, mcp_config, timeout: float = 30.0) -> MCPClient:
+        return cast(
+            MCPClient,
+            _StaticMCPClient([_AllowedTool.create()[0], _BlockedTool.create()[0]]),
+        )
+
+
+def test_runtime_mcp_tools_apply_filter_tools_regex(tmp_path):
+    """End-to-end through `LocalConversation._ensure_agent_ready()`."""
+    agent = _make_agent(
+        filter_tools_regex=r"^allowed$",
+        mcp_config={"fake": {"command": "true", "args": []}},
+    )
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        mcp_tool_provider=_StaticMCPToolProvider(),
+    )
+    conversation._ensure_agent_ready()
+
+    assert "allowed" in conversation.agent.tools_map
+    assert "blocked" not in conversation.agent.tools_map

--- a/tests/sdk/agent/test_filter_tools_regex.py
+++ b/tests/sdk/agent/test_filter_tools_regex.py
@@ -4,13 +4,13 @@ The regex must apply both to statically configured tools resolved during
 `_initialize()` and to tools materialized at runtime (e.g. MCP tools) that are
 registered through `add_runtime_tools()`. Built-in default tools are exempt in
 both paths.
-
-Regression tests for https://github.com/OpenHands/software-agent-sdk/issues/4184
 """
 
 import uuid
 from collections.abc import Sequence
 from typing import ClassVar, cast
+
+import pytest
 
 from openhands.sdk import LLM
 from openhands.sdk.agent import Agent
@@ -71,6 +71,29 @@ class _BlockedTool(ToolDefinition[_FilterAction, _FilterObs]):
                 executor=_NoopExec(),
             )
         ]
+
+
+class _DisallowedTool(ToolDefinition[_FilterAction, _FilterObs]):
+    """Name contains 'allow' but not at the start; used for anchor tests."""
+
+    name: ClassVar[str] = "disallowed"
+
+    @classmethod
+    def create(cls, conv_state=None, **params) -> Sequence["_DisallowedTool"]:
+        return [
+            cls(
+                description="disallowed tool",
+                action_type=_FilterAction,
+                observation_type=_FilterObs,
+                executor=_NoopExec(),
+            )
+        ]
+
+
+class _ExemptThinkTool(ThinkTool):
+    """Built-in subclass whose name does not match any test regex."""
+
+    name = "subclassed_think"
 
 
 def _make_agent(**agent_kwargs) -> Agent:
@@ -134,6 +157,82 @@ def test_static_tools_apply_filter_tools_regex(tmp_path):
     _initialize_agent(agent, tmp_path)
 
     assert "allowed" in agent.tools_map
+    assert "blocked" not in agent.tools_map
+
+
+def test_add_runtime_tools_mixed_batch(tmp_path):
+    """One call mixing a built-in, a matching, and a non-matching tool."""
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    think_tool = ThinkTool.create()[0]
+    agent.add_runtime_tools(
+        [_AllowedTool.create()[0], _BlockedTool.create()[0], think_tool]
+    )
+
+    assert "allowed" in agent.tools_map
+    assert think_tool.name in agent.tools_map
+    assert "blocked" not in agent.tools_map
+
+
+def test_add_runtime_tools_all_filtered_is_noop(tmp_path):
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+    before = dict(agent.tools_map)
+
+    agent.add_runtime_tools([_BlockedTool.create()[0]])
+
+    assert agent.tools_map == before
+
+
+def test_filter_uses_prefix_match_semantics(tmp_path):
+    """`re.match` anchors at the start of the name, like `_initialize()`:
+    an unanchored pattern matches a prefix but never mid-name."""
+    agent = _make_agent(filter_tools_regex=r"allow")
+    _initialize_agent(agent, tmp_path)
+
+    agent.add_runtime_tools([_AllowedTool.create()[0], _DisallowedTool.create()[0]])
+
+    assert "allowed" in agent.tools_map
+    assert "disallowed" not in agent.tools_map
+
+
+def test_add_runtime_tools_builtin_subclass_is_exempt(tmp_path):
+    """Subclasses of built-in tools count as built-ins for the exemption."""
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    agent.add_runtime_tools([_ExemptThinkTool.create()[0]])
+
+    assert "subclassed_think" in agent.tools_map
+
+
+def test_add_runtime_tools_duplicate_kept_names_still_raise(tmp_path):
+    """Filtering must not weaken duplicate detection for surviving tools."""
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    with pytest.raises(ValueError, match="Duplicate runtime tool names"):
+        agent.add_runtime_tools([_AllowedTool.create()[0], _AllowedTool.create()[0]])
+
+
+def test_add_runtime_tools_conflict_with_registered_tool_still_raises(tmp_path):
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+    agent.add_runtime_tools([_AllowedTool.create()[0]])
+
+    with pytest.raises(ValueError, match="Duplicate tool names"):
+        agent.add_runtime_tools([_AllowedTool.create()[0]])
+
+
+def test_add_runtime_tools_duplicate_filtered_names_do_not_raise(tmp_path):
+    """Duplicates among filtered-out tools are dropped before the duplicate
+    check, matching `_initialize()` which filters before validating names."""
+    agent = _make_agent(filter_tools_regex=r"^allowed$")
+    _initialize_agent(agent, tmp_path)
+
+    agent.add_runtime_tools([_BlockedTool.create()[0], _BlockedTool.create()[0]])
+
     assert "blocked" not in agent.tools_map
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fixing the filter_tools_regext for runtime tools.

---

AGENT:

## Why

`Agent.filter_tools_regex` is documented as being "applied after any tools provided in `tools` and any MCP tools are added", but runtime-materialized MCP tools bypass it entirely. Tools excluded by the regex still land in `agent.tools_map`, are advertised to the LLM (`agent.py`, `tools=list(self.tools_map.values())`), and are executable — so applications using the regex as a tool boundary silently expose filtered-out MCP tools.

This is a regression: until #3964, `AgentBase._initialize()` materialized MCP tools itself and applied the regex afterwards (see `create_mcp_tools` followed by the `filter_tools_regex` block at `fe924f705^`). #3964 moved materialization into `LocalConversation._ensure_agent_ready()`, which registers the tools via `add_runtime_tools()` — a method introduced in #3826 that never applied the filter. The subsequent `init_state()` call does not re-filter because `_initialize()` returns immediately once `_initialized` is set.

## Summary

- Apply `filter_tools_regex` in `AgentBase.add_runtime_tools()`, so the single choke point covers both runtime-tool paths (conversation-start MCP tools and plugin-added tools) as well as any future dynamic-tool source.
- Built-in default tools (e.g. `InvokeSkillTool`, which the plugin path routes through the same method) are exempt, matching the existing exemption in `_initialize()`.
- Add regression tests (12) covering both paths plus edge cases — mixed batches, all-filtered batches, prefix-match anchoring, built-in subclasses, and duplicate handling around the filter; `filter_tools_regex` previously had zero test coverage anywhere in the repo, which is how this slipped through.

## Issue Number

Fixes #4184

## How to Test

End-to-end through the real production path (not just unit tests): build a `LocalConversation` whose injected `mcp_tool_provider` advertises tools named `allowed` and `blocked`, with the agent configured with `filter_tools_regex=r"^allowed$"`, then trigger `_ensure_agent_ready()` and inspect `tools_map`.

Before this fix (at `cae92b879`):

```text
filter_tools_regex = '^allowed$'
agent.tools_map    = ['allowed', 'blocked', 'inspect_image_with_vision']
AssertionError: BUG REPRODUCED: 'blocked' does not match ^allowed$ but is exposed to the agent/LLM
```

After this fix:

```text
INFO  Filtered runtime tools from 2 to 1 after applying regex filter
filter_tools_regex = '^allowed$'
agent.tools_map    = ['allowed', 'inspect_image_with_vision']
OK: filter applied to runtime MCP tools
```

(`inspect_image_with_vision` is an auto-attached built-in default tool, documented as exempt from the filter.)

That scenario is captured as `test_runtime_mcp_tools_apply_filter_tools_regex` in the new test file, so reviewers can reproduce with:

```bash
uv run pytest tests/sdk/agent/test_filter_tools_regex.py -q
```

Verification performed:

- `uv run pytest tests/sdk/agent/test_filter_tools_regex.py -q` → 12 passed. With `base.py` reverted to `origin/main`, the 6 regression tests fail and the 6 behavior-preservation tests still pass — confirming the tests catch the bug and guard existing behavior.
- `uv run pytest tests/sdk -q` (single process) → 5443 passed, 9 skipped, 13 xfailed; matches the pre-change baseline plus the 12 new tests.
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/base.py tests/sdk/agent/test_filter_tools_regex.py` → all hooks pass (ruff format/lint, pycodestyle, pyright, import rules, tool registration).

## Video/Screenshots

Terminal logs above (before/after output of the end-to-end reproduction and test runs).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Filtering exempts built-ins via `isinstance` against `BUILT_IN_TOOL_CLASSES`, mirroring `_initialize()`'s exemption; without it, a restrictive regex would silently drop `InvokeSkillTool` injected by the plugin path and break skill invocation.
- `pattern.match` (prefix semantics) is deliberately kept consistent with `_initialize()`.
- Filtered-out MCP tools are dropped without closing their executors — identical to the pre-#3964 behavior, where `_initialize()` also discarded filtered MCP tools without cleanup. If a server's tools are all filtered its client connection lingers; flagging as a possible follow-up rather than expanding this fix.
- The plugin path has bypassed the filter since #3826 (two weeks before #3964 regressed the main `mcp_config` path); this fix covers both.
