### PR TITLE
feat(agent-server): resolve title LLM profile references

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -33,7 +33,7 @@ from openhands.agent_server.models import (
     StoredConversation,
     UpdateConversationRequest,
 )
-from openhands.agent_server.persistence import FileSecretsStore
+from openhands.agent_server.persistence import FileSecretsStore, SettingsStore
 from openhands.agent_server.pub_sub import Subscriber
 from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.agent_server.skills_service import discover_profile_skills
@@ -64,6 +64,7 @@ from openhands.sdk.event import MessageEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
@@ -567,6 +568,8 @@ class ConversationService:
     cipher: Cipher | None = None
     mcp_tool_provider: MCPToolProvider | None = None
     secrets_store: FileSecretsStore | None = None
+    settings_store: SettingsStore | None = None
+    llm_profile_store: LLMProfileStore | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
     lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
@@ -751,6 +754,20 @@ class ConversationService:
                 CODEX_AUTH_SECRET_NAME,
             )
         return bindings
+
+    def _resolve_title_llm_profile(self, requested: str | None) -> str | None:
+        if self.settings_store is None or self.llm_profile_store is None:
+            return requested
+
+        settings = self.settings_store.load()
+        available = {
+            profile["name"] for profile in self.llm_profile_store.list_summaries()
+        }
+        if requested in available:
+            return requested
+        if settings and settings.active_profile in available:
+            return settings.active_profile
+        return None
 
     async def _conversation_info(
         self,
@@ -1327,6 +1344,21 @@ class ConversationService:
                 mcp_config,
             )
             request = request.model_copy(update={"agent": resolved_agent})
+
+        try:
+            title_llm_profile = await asyncio.to_thread(
+                self._resolve_title_llm_profile,
+                request.title_llm_profile,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to resolve title LLM profile; using the requested profile",
+                exc_info=True,
+            )
+        else:
+            request = request.model_copy(
+                update={"title_llm_profile": title_llm_profile}
+            )
 
         additions = request.agent_launch_additions
         suffix = (
@@ -1975,11 +2007,12 @@ class ConversationService:
             create_settings_backed_mcp_tool_provider,
         )
         from openhands.agent_server.persistence import (
+            get_llm_profile_store,
             get_secrets_store,
             get_settings_store,
         )
 
-        get_settings_store(config)
+        settings_store = get_settings_store(config)
         return ConversationService(
             conversations_dir=config.conversations_path,
             webhook_specs=config.webhooks,
@@ -1989,6 +2022,8 @@ class ConversationService:
             cipher=config.cipher,
             mcp_tool_provider=create_settings_backed_mcp_tool_provider(config),
             secrets_store=get_secrets_store(config),
+            settings_store=settings_store,
+            llm_profile_store=get_llm_profile_store(),
             max_concurrent_runs=config.max_concurrent_runs,
             lease_ttl_seconds=config.lease_ttl_seconds,
             conversation_idle_ttl_seconds=config.conversation_idle_ttl_seconds,

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -33,6 +33,7 @@ from openhands.agent_server.models import (
     StoredConversation,
     UpdateConversationRequest,
 )
+from openhands.agent_server.persistence import FileSettingsStore, PersistedSettings
 from openhands.agent_server.utils import safe_rmtree as _safe_rmtree
 from openhands.sdk import LLM, Agent, Message
 from openhands.sdk.agent.acp_agent import ACPAgent
@@ -47,6 +48,7 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.git.utils import run_git_command
 from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.mcp.config import dump_mcp_config
 from openhands.sdk.secret import SecretSource, StaticSecret
 from openhands.sdk.security.confirmation_policy import NeverConfirm
@@ -153,6 +155,47 @@ async def persisted_conversation(tmp_path) -> tuple[Path, UUID]:
     async with ConversationService(conversations_dir=conversations_dir) as service:
         conversation_info, _ = await service.start_conversation(request)
     return conversations_dir, conversation_info.id
+
+
+@pytest.mark.parametrize(
+    ("requested", "active", "available", "expected"),
+    [
+        ("titles", "default", ("titles", "default"), "titles"),
+        (None, "default", ("default",), "default"),
+        ("deleted", "default", ("default",), "default"),
+        ("deleted", "missing", (), None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_start_conversation_resolves_title_llm_profile(
+    tmp_path: Path,
+    requested: str | None,
+    active: str | None,
+    available: tuple[str, ...],
+    expected: str | None,
+) -> None:
+    settings_store = FileSettingsStore(tmp_path / "settings")
+    settings_store.save(PersistedSettings(active_profile=active))
+    profile_store = LLMProfileStore(tmp_path / "profiles")
+    for name in available:
+        profile_store.save(name, LLM(model="gpt-4o-mini", usage_id=name))
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="agent"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace)),
+        confirmation_policy=NeverConfirm(),
+        title_llm_profile=requested,
+    )
+    async with ConversationService(
+        conversations_dir=tmp_path / "conversations",
+        settings_store=settings_store,
+        llm_profile_store=profile_store,
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        stored = service._conversation_records[info.id].stored
+        assert stored.title_llm_profile == expected
 
 
 @pytest.mark.asyncio

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -196,6 +196,69 @@ def test_prepare_for_sandbox_pause_drains_conversations(server_env):
     assert conversation_id in server_env["conversation_service"]._conversation_records
 
 
+def test_conversation_start_resolves_active_title_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from openhands.agent_server import (
+        config as config_module,
+        conversation_service as service_module,
+    )
+    from openhands.agent_server.persistence import reset_stores
+
+    monkeypatch.setattr(config_module, "_default_config", None)
+    monkeypatch.setattr(service_module, "_conversation_service", None)
+    monkeypatch.setenv("OH_PERSISTENCE_DIR", str(tmp_path / "persistence"))
+    reset_stores()
+    try:
+        with live_server_env(tmp_path, monkeypatch) as env:
+            title_llm = LLM(model="gpt-4o-mini", usage_id="title-default")
+            agent = Agent(
+                llm=LLM(
+                    model="gpt-4o-mini",
+                    api_key=SecretStr("test"),
+                    usage_id="agent",
+                ),
+                tools=[],
+            )
+            with httpx.Client(base_url=env["host"], timeout=10.0) as client:
+                save = client.post(
+                    "/api/profiles/default",
+                    json={
+                        "llm": title_llm.model_dump(
+                            mode="json", context={"expose_secrets": True}
+                        )
+                    },
+                )
+                save.raise_for_status()
+                activate = client.post("/api/profiles/default/activate")
+                activate.raise_for_status()
+
+                start = client.post(
+                    "/api/conversations",
+                    json={
+                        "agent": agent.model_dump(
+                            mode="json", context={"expose_secrets": True}
+                        ),
+                        "workspace": {
+                            "working_dir": str(env["workspace_path"]),
+                        },
+                        "title_llm_profile": "deleted",
+                        "autotitle": False,
+                    },
+                )
+                start.raise_for_status()
+
+            conversation_id = UUID(start.json()["id"])
+            stored = (
+                env["conversation_service"]
+                ._conversation_records[conversation_id]
+                .stored
+            )
+            assert stored.title_llm_profile == "default"
+    finally:
+        reset_stores()
+
+
 @pytest.fixture
 def server_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[dict]:
     with live_server_env(tmp_path, monkeypatch) as env:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Agent Canvas currently has to fetch the local LLM-profile list before every conversation start so it can validate the selected title profile and replace Automatic or a stale reference with the active profile. The long-running agent-server already owns both the profile store and the active-profile setting, so that resolution belongs at the server boundary.

Without server-side fallback, sending `null` or a stale name uses `agent.llm`; for ACP agents that can degrade directly to title truncation instead of using the active auxiliary LLM profile.

## Summary

- Resolve `title_llm_profile` against the agent-server profile store when creating a conversation.
- Prefer an existing requested profile, then the active profile, then preserve the existing agent-LLM/truncation fallback.
- Persist the effective profile name on the conversation and cover the behavior through service-level and live HTTP tests.

## Issue Number

Part of #4199. Implements the server-side resolution proposed in OpenHands/agent-canvas#1910 review discussion.

## How to Test

Automated verification completed from the repository root:

- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/conversation_service.py tests/agent_server/test_conversation_service.py tests/cross/test_remote_conversation_live_server.py` — formatting, Ruff, pycodestyle, Pyright, import rules, and tool-registration checks passed.
- `uv run pytest tests/agent_server/test_conversation_service.py -q` — 105 passed.
- `uv run pytest tests/cross/test_remote_conversation_live_server.py::test_conversation_start_resolves_active_title_profile -q` — 1 passed. This starts a real FastAPI/Uvicorn agent-server, saves and activates an LLM profile over HTTP, starts a conversation over HTTP with a stale title-profile reference, and verifies the server persisted the active profile as the effective reference.
- `uv run pytest tests/agent_server -q` — 1,818 passed, 13 stress tests deselected.

Reviewer reproduction:

1. Save two LLM profiles through `/api/profiles/{name}` and activate one through `/api/profiles/{name}/activate`.
2. Start a conversation with the other profile name, with `null`, or with a missing profile name in `title_llm_profile`.
3. Verify the stored conversation keeps the existing requested name, falls back to the active name, or stores no name when neither exists.

## Video/Screenshots

Not applicable; this is backend-only request-resolution behavior. The live-server test exercises the full HTTP path.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The existing request field and REST schema are unchanged.
- Resolution failures remain non-blocking: the server preserves the requested reference and the existing title-generation fallback still applies.
- After an agent-server release and Canvas version bump, OpenHands/agent-canvas#1910 can remove its client-side profile-list lookup.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c5a1c92-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c5a1c92-python \
  ghcr.io/openhands/agent-server:c5a1c92-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c5a1c92-golang-amd64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-golang-amd64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-golang-amd64
ghcr.io/openhands/agent-server:c5a1c92-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c5a1c92-golang-arm64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-golang-arm64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-golang-arm64
ghcr.io/openhands/agent-server:c5a1c92-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c5a1c92-java-amd64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-java-amd64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-java-amd64
ghcr.io/openhands/agent-server:c5a1c92-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c5a1c92-java-arm64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-java-arm64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-java-arm64
ghcr.io/openhands/agent-server:c5a1c92-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c5a1c92-python-amd64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-python-amd64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-python-amd64
ghcr.io/openhands/agent-server:c5a1c92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c5a1c92-python-arm64
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-python-arm64
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-python-arm64
ghcr.io/openhands/agent-server:c5a1c92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c5a1c92-golang
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-golang
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-golang
ghcr.io/openhands/agent-server:c5a1c92-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c5a1c92-java
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-java
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-java
ghcr.io/openhands/agent-server:c5a1c92-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c5a1c92-python
ghcr.io/openhands/agent-server:c5a1c9271596c124dd979107ca2310b031690d7a-python
ghcr.io/openhands/agent-server:resolve-title-profile-server-side-python
ghcr.io/openhands/agent-server:c5a1c92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c5a1c92-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c5a1c92-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->