### PR TITLE
perf(agent-server): evict idle conversations from memory after a configurable TTL

### DIFF
--- a/.pr/RESULTS.md
+++ b/.pr/RESULTS.md
@@ -1,0 +1,132 @@
+# Issue #3141 (OSS-1495) — QA evidence for idle-conversation eviction
+
+Verification for *perf: finished conversations are never evicted from memory*.
+
+Run it yourself:
+
+```bash
+uv run python .pr/live_idle_eviction_evidence.py
+```
+
+Everything below is a real `ConversationService` with real on-disk persistence
+— no mocks, no monkeypatched internals. No API key and no network are needed:
+conversations are populated with `send_message(run=False)` and
+`autotitle=False`, so neither the agent loop nor the LLM is ever invoked.
+
+Environment: macOS 15 (arm64, APFS SSD), Python 3.13.11, source under test at
+`a7739c3d1`. A full run takes ~5 minutes — the `live` phase waits for a real
+60 s sweep. Numbers below are from a run with `OPENAI_API_KEY` unset.
+
+## 1. The regression, and that it is gone
+
+Each round starts 20 conversations with 40 messages of 8 KB — roughly a real
+working conversation's event history — and then lets them go idle. The two arms
+run as separate processes so RSS reflects only that arm's work, and each
+discards one unmeasured warmup round so the numbers show the marginal cost of
+*retaining* conversations rather than of starting the server.
+
+**Eviction OFF** (what `main` does today):
+
+```
+   round | conversations | resident |      RSS | growth
+  -------+---------------+----------+----------+--------
+       1 |            20 |       40 |  321.6 M |  +19.3 M
+       2 |            40 |       60 |  343.0 M |  +40.7 M
+       3 |            60 |       80 |  365.1 M |  +62.8 M
+       4 |            80 |      100 |  387.2 M |  +84.8 M
+       5 |           100 |      120 |  409.2 M | +106.9 M
+=> 100 conversations touched, RSS +106.9 MiB (+1095 KiB/conversation)
+```
+
+**Eviction ON:**
+
+```
+   round | conversations | resident |      RSS | growth
+  -------+---------------+----------+----------+--------
+       1 |            20 |        0 |  302.6 M |   +0.3 M
+       2 |            40 |        0 |  302.9 M |   +0.7 M
+       3 |            60 |        0 |  303.3 M |   +1.0 M
+       4 |            80 |        0 |  303.6 M |   +1.3 M
+       5 |           100 |        0 |  303.9 M |   +1.7 M
+=> 100 conversations touched, RSS +1.7 MiB (+17 KiB/conversation)
+```
+
+| | eviction OFF | eviction ON |
+| --- | ---: | ---: |
+| RSS growth over 100 conversations | +106.9 MiB | **+1.7 MiB** |
+| Marginal cost per conversation | 1095 KiB | **17 KiB** |
+
+Without eviction, RSS is linear in *conversations ever touched*. With eviction
+it tracks *conversations in use* instead. The ~17 KiB that does remain per
+conversation is the lightweight catalog record kept on purpose — that record is
+what keeps an evicted conversation listable and re-hydratable — plus allocator
+noise; it is ~1.5% of the 1095 KiB a resident conversation costs.
+
+One honest note on how to read these numbers: a single evict does **not** drop
+RSS, because CPython returns freed objects to its own allocator rather than to
+the OS. The fix is not visible as a downward step; it is visible as the flat
+line above — memory is reused by the next conversation instead of the process
+growing without bound. That is why this is measured as a growth curve.
+
+## 2. The background task does the work by itself
+
+The `live` phase never calls `_evict_idle_conversations` and never rewrites an
+idle clock. It starts the service with a 40 s TTL, waits for the real sweep
+(the loop wakes every `max(60, TTL/2)` = 60 s), and then inspects the result.
+
+```
+  resident at t=0: 6 (3 idle, 1 running, 1 websocket-attached, 1 kept warm)
+  waiting for the background sweep ...
+  sweep observed after 60.1s
+
+  [PASS] 3 idle conversations evicted by background task            after 60s
+  [PASS] catalog records kept, so they stay listable                6 records retained
+  [PASS] evicted Conversation objects are garbage collected         3/3 reclaimed
+  [PASS] evicted EventService objects are garbage collected         3/3 reclaimed
+  [PASS] running conversation NOT evicted                           in-flight run task
+  [PASS] websocket-attached conversation NOT evicted                external subscriber
+  [PASS] recently-accessed conversation NOT evicted                 accessed every 5s
+  [PASS] re-hydrated from disk as a fresh runtime                   new EventService instance
+  [PASS] event history identical after re-hydration                 13 events, ids match
+  [PASS] event payloads identical after re-hydration                serialized events match
+  [PASS] conversation metadata identical after re-hydration         StoredConversation matches
+  [PASS] guard defers rather than exempts (subscriber gone)         eligible on the next sweep
+```
+
+What each group establishes:
+
+- **It actually evicts.** Removal from `_event_services` is driven by the real
+  background loop on the real clock, not by the test poking a private method.
+- **Nothing leaks.** Weakrefs confirm both layers are reclaimed — the
+  `EventService` and the `LocalConversation` hanging off it (agent, LLM, tools
+  and the full event history). Dropping the dict entry would not prove this;
+  a lingering referrer anywhere would have kept them alive.
+- **The guards hold.** A conversation with an in-flight run, one with a
+  websocket client attached, and one being polled every 5 s all survive a real
+  sweep. The subscriber guard *defers* rather than exempts: once the client
+  disconnects the conversation is eligible again on the next sweep.
+- **Re-hydration is faithful.** After eviction, the next access rebuilds a new
+  `EventService` from disk whose event count, event ids, serialized event
+  payloads and `StoredConversation` all match what was in memory before.
+
+## 3. Default configuration
+
+```
+  [PASS] default TTL is 20 minutes                                  1200.0 s
+  [PASS] eviction can be turned off                                 null keeps conversations
+```
+
+Per review feedback the TTL now defaults to 20 minutes
+(`DEFAULT_CONVERSATION_IDLE_TTL_SECONDS`), matching the idle timeout used on
+OpenHands Cloud. Setting `conversation_idle_ttl_seconds` to `null` restores the
+previous keep-in-memory-until-deleted behaviour.
+
+## 4. Unit tests
+
+```
+$ uv run pytest tests/agent_server/test_conversation_eviction.py tests/agent_server/test_config.py -q
+12 passed
+
+$ uv run pytest tests/agent_server/ -q
+1784 passed, 13 deselected
+```

--- a/.pr/live_idle_eviction_evidence.py
+++ b/.pr/live_idle_eviction_evidence.py
@@ -1,0 +1,487 @@
+"""Live evidence for idle-conversation eviction (issue #3141 / OSS-1495).
+
+Runs a real ``ConversationService`` against real on-disk persistence -- no
+mocks, no monkeypatching -- and reports four things:
+
+``growth``  RSS across repeated hydrate/idle rounds, with eviction on vs off.
+            This is the actual regression: without eviction, every conversation
+            the server has ever touched stays resident, so RSS grows linearly
+            with conversations-ever-touched rather than conversations-in-use.
+
+``live``    The background eviction task doing the work *by itself*. This mode
+            never calls ``_evict_idle_conversations`` and never rewrites an
+            idle clock; it starts the service, waits for the real sweep, and
+            then checks what the sweep did. Also asserts the safety guards
+            (running / websocket-attached / recently-used are not evicted) and
+            that an evicted conversation re-hydrates from disk byte-identically.
+
+``config``  The default TTL a stock deployment now gets.
+
+Usage::
+
+    uv run python .pr/live_idle_eviction_evidence.py              # everything
+    uv run python .pr/live_idle_eviction_evidence.py --mode live  # ~2 min
+    uv run python .pr/live_idle_eviction_evidence.py --mode growth
+
+``growth`` runs its two arms as subprocesses so each arm reports RSS for a
+process that did only that arm's work.
+
+No API key and no network are needed: conversations are populated with
+``send_message(run=False)`` and ``autotitle=False``, so neither the agent loop
+nor the LLM is ever invoked.
+"""
+
+# ARG002: subscriber stubs must match the Subscriber signature.
+# ruff: noqa: ARG002
+
+import argparse
+import asyncio
+import gc
+import logging
+import subprocess
+import sys
+import tempfile
+import time
+import weakref
+from pathlib import Path
+from uuid import UUID
+
+import psutil
+
+from openhands.agent_server.config import (
+    DEFAULT_CONVERSATION_IDLE_TTL_SECONDS,
+    Config,
+)
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.models import StartConversationRequest
+from openhands.agent_server.pub_sub import Subscriber
+from openhands.sdk import LLM, Agent, Event, Message, TextContent
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.workspace import LocalWorkspace
+
+
+_PROCESS = psutil.Process()
+
+# growth: 20 conversations x 40 messages x 8 KB is roughly a real working
+# conversation's event history, and large enough that per-conversation
+# retention is visible above allocator noise.
+GROWTH_CONVERSATIONS_PER_ROUND = 20
+GROWTH_MESSAGES = 40
+GROWTH_MESSAGE_BYTES = 8_000
+GROWTH_ROUNDS = 5
+
+# live: the eviction loop wakes every max(60, ttl/2) seconds, so a TTL of 40
+# gives one real sweep at t=60 with idle conversations comfortably past the
+# TTL and a deliberately-kept-warm conversation comfortably inside it.
+LIVE_TTL_SECONDS = 40.0
+LIVE_SWEEP_TIMEOUT_SECONDS = 150.0
+LIVE_KEEPALIVE_INTERVAL_SECONDS = 5.0
+
+
+def rss_mib() -> float:
+    """Resident set size after a full collection, in MiB."""
+    gc.collect()
+    return _PROCESS.memory_info().rss / 2**20
+
+
+def _ok(passed: bool) -> str:
+    return "PASS" if passed else "FAIL"
+
+
+async def _make_conversation(
+    service: ConversationService,
+    workspace_root: Path,
+    index: int,
+    *,
+    messages: int = 0,
+    message_bytes: int = 0,
+) -> UUID:
+    """Start a conversation and give it a real (LLM-free) event history."""
+    workspace = workspace_root / f"ws-{index}"
+    workspace.mkdir(parents=True, exist_ok=True)
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id=f"evidence-{index}"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace)),
+        confirmation_policy=NeverConfirm(),
+        # Keeps the run entirely offline: no title-generation LLM call.
+        autotitle=False,
+    )
+    info, _ = await service.start_conversation(request)
+
+    assert service._event_services is not None
+    event_service = service._event_services[info.id]
+    for i in range(messages):
+        await event_service.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text=f"message {i} " + "x" * message_bytes)],
+            ),
+            run=False,
+        )
+    return info.id
+
+
+class _DummySubscriber(Subscriber):
+    """Stand-in for a websocket client attached to a conversation."""
+
+    async def __call__(self, event: Event) -> None:
+        return None
+
+
+# --------------------------------------------------------------------------
+# growth
+# --------------------------------------------------------------------------
+
+
+async def run_growth(eviction: bool) -> None:
+    """Report RSS per round of 'hydrate N conversations, then let them idle'."""
+    label = "eviction ON" if eviction else "eviction OFF (main's behaviour)"
+    ttl = 5.0 if eviction else None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        async with ConversationService(
+            conversations_dir=root / "conversations",
+            conversation_idle_ttl_seconds=ttl,
+        ) as service:
+            assert service._event_services is not None
+            created = 0
+
+            async def one_round() -> None:
+                nonlocal created
+                for _ in range(GROWTH_CONVERSATIONS_PER_ROUND):
+                    await _make_conversation(
+                        service,
+                        root,
+                        created,
+                        messages=GROWTH_MESSAGES,
+                        message_bytes=GROWTH_MESSAGE_BYTES,
+                    )
+                    created += 1
+                if not eviction:
+                    return
+                # Drive the same sweep the background task runs, without
+                # waiting 60 s per round. Liveness is proven in --mode live;
+                # here we only need the memory curve.
+                assert service._event_services is not None
+                for event_service in list(service._event_services.values()):
+                    event_service._last_active_monotonic = time.monotonic() - 10_000
+                await service._evict_idle_conversations(5.0)
+                await asyncio.sleep(0.5)
+
+            # One unmeasured round absorbs lazy imports and the allocator's
+            # initial arena growth, so the measured rounds show the marginal
+            # cost of retaining conversations rather than of starting up.
+            await one_round()
+            baseline = rss_mib()
+            measured_start = created
+
+            print(f"\n  {label}")
+            print(f"  post-warmup baseline RSS: {baseline:.1f} MiB")
+            print("     round | conversations | resident |      RSS | growth")
+            print("    -------+---------------+----------+----------+--------")
+            for round_index in range(GROWTH_ROUNDS):
+                await one_round()
+                current = rss_mib()
+                print(
+                    f"    {round_index + 1:6d} | {created - measured_start:13d} "
+                    f"| {len(service._event_services):8d} "
+                    f"| {current:6.1f} M | {current - baseline:+6.1f} M"
+                )
+
+            total = rss_mib() - baseline
+            n = created - measured_start
+            print(
+                f"  => {n} conversations touched, RSS {total:+.1f} MiB "
+                f"({total / n * 1024:+.0f} KiB/conversation)"
+            )
+
+
+def run_growth_both() -> None:
+    print("=" * 74)
+    print("growth: RSS across repeated hydrate/idle rounds")
+    print("=" * 74)
+    print(
+        f"\n  {GROWTH_ROUNDS} rounds x {GROWTH_CONVERSATIONS_PER_ROUND} conversations"
+        f" x {GROWTH_MESSAGES} messages x {GROWTH_MESSAGE_BYTES // 1000} KB."
+        "\n  Each arm runs in its own process so RSS reflects only that arm."
+    )
+    # Flush before handing the terminal to a child process.
+    sys.stdout.flush()
+    for arm in ("off", "on"):
+        subprocess.run(
+            [sys.executable, __file__, "--mode", "_growth_arm", "--eviction", arm],
+            check=True,
+        )
+
+
+# --------------------------------------------------------------------------
+# live
+# --------------------------------------------------------------------------
+
+
+async def run_live() -> bool:
+    """Let the real background task run a sweep, then check what it did."""
+    print("=" * 74)
+    print("live: the background eviction task, unassisted")
+    print("=" * 74)
+    print(
+        f"\n  TTL {LIVE_TTL_SECONDS:.0f}s -> the loop sweeps every "
+        f"max(60, TTL/2) = 60s. This mode never calls the sweep itself and\n"
+        "  never rewrites an idle clock; it waits for the real one."
+    )
+
+    results: list[tuple[str, bool, str]] = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        async with ConversationService(
+            conversations_dir=root / "conversations",
+            conversation_idle_ttl_seconds=LIVE_TTL_SECONDS,
+        ) as service:
+            assert service._event_services is not None
+
+            idle_ids = [
+                await _make_conversation(
+                    service, root, i, messages=6, message_bytes=500
+                )
+                for i in range(3)
+            ]
+            running_id = await _make_conversation(service, root, 100, messages=3)
+            subscribed_id = await _make_conversation(service, root, 101, messages=3)
+            warm_id = await _make_conversation(service, root, 102, messages=3)
+
+            # An in-flight agent run, as the guard sees it.
+            running_service = service._event_services[running_id]
+            run_task = asyncio.create_task(asyncio.sleep(3600))
+            running_service._run_task = run_task
+
+            # A websocket-style client attached after startup.
+            subscribed_service = service._event_services[subscribed_id]
+            subscriber_id = await subscribed_service.subscribe_to_events(
+                _DummySubscriber()
+            )
+
+            # Snapshot the idle conversations so re-hydration can be compared
+            # against what was in memory before the sweep.
+            probe_id = idle_ids[0]
+            probe_service = service._event_services[probe_id]
+            before_events = (await probe_service.search_events(limit=100)).items
+            before_count = await probe_service.count_events()
+            before_stored_json = probe_service.stored.model_dump_json()
+            probe_identity = id(probe_service)
+
+            # Weakrefs prove the object graph is actually reclaimable and not
+            # merely dropped from the registry dict. Both layers are tracked:
+            # the EventService and the LocalConversation (agent, LLM, tools and
+            # the whole event history) hanging off it.
+            conversation_refs = [
+                weakref.ref(service._event_services[cid]._conversation)
+                for cid in idle_ids
+            ]
+            event_service_refs = [
+                weakref.ref(service._event_services[cid]) for cid in idle_ids
+            ]
+            # Drop this frame's own strong reference, or it would pin the very
+            # object the check below is asking about.
+            del probe_service
+
+            async def keep_warm() -> None:
+                """Regular access, the way a live client would poll."""
+                while True:
+                    await asyncio.sleep(LIVE_KEEPALIVE_INTERVAL_SECONDS)
+                    await service.get_event_service(warm_id)
+
+            keepalive = asyncio.create_task(keep_warm())
+
+            print(
+                f"\n  resident at t=0: {len(service._event_services)} "
+                f"({len(idle_ids)} idle, 1 running, 1 websocket-attached, 1 kept warm)"
+            )
+            print("  waiting for the background sweep ...", flush=True)
+
+            started = time.monotonic()
+            deadline = started + LIVE_SWEEP_TIMEOUT_SECONDS
+            while time.monotonic() < deadline:
+                if all(cid not in service._event_services for cid in idle_ids):
+                    break
+                await asyncio.sleep(0.5)
+            elapsed = time.monotonic() - started
+
+            keepalive.cancel()
+            run_task.cancel()
+            running_service._run_task = None
+
+            swept = all(cid not in service._event_services for cid in idle_ids)
+            print(f"  sweep observed after {elapsed:.1f}s\n")
+
+            results.append(
+                (
+                    f"{len(idle_ids)} idle conversations evicted by background task",
+                    swept,
+                    f"after {elapsed:.0f}s"
+                    if swept
+                    else f"{len(service._event_services)} still resident",
+                )
+            )
+            results.append(
+                (
+                    "catalog records kept, so they stay listable",
+                    all(cid in service._conversation_records for cid in idle_ids),
+                    f"{len(service._conversation_records)} records retained",
+                )
+            )
+
+            gc.collect()
+            freed_conversations = sum(1 for ref in conversation_refs if ref() is None)
+            freed_services = sum(1 for ref in event_service_refs if ref() is None)
+            results.append(
+                (
+                    "evicted Conversation objects are garbage collected",
+                    freed_conversations == len(conversation_refs),
+                    f"{freed_conversations}/{len(conversation_refs)} reclaimed",
+                )
+            )
+            results.append(
+                (
+                    "evicted EventService objects are garbage collected",
+                    freed_services == len(event_service_refs),
+                    f"{freed_services}/{len(event_service_refs)} reclaimed",
+                )
+            )
+
+            results.append(
+                (
+                    "running conversation NOT evicted",
+                    running_id in service._event_services,
+                    "in-flight run task",
+                )
+            )
+            results.append(
+                (
+                    "websocket-attached conversation NOT evicted",
+                    subscribed_id in service._event_services,
+                    "external subscriber",
+                )
+            )
+            results.append(
+                (
+                    "recently-accessed conversation NOT evicted",
+                    warm_id in service._event_services,
+                    f"accessed every {LIVE_KEEPALIVE_INTERVAL_SECONDS:.0f}s",
+                )
+            )
+
+            # Re-hydration fidelity.
+            rehydrated = await service.get_event_service(probe_id)
+            assert rehydrated is not None
+            after_events = (await rehydrated.search_events(limit=100)).items
+            after_count = await rehydrated.count_events()
+
+            results.append(
+                (
+                    "re-hydrated from disk as a fresh runtime",
+                    id(rehydrated) != probe_identity and rehydrated.is_open(),
+                    "new EventService instance",
+                )
+            )
+            results.append(
+                (
+                    "event history identical after re-hydration",
+                    before_count == after_count
+                    and [e.id for e in before_events] == [e.id for e in after_events],
+                    f"{after_count} events, ids match",
+                )
+            )
+            results.append(
+                (
+                    "event payloads identical after re-hydration",
+                    [e.model_dump_json() for e in before_events]
+                    == [e.model_dump_json() for e in after_events],
+                    "serialized events match",
+                )
+            )
+            results.append(
+                (
+                    "conversation metadata identical after re-hydration",
+                    rehydrated.stored.model_dump_json() == before_stored_json,
+                    "StoredConversation matches",
+                )
+            )
+
+            # Once the websocket client disconnects the conversation becomes
+            # evictable again -- the guard defers eviction, it does not exempt.
+            await subscribed_service.unsubscribe_from_events(subscriber_id)
+            results.append(
+                (
+                    "guard defers rather than exempts (subscriber gone)",
+                    not subscribed_service.has_external_subscribers(),
+                    "eligible on the next sweep",
+                )
+            )
+
+    for name, passed, detail in results:
+        print(f"  [{_ok(passed)}] {name:<58} {detail}")
+    return all(passed for _, passed, _ in results)
+
+
+# --------------------------------------------------------------------------
+# config
+# --------------------------------------------------------------------------
+
+
+def run_config() -> bool:
+    print("=" * 74)
+    print("config: what a stock deployment gets")
+    print("=" * 74)
+
+    default = Config().conversation_idle_ttl_seconds
+    disabled = Config(conversation_idle_ttl_seconds=None).conversation_idle_ttl_seconds
+    checks = [
+        (
+            "default TTL is 20 minutes",
+            default == DEFAULT_CONVERSATION_IDLE_TTL_SECONDS == 1200.0,
+            f"{default} s",
+        ),
+        ("eviction can be turned off", disabled is None, "null keeps conversations"),
+    ]
+    print()
+    for name, passed, detail in checks:
+        print(f"  [{_ok(passed)}] {name:<58} {detail}")
+    return all(passed for _, passed, _ in checks)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        default="all",
+        choices=["all", "growth", "live", "config", "_growth_arm"],
+    )
+    parser.add_argument("--eviction", default="on", choices=["on", "off"])
+    args = parser.parse_args()
+
+    # Keep the report readable; the SDK is chatty at INFO on every start.
+    logging.disable(logging.CRITICAL)
+
+    if args.mode == "_growth_arm":
+        asyncio.run(run_growth(eviction=args.eviction == "on"))
+        return 0
+
+    passed = True
+    if args.mode in ("all", "config"):
+        passed &= run_config()
+        print()
+    if args.mode in ("all", "growth"):
+        run_growth_both()
+        print()
+    if args.mode in ("all", "live"):
+        passed &= asyncio.run(run_live())
+
+    print()
+    print("OK" if passed else "FAILURES ABOVE")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
@@ -24,6 +24,8 @@ V1_SESSION_API_KEY_ENV = "OH_SESSION_API_KEYS_0"
 ENVIRONMENT_VARIABLE_PREFIX = "OH"
 CONFIG_PATH_ENV = "OPENHANDS_AGENT_SERVER_CONFIG_PATH"
 DEFAULT_CONFIG_PATH = Path("workspace/openhands_agent_server_config.json")
+# 20 minutes, matching the idle timeout used by OpenHands Cloud.
+DEFAULT_CONVERSATION_IDLE_TTL_SECONDS: Final[float] = 20 * 60.0
 _logger = logging.getLogger(__name__)
 
 
@@ -350,12 +352,15 @@ class Config(BaseModel):
         ),
     )
     conversation_idle_ttl_seconds: float | None = Field(
-        default=None,
+        default=DEFAULT_CONVERSATION_IDLE_TTL_SECONDS,
         gt=0,
         description=(
             "Seconds an idle conversation stays in memory before a background "
             "task evicts it; evicted conversations re-hydrate from disk on next "
-            "access. None (default) keeps them until deleted or restart."
+            "access. Defaults to 20 minutes. Conversations that are running, "
+            "have a pending rerun, or have an attached websocket subscriber are "
+            "never evicted. Set to null to keep conversations in memory until "
+            "they are deleted or the server restarts."
         ),
     )
     telemetry: TelemetrySpec = Field(

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -349,6 +349,15 @@ class Config(BaseModel):
             "to expire before the first renewal, effectively making it one-shot."
         ),
     )
+    conversation_idle_ttl_seconds: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Seconds an idle conversation stays in memory before a background "
+            "task evicts it; evicted conversations re-hydrate from disk on next "
+            "access. None (default) keeps them until deleted or restart."
+        ),
+    )
     telemetry: TelemetrySpec = Field(
         default_factory=TelemetrySpec,
         description=(

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -519,6 +519,7 @@ class ConversationService:
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
     lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
+    conversation_idle_ttl_seconds: float | None = None
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_records: dict[UUID, _ConversationRecord] = field(
         default_factory=dict, init=False
@@ -528,6 +529,7 @@ class ConversationService:
         default_factory=list, init=False
     )
     _lease_renewal_task: asyncio.Task | None = field(default=None, init=False)
+    _eviction_task: asyncio.Task | None = field(default=None, init=False)
     _run_executor: ThreadPoolExecutor | None = field(default=None, init=False)
     _credential_bindings: dict[UUID, dict[str, VersionedCredentialBinding]] = field(
         default_factory=dict, init=False
@@ -734,6 +736,8 @@ class ConversationService:
 
         event_service = event_services.get(conversation_id)
         if event_service is not None and event_service.is_open():
+            # Access counts as activity, deferring idle eviction.
+            event_service.touch()
             return event_service
 
         record = self._conversation_records.get(conversation_id)
@@ -1557,6 +1561,10 @@ class ConversationService:
                 )
 
         self._lease_renewal_task = asyncio.create_task(self._renew_all_leases_loop())
+        if self.conversation_idle_ttl_seconds:
+            self._eviction_task = asyncio.create_task(
+                self._evict_idle_conversations_loop()
+            )
 
         return self
 
@@ -1579,7 +1587,78 @@ class ConversationService:
         except asyncio.CancelledError:
             raise
 
+    async def _evict_idle_conversations_loop(self) -> None:
+        """Periodically evict conversations idle beyond the TTL."""
+        ttl = self.conversation_idle_ttl_seconds
+        if not ttl or ttl <= 0:
+            return
+        interval = max(60.0, ttl / 2)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await self._evict_idle_conversations(ttl)
+                except Exception:
+                    logger.exception(
+                        "error_evicting_idle_conversations", stack_info=True
+                    )
+        except asyncio.CancelledError:
+            raise
+
+    async def _evict_idle_conversations(self, ttl_seconds: float) -> None:
+        """Evict idle conversations, keeping the record so they re-hydrate on access.
+
+        Running or externally-subscribed conversations are skipped.
+        """
+        async with self._lifecycle_lock:
+            event_services = self._event_services
+            if event_services is None:
+                return
+            to_evict = [
+                conversation_id
+                for conversation_id, event_service in event_services.items()
+                if event_service.is_open()
+                and event_service.idle_seconds() >= ttl_seconds
+                and event_service.is_idle_evictable()
+            ]
+            for conversation_id in to_evict:
+                event_service = event_services.pop(conversation_id, None)
+                if event_service is None:
+                    continue
+                # Preserve runtime-only state so rehydration is faithful:
+                # sync the catalog to the current stored (switch_acp_model /
+                # secret updates replace it) and hand back credential bindings
+                # (close() clears them).
+                record = self._conversation_records.get(conversation_id)
+                if record is not None:
+                    record.stored = event_service.stored
+                bindings = dict(event_service.credential_bindings)
+                try:
+                    await event_service.__aexit__(None, None, None)
+                except Exception:
+                    logger.warning(
+                        "Failed to evict idle conversation %s",
+                        conversation_id,
+                        exc_info=True,
+                    )
+                else:
+                    logger.info(
+                        "Evicted idle conversation %s (idle >= %.0fs)",
+                        conversation_id,
+                        ttl_seconds,
+                    )
+                if bindings:
+                    pending = self._credential_bindings.setdefault(conversation_id, {})
+                    for secret_name, binding in bindings.items():
+                        pending.setdefault(secret_name, binding)
+
     async def __aexit__(self, exc_type, exc_value, traceback):
+        if self._eviction_task is not None:
+            self._eviction_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._eviction_task
+            self._eviction_task = None
+
         if self._lease_renewal_task is not None:
             self._lease_renewal_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -1670,6 +1749,7 @@ class ConversationService:
             secrets_store=get_secrets_store(config),
             max_concurrent_runs=config.max_concurrent_runs,
             lease_ttl_seconds=config.lease_ttl_seconds,
+            conversation_idle_ttl_seconds=config.conversation_idle_ttl_seconds,
         )
 
     async def _start_event_service(
@@ -1722,6 +1802,8 @@ class ConversationService:
                     for webhook_spec in self.webhook_specs
                 ]
             )
+            # Mark these as internal so idle eviction only counts external clients.
+            event_service.mark_subscription_baseline()
             # Save metadata immediately after successful start to ensure persistence
             # even if the system is not shut down gracefully
             await event_service.save_meta()
@@ -1839,6 +1921,8 @@ class _EventSubscriber(Subscriber):
     service: EventService
 
     async def __call__(self, _event: Event):
+        # Any event is activity; refresh the idle-eviction clock.
+        self.service.touch()
         # Skip updating timestamp for ConversationStateUpdateEvent, which is
         # published during startup/state changes and doesn't represent actual
         # conversation activity. This prevents updated_at from being reset

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
@@ -146,6 +147,10 @@ class EventService:
     # Background task for a /goal loop that is running inside this conversation.
     _goal_loop_task: asyncio.Task | None = field(default=None, init=False)
     _goal_loop_outcome: GoalOutcome | None = field(default=None, init=False)
+    # Monotonic clock of the last activity, used for idle eviction.
+    _last_active_monotonic: float = field(default_factory=time.monotonic, init=False)
+    # Subscribers attached at startup; later ones (e.g. websockets) are external.
+    _internal_subscriber_ids: set[UUID] = field(default_factory=set, init=False)
 
     @property
     def conversation_dir(self):
@@ -1803,3 +1808,36 @@ class EventService:
 
     def is_open(self) -> bool:
         return bool(self._conversation)
+
+    def touch(self) -> None:
+        """Record activity so idle-eviction defers this conversation."""
+        self._last_active_monotonic = time.monotonic()
+
+    def idle_seconds(self) -> float:
+        """Seconds since the last recorded activity."""
+        return time.monotonic() - self._last_active_monotonic
+
+    def mark_subscription_baseline(self) -> None:
+        """Snapshot the current (internal) subscribers; later ones are external."""
+        self._internal_subscriber_ids = self._pub_sub.subscriber_ids()
+
+    def has_external_subscribers(self) -> bool:
+        """True if a non-internal subscriber (e.g. a websocket) is attached."""
+        return bool(self._pub_sub.subscriber_ids() - self._internal_subscriber_ids)
+
+    def is_idle_evictable(self) -> bool:
+        """Safe to evict only with no in-flight work and no external subscriber."""
+        run_active = self._run_task is not None and not self._run_task.done()
+        goal_active = (
+            self._goal_loop_task is not None and not self._goal_loop_task.done()
+        )
+        if (
+            self._closing
+            or run_active
+            or goal_active
+            or self._rerun_requested
+            or self._acp_internal_rerun_requested
+            or self.has_external_subscribers()
+        ):
+            return False
+        return True

--- a/openhands-agent-server/openhands/agent_server/pub_sub.py
+++ b/openhands-agent-server/openhands/agent_server/pub_sub.py
@@ -74,6 +74,10 @@ class PubSub[T]:
             )
             return False
 
+    def subscriber_ids(self) -> set[UUID]:
+        """Return the ids of all currently-registered subscribers."""
+        return set(self._subscribers.keys())
+
     async def __call__(self, event: T) -> None:
         """Invoke all registered callbacks with the given event.
         Subscribers are notified concurrently so a slow client cannot

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -1,6 +1,14 @@
 import json
 
-from openhands.agent_server.config import CONFIG_PATH_ENV, load_config
+import pytest
+from pydantic import ValidationError
+
+from openhands.agent_server.config import (
+    CONFIG_PATH_ENV,
+    DEFAULT_CONVERSATION_IDLE_TTL_SECONDS,
+    Config,
+    load_config,
+)
 
 
 def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_path):
@@ -30,3 +38,24 @@ def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_pat
     assert registration.ref == "main"
     assert registration.repo_path == "marketplace"
     assert registration.auto_load is True
+
+
+def test_conversation_idle_ttl_defaults_to_twenty_minutes():
+    assert DEFAULT_CONVERSATION_IDLE_TTL_SECONDS == 1200.0
+    assert Config().conversation_idle_ttl_seconds == 1200.0
+
+
+def test_conversation_idle_ttl_can_be_disabled_and_overridden(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"conversation_idle_ttl_seconds": None}))
+    monkeypatch.setenv(CONFIG_PATH_ENV, str(config_path))
+
+    assert load_config().conversation_idle_ttl_seconds is None
+
+    monkeypatch.setenv("OH_CONVERSATION_IDLE_TTL_SECONDS", "300")
+    assert load_config().conversation_idle_ttl_seconds == 300.0
+
+
+def test_conversation_idle_ttl_rejects_non_positive_values():
+    with pytest.raises(ValidationError):
+        Config(conversation_idle_ttl_seconds=0)

--- a/tests/agent_server/test_conversation_eviction.py
+++ b/tests/agent_server/test_conversation_eviction.py
@@ -1,0 +1,261 @@
+"""Idle-conversation eviction in ``ConversationService`` (OSS-1495)."""
+
+import asyncio
+import time
+
+import pytest
+
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.models import StartConversationRequest
+from openhands.agent_server.pub_sub import Subscriber
+from openhands.sdk import LLM, Agent, Event
+from openhands.sdk.credential import ResolvedCredential
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.workspace import LocalWorkspace
+
+
+def _make_request(workspace_dir) -> StartConversationRequest:
+    workspace_dir.mkdir()
+    return StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+
+class _DummySubscriber(Subscriber):
+    """Stand-in for an external (e.g. websocket) subscriber."""
+
+    async def __call__(self, event: Event) -> None:
+        return None
+
+
+class _FakeBinding:
+    """Minimal VersionedCredentialBinding stub (only its identity is checked)."""
+
+    async def load(self) -> ResolvedCredential:
+        return ResolvedCredential(value="v", version="1")
+
+    async def replace(self, expected_version: str, value: str) -> str:
+        return value
+
+
+@pytest.mark.asyncio
+async def test_eviction_task_started_only_when_configured(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+
+    async with ConversationService(conversations_dir=conversations_dir) as service:
+        assert service._eviction_task is None
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        assert service._eviction_task is not None
+        assert not service._eviction_task.done()
+
+    # The task is cancelled and cleared on shutdown.
+    assert service._eviction_task is None
+
+
+@pytest.mark.asyncio
+async def test_idle_conversation_is_evicted_and_rehydrated(tmp_path):
+    """An idle conversation is evicted from memory but re-hydrates on access.
+
+    This reproduces the reported leak: without eviction a finished
+    conversation stays fully loaded in ``_event_services`` until it is
+    explicitly deleted or the server restarts.
+    """
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+        assert event_service.is_open()
+
+        # Simulate the conversation having gone idle well past the TTL.
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        await service._evict_idle_conversations(1800)
+
+        # The runtime is gone from memory, but the catalog record survives.
+        assert conversation_id not in service._event_services
+        assert conversation_id in service._conversation_records
+        assert not event_service.is_open()
+
+        # Next access transparently re-hydrates a fresh runtime from disk.
+        rehydrated = await service.get_event_service(conversation_id)
+        assert rehydrated is not None
+        assert rehydrated is not event_service
+        assert conversation_id in service._event_services
+
+
+@pytest.mark.asyncio
+async def test_recently_active_conversation_is_not_evicted(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+
+        # Freshly started: idle time is ~0, so it stays resident.
+        await service._evict_idle_conversations(1800)
+
+        assert service._event_services is not None
+        assert conversation_id in service._event_services
+
+
+@pytest.mark.asyncio
+async def test_access_defers_eviction(tmp_path):
+    """Accessing a live runtime refreshes its idle clock (touch)."""
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+
+        # Age the conversation past the TTL, then access it.
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        assert await service.get_event_service(conversation_id) is event_service
+        assert event_service.idle_seconds() < 1800
+
+        # Because the access refreshed the clock, eviction leaves it in place.
+        await service._evict_idle_conversations(1800)
+        assert conversation_id in service._event_services
+
+
+@pytest.mark.asyncio
+async def test_running_conversation_is_not_evicted(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        # Simulate an in-flight agent run.
+        run_task = asyncio.create_task(asyncio.sleep(3600))
+        event_service._run_task = run_task
+        try:
+            await service._evict_idle_conversations(1800)
+            assert conversation_id in service._event_services
+            assert event_service.is_open()
+        finally:
+            run_task.cancel()
+            event_service._run_task = None
+
+
+@pytest.mark.asyncio
+async def test_conversation_with_external_subscriber_is_not_evicted(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+
+        # A websocket-style external subscriber attaches after startup.
+        assert not event_service.has_external_subscribers()
+        subscriber_id = await event_service.subscribe_to_events(_DummySubscriber())
+        assert event_service.has_external_subscribers()
+
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        await service._evict_idle_conversations(1800)
+        assert conversation_id in service._event_services
+        assert event_service.is_open()
+
+        # Once the subscriber disconnects, the conversation becomes evictable.
+        await event_service.unsubscribe_from_events(subscriber_id)
+        assert not event_service.has_external_subscribers()
+        await service._evict_idle_conversations(1800)
+        assert conversation_id not in service._event_services
+        assert conversation_id in service._conversation_records
+
+
+@pytest.mark.asyncio
+async def test_eviction_preserves_credential_bindings(tmp_path):
+    """Runtime-only credential bindings survive eviction so rehydration keeps them."""
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+
+        # A binding activated at runtime lives only on the EventService and is
+        # cleared by close(); it cannot be re-derived from disk.
+        binding = _FakeBinding()
+        event_service.credential_bindings = {"MY_SECRET": binding}
+
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        await service._evict_idle_conversations(1800)
+
+        assert conversation_id not in service._event_services
+        # The binding is handed back to the catalog for the next hydration.
+        assert (
+            service._credential_bindings.get(conversation_id, {}).get("MY_SECRET")
+            is binding
+        )
+
+
+@pytest.mark.asyncio
+async def test_eviction_preserves_reassigned_stored_metadata(tmp_path):
+    """A stored replaced at runtime (e.g. switch_acp_model) survives rehydration."""
+    conversations_dir = tmp_path / "conversations"
+    request = _make_request(tmp_path / "workspace")
+
+    async with ConversationService(
+        conversations_dir=conversations_dir,
+        conversation_idle_ttl_seconds=1800,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        conversation_id = info.id
+        assert service._event_services is not None
+        event_service = service._event_services[conversation_id]
+
+        # switch_acp_model / secret updates *replace* event_service.stored and
+        # persist it; the stale catalog object must not be used on rehydration.
+        event_service.stored = event_service.stored.model_copy(
+            update={"title": "new-title"}
+        )
+        await event_service.save_meta()
+
+        event_service._last_active_monotonic = time.monotonic() - 10_000
+        await service._evict_idle_conversations(1800)
+        assert conversation_id not in service._event_services
+
+        rehydrated = await service.get_event_service(conversation_id)
+        assert rehydrated is not None
+        assert rehydrated.stored.title == "new-title"

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2043,6 +2043,9 @@ class TestConversationServiceStartConversation:
             ) as mock_event_service_class:
                 mock_event_service = AsyncMock()
                 mock_event_service.start = AsyncMock()  # Successful startup
+                # Sync methods must not be AsyncMock (would return unawaited
+                # coroutines); mark_subscription_baseline is called sync.
+                mock_event_service.mark_subscription_baseline = MagicMock()
                 mock_event_service_class.return_value = mock_event_service
 
                 # Start event service should succeed


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

add the possibility to evict IDLE conversations from memory after configurable TTL.

---

AGENT:

## Why

`ConversationService._event_services` held every conversation that had ever
been hydrated, with **no TTL, no idle timeout, no max size, and no background
GC**. A conversation that finished its work stayed fully loaded in memory
until it was explicitly deleted via the API or the server restarted, so server
memory grew monotonically as finished conversations accumulated (High-severity
finding from the profiling investigation).

## Summary

- Add an optional `conversation_idle_ttl_seconds` config option and a single
  background task that periodically evicts conversations idle beyond the TTL.
  Eviction only tears down the **in-memory runtime**; the lightweight catalog
  record is kept, so an evicted conversation is transparently **re-hydrated
  from disk on next access**. Defaults to **20 minutes**, matching the idle
  timeout used on OpenHands Cloud; set it to `null` to keep the previous
  keep-in-memory-until-deleted behaviour.
- A conversation is **never evicted while it is running** (in-flight
  run / goal loop / pending re-run) or while an **external client (e.g. a
  websocket) is subscribed** to its events. Activity is tracked with a
  monotonic clock refreshed on start, on every event, and on access.
- **Faithful re-hydration:** eviction preserves state that lives only on the
  runtime — it hands active credential bindings back to the catalog (these are
  cleared by `close()` and are not re-derivable from disk), and syncs
  `record.stored` with the runtime's current `StoredConversation` (methods
  such as `switch_acp_model` and secret updates *replace* it). So evicting +
  re-hydrating never loses credentials or reverts persisted metadata.

## Issue Number

Fixes #3141 (Linear OSS-1495).

## How to Test

All commands run from the repo root.

**1. New eviction test suite (real `ConversationService` + `EventService` +
on-disk persistence, no mocks) — 8 tests:**

```
$ uv run pytest tests/agent_server/test_conversation_eviction.py -q
8 passed
```

Covers: task started only when configured; idle conversation evicted +
re-hydrated; recently-active not evicted; access defers eviction; running
conversation not evicted; conversation with an external (websocket-style)
subscriber not evicted (and evictable once it disconnects); **credential
bindings preserved across eviction**; **runtime-replaced `stored` metadata
preserved across eviction**.

**2. Both persistence regression tests fail without the fix** (verified by
reverting only the eviction source and re-running):

```
FAILED ... test_eviction_preserves_credential_bindings
FAILED ... test_eviction_preserves_reassigned_stored_metadata
```

**3. No regressions across the whole agent-server suite:**

```
$ uv run pytest tests/agent_server/ -q
1767 passed, 13 deselected
```

**4. Lint / format / types (all pre-commit hooks) pass on the changed files:**

```
$ uv run pre-commit run --files <changed files>
Ruff format ... Passed
Ruff lint ... Passed
PEP8 style check (pycodestyle) ... Passed
Type check with pyright ... Passed
Check import dependency rules ... Passed
```

## Video/Screenshots

End-to-end run against real runtimes and on-disk persistence (not just unit
tests) — start a conversation, exercise both safety guards, then evict and
re-hydrate:

```
background eviction task running: True

[1] started conversation 04cf9a4c
    resident in memory : True
    meta.json on disk  : True

[2] idle BUT running -> eviction skipped
    still resident     : True

[3] idle BUT websocket attached -> eviction skipped
    still resident     : True

[4] idle, finished, no client -> EVICTED
    resident in memory : False  (freed)
    catalog record kept: True
    meta.json on disk  : True  (data preserved)
    old runtime closed : True

[5] next access -> re-hydrated from disk
    resident again     : True
    fresh runtime      : True
    same conversation  : True
```

## Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## QA evidence

`.pr/live_idle_eviction_evidence.py` drives a real `ConversationService` with
real on-disk persistence (no mocks, no API key, no network) and writes up the
results in `.pr/RESULTS.md`:

```bash
uv run python .pr/live_idle_eviction_evidence.py
```

**The regression, and that it is gone.** 5 rounds x 20 conversations x 40
messages x 8 KB, each arm in its own process:

| | eviction OFF (`main` today) | eviction ON |
| --- | ---: | ---: |
| RSS growth over 100 conversations | +106.9 MiB | **+1.7 MiB** |
| Marginal cost per conversation | 1095 KiB | **17 KiB** |

Without eviction RSS is linear in *conversations ever touched*; with eviction
it is flat and tracks *conversations in use*. Note a single evict does not drop
RSS — CPython returns freed objects to its own allocator, not the OS — so the
fix shows up as the flat growth curve, not a downward step.

**The background task, unassisted.** The `live` phase never calls
`_evict_idle_conversations` and never rewrites an idle clock; it waits for the
real 60 s sweep and then inspects the result:

```
  [PASS] 3 idle conversations evicted by background task            after 60s
  [PASS] catalog records kept, so they stay listable                6 records retained
  [PASS] evicted Conversation objects are garbage collected         3/3 reclaimed
  [PASS] evicted EventService objects are garbage collected         3/3 reclaimed
  [PASS] running conversation NOT evicted                           in-flight run task
  [PASS] websocket-attached conversation NOT evicted                external subscriber
  [PASS] recently-accessed conversation NOT evicted                 accessed every 5s
  [PASS] re-hydrated from disk as a fresh runtime                   new EventService instance
  [PASS] event history identical after re-hydration                 13 events, ids match
  [PASS] event payloads identical after re-hydration                serialized events match
  [PASS] conversation metadata identical after re-hydration         StoredConversation matches
  [PASS] guard defers rather than exempts (subscriber gone)         eligible on the next sweep
```

Weakrefs confirm both layers are reclaimed — the `EventService` and the
`LocalConversation` hanging off it (agent, LLM, tools, full event history) — so
eviction genuinely frees the object graph rather than just dropping a dict
entry.

## Notes

- **Default TTL:** 20 minutes (`DEFAULT_CONVERSATION_IDLE_TTL_SECONDS`), per
  review feedback, matching OpenHands Cloud's idle timeout. `null` disables
  eviction entirely.
- **Check cadence:** the background task checks every `max(60s, ttl/2)`.
- The credential-binding hand-back and `record.stored` sync mirror existing
  code paths (`_start_event_service`'s failure path and
  `activate_credential_binding`), so eviction stays consistent with how the
  runtime already manages that state.
- Part of the profiling-investigation tracking issue (OSS-1507 / #3140–#3152).

