### PR TITLE
fix(ci): accept the /api/vscode/url base_url documented-default removal

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -632,6 +632,42 @@ _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH = "/api/cloud-proxy"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD = "post"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_OPERATION_ID = "cloud_proxy_api_cloud_proxy_post"
 
+_ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_ID = "request-parameter-default-value-removed"
+_ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_PATH = "/api/vscode/url"
+_ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_METHOD = "get"
+_ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_OPERATION_ID = (
+    "get_vscode_url_api_vscode_url_get"
+)
+_ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_PARAM_RE = re.compile(
+    r"request parameter `base_url`, default value `http://localhost:8001` "
+    r"was removed"
+)
+
+
+def _is_accepted_vscode_base_url_default_removal(change: dict) -> bool:
+    """Return True for the accepted /api/vscode/url base_url default removal.
+
+    Maintainers accepted this documented-default removal in PR #4181: the
+    ``base_url`` query parameter stays optional, only the server-side fallback
+    changed (from a hardcoded ``http://localhost:8001`` to the actually
+    configured VSCode port). Requests that omit ``base_url`` keep working, so
+    no client contract is broken.
+    """
+    return (
+        str(change.get("id", "")) == _ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_ID
+        and str(change.get("path", ""))
+        == _ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_PATH
+        and str(change.get("operation", "")).lower()
+        == _ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_METHOD
+        and str(change.get("operationId", ""))
+        == _ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_OPERATION_ID
+        and bool(
+            _ACCEPTED_VSCODE_BASE_URL_DEFAULT_REMOVAL_PARAM_RE.search(
+                str(change.get("text", ""))
+            )
+        )
+    )
+
 
 def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
     """Return True for the accepted /api/cloud-proxy removal from PR #3326."""
@@ -994,6 +1030,16 @@ def main() -> int:
             for change in other_breaking_changes
             if not _is_accepted_cloud_proxy_path_removal(change)
         ]
+        accepted_vscode_base_url_default_removals = [
+            change
+            for change in other_breaking_changes
+            if _is_accepted_vscode_base_url_default_removal(change)
+        ]
+        other_breaking_changes = [
+            change
+            for change in other_breaking_changes
+            if not _is_accepted_vscode_base_url_default_removal(change)
+        ]
 
         removal_errors = _validate_removed_operations(
             removed_operations,
@@ -1015,6 +1061,15 @@ def main() -> int:
                 "Accepted removal of POST /api/cloud-proxy. Maintainers "
                 "explicitly accepted this REST break in PR #3326, and that PR "
                 "is labeled release-note-required."
+            )
+
+        if accepted_vscode_base_url_default_removals:
+            print(
+                f"\n::notice title={PYPI_DISTRIBUTION} REST API::"
+                "Accepted removal of the documented default for the optional "
+                "`base_url` query parameter of GET /api/vscode/url (PR #4181). "
+                "The parameter stays optional; only the server-side fallback "
+                "changed, so requests that omit it keep working."
             )
 
         if additive_response_oneof:
@@ -1084,7 +1139,8 @@ def main() -> int:
             print(
                 "Breaking changes are limited to previously-deprecated operations "
                 "or properties whose scheduled removal versions have been reached, "
-                "the accepted POST /api/cloud-proxy removal, additive response "
+                "the accepted POST /api/cloud-proxy removal, the accepted "
+                "GET /api/vscode/url base_url default removal, additive response "
                 "oneOf expansions, and/or additive response property type widenings."
             )
         else:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
This PR proposes to accept explicitly and document the removal of the VSCode base_url value by default

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The `REST API breakage checks` workflow has been failing on `main` (and on every PR branched from it) since #4181 merged. That PR changed the server-side fallback for the **optional** `base_url` query parameter of `GET /api/vscode/url` from a hardcoded `http://localhost:8001` to the actually configured VSCode port. oasdiff reports the removed documented default as breaking:

```
- for the `query` request parameter `base_url`, default value `http://localhost:8001` was removed
```

The parameter stays optional and requests that omit it keep working (they now get a *more* correct URL), so no client contract is broken. This is a maintainer-approved behavior change (merged in #4181), not an in-place contract break.

## Summary

- Add a narrowly-scoped accepted exception to `check_agent_server_rest_api_breakage.py`, following the existing `/api/cloud-proxy` (PR #3326) pattern
- The exception matches only: oasdiff rule id `request-parameter-default-value-removed` + path `/api/vscode/url` + method `GET` + operationId `get_vscode_url_api_vscode_url_get` + the exact `base_url` / `http://localhost:8001` text
- Accepted changes are surfaced as a `::notice` in the workflow output, mirroring the cloud-proxy notice

## Issue Number

N/A (CI fix for the failure introduced by #4181; failing runs: [main](https://github.com/OpenHands/software-agent-sdk/actions/workflows/agent-server-rest-api-breakage.yml?query=branch%3Amain))

## How to Test

Reproduce locally against the v1.37.0 PyPI baseline exactly as CI does:

```bash
uv sync --frozen --group dev
# install oasdiff 1.19.1
uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py
```

Before this change: exit 1 with the breaking-change error above.
After this change: exit 0 with:

```
::notice title=openhands-agent-server REST API::Accepted removal of the documented default for the optional `base_url` query parameter of GET /api/vscode/url (PR #4181). The parameter stays optional; only the server-side fallback changed, so requests that omit it keep working.
```

Narrowness verified with negative tests: a different parameter on the same endpoint, the same text on a different endpoint, a different oasdiff rule id, and a different default value are all still treated as breaking.

## Video/Screenshots

See the before/after CLI output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `REST API (OpenAPI)` check on this very PR should flip to green, which is the end-to-end proof. Unblocks the same failure on other open PRs (e.g. #4211) once merged.

This PR was created by an AI agent (OpenHands) on behalf of the repository maintainers.
