### PR TITLE
docs(examples): show LLM action summary in confirmation previews

### DIFF
--- a/examples/01_standalone_sdk/04_confirmation_mode_example.py
+++ b/examples/01_standalone_sdk/04_confirmation_mode_example.py
@@ -23,8 +23,13 @@ signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt(
 def _print_action_preview(pending_actions) -> None:
     print(f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting confirmation:")
     for i, action in enumerate(pending_actions, start=1):
+        # Prefer the LLM-provided natural-language summary as the headline,
+        # keeping the raw action snippet as secondary detail so users can
+        # still see exactly what will run before approving.
+        headline = action.summary or "(no summary provided)"
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. {action.tool_name}: {snippet}...")
+        print(f"  {i}. [{action.tool_name}] {headline}")
+        print(f"     {snippet}...")
 
 
 def confirm_in_console(pending_actions) -> bool:

--- a/examples/01_standalone_sdk/04_confirmation_mode_example.py
+++ b/examples/01_standalone_sdk/04_confirmation_mode_example.py
@@ -23,13 +23,15 @@ signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt(
 def _print_action_preview(pending_actions) -> None:
     print(f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting confirmation:")
     for i, action in enumerate(pending_actions, start=1):
-        # Prefer the LLM-provided natural-language summary as the headline,
-        # keeping the raw action snippet as secondary detail so users can
-        # still see exactly what will run before approving.
-        headline = action.summary or "(no summary provided)"
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. [{action.tool_name}] {headline}")
-        print(f"     {snippet}...")
+        # Lead with the LLM's natural-language summary when available, keeping
+        # the raw action snippet as secondary detail. When no summary was
+        # provided, the raw action itself is the most useful headline.
+        if action.summary:
+            print(f"  {i}. [{action.tool_name}] {action.summary}")
+            print(f"     {snippet}...")
+        else:
+            print(f"  {i}. [{action.tool_name}] {snippet}...")
 
 
 def confirm_in_console(pending_actions) -> bool:

--- a/examples/01_standalone_sdk/16_llm_security_analyzer.py
+++ b/examples/01_standalone_sdk/16_llm_security_analyzer.py
@@ -29,13 +29,15 @@ signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt(
 def _print_blocked_actions(pending_actions) -> None:
     print(f"\n🔒 Security analyzer blocked {len(pending_actions)} high-risk action(s):")
     for i, action in enumerate(pending_actions, start=1):
-        # Prefer the LLM-provided natural-language summary as the headline,
-        # keeping the raw action snippet as secondary detail so users can
-        # still see exactly what will run before approving.
-        headline = action.summary or "(no summary provided)"
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. [{action.tool_name}] {headline}")
-        print(f"     {snippet}...")
+        # Lead with the LLM's natural-language summary when available, keeping
+        # the raw action snippet as secondary detail. When no summary was
+        # provided, the raw action itself is the most useful headline.
+        if action.summary:
+            print(f"  {i}. [{action.tool_name}] {action.summary}")
+            print(f"     {snippet}...")
+        else:
+            print(f"  {i}. [{action.tool_name}] {snippet}...")
 
 
 def confirm_high_risk_in_console(pending_actions) -> bool:

--- a/examples/01_standalone_sdk/16_llm_security_analyzer.py
+++ b/examples/01_standalone_sdk/16_llm_security_analyzer.py
@@ -29,8 +29,13 @@ signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt(
 def _print_blocked_actions(pending_actions) -> None:
     print(f"\n🔒 Security analyzer blocked {len(pending_actions)} high-risk action(s):")
     for i, action in enumerate(pending_actions, start=1):
+        # Prefer the LLM-provided natural-language summary as the headline,
+        # keeping the raw action snippet as secondary detail so users can
+        # still see exactly what will run before approving.
+        headline = action.summary or "(no summary provided)"
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. {action.tool_name}: {snippet}...")
+        print(f"  {i}. [{action.tool_name}] {headline}")
+        print(f"     {snippet}...")
 
 
 def confirm_high_risk_in_console(pending_actions) -> bool:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
The SDK already receives a tool call summary, this PR proposes to surface it to the user in the visualized examples (lead with it, simply)

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

When confirmation mode is enabled, the pending-action preview in our reference examples printed a raw truncated Pydantic dump of the action, asking users to parse a bash command string to decide whether to approve. The SDK already asks the LLM for a concise natural-language summary on every tool call (`ActionEvent.summary`), which is exactly what a confirmation prompt should lead with — other agent apps (e.g. the Codex app) show this style of one-line description in their confirmation prompts.

## Summary

- `04_confirmation_mode_example.py` and `16_llm_security_analyzer.py` confirmation previews now lead with `action.summary` as the headline of each pending action, keeping the raw action snippet as secondary detail so users can still see exactly what will run before approving.
- `ActionEvent.summary` is `str | None`. When no summary is available, the preview leads with the raw action itself instead of a `(no summary provided)` placeholder — so the headline always carries the information the user needs to approve, and the fallback never renders below the examples' original behavior.

## Issue Number

Closes #4210

## How to Test

```bash
printf 'yes\nyes\nyes\n' | LLM_API_KEY=... LLM_BASE_URL=... uv run python examples/01_standalone_sdk/04_confirmation_mode_example.py
```

Verified live against the All-Hands LLM proxy (claude-sonnet-4-5). Output (summary present):

```
🔍 Agent created 1 action(s) awaiting confirmation:
  1. [terminal] List all files in current directory with details
     command='ls -la' is_input=False timeout=None reset=False kind='TerminalAction'...
✅ Approved — executing actions…
🔍 Agent created 1 action(s) awaiting confirmation:
  1. [file_editor] Create empty file named dangerous_file.txt
     command='create' path='.../dangerous_file.txt' file_text='' old_st...
✅ Approved — executing actions…
=== Example Complete ===
```

Also smoke-tested the fallback path (`summary=None`): the preview now leads with the raw action as the headline on a single line, with no placeholder text —

```
🔍 Agent created 1 action(s) awaiting confirmation:
  1. [terminal] command='ls -la' is_input=False timeout=None reset=False kind='TerminalAction'...
```

Pre-commit (ruff, pycodestyle, pyright, import rules) passes on both files.

## Video/Screenshots

See the live run output above.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Examples-only change; no SDK runtime behavior is affected.

This PR was created by an AI agent (OpenHands) on behalf of the repository maintainers.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f0c2dd6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f0c2dd6-python \
  ghcr.io/openhands/agent-server:f0c2dd6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f0c2dd6-golang-amd64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-golang-amd64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-golang-amd64
ghcr.io/openhands/agent-server:f0c2dd6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f0c2dd6-golang-arm64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-golang-arm64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-golang-arm64
ghcr.io/openhands/agent-server:f0c2dd6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f0c2dd6-java-amd64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-java-amd64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-java-amd64
ghcr.io/openhands/agent-server:f0c2dd6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f0c2dd6-java-arm64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-java-arm64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-java-arm64
ghcr.io/openhands/agent-server:f0c2dd6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f0c2dd6-python-amd64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-python-amd64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-python-amd64
ghcr.io/openhands/agent-server:f0c2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f0c2dd6-python-arm64
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-python-arm64
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-python-arm64
ghcr.io/openhands/agent-server:f0c2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f0c2dd6-golang
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-golang
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-golang
ghcr.io/openhands/agent-server:f0c2dd6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f0c2dd6-java
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-java
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-java
ghcr.io/openhands/agent-server:f0c2dd6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f0c2dd6-python
ghcr.io/openhands/agent-server:f0c2dd6e8b8ea73235851ac21149d6d03caea5ca-python
ghcr.io/openhands/agent-server:feat-confirmation-preview-summaries-python
ghcr.io/openhands/agent-server:f0c2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f0c2dd6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f0c2dd6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
