### PR TITLE
fix(agent-server): disable conversation leasing by default

### DIFF
--- a/.pr/evidence.md
+++ b/.pr/evidence.md
@@ -1,0 +1,56 @@
+# Evidence for #4192 fix
+
+## Root-cause repro (service level): `.pr/repro_4192.py`
+
+Four restart shapes against `ConversationService` on unmodified `main`:
+
+```
+== A: graceful stop, then restart ==
+  lease exists after graceful stop: False
+  [restarted server] listed=True (n=1) info=YES event_service=YES
+== B: crash (dead pid, same host), quick restart ==
+  [restarted server] listed=True (n=1) info=YES event_service=YES
+== C: docker-style restart (different host in lease) ==
+  [restarted server] listed=True (n=1) info=YES event_service=NO (lease held?)
+== D: quick restart while old process still alive ==
+  [restarted server] listed=True (n=1) info=YES event_service=NO (lease held?)
+```
+
+Graceful restarts (A) and same-host crash recovery (B, from #3184) already
+work. The reported symptom comes from C/D: the conversation is still *listed*,
+but `_get_or_load_event_service` swallows `ConversationLeaseHeldError` and
+returns `None`, so every `/events/*` route 404s for up to the 45 s TTL — in a
+UI the history is effectively gone.
+
+## Live end-to-end (real server over REST): `.pr/live_test_4192.sh`
+
+Create a conversation via `POST /api/conversations`, SIGKILL the server,
+rewrite the lease's `owner_host` to a vanished hostname (what a recreated
+container looks like — pid liveness can't be verified cross-host), restart on
+the same storage, and query:
+
+```
+=== OLD default (leasing on, OH_LEASE_TTL_SECONDS=45) ===
+created conversation: 924dbea3-2a10-40a5-b256-359e5c218f44
+lease rewritten to foreign host (still live)
+restarted server: conversations listed=1 events endpoint HTTP=404
+
+=== NEW default (leasing disabled) ===
+created conversation: 54b41ef0-d906-40e3-aace-6037107abebe
+no lease file present (leasing disabled)
+restarted server: conversations listed=1 events endpoint HTTP=200
+```
+
+The OLD run also confirms `OH_LEASE_TTL_SECONDS` still enables leasing
+end-to-end (the opt-in path for shared-storage deployments).
+
+## Test suites
+
+- `tests/agent_server/test_config.py`, `tests/agent_server/test_env_parser.py`,
+  `tests/agent_server/test_conversation_lease.py`,
+  `tests/cross/test_conversation_lease_behavior.py`: all pass.
+- Full `tests/cross`: 362 passed, 1 skipped.
+- Full `tests/agent_server` + `tests/cross` in one run: only failure is
+  `test_openai_chat_completions_gateway_over_real_server`, which fails
+  identically on unmodified `main` under full-suite load (flaky live-server
+  test, unrelated).

--- a/.pr/live_test_4192.sh
+++ b/.pr/live_test_4192.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Live end-to-end evidence for issue #4192.
+# Flow: server A creates a conversation over REST -> SIGKILL A -> rewrite the
+# lease as held by a vanished container hostname (unverifiable owner) ->
+# restart server B on the same storage -> can B list the conversation AND
+# serve its events?
+# Run twice: OLD behavior (OH_LEASE_TTL_SECONDS=45) vs NEW default (unset).
+set -u
+cd "$(dirname "$0")/.."
+PORT=8055
+BASE="http://127.0.0.1:$PORT/api"
+
+run_scenario() {
+  local label="$1"; shift
+  local tmp
+  tmp=$(mktemp -d)
+  echo "=== $label ==="
+
+  env "$@" OH_CONVERSATIONS_PATH="$tmp/conversations" OPENHANDS_SUPPRESS_BANNER=1 \
+    .venv/bin/python -m openhands.agent_server --port $PORT >"$tmp/serverA.log" 2>&1 &
+  local pid_a=$!
+  for _ in $(seq 1 60); do curl -sf "$BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+
+  local cid
+  cid=$(curl -sf -X POST "$BASE/conversations" -H 'Content-Type: application/json' -d '{
+    "agent": {"llm": {"model": "gpt-4o", "usage_id": "test-llm"}, "tools": []},
+    "workspace": {"kind": "LocalWorkspace", "working_dir": "'"$tmp"'/ws"},
+    "confirmation_policy": {"kind": "NeverConfirm"}
+  }' | .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+  echo "created conversation: $cid"
+
+  kill -9 $pid_a 2>/dev/null; wait $pid_a 2>/dev/null
+
+  local lease="$tmp/conversations/$(echo "$cid" | tr -d -)/owner_lease.json"
+  if [ -f "$lease" ]; then
+    .venv/bin/python - "$lease" <<'EOF'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["owner_host"] = "vanished-container-1234"
+json.dump(d, open(p, "w"))
+EOF
+    echo "lease rewritten to foreign host (still live)"
+  else
+    echo "no lease file present (leasing disabled)"
+  fi
+
+  env "$@" OH_CONVERSATIONS_PATH="$tmp/conversations" OPENHANDS_SUPPRESS_BANNER=1 \
+    .venv/bin/python -m openhands.agent_server --port $PORT >"$tmp/serverB.log" 2>&1 &
+  local pid_b=$!
+  for _ in $(seq 1 60); do curl -sf "$BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+
+  local n_listed events_status
+  n_listed=$(curl -sf "$BASE/conversations/search" | .venv/bin/python -c 'import json,sys; print(len(json.load(sys.stdin)["items"]))')
+  events_status=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/conversations/$cid/events/search")
+  echo "restarted server: conversations listed=$n_listed events endpoint HTTP=$events_status"
+
+  kill -9 $pid_b 2>/dev/null; wait $pid_b 2>/dev/null
+  rm -rf "$tmp"
+}
+
+run_scenario "OLD default (leasing on, OH_LEASE_TTL_SECONDS=45)" OH_LEASE_TTL_SECONDS=45
+run_scenario "NEW default (leasing disabled)"

--- a/.pr/repro_4192.py
+++ b/.pr/repro_4192.py
@@ -1,0 +1,98 @@
+"""Repro for issue #4192: restarting agent-server quickly loses conversations.
+
+Simulates three restart shapes against ConversationService and reports what a
+freshly restarted server can see: catalog list, conversation info, and event
+service availability.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from openhands.agent_server.conversation_lease import LEASE_FILE_NAME
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.models import StartConversationRequest
+from openhands.sdk import LLM, Agent
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.workspace import LocalWorkspace
+
+
+def _request(workspace_dir: Path) -> StartConversationRequest:
+    return StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+
+async def observe(service: ConversationService, cid, label: str) -> None:
+    page = await service.search_conversations()
+    listed = [i.id for i in page.items]
+    info = await service.get_conversation(cid)
+    events_service = await service.get_event_service(cid)
+    print(
+        f"  [{label}] listed={cid in listed} (n={len(listed)}) "
+        f"info={'YES' if info else 'NO'} "
+        f"event_service={'YES' if events_service else 'NO (lease held?)'}"
+    )
+
+
+async def scenario(name: str, mutate_lease) -> None:
+    print(f"== {name} ==")
+    tmp = Path(tempfile.mkdtemp())
+    conversations_dir = tmp / "conversations"
+    workspace = tmp / "ws"
+    workspace.mkdir()
+
+    primary = ConversationService(conversations_dir=conversations_dir)
+    await primary.__aenter__()
+    info, _ = await primary.start_conversation(_request(workspace))
+    cid = info.id
+    conversation_dir = conversations_dir / cid.hex
+    lease_path = conversation_dir / LEASE_FILE_NAME
+
+    if mutate_lease is None:
+        # graceful shutdown
+        await primary.__aexit__(None, None, None)
+        print(f"  lease exists after graceful stop: {lease_path.exists()}")
+    else:
+        # hard crash: abandon primary without closing, then adjust the lease
+        primary._event_services = None  # prevent accidental reuse
+        mutate_lease(lease_path)
+
+    secondary = ConversationService(conversations_dir=conversations_dir)
+    await secondary.__aenter__()
+    await observe(secondary, cid, "restarted server")
+    await secondary.__aexit__(None, None, None)
+
+
+def make_dead_pid(lease_path: Path) -> None:
+    payload = json.loads(lease_path.read_text())
+    payload["owner_pid"] = 2**22 + 12345  # unlikely to exist
+    lease_path.write_text(json.dumps(payload))
+
+
+def make_other_host(lease_path: Path) -> None:
+    payload = json.loads(lease_path.read_text())
+    payload["owner_host"] = "old-container-abc123"
+    lease_path.write_text(json.dumps(payload))
+
+
+def keep_alive_pid(lease_path: Path) -> None:
+    # Same host, pid = our own parent shell (alive, not us): simulates the old
+    # server process still shutting down during a quick restart.
+    payload = json.loads(lease_path.read_text())
+    payload["owner_pid"] = os.getppid()
+    lease_path.write_text(json.dumps(payload))
+
+
+async def main() -> None:
+    await scenario("A: graceful stop, then restart", None)
+    await scenario("B: crash (dead pid, same host), quick restart", make_dead_pid)
+    await scenario("C: docker-style restart (different host in lease)", make_other_host)
+    await scenario("D: quick restart while old process still alive", keep_alive_pid)
+
+
+asyncio.run(main())

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
-from openhands.agent_server.conversation_lease import DEFAULT_LEASE_TTL_SECONDS
 from openhands.agent_server.env_parser import (
     MISSING,
     _get_default_parsers,
@@ -338,17 +337,20 @@ class Config(BaseModel):
         ),
     )
     lease_ttl_seconds: float = Field(
-        default=DEFAULT_LEASE_TTL_SECONDS,
+        default=0.0,
         ge=0.0,
         description=(
             "How long (in seconds) a conversation ownership lease remains valid "
             "without renewal. The lease prevents two server instances from "
             "concurrently owning the same conversation when storage is shared "
-            "across instances. Set to 0 to disable leasing entirely, which is "
-            "appropriate for single-instance deployments where concurrent "
-            "ownership is impossible. Values between 0 and "
-            "LEASE_RENEW_INTERVAL_SECONDS (15 s) are valid but cause the lease "
-            "to expire before the first renewal, effectively making it one-shot."
+            "across instances. Leasing is disabled by default (0) because most "
+            "servers are single-instance, where a held lease only delays "
+            "conversation rehydration after a restart. Deployments that share "
+            "conversation storage across instances should set this to a "
+            "positive value such as DEFAULT_LEASE_TTL_SECONDS (45 s). Values "
+            "between 0 and LEASE_RENEW_INTERVAL_SECONDS (15 s) are valid but "
+            "cause the lease to expire before the first renewal, effectively "
+            "making it one-shot."
         ),
     )
     conversation_idle_ttl_seconds: float | None = Field(

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -59,3 +59,17 @@ def test_conversation_idle_ttl_can_be_disabled_and_overridden(monkeypatch, tmp_p
 def test_conversation_idle_ttl_rejects_non_positive_values():
     with pytest.raises(ValidationError):
         Config(conversation_idle_ttl_seconds=0)
+
+
+def test_lease_ttl_defaults_to_disabled():
+    assert Config().lease_ttl_seconds == 0.0
+
+
+def test_lease_ttl_can_be_enabled_via_env(monkeypatch):
+    monkeypatch.setenv("OH_LEASE_TTL_SECONDS", "45")
+    assert load_config().lease_ttl_seconds == 45.0
+
+
+def test_lease_ttl_rejects_negative_values():
+    with pytest.raises(ValidationError):
+        Config(lease_ttl_seconds=-1.0)

--- a/tests/agent_server/test_env_parser.py
+++ b/tests/agent_server/test_env_parser.py
@@ -1433,10 +1433,10 @@ def test_discriminated_union_single_empty_kind_no_variables(clean_env):
 
 def test_config_lease_ttl_seconds_default(clean_env):
     config = from_env(Config, "OH")
-    assert config.lease_ttl_seconds == DEFAULT_LEASE_TTL_SECONDS
+    assert config.lease_ttl_seconds == 0.0
 
 
 def test_config_lease_ttl_seconds_env_var(clean_env):
-    os.environ["OH_LEASE_TTL_SECONDS"] = "0"
+    os.environ["OH_LEASE_TTL_SECONDS"] = str(DEFAULT_LEASE_TTL_SECONDS)
     config = from_env(Config, "OH")
-    assert config.lease_ttl_seconds == 0.0
+    assert config.lease_ttl_seconds == DEFAULT_LEASE_TTL_SECONDS

--- a/tests/cross/test_conversation_lease_behavior.py
+++ b/tests/cross/test_conversation_lease_behavior.py
@@ -151,3 +151,38 @@ async def test_expired_lease_takeover_fences_stale_writer_with_disk_events(tmp_p
 
             with pytest.raises(ConversationOwnershipLostError):
                 primary_state.execution_status = ConversationExecutionStatus.ERROR
+
+
+def _assign_lease_to_foreign_host(conversation_dir: Path) -> None:
+    """Rewrite the lease as held by an unverifiable owner on another host."""
+    lease_path = conversation_dir / LEASE_FILE_NAME
+    payload = json.loads(lease_path.read_text())
+    payload["owner_host"] = "vanished-container-1234"
+    lease_path.write_text(json.dumps(payload))
+
+
+@pytest.mark.asyncio
+async def test_leasing_disabled_server_rehydrates_despite_live_foreign_lease(tmp_path):
+    """https://github.com/OpenHands/software-agent-sdk/issues/4192
+
+    With the server default (leasing disabled), a restarted server rehydrates
+    conversations even when the previous owner left a still-live lease that
+    cannot be verified dead (e.g. a recreated container with a new hostname).
+    """
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(_request(workspace_dir))
+        conversation_dir = conversations_dir / conversation_info.id.hex
+        _assign_lease_to_foreign_host(conversation_dir)
+
+        async with ConversationService(
+            conversations_dir=conversations_dir,
+            lease_ttl_seconds=0,
+        ) as restarted:
+            page = await restarted.search_conversations()
+            assert conversation_info.id in [item.id for item in page.items]
+            event_service = await restarted.get_event_service(conversation_info.id)
+            assert event_service is not None


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Restarts were hiding conversation history for ~45s because of the ownership lease, which only matters for multi-server setups — this turns leasing off by default (env var re-enables it). I reviewed the diff and repro before marking ready, ping me with any feedback.

---

AGENT:

Disclosure: this PR was authored end-to-end by an AI agent (Claude Code, model Claude Fable 5), operated by @andreruizloera, who will review it and fill in the HUMAN section before marking it ready.

## Why

Fixes #4192.

On a quick or containerized restart, all conversation history appears to vanish for up to 45 s. Reproducing against `main` (details and scripts in `.pr/`), the conversations are still *listed*, but `_get_or_load_event_service` swallows `ConversationLeaseHeldError` and returns `None`, so every `/conversations/{id}/events/*` route 404s while the previous server's lease is still live. Graceful restarts release leases and same-host crashes are healed by the dead-pid takeover from #3184 — the surviving failure modes are (a) a restart racing the old process's shutdown and (b) container recreation, where the new hostname makes pid liveness unverifiable and only TTL expiry unblocks.

Live REST demonstration (full transcript in `.pr/evidence.md`):

```
OLD default (leasing on):  restarted server: conversations listed=1  events endpoint HTTP=404
NEW default (leasing off): restarted server: conversations listed=1  events endpoint HTTP=200
```

## Summary

- `Config.lease_ttl_seconds` now defaults to `0.0` (leasing disabled), per the direction suggested in #4192. Most servers are single-instance, where a lease can only delay rehydration; deployments sharing conversation storage across instances opt in with `OH_LEASE_TTL_SECONDS` (e.g. `45`).
- The lease machinery itself is unchanged, and `DEFAULT_LEASE_TTL_SECONDS` (45 s) still applies to direct `ConversationService`/`EventService` embedders — only the server config default changes.
- Tests: config default/env-override/validation, plus a regression test that a leasing-disabled server rehydrates a conversation despite a live foreign-host lease.

## Issue Number

#4192

## How to Test

- `uv run pytest tests/agent_server/test_config.py tests/agent_server/test_env_parser.py tests/agent_server/test_conversation_lease.py tests/cross/test_conversation_lease_behavior.py`
- End-to-end: `bash .pr/live_test_4192.sh` runs the old and new defaults against a real server over REST (create conversation → SIGKILL → rewrite lease to a vanished hostname → restart → list + fetch events).
- Full `tests/agent_server` + `tests/cross` pass except `test_openai_chat_completions_gateway_over_real_server`, which fails identically on unmodified `main` under full-suite load (pre-existing flake, passes solo).

## Video/Screenshots

Terminal transcripts in `.pr/evidence.md`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Deployment callout:** any multi-instance deployment relying on the previous default (e.g. OpenHands Cloud, if it does not set this explicitly) should set `OH_LEASE_TTL_SECONDS=45` when picking this up, otherwise split-brain protection is off. Flagging because I cannot inspect deployment configs from this repo.
- This is a public `Field(default=...)` behavioral change, so the API-breakage workflow should apply `release-note-required`.
- Alternative considered: serving `/events` reads from persisted state when the lease is held (keeps leasing on with no read outage). Strictly safer but a much larger change touching the router dependency and `EventService`; happy to pursue it instead if preferred.
- `.pr/` contains the repro script, live test, and evidence; per repo policy it must be removed before merge since auto-cleanup cannot push to forks — say the word and I'll drop it once review is done.
