### PR TITLE
fix(agent-server): make base_state.json authoritative for the resume agent (#4032)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -177,6 +177,42 @@ class EventService:
                 )
             )
 
+    def _resume_agent_with_live_llm(self) -> AgentBase:
+        """The agent to instantiate on start, with live LLM/condenser applied.
+
+        Fresh conversation (no ``base_state.json`` yet): returns
+        ``self.stored.agent`` from the create request unchanged.
+
+        Resume: returns the creation-time ``self.stored.agent`` (so ``tools`` /
+        ``agent_context`` / ``mcp_config`` are the un-merged config the plugin
+        merge expects) but with ``llm`` and ``condenser`` overridden from
+        ``base_state.json``. Those two are exactly what a live ``switch_llm``
+        can change, and base_state.json is where such changes are persisted —
+        so this is what keeps a switched config from reverting after a restart
+        (#4032) without any write-side mirror into meta.json.
+
+        ACP agents are left untouched: they do not use the ``switch_llm`` /
+        condenser path, and their model switch already persists to meta.json.
+        """
+        stored_agent = self.stored.agent
+        if isinstance(stored_agent, ACPAgent):
+            return stored_agent
+
+        base_state_file = self.conversation_dir / BASE_STATE
+        if not base_state_file.exists():
+            return stored_agent  # fresh conversation
+
+        context = {"cipher": self.cipher} if self.cipher else None
+        persisted = ConversationState.model_validate_json(
+            base_state_file.read_text(), context=context
+        ).agent
+        if isinstance(persisted, ACPAgent):
+            return stored_agent
+
+        return stored_agent.model_copy(
+            update={"llm": persisted.llm, "condenser": persisted.condenser}
+        )
+
     def _without_stored_secret(self, secret_name: str) -> StoredConversation:
         secrets = dict(self.stored.secrets)
         secrets.pop(secret_name, None)
@@ -971,9 +1007,29 @@ class EventService:
         working_dir = Path(workspace.working_dir)
         working_dir.mkdir(parents=True, exist_ok=True)
         self._ensure_workspace_is_git_repo(working_dir)
-        agent_cls = type(self.stored.agent)
+        # base_state.json is authoritative for the LIVE-mutable agent config.
+        #
+        # meta.json also carries an ``agent`` blob, but it is only a
+        # creation-time snapshot: it is NOT re-written when the running agent's
+        # LLM/condenser change (the switch_llm tool/endpoint updates
+        # ConversationState.agent → base_state.json only). Rebuilding the resume
+        # agent purely from meta.json therefore reinstated the stale
+        # creation-time LLM and clobbered base_state.json inside
+        # ConversationState.create() (``state.agent = agent``), reverting e.g. a
+        # switched LLM's timeout on the next restart (issue #4032).
+        #
+        # Fix: on resume, take ``llm`` and ``condenser`` from base_state.json
+        # (the file the SDK already owns and every mutation writes to) while
+        # keeping the rest of the agent — ``tools``, ``agent_context``,
+        # ``mcp_config`` — from the creation-time ``meta.json`` snapshot. Those
+        # are re-derived by the plugin merge on first run; taking the already
+        # merged copy from base_state would double-merge them. This scoping
+        # matches the fields a live switch can change, so no mutation path has
+        # to mirror into meta.json.
+        source_agent = self._resume_agent_with_live_llm()
+        agent_cls = type(source_agent)
         agent = agent_cls.model_validate(
-            self.stored.agent.model_dump(context={"expose_secrets": True}),
+            source_agent.model_dump(context={"expose_secrets": True}),
         )
 
         # Create LocalConversation with plugins and hook_config.

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1862,6 +1862,66 @@ class TestEventServiceSaveMeta:
         assert loaded.agent.acp_model == "new-model"
 
     @pytest.mark.asyncio
+    async def test_switched_llm_survives_restart_via_base_state(self, tmp_path):
+        """A live switch_llm survives an agent-server restart with NO meta mirror.
+
+        Regression for #4032. The conversation is created with timeout=300 and
+        then switched to an LLM with timeout=600 while running. ``switch_llm``
+        writes the new LLM to ``base_state.json`` only (not ``meta.json``).
+        After tearing the service down and starting a fresh one over the same
+        dir (a restart), the live agent must use the switched timeout=600,
+        because start() now rebuilds the resume agent's llm/condenser from
+        ``base_state.json`` rather than the stale ``meta.json`` snapshot.
+        """
+        stored = StoredConversation(
+            id=uuid4(),
+            agent=Agent(
+                llm=LLM(model="gpt-4o", usage_id="agent", timeout=300), tools=[]
+            ),
+            workspace=LocalWorkspace(working_dir=str(tmp_path / "ws")),
+            confirmation_policy=NeverConfirm(),
+            initial_message=None,
+            metrics=None,
+        )
+        (tmp_path / "ws").mkdir(parents=True, exist_ok=True)
+
+        # ---- first boot: start, switch the LLM, shut down ----
+        # ``async with`` runs save_meta() on exit, exactly like a real shutdown.
+        async with EventService(stored=stored, conversations_dir=tmp_path) as service:
+            assert service._conversation is not None
+            service._conversation.switch_llm(
+                LLM(model="gpt-4o", usage_id="agent", timeout=600)
+            )
+            assert service._conversation.agent.llm.timeout == 600
+
+        conv_dir = tmp_path / stored.id.hex
+        base_state = ConversationState.model_validate_json(
+            (conv_dir / "base_state.json").read_text()
+        )
+        meta = StoredConversation.model_validate_json(
+            (conv_dir / "meta.json").read_text()
+        )
+        # The switch reached base_state.json; meta.json still holds the old one.
+        assert base_state.agent.llm.timeout == 600
+        assert meta.agent.llm.timeout == 300
+
+        # ---- restart: a brand-new service over the same dir ----
+        restarted = EventService(
+            stored=StoredConversation.model_validate_json(
+                (conv_dir / "meta.json").read_text()
+            ),
+            conversations_dir=tmp_path,
+        )
+        await restarted.start()
+        try:
+            # The live agent uses the SWITCHED timeout, read from base_state.json,
+            # not the stale 300 in meta.json.
+            assert restarted._conversation is not None
+            assert restarted._conversation.agent.llm.timeout == 600
+        finally:
+            await restarted.close()
+
+    @pytest.mark.asyncio
     async def test_switch_acp_model_inactive_service_raises_value_error(self, tmp_path):
         """An inactive service (no live conversation) raises the shared
         ``inactive_service`` ValueError — consistent with the other


### PR DESCRIPTION
## What & why

Fixes #4032 (LLM/profile timeout reverts after an agent-server restart) by removing its **root cause** rather than papering over it.

The full agent is persisted in **two** places:
- `base_state.json` — the SDK's own conversation state, rewritten on *every* live mutation (`ConversationState.agent = ...`, e.g. `switch_llm`);
- `meta.json` — a `StoredConversation` snapshot taken at creation.

On resume, `EventService.start()` rebuilt the runtime agent from **`meta.json`**, and `ConversationState.create()` then copies that agent over `base_state.json` (`state.agent = agent`). So a live `switch_llm` — which writes only `base_state.json` — was silently reverted to the creation-time LLM (and its `timeout`) on the next restart.

This is a duplicate-source-of-truth bug. Background write-up (plain-English, code-grounded): https://enyst.github.io/arch/meta-vs-base-state-duplication.html

## The fix

Make `base_state.json` authoritative for the resume agent. On resume, take **`llm` and `condenser`** from `base_state.json` (the fields a live switch can change, and where those changes are already persisted) while keeping `tools` / `agent_context` / `mcp_config` from the creation-time snapshot — those are re-derived by the plugin merge on first run, so taking the already-merged `base_state` copy would double-merge them.

No new write-side mirror. `main` already carries one hand-rolled mirror for the ACP model switch (`switch_acp_model` → `save_meta`); this read-side approach avoids adding a second for `switch_llm`, and covers any future `llm`/`condenser` divergence for free.

## Relationship to #4028

Same bug, different level. #4028 (Vasco) fixes it by *mirroring* the switched `llm`/`condenser` into `meta.json` on change — correct and minimal within the current model. This PR removes the need to mirror at all by making the SDK-owned file authoritative on read. Same field-scoping insight (`llm`+`condenser`), applied on the read side. Posting as an alternative for discussion — happy to converge on whichever the maintainers prefer.

## Tests

Adds `test_switched_llm_survives_restart_via_base_state`: create with `timeout=300`, `switch_llm` to `600` (writes `base_state.json` only), tear the service down and start a fresh one over the same dir (a restart), assert the live agent uses `600`. Verified it **fails on the pre-fix behavior**. Full `test_event_service.py` + `test_conversation_service.py` (212) pass; ruff + pyright clean.

## Not in this PR

Fully removing the `agent` blob from `meta.json` (it's still read cold for codex-detection and conversation-info). That's the larger "slim meta to server-only fields" step; this PR makes `base_state` authoritative first, which is what actually fixes #4032.
