### PR TITLE
fix(agent-server): redact LLM & condenser secrets in download-trajectory

### DIFF
--- a/openhands-agent-server/openhands/agent_server/_secret_redaction.py
+++ b/openhands-agent-server/openhands/agent_server/_secret_redaction.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 
 from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
+from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX
 from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 
@@ -19,6 +20,18 @@ from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 TRAJECTORY_SECRET_FIELDS: frozenset[str] = frozenset(
     (*LLM_SECRET_FIELDS, "llm_api_key")
 )
+
+
+def _is_secret_value(key: object, value: object) -> bool:
+    if not isinstance(value, str) or value in ("", REDACTED_SECRET_VALUE):
+        return False
+    # Any Fernet token in a persisted conversation is ciphertext produced with
+    # the server's OH_SECRET_KEY (e.g. custom secrets in
+    # ``secret_registry.secret_sources``) and therefore recoverable secret
+    # material, regardless of which field carries it.
+    if value.startswith(FERNET_TOKEN_PREFIX):
+        return True
+    return key in TRAJECTORY_SECRET_FIELDS
 
 
 def redact_secrets_in_obj(obj: object) -> bool:
@@ -32,19 +45,17 @@ def redact_secrets_in_obj(obj: object) -> bool:
     changed = False
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if (
-                key in TRAJECTORY_SECRET_FIELDS
-                and isinstance(value, str)
-                and value != ""
-                and value != REDACTED_SECRET_VALUE
-            ):
+            if _is_secret_value(key, value):
                 obj[key] = REDACTED_SECRET_VALUE
                 changed = True
             elif redact_secrets_in_obj(value):
                 changed = True
     elif isinstance(obj, list):
-        for item in obj:
-            if redact_secrets_in_obj(item):
+        for index, item in enumerate(obj):
+            if _is_secret_value(None, item):
+                obj[index] = REDACTED_SECRET_VALUE
+                changed = True
+            elif redact_secrets_in_obj(item):
                 changed = True
     return changed
 

--- a/openhands-agent-server/openhands/agent_server/_secret_redaction.py
+++ b/openhands-agent-server/openhands/agent_server/_secret_redaction.py
@@ -1,0 +1,93 @@
+"""Redaction helpers that keep secrets out of exported artifacts.
+
+Used at export boundaries (e.g. trajectory download) where persisted
+conversation data leaves the server and must never carry credential
+material — neither plaintext nor recoverable Fernet ciphertext.
+"""
+
+import json
+from pathlib import Path
+
+from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
+from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
+
+
+# Field names that carry credentials anywhere in a persisted conversation
+# payload (base_state.json, meta.json, events). Kept in sync with
+# ``LLM_SECRET_FIELDS`` and extended with the settings-level ``llm_api_key``
+# alias.
+TRAJECTORY_SECRET_FIELDS: frozenset[str] = frozenset(
+    (*LLM_SECRET_FIELDS, "llm_api_key")
+)
+
+
+def redact_secrets_in_obj(obj: object) -> bool:
+    """Recursively replace secret-bearing values with the redaction marker.
+
+    Returns ``True`` if anything was changed. Both plaintext and encrypted
+    (Fernet) secret material are masked, so the guarantee holds regardless of
+    whether ``OH_SECRET_KEY`` was configured when the conversation was
+    persisted.
+    """
+    changed = False
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if (
+                key in TRAJECTORY_SECRET_FIELDS
+                and isinstance(value, str)
+                and value != ""
+                and value != REDACTED_SECRET_VALUE
+            ):
+                obj[key] = REDACTED_SECRET_VALUE
+                changed = True
+            elif redact_secrets_in_obj(value):
+                changed = True
+    elif isinstance(obj, list):
+        for item in obj:
+            if redact_secrets_in_obj(item):
+                changed = True
+    return changed
+
+
+def redacted_file_bytes(path: Path) -> bytes | None:
+    """Return redacted bytes for a JSON/JSONL file, or ``None`` if unchanged.
+
+    Persisted conversation files are JSON (``*.json``) or newline-delimited
+    JSON (``*.jsonl``/the per-event log files). Anything that does not parse as
+    JSON is left untouched (returns ``None``) so the archive is byte-identical
+    for non-secret content.
+    """
+    suffix = path.suffix.lower()
+    if suffix not in (".json", ".jsonl"):
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if suffix == ".jsonl":
+        changed = False
+        out_lines: list[str] = []
+        for line in raw.splitlines(keepends=True):
+            stripped = line.strip()
+            if not stripped:
+                out_lines.append(line)
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                out_lines.append(line)
+                continue
+            if redact_secrets_in_obj(obj):
+                changed = True
+            newline = "\n" if line.endswith("\n") else ""
+            out_lines.append(json.dumps(obj) + newline)
+        return "".join(out_lines).encode("utf-8") if changed else None
+
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not redact_secrets_in_obj(obj):
+        return None
+    return json.dumps(obj).encode("utf-8")

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -25,6 +25,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
+from openhands.agent_server._secret_redaction import redacted_file_bytes
 from openhands.agent_server.config import get_default_config
 from openhands.agent_server.models import Success
 from openhands.agent_server.server_details_router import update_last_execution_time
@@ -36,9 +37,7 @@ from openhands.sdk.git.utils import (
     run_git_command,
     validate_git_repository,
 )
-from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 
 class SubdirectoryEntry(BaseModel):
@@ -140,94 +139,12 @@ async def _download_file(path: str) -> FileResponse:
         )
 
 
-# Field names that carry credentials anywhere in a persisted conversation
-# payload (base_state.json, meta.json, events). Kept in sync with
-# ``LLM_SECRET_FIELDS`` and extended with the settings-level ``llm_api_key``
-# alias. A trajectory archive is meant to be shared for debugging, so these
-# must never leave the server as plaintext OR as recoverable ciphertext.
-_TRAJECTORY_SECRET_FIELDS: frozenset[str] = frozenset(
-    (*LLM_SECRET_FIELDS, "llm_api_key")
-)
-
-
-def _redact_secrets_in_obj(obj: object) -> bool:
-    """Recursively replace secret-bearing values with the redaction marker.
-
-    Returns ``True`` if anything was changed. Both plaintext and encrypted
-    (Fernet) secret material are masked, so the guarantee holds regardless of
-    whether ``OH_SECRET_KEY`` was configured when the conversation was
-    persisted.
-    """
-    changed = False
-    if isinstance(obj, dict):
-        for key, value in obj.items():
-            if (
-                key in _TRAJECTORY_SECRET_FIELDS
-                and isinstance(value, str)
-                and value != ""
-                and value != REDACTED_SECRET_VALUE
-            ):
-                obj[key] = REDACTED_SECRET_VALUE
-                changed = True
-            elif _redact_secrets_in_obj(value):
-                changed = True
-    elif isinstance(obj, list):
-        for item in obj:
-            if _redact_secrets_in_obj(item):
-                changed = True
-    return changed
-
-
-def _redacted_file_bytes(path: Path) -> bytes | None:
-    """Return redacted bytes for a JSON/JSONL file, or ``None`` if unchanged.
-
-    Persisted conversation files are JSON (``*.json``) or newline-delimited
-    JSON (``*.jsonl``/the per-event log files). Anything that does not parse as
-    JSON is left untouched (returns ``None``) so the archive is byte-identical
-    for non-secret content.
-    """
-    suffix = path.suffix.lower()
-    if suffix not in (".json", ".jsonl"):
-        return None
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
-
-    if suffix == ".jsonl":
-        changed = False
-        out_lines: list[str] = []
-        for line in raw.splitlines(keepends=True):
-            stripped = line.strip()
-            if not stripped:
-                out_lines.append(line)
-                continue
-            try:
-                obj = json.loads(stripped)
-            except json.JSONDecodeError:
-                out_lines.append(line)
-                continue
-            if _redact_secrets_in_obj(obj):
-                changed = True
-            newline = "\n" if line.endswith("\n") else ""
-            out_lines.append(json.dumps(obj) + newline)
-        return "".join(out_lines).encode("utf-8") if changed else None
-
-    try:
-        obj = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    if not _redact_secrets_in_obj(obj):
-        return None
-    return json.dumps(obj).encode("utf-8")
-
-
 def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
     """Create a zip archive for source_dir using only Python stdlib APIs.
 
     Secret-bearing fields (LLM/AWS credentials) in the persisted JSON payloads
     are redacted on the way into the archive so a downloaded trajectory never
-    leaks API keys — see ``_redacted_file_bytes``.
+    leaks API keys — see ``redacted_file_bytes``.
     """
     try:
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as archive:
@@ -235,7 +152,7 @@ def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
             for path in sorted(source_dir.rglob("*")):
                 arcname = str(path.relative_to(source_dir.parent))
                 if path.is_file():
-                    redacted = _redacted_file_bytes(path)
+                    redacted = redacted_file_bytes(path)
                     if redacted is not None:
                         archive.writestr(arcname, redacted)
                         continue

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -36,7 +36,9 @@ from openhands.sdk.git.utils import (
     run_git_command,
     validate_git_repository,
 )
+from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 
 class SubdirectoryEntry(BaseModel):
@@ -138,13 +140,106 @@ async def _download_file(path: str) -> FileResponse:
         )
 
 
+# Field names that carry credentials anywhere in a persisted conversation
+# payload (base_state.json, meta.json, events). Kept in sync with
+# ``LLM_SECRET_FIELDS`` and extended with the settings-level ``llm_api_key``
+# alias. A trajectory archive is meant to be shared for debugging, so these
+# must never leave the server as plaintext OR as recoverable ciphertext.
+_TRAJECTORY_SECRET_FIELDS: frozenset[str] = frozenset(
+    (*LLM_SECRET_FIELDS, "llm_api_key")
+)
+
+
+def _redact_secrets_in_obj(obj: object) -> bool:
+    """Recursively replace secret-bearing values with the redaction marker.
+
+    Returns ``True`` if anything was changed. Both plaintext and encrypted
+    (Fernet) secret material are masked, so the guarantee holds regardless of
+    whether ``OH_SECRET_KEY`` was configured when the conversation was
+    persisted.
+    """
+    changed = False
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if (
+                key in _TRAJECTORY_SECRET_FIELDS
+                and isinstance(value, str)
+                and value != ""
+                and value != REDACTED_SECRET_VALUE
+            ):
+                obj[key] = REDACTED_SECRET_VALUE
+                changed = True
+            elif _redact_secrets_in_obj(value):
+                changed = True
+    elif isinstance(obj, list):
+        for item in obj:
+            if _redact_secrets_in_obj(item):
+                changed = True
+    return changed
+
+
+def _redacted_file_bytes(path: Path) -> bytes | None:
+    """Return redacted bytes for a JSON/JSONL file, or ``None`` if unchanged.
+
+    Persisted conversation files are JSON (``*.json``) or newline-delimited
+    JSON (``*.jsonl``/the per-event log files). Anything that does not parse as
+    JSON is left untouched (returns ``None``) so the archive is byte-identical
+    for non-secret content.
+    """
+    suffix = path.suffix.lower()
+    if suffix not in (".json", ".jsonl"):
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if suffix == ".jsonl":
+        changed = False
+        out_lines: list[str] = []
+        for line in raw.splitlines(keepends=True):
+            stripped = line.strip()
+            if not stripped:
+                out_lines.append(line)
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                out_lines.append(line)
+                continue
+            if _redact_secrets_in_obj(obj):
+                changed = True
+            newline = "\n" if line.endswith("\n") else ""
+            out_lines.append(json.dumps(obj) + newline)
+        return "".join(out_lines).encode("utf-8") if changed else None
+
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not _redact_secrets_in_obj(obj):
+        return None
+    return json.dumps(obj).encode("utf-8")
+
+
 def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
-    """Create a zip archive for source_dir using only Python stdlib APIs."""
+    """Create a zip archive for source_dir using only Python stdlib APIs.
+
+    Secret-bearing fields (LLM/AWS credentials) in the persisted JSON payloads
+    are redacted on the way into the archive so a downloaded trajectory never
+    leaks API keys — see ``_redacted_file_bytes``.
+    """
     try:
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as archive:
             archive.write(source_dir, source_dir.name)
             for path in sorted(source_dir.rglob("*")):
-                archive.write(path, path.relative_to(source_dir.parent))
+                arcname = str(path.relative_to(source_dir.parent))
+                if path.is_file():
+                    redacted = _redacted_file_bytes(path)
+                    if redacted is not None:
+                        archive.writestr(arcname, redacted)
+                        continue
+                archive.write(path, arcname)
     except Exception:
         output_path.unlink(missing_ok=True)
         raise

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -294,6 +294,7 @@ def test_download_trajectory_redacts_llm_and_condenser_secrets(
     plaintext_key = "sk-plaintext-main-0123456789"
     condenser_key = "sk-plaintext-condenser-987654321"
     encrypted_blob = "gAAAAABencrypted_condenser_blob_value"
+    encrypted_custom_secret = "gAAAAABencrypted_custom_registry_secret"
 
     # meta.json: plaintext main key + encrypted condenser key
     meta = {
@@ -305,12 +306,19 @@ def test_download_trajectory_redacts_llm_and_condenser_secrets(
     }
     (conversation_dir / "meta.json").write_text(json.dumps(meta))
 
-    # base_state.json mirrors the agent config with a plaintext condenser key
+    # base_state.json mirrors the agent config with a plaintext condenser key,
+    # plus a cipher-encrypted custom secret whose field name ("value") is not
+    # in the LLM secret-field list.
     base_state = {
         "agent": {
             "llm": {"model": "gpt-4o", "api_key": plaintext_key},
             "condenser": {"llm": {"model": "gpt-4o-mini", "api_key": condenser_key}},
-        }
+        },
+        "secret_registry": {
+            "secret_sources": {
+                "MY_TOKEN": {"kind": "StaticSecret", "value": encrypted_custom_secret}
+            }
+        },
     }
     (conversation_dir / "base_state.json").write_text(json.dumps(base_state))
 
@@ -341,7 +349,12 @@ def test_download_trajectory_redacts_llm_and_condenser_secrets(
         blob = b"\n".join(archive.read(name) for name in archive.namelist())
 
     # No secret material of any kind survives into the archive.
-    for secret in (plaintext_key, condenser_key, encrypted_blob):
+    for secret in (
+        plaintext_key,
+        condenser_key,
+        encrypted_blob,
+        encrypted_custom_secret,
+    ):
         assert secret.encode() not in blob
 
     # The redaction marker is present where keys used to be, and non-secret

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -277,6 +277,82 @@ def test_download_trajectory_uses_python_zipfile(client, monkeypatch, tmp_path):
     assert not (conversations_path / f"{conversation_id.hex}.zip").exists()
 
 
+def test_download_trajectory_redacts_llm_and_condenser_secrets(
+    client, monkeypatch, tmp_path
+):
+    """A downloaded trajectory must never carry LLM/condenser API keys.
+
+    Covers both plaintext keys (no ``OH_SECRET_KEY`` configured) and encrypted
+    Fernet blobs (cipher configured) — neither belongs in a shareable archive.
+    """
+    conversations_path = tmp_path / "conversations"
+    conversation_id = uuid4()
+    conversation_dir = conversations_path / conversation_id.hex
+    events_dir = conversation_dir / "events"
+    events_dir.mkdir(parents=True)
+
+    plaintext_key = "sk-plaintext-main-0123456789"
+    condenser_key = "sk-plaintext-condenser-987654321"
+    encrypted_blob = "gAAAAABencrypted_condenser_blob_value"
+
+    # meta.json: plaintext main key + encrypted condenser key
+    meta = {
+        "id": conversation_id.hex,
+        "agent": {
+            "llm": {"model": "gpt-4o", "api_key": plaintext_key},
+            "condenser": {"llm": {"model": "gpt-4o-mini", "api_key": encrypted_blob}},
+        },
+    }
+    (conversation_dir / "meta.json").write_text(json.dumps(meta))
+
+    # base_state.json mirrors the agent config with a plaintext condenser key
+    base_state = {
+        "agent": {
+            "llm": {"model": "gpt-4o", "api_key": plaintext_key},
+            "condenser": {"llm": {"model": "gpt-4o-mini", "api_key": condenser_key}},
+        }
+    }
+    (conversation_dir / "base_state.json").write_text(json.dumps(base_state))
+
+    # A full_state event (JSONL) embedding the whole agent, plaintext keys
+    event = {
+        "kind": "ConversationStateUpdateEvent",
+        "key": "full_state",
+        "value": {
+            "agent": {
+                "llm": {"model": "gpt-4o", "api_key": plaintext_key},
+                "condenser": {
+                    "llm": {"model": "gpt-4o-mini", "api_key": condenser_key}
+                },
+            }
+        },
+    }
+    (events_dir / "event-00000.json").write_text(json.dumps(event))
+
+    monkeypatch.setattr(
+        "openhands.agent_server.file_router.get_default_config",
+        lambda: Config(session_api_keys=[], conversations_path=conversations_path),
+    )
+
+    response = client.get(f"/api/file/download-trajectory/{conversation_id}")
+    assert response.status_code == 200
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        blob = b"\n".join(archive.read(name) for name in archive.namelist())
+
+    # No secret material of any kind survives into the archive.
+    for secret in (plaintext_key, condenser_key, encrypted_blob):
+        assert secret.encode() not in blob
+
+    # The redaction marker is present where keys used to be, and non-secret
+    # content (model names) is preserved.
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        meta_out = json.loads(archive.read(f"{conversation_id.hex}/meta.json"))
+    assert meta_out["agent"]["llm"]["api_key"] == "**********"
+    assert meta_out["agent"]["condenser"]["llm"]["api_key"] == "**********"
+    assert meta_out["agent"]["llm"]["model"] == "gpt-4o"
+
+
 def test_download_file_with_special_characters_in_path(client, tmp_path):
     """Test download with special characters in path (via query param)."""
     test_file = tmp_path / "file with spaces.txt"


### PR DESCRIPTION
HUMAN:

Trajectory downloads must not leak LLM API keys — asked the agent to fix this and keep the redaction logic out of the router files.

---

AGENT:

## Why

`GET /api/file/download-trajectory/{id}` zips the raw conversation directory with no masking of its own, so a downloaded trajectory carries LLM API-key material:

- **plaintext** keys when the server runs without `OH_SECRET_KEY`, or
- **recoverable Fernet ciphertext** when a cipher is configured.

Both the agent LLM key and the **condenser** LLM key leak, since the whole agent config is serialized into `base_state.json` / `meta.json`. A trajectory archive is meant to be shared for debugging, so secrets must never leave the server in it.

## Summary

- New security utility module `openhands/agent_server/_secret_redaction.py` (mirroring the existing `_secrets_exposure.py` pattern) that redacts secret-bearing fields at the export boundary: `redact_secrets_in_obj` walks parsed JSON and masks any `LLM_SECRET_FIELDS` (`api_key`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`) plus the settings-level `llm_api_key` alias, for **both** plaintext and Fernet (`gAAAA…`) values. Any Fernet ciphertext is redacted **regardless of field name**, so cipher-encrypted custom secrets in `secret_registry.secret_sources` (stored under `value`) are covered too.
- `redacted_file_bytes` applies this to `*.json` and `*.jsonl` (per-event log) files; anything that isn't JSON is passed through untouched, so non-secret content stays byte-identical.
- `_create_zip_from_directory` in `file_router.py` streams redacted bytes for changed files and copies the rest verbatim, so the guarantee holds regardless of how the conversation was persisted.

## Issue Number

Fixes #4216

## How to Test

1. Start the agent server without `OH_SECRET_KEY` and run a conversation with a real `api_key` configured (optionally with a condenser LLM).
2. `curl -OJ http://localhost:8000/api/file/download-trajectory/<conversation_id>` and unzip the archive.
3. `grep -r "sk-" <unzipped dir>` — no API-key material (plaintext or `gAAAA…` ciphertext) appears; `api_key` fields read `**********` while model names and all other content are preserved.
4. Automated: `uv run pytest tests/agent_server/test_file_router.py -q` → 78 passed. The new `test_download_trajectory_redacts_llm_and_condenser_secrets` seeds `meta.json` (plaintext main key + encrypted condenser blob), `base_state.json`, and a `full_state` event, and asserts no secret material survives into the zip. Verified it fails without the fix and passes with it. ruff + pyright clean.

## Video/Screenshots

N/A (backend security fix; see test evidence above)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Redaction happens only at the download boundary; on-disk persistence is unchanged, so resuming conversations on the server keeps working with the original (optionally encrypted) secrets.
