### PR TITLE
fix(sdk): mask all registered secrets, not only exported ones

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -845,9 +845,10 @@ def _mask_json_value(value: Any, mask: Callable[[str], str]) -> Any:
 
     ACP tool-call ``raw_input`` / ``raw_output`` / ``content`` blocks are
     arbitrary JSON (a bare string, a dict of params, a list of content
-    blocks). ``SecretRegistry.mask_secrets_in_output`` is a pure string op,
-    so walk the structure and mask each leaf string; non-string leaves
-    (ints, bools, ``None``) pass through unchanged.
+    blocks). ``SecretRegistry.mask_secrets_in_output`` maps a string to a
+    string, so walk the structure and mask each leaf string; non-string leaves
+    (ints, bools, ``None``) pass through unchanged. Note it resolves uncached
+    secret sources on first use, so a leaf-heavy value is not free.
     """
     if isinstance(value, str):
         return mask(value)
@@ -1196,7 +1197,8 @@ class _OpenHandsACPBridge:
         Defensive: on mask failure, returns the original value unchanged and
         logs at DEBUG — this may transiently leak the credential but prevents a
         crash, matching the regular terminal tool's masking contract. (Masking
-        is a pure ``str.replace`` and should never raise in practice.)
+        swallows secret-resolution errors internally, so it should never raise
+        in practice.)
         """
         if self.mask is None:
             return value

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2335,13 +2335,12 @@ class ACPAgent(AgentBase):
         client = _OpenHandsACPBridge()
         self._client = client
         # Bind the secret masker for the conversation's lifetime. It's derived
-        # from state.secret_registry (stable for the conversation) and only
-        # resolves/reads that registry's own secrets, so it has none of the
-        # cross-thread/state-lock hazards that make on_event/on_token strictly
-        # per-turn. Binding it here (rather than per-turn in
-        # _reset_client_for_turn) keeps it available for session updates AND for
-        # ask_agent() forks, which run on the shared client and may fire while
-        # no step()/astep() turn is active.
+        # from state.secret_registry (stable for the conversation) and touches
+        # only that registry, so it has none of the cross-thread/state-lock
+        # hazards that make on_event/on_token strictly per-turn. Binding it here
+        # (rather than per-turn in _reset_client_for_turn) keeps it available for
+        # session updates AND for ask_agent() forks, which run on the shared
+        # client and may fire while no step()/astep() turn is active.
         client.mask = state.secret_registry.mask_secrets_in_output
 
         # Build the subprocess environment. Precedence, highest first:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2335,12 +2335,13 @@ class ACPAgent(AgentBase):
         client = _OpenHandsACPBridge()
         self._client = client
         # Bind the secret masker for the conversation's lifetime. It's derived
-        # from state.secret_registry (stable for the conversation) and is a pure
-        # read of _exported_values, so it has none of the cross-thread/state-lock
-        # hazards that make on_event/on_token strictly per-turn. Binding it here
-        # (rather than per-turn in _reset_client_for_turn) keeps it available for
-        # session updates AND for ask_agent() forks, which run on the shared
-        # client and may fire while no step()/astep() turn is active.
+        # from state.secret_registry (stable for the conversation) and only
+        # resolves/reads that registry's own secrets, so it has none of the
+        # cross-thread/state-lock hazards that make on_event/on_token strictly
+        # per-turn. Binding it here (rather than per-turn in
+        # _reset_client_for_turn) keeps it available for session updates AND for
+        # ask_agent() forks, which run on the shared client and may fire while
+        # no step()/astep() turn is active.
         client.mask = state.secret_registry.mask_secrets_in_output
 
         # Build the subprocess environment. Precedence, highest first:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -847,8 +847,8 @@ def _mask_json_value(value: Any, mask: Callable[[str], str]) -> Any:
     arbitrary JSON (a bare string, a dict of params, a list of content
     blocks). ``SecretRegistry.mask_secrets_in_output`` maps a string to a
     string, so walk the structure and mask each leaf string; non-string leaves
-    (ints, bools, ``None``) pass through unchanged. Note it resolves uncached
-    secret sources on first use, so a leaf-heavy value is not free.
+    (ints, bools, ``None``) pass through unchanged. It resolves uncached
+    sources on first use, so this is not free.
     """
     if isinstance(value, str):
         return mask(value)

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -131,8 +131,10 @@ class SecretRegistry(OpenHandsModel):
     def mask_secrets_in_output(self, text: str) -> str:
         """Mask secret values in the given text.
 
-        This method uses both the current exported values and attempts to get
-        fresh values from callables to ensure comprehensive masking.
+        Every registered secret is masked, not just the ones already exported:
+        a value can reach the output without the command ever referencing the
+        secret's name (e.g. a token embedded in a git remote URL printed by
+        `git remote -v`), and it must be masked all the same.
 
         Args:
             text: The text to mask secrets in
@@ -143,9 +145,15 @@ class SecretRegistry(OpenHandsModel):
         if not text:
             return text
 
-        masked_text = text
+        # Resolve any source not yet cached in _exported_values. Retrieval
+        # failures are logged and skipped by get_secret_value, which keeps the
+        # last known value, so a flaky source degrades rather than breaking
+        # masking. Static secrets resolve once and then hit the cache.
+        for key in list(self.secret_sources):
+            if key not in self._exported_values:
+                self.get_secret_value(key)
 
-        # First, mask using currently exported values (always available)
+        masked_text = text
         for value in self._exported_values.values():
             masked_text = masked_text.replace(value, "<secret-hidden>")
 

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -1,5 +1,6 @@
 """Secrets manager for handling sensitive data in conversations."""
 
+import time
 from collections.abc import Collection, Mapping
 
 from pydantic import Field, PrivateAttr, SecretStr
@@ -10,6 +11,11 @@ from openhands.sdk.utils.models import OpenHandsModel
 
 
 logger = get_logger(__name__)
+
+# How long masking waits before retrying a source that failed to resolve.
+# A failed lookup yields no value to mask with, so backing off costs no
+# masking coverage — only a delay in picking a recovered source back up.
+FAILED_LOOKUP_RETRY_SECONDS = 60.0
 
 
 class SecretRegistry(OpenHandsModel):
@@ -32,6 +38,7 @@ class SecretRegistry(OpenHandsModel):
 
     secret_sources: dict[str, SecretSource] = Field(default_factory=dict)
     _exported_values: dict[str, str] = PrivateAttr(default_factory=dict)
+    _failed_lookups: dict[str, float] = PrivateAttr(default_factory=dict)
 
     def update_secrets(
         self,
@@ -131,9 +138,11 @@ class SecretRegistry(OpenHandsModel):
     def mask_secrets_in_output(self, text: str) -> str:
         """Mask secret values in the given text.
 
-        Masks every registered secret, not only the exported ones: a value can
-        reach the output without the command ever referencing the secret's name
-        (e.g. a token in a git remote URL printed by `git remote -v`).
+        Masks the last resolved value of every registered secret, not only the
+        exported ones: a value can reach the output without the command ever
+        referencing the secret's name (e.g. a token in a git remote URL printed
+        by `git remote -v`). Already-cached values are not re-resolved, so a
+        rotated secret keeps masking its previous value, not its current one.
 
         Args:
             text: The text to mask secrets in
@@ -144,10 +153,19 @@ class SecretRegistry(OpenHandsModel):
         if not text:
             return text
 
-        # Resolve uncached sources; get_secret_value swallows failures.
+        # Resolve uncached sources; get_secret_value swallows failures. Sources
+        # that fail back off for FAILED_LOOKUP_RETRY_SECONDS: get_value() may do
+        # blocking network I/O (LookupSecret), and masking runs per tool output
+        # and per streamed ACP chunk.
+        now = time.monotonic()
         for key in list(self.secret_sources):
-            if key not in self._exported_values:
-                self.get_secret_value(key)
+            if key in self._exported_values:
+                continue
+            failed_at = self._failed_lookups.get(key)
+            if failed_at is not None and now - failed_at < FAILED_LOOKUP_RETRY_SECONDS:
+                continue
+            if not self.get_secret_value(key):
+                self._failed_lookups[key] = now
 
         # Snapshot: other threads may insert while we iterate.
         masked_text = text

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -2,6 +2,7 @@
 
 import time
 from collections.abc import Collection, Mapping
+from typing import Final
 
 from pydantic import Field, PrivateAttr, SecretStr
 
@@ -12,10 +13,8 @@ from openhands.sdk.utils.models import OpenHandsModel
 
 logger = get_logger(__name__)
 
-# How long masking waits before retrying a source that failed to resolve.
-# A failed lookup yields no value to mask with, so backing off costs no
-# masking coverage — only a delay in picking a recovered source back up.
-FAILED_LOOKUP_RETRY_SECONDS = 60.0
+# Back-off before retrying a failed source; a failed lookup masks nothing anyway.
+FAILED_LOOKUP_RETRY_SECONDS: Final[float] = 60.0
 
 
 class SecretRegistry(OpenHandsModel):
@@ -140,9 +139,8 @@ class SecretRegistry(OpenHandsModel):
 
         Masks the last resolved value of every registered secret, not only the
         exported ones: a value can reach the output without the command ever
-        referencing the secret's name (e.g. a token in a git remote URL printed
-        by `git remote -v`). Already-cached values are not re-resolved, so a
-        rotated secret keeps masking its previous value, not its current one.
+        referencing its name (e.g. a token in a git remote URL). Cached values
+        are not re-resolved, so a rotated secret masks its previous value.
 
         Args:
             text: The text to mask secrets in
@@ -153,10 +151,8 @@ class SecretRegistry(OpenHandsModel):
         if not text:
             return text
 
-        # Resolve uncached sources; get_secret_value swallows failures. Sources
-        # that fail back off for FAILED_LOOKUP_RETRY_SECONDS: get_value() may do
-        # blocking network I/O (LookupSecret), and masking runs per tool output
-        # and per streamed ACP chunk.
+        # Resolve uncached sources, backing off on failure: get_value() may do
+        # blocking network I/O and masking runs per output and per ACP chunk.
         now = time.monotonic()
         for key in list(self.secret_sources):
             if key in self._exported_values:

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -153,8 +153,10 @@ class SecretRegistry(OpenHandsModel):
             if key not in self._exported_values:
                 self.get_secret_value(key)
 
+        # Snapshot the values: masking runs on tool-output paths while other
+        # threads may still be resolving secrets into _exported_values.
         masked_text = text
-        for value in self._exported_values.values():
+        for value in list(self._exported_values.values()):
             masked_text = masked_text.replace(value, "<secret-hidden>")
 
         return masked_text

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -131,10 +131,9 @@ class SecretRegistry(OpenHandsModel):
     def mask_secrets_in_output(self, text: str) -> str:
         """Mask secret values in the given text.
 
-        Every registered secret is masked, not just the ones already exported:
-        a value can reach the output without the command ever referencing the
-        secret's name (e.g. a token embedded in a git remote URL printed by
-        `git remote -v`), and it must be masked all the same.
+        Masks every registered secret, not only the exported ones: a value can
+        reach the output without the command ever referencing the secret's name
+        (e.g. a token in a git remote URL printed by `git remote -v`).
 
         Args:
             text: The text to mask secrets in
@@ -145,16 +144,12 @@ class SecretRegistry(OpenHandsModel):
         if not text:
             return text
 
-        # Resolve any source not yet cached in _exported_values. Retrieval
-        # failures are logged and skipped by get_secret_value, which keeps the
-        # last known value, so a flaky source degrades rather than breaking
-        # masking. Static secrets resolve once and then hit the cache.
+        # Resolve uncached sources; get_secret_value swallows failures.
         for key in list(self.secret_sources):
             if key not in self._exported_values:
                 self.get_secret_value(key)
 
-        # Snapshot the values: masking runs on tool-output paths while other
-        # threads may still be resolving secrets into _exported_values.
+        # Snapshot: other threads may insert while we iterate.
         masked_text = text
         for value in list(self._exported_values.values()):
             masked_text = masked_text.replace(value, "<secret-hidden>")

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -2,7 +2,10 @@
 
 from pydantic import SecretStr
 
-from openhands.sdk.conversation.secret_registry import SecretRegistry
+from openhands.sdk.conversation.secret_registry import (
+    FAILED_LOOKUP_RETRY_SECONDS,
+    SecretRegistry,
+)
 from openhands.sdk.secret import SecretSource, StaticSecret
 
 
@@ -25,6 +28,23 @@ class MyFailingTokenSource(SecretSource):
 class MyWorkingTokenSource(SecretSource):
     def get_value(self):
         return "working-value"
+
+
+class MyCountingFailingSource(SecretSource):
+    attempts: int = 0
+
+    def get_value(self):
+        type(self).attempts += 1
+        raise OSError("Secret retrieval failed")
+
+
+class MyRecoveringSource(SecretSource):
+    fail: bool = True
+
+    def get_value(self):
+        if type(self).fail:
+            raise OSError("Secret retrieval failed")
+        return "recovered-value"
 
 
 def test_update_secrets_with_static_values():
@@ -381,3 +401,40 @@ def test_mask_secrets_tolerates_failing_source():
 
     masked = secret_registry.mask_secrets_in_output("leak: working-value")
     assert masked == "leak: <secret-hidden>"
+
+
+def test_mask_secrets_backs_off_failing_source():
+    """A failing source is retried once per window, not on every mask call.
+
+    get_value() may do blocking network I/O (LookupSecret), and masking runs
+    per tool output and per streamed ACP chunk.
+    """
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"FAILING_SECRET": MyCountingFailingSource()})
+
+    MyCountingFailingSource.attempts = 0
+    for _ in range(25):
+        secret_registry.mask_secrets_in_output("unrelated output")
+    assert MyCountingFailingSource.attempts == 1
+
+    # Once the window has elapsed, the source is retried again.
+    secret_registry._failed_lookups["FAILING_SECRET"] -= FAILED_LOOKUP_RETRY_SECONDS
+    secret_registry.mask_secrets_in_output("unrelated output")
+    assert MyCountingFailingSource.attempts == 2
+
+
+def test_mask_secrets_retries_until_source_succeeds():
+    """Back-off does not permanently disable masking for a recovered source."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"FLAKY": MyRecoveringSource()})
+
+    MyRecoveringSource.fail = True
+    assert secret_registry.mask_secrets_in_output("leak: recovered-value") == (
+        "leak: recovered-value"
+    )
+
+    MyRecoveringSource.fail = False
+    secret_registry._failed_lookups["FLAKY"] -= FAILED_LOOKUP_RETRY_SECONDS
+    assert secret_registry.mask_secrets_in_output("leak: recovered-value") == (
+        "leak: <secret-hidden>"
+    )

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -404,11 +404,7 @@ def test_mask_secrets_tolerates_failing_source():
 
 
 def test_mask_secrets_backs_off_failing_source():
-    """A failing source is retried once per window, not on every mask call.
-
-    get_value() may do blocking network I/O (LookupSecret), and masking runs
-    per tool output and per streamed ACP chunk.
-    """
+    """A failing source is retried once per window, not on every mask call."""
     secret_registry = SecretRegistry()
     secret_registry.update_secrets({"FAILING_SECRET": MyCountingFailingSource()})
 
@@ -417,7 +413,7 @@ def test_mask_secrets_backs_off_failing_source():
         secret_registry.mask_secrets_in_output("unrelated output")
     assert MyCountingFailingSource.attempts == 1
 
-    # Once the window has elapsed, the source is retried again.
+    # Window elapsed: retried again.
     secret_registry._failed_lookups["FAILING_SECRET"] -= FAILED_LOOKUP_RETRY_SECONDS
     secret_registry.mask_secrets_in_output("unrelated output")
     assert MyCountingFailingSource.attempts == 2

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -340,12 +340,7 @@ def test_get_secret_value_missing_not_tracked():
 
 
 def test_mask_secrets_without_name_reference_in_command():
-    """A secret value is masked even if no command ever referenced its name.
-
-    A token embedded in a git remote URL is printed by `git remote -v`, a
-    command that contains no secret name, so nothing gets exported by the
-    name-scan. The value must still be masked.
-    """
+    """A secret value is masked even if no command ever referenced its name."""
     token = "github_pat_REALSECRETVALUE123"
     secret_registry = SecretRegistry()
     secret_registry.update_secrets({"github_token": token})
@@ -360,11 +355,7 @@ def test_mask_secrets_without_name_reference_in_command():
 
 
 def test_mask_secrets_survives_serialization_round_trip():
-    """Masking still works after a conversation is persisted and resumed.
-
-    _exported_values is a PrivateAttr and is not serialized, so a restored
-    registry must re-resolve its sources rather than leak in cleartext.
-    """
+    """Masking survives a resume: _exported_values is not serialized."""
     token = "github_pat_REALSECRETVALUE123"
     secret_registry = SecretRegistry()
     secret_registry.update_secrets({"github_token": token})

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -337,3 +337,56 @@ def test_get_secret_value_missing_not_tracked():
     result = secret_registry.get_secret_value("NONEXISTENT")
     assert result is None
     assert "NONEXISTENT" not in secret_registry._exported_values
+
+
+def test_mask_secrets_without_name_reference_in_command():
+    """A secret value is masked even if no command ever referenced its name.
+
+    A token embedded in a git remote URL is printed by `git remote -v`, a
+    command that contains no secret name, so nothing gets exported by the
+    name-scan. The value must still be masked.
+    """
+    token = "github_pat_REALSECRETVALUE123"
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"github_token": token})
+
+    # The name-scan exports nothing: the command does not mention the name.
+    assert secret_registry.get_secrets_as_env_vars("git remote -v") == {}
+
+    output = f"origin\thttps://{token}@github.com/repo/test.git (fetch)"
+    masked = secret_registry.mask_secrets_in_output(output)
+    assert token not in masked
+    assert masked == "origin\thttps://<secret-hidden>@github.com/repo/test.git (fetch)"
+
+
+def test_mask_secrets_survives_serialization_round_trip():
+    """Masking still works after a conversation is persisted and resumed.
+
+    _exported_values is a PrivateAttr and is not serialized, so a restored
+    registry must re-resolve its sources rather than leak in cleartext.
+    """
+    token = "github_pat_REALSECRETVALUE123"
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"github_token": token})
+
+    restored = SecretRegistry.model_validate_json(
+        secret_registry.model_dump_json(context={"expose_secrets": True})
+    )
+    assert restored._exported_values == {}
+
+    output = f"origin\thttps://{token}@github.com/repo/test.git (fetch)"
+    assert token not in restored.mask_secrets_in_output(output)
+
+
+def test_mask_secrets_tolerates_failing_source():
+    """A source that fails to resolve is skipped; other secrets still mask."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets(
+        {
+            "FAILING_SECRET": MyFailingTokenSource(),
+            "WORKING_SECRET": MyWorkingTokenSource(),
+        }
+    )
+
+    masked = secret_registry.mask_secrets_in_output("leak: working-value")
+    assert masked == "leak: <secret-hidden>"

--- a/tests/tools/terminal/test_secrets_masking.py
+++ b/tests/tools/terminal/test_secrets_masking.py
@@ -92,11 +92,7 @@ def test_terminal_executor_with_conversation_secrets():
 
 
 def test_terminal_executor_masks_secret_not_referenced_by_command():
-    """Secrets are masked even when the command never references their name.
-
-    `git remote -v` mentions no secret name, so the name-scan exports nothing,
-    but a token embedded in the remote URL still reaches the observation.
-    """
+    """Secrets are masked even when the command never references their name."""
     with tempfile.TemporaryDirectory() as temp_dir:
         llm = LLM(
             model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"

--- a/tests/tools/terminal/test_secrets_masking.py
+++ b/tests/tools/terminal/test_secrets_masking.py
@@ -89,3 +89,52 @@ def test_terminal_executor_with_conversation_secrets():
         finally:
             executor.close()
             conversation.close()
+
+
+def test_terminal_executor_masks_secret_not_referenced_by_command():
+    """Secrets are masked even when the command never references their name.
+
+    `git remote -v` mentions no secret name, so the name-scan exports nothing,
+    but a token embedded in the remote URL still reaches the observation.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"
+        )
+        agent = Agent(llm=llm, tools=[])
+
+        token = "github_pat_REALSECRETVALUE123"
+        conversation = Conversation(
+            agent=agent,
+            workspace=temp_dir,
+            persistence_dir=temp_dir,
+            secrets={"GITHUB_TOKEN": token},
+        )
+
+        executor = TerminalExecutor(working_dir=temp_dir, terminal_type="subprocess")
+
+        try:
+            command = "git remote -v"
+            mock_session = Mock()
+            mock_session.execute.return_value = TerminalObservation(
+                command=command,
+                exit_code=0,
+                content=[
+                    TextContent(
+                        text=f"origin\thttps://{token}@github.com/repo/test.git (fetch)"
+                    )
+                ],
+            )
+            mock_session._closed = False
+            executor._session = mock_session
+
+            result = executor(
+                TerminalAction(command=command), conversation=conversation
+            )
+
+            assert token not in result.text
+            assert "<secret-hidden>" in result.text
+
+        finally:
+            executor.close()
+            conversation.close()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix secret values leaked.

---

AGENT:

## Why

Registered secret values leaked **unmasked** into terminal observations (and therefore into the LLM context, the event stream, and any log sink) whenever the secret's value appeared in command output but the command text never referenced the secret's *name*.

`mask_secrets_in_output` only replaced values present in `_exported_values`, which is populated in just two places: the name-scan in `get_secrets_as_env_vars` (the secret's *name* must appear in the command text) and an explicit `get_secret_value` lookup. A command like `git remote -v` mentions no secret name, so nothing was exported — and a token embedded in the remote URL by the authenticated-clone flow was printed in cleartext.

The method's own docstring already promised the correct behaviour ("attempts to get fresh values from callables to ensure comprehensive masking"); the implementation never did it.

## Summary

- `mask_secrets_in_output` now resolves every registered source (caching into `_exported_values`) before the replace loop, so all registered secrets are masked — not only the ones previously handed out.
- This also fixes masking after resume **when the restored sources still hold their values** — `_exported_values` is a `PrivateAttr` and is not serialized, so a restored registry previously leaked until something re-triggered an export. It now re-resolves. Note this does not help the no-cipher persistence path, where secrets are redacted on save (`state.py:421-437`) and the value is simply gone on restore; see *Known limitations*.
- Regression tests for the value-appears-without-name-reference path, the serialize/restore round-trip, and graceful degradation when a source fails to resolve.
- A source that fails to resolve now backs off for 60s instead of being retried on every mask call. `LookupSecret.get_value()` is a synchronous `httpx.get(..., timeout=30.0)`, and masking runs per tool output and per streamed ACP chunk, so the old behaviour turned a broken source into a network round-trip per call. Measured: 25 mask calls went from 25 `get_value()` attempts (and 25 warning lines) to 1.
- Masking now iterates a snapshot of `_exported_values`, since it resolves as well as reads and runs on tool-output paths while other threads may still be writing to the registry. Three ACP comments that described masking as "a pure read of `_exported_values`" / "a pure string op" / "a pure `str.replace`" are corrected to match.

## Issue Number

Closes #4190

## How to Test

**End-to-end** (real git repo with a token-embedded remote, real `Conversation` with the token registered, real unmocked `TerminalExecutor` running `git remote -v`) — script at the bottom of this section.

Before this change:

```
--- raw .git/config remote (on disk) ---
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (fetch)
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (push)

--- observation seen by the agent/LLM ---
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (fetch)
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (push)

--- verdict ---
LEAK: raw token present in observation (github_pat_REALSECRETVALUE123)
```

After this change (same script, same repo state — note the token is still on disk, but no longer reaches the observation):

```
--- raw .git/config remote (on disk) ---
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (fetch)
origin	https://github_pat_REALSECRETVALUE123@github.com/repo/test.git (push)

--- observation seen by the agent/LLM ---
origin	https://<secret-hidden>@github.com/repo/test.git (fetch)
origin	https://<secret-hidden>@github.com/repo/test.git (push)

--- verdict ---
MASKED: token absent; <secret-hidden> present: True
```

<details>
<summary>e2e script used to produce the output above</summary>

```python
import subprocess
import tempfile

from pydantic import SecretStr

from openhands.sdk.agent import Agent
from openhands.sdk.conversation import Conversation
from openhands.sdk.llm import LLM
from openhands.tools.terminal import TerminalAction
from openhands.tools.terminal.impl import TerminalExecutor

TOKEN = "github_pat_REALSECRETVALUE123"

with tempfile.TemporaryDirectory() as repo_dir:
    subprocess.run(["git", "init", "-q"], cwd=repo_dir, check=True)
    subprocess.run(
        ["git", "remote", "add", "origin", f"https://{TOKEN}@github.com/repo/test.git"],
        cwd=repo_dir,
        check=True,
    )
    print("--- raw .git/config remote (on disk) ---")
    print(subprocess.run(["git", "remote", "-v"], cwd=repo_dir,
                         capture_output=True, text=True).stdout.strip())

    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="e2e-llm")
    conversation = Conversation(
        agent=Agent(llm=llm, tools=[]),
        workspace=repo_dir,
        persistence_dir=repo_dir,
        secrets={"GITHUB_TOKEN": TOKEN},
    )
    executor = TerminalExecutor(working_dir=repo_dir, terminal_type="subprocess")
    try:
        result = executor(TerminalAction(command="git remote -v"),
                          conversation=conversation)
        print("\n--- observation seen by the agent/LLM ---")
        print(result.text.strip())
        print("\n--- verdict ---")
        if TOKEN in result.text:
            raise SystemExit(f"LEAK: raw token present in observation ({TOKEN})")
        print("MASKED: token absent; <secret-hidden> present:",
              "<secret-hidden>" in result.text)
    finally:
        executor.close()
        conversation.close()
```

Run with `uv run python <script>.py`. It needs no network and no real credentials.

</details>

**Registry level** — the three checks from the issue:

```python
from openhands.sdk.conversation.secret_registry import SecretRegistry

TOKEN = "github_pat_REALSECRETVALUE123"
OUTPUT = f"origin\thttps://{TOKEN}@github.com/repo/test.git (fetch)"

reg = SecretRegistry()
reg.update_secrets({"github_token": TOKEN})

assert reg.get_secrets_as_env_vars("git remote -v") == {}   # name-scan exports nothing
assert TOKEN not in reg.mask_secrets_in_output(OUTPUT)      # was: leaked

reg2 = SecretRegistry.model_validate_json(
    reg.model_dump_json(context={"expose_secrets": True})
)
assert TOKEN not in reg2.mask_secrets_in_output(OUTPUT)     # was: leaked after resume
```

**Automated tests** — the four new tests fail on `main` and pass here:

```
$ uv run pytest tests/sdk/conversation/test_secrets_manager.py \
    tests/tools/terminal/test_secrets_masking.py -q \
    -k "without_name_reference or serialization_round_trip or tolerates_failing_source or not_referenced_by_command"

# on main:
FAILED tests/sdk/conversation/test_secrets_manager.py::test_mask_secrets_without_name_reference_in_command
FAILED tests/sdk/conversation/test_secrets_manager.py::test_mask_secrets_survives_serialization_round_trip
FAILED tests/sdk/conversation/test_secrets_manager.py::test_mask_secrets_tolerates_failing_source
FAILED tests/tools/terminal/test_secrets_masking.py::test_terminal_executor_masks_secret_not_referenced_by_command
4 failed

# with this change:
24 passed
```

Back-off behaviour, measured with a source that always raises (25 mask calls):

```
before: 25 mask calls -> 25 get_value() attempts, 25 warning lines
after:  25 mask calls -> 1  get_value() attempt,  1  warning line
```

Regression suites, all green:

```
$ uv run pytest tests/sdk/conversation tests/sdk/mcp tests/sdk/agent \
    tests/cross/test_agent_secrets_integration.py \
    tests/tools/terminal/test_secrets_masking.py -q
1645 passed

$ uv run pytest tests/tools/terminal -q
2 failed, 312 passed, 9 skipped
```

The two failures are `test_terminal_session.py::test_bash_server[tmux|subprocess]`, and they are **pre-existing and unrelated** — that test runs `python -u -m http.server 8081` in a bare terminal session with no conversation and no secret registry, so it never reaches masking. Verified by checking out `origin/main`'s `secret_registry.py` and `acp_agent.py` into the same tree and re-running: identical failure (`AssertionError: assert 'Serving HTTP on' in ''`). Local environment issue on this macOS box.

`pre-commit run --files <changed files>` passes (ruff format, ruff lint, pycodestyle, pyright, import rules, tool registration).

## Video/Screenshots

Terminal output rather than a GUI — the before/after observations are quoted verbatim under **How to Test**.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Scope.** The issue lists four proposed fixes; this PR implements Fix 1 (the masking gap) plus Fix 4 (regression tests). Fix 1 subsumes Fix 3 (masking state across resume) — covered by a test here. **Fix 2 is deliberately left out**: `_build_clone_url` still persists the raw token into `.git/config`, so the credential remains on disk and reachable through non-terminal paths (file tools reading `.git/config`, `env` dumps). That is a separate, larger change to the clone flow (`git remote set-url` after clone, plus a non-persistent auth mechanism for the clone itself) and is worth its own PR as defence in depth.

**Cost per observation.** Resolution is cached in `_exported_values`, so a `StaticSecret` — the common case — resolves once and every later observation hits the cache. Failing sources back off for 60s (see above). Backing off costs no masking coverage: a failed lookup yields no value to mask with either way, so the only effect is a delay in picking a recovered source back up.

**Rotate exposed tokens.** Masking only protects output produced from here on. Any token that already appeared in stored conversation logs is still there in cleartext and should be rotated.

## Known limitations

These are real and deliberately not fixed here. Flagging them rather than leaving them implied.

1. **Masking can still do blocking I/O on the first resolution of a remote source.** `LookupSecret.get_value()` is a synchronous 30s-timeout HTTP call, and `RemoteWorkspace` builds real HTTP-backed `LookupSecret`s (`remote/base.py:479-483`), so this is a production path. The 60s back-off bounds the repeat cost, but the *first* attempt still blocks the caller — and on ACP that caller is the portal event loop (`acp/connection.py:250-253` → `acp_agent.py:1259`, masking runs per streamed chunk). ACP pre-caches the whole registry off-loop at startup (`acp_agent.py:2369-2371`), so the exposure is narrow: a source that failed at startup, or a secret registered mid-conversation. On the terminal path it is paid in the tool thread, not a loop. **I think the real fix is to take resolution off the masking path entirely** — prime on registration, make `mask_secrets_in_output` cache-only — but that changes the registry's contract and its failure modes, so it wants its own PR and a reviewer's opinion rather than being folded into a security fix. Happy to do it either way.

2. **Rotated secrets mask the stale value.** `_exported_values` holds one value per key and cached keys are never refreshed, so this masks "the most recently resolved value of each secret," not "the current value." After a rotation the new value leaks; if something refreshes the cache, the *old* value stops being masked — and in this issue's own scenario the old value is exactly what is sitting in `.git/config`. The docstring now states this explicitly instead of promising fresh re-resolution.

3. **No-cipher persistence still loses the value.** The resume test here uses `expose_secrets: True`. On the real no-cipher path secrets are redacted on save, so a restored `StaticSecret.value` is `None` and the token leaks. Once the value is gone no masking layer can recover it — the fix is Fix 2 (stop writing the credential to disk).

4. **File tools have no masking at all.** `mask_secrets_in_output` has exactly three non-test call sites: terminal, ACP, MCP. `file_editor/impl.py` has none, so reading `.git/config` with the file tool leaks the raw token regardless of this PR. That is a missing masking layer, not an incomplete one, and it is the strongest argument for prioritising Fix 2.
