### PR TITLE
feat(settings): explicitly curate nested schema fields

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -23,6 +23,7 @@ from openhands.sdk.llm.utils.model_prompt_spec import get_model_prompt_spec
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.secret import SecretSource, SecretValue
+from openhands.sdk.settings.metadata import SettingProminence, field_meta
 from openhands.sdk.skills import (
     Skill,
     SkillKnowledge,
@@ -150,7 +151,10 @@ class AgentContext(BaseModel):
             "first send_message() / run() and stores the result in "
             "memory_context."
         ),
-        json_schema_extra={"acp_compatible": True},
+        json_schema_extra={
+            "acp_compatible": True,
+            **field_meta(SettingProminence.MAJOR, label="Persistent memory"),
+        },
     )
     memory_context: str | None = Field(
         default=None,

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -272,58 +272,71 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     api_version: str | None = Field(
         default=None,
         description="API version (e.g., Azure).",
+        json_schema_extra=field_meta(),
     )
 
     aws_access_key_id: str | SecretStr | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_secret_access_key: str | SecretStr | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_session_token: str | SecretStr | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_region_name: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_profile_name: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_role_name: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_session_name: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
     aws_bedrock_runtime_endpoint: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
 
     # OpenRouter uses HTTP-Referer as the app identity for rankings.
     # Keep this stable unless the OpenRouter app attribution is migrated.
     openrouter_site_url: str = Field(
         default="https://docs.all-hands.dev/",
+        json_schema_extra=field_meta(),
     )
     openrouter_app_name: str = Field(
         default="OpenHands",
+        json_schema_extra=field_meta(),
     )
 
-    num_retries: int = Field(default=5, ge=0)
-    retry_multiplier: float = Field(default=8.0, ge=0)
-    retry_min_wait: int = Field(default=8, ge=0)
-    retry_max_wait: int = Field(default=64, ge=0)
+    num_retries: int = Field(default=5, ge=0, json_schema_extra=field_meta())
+    retry_multiplier: float = Field(default=8.0, ge=0, json_schema_extra=field_meta())
+    retry_min_wait: int = Field(default=8, ge=0, json_schema_extra=field_meta())
+    retry_max_wait: int = Field(default=64, ge=0, json_schema_extra=field_meta())
 
     timeout: int | None = Field(
         default=300,
         ge=0,
         description="HTTP timeout in seconds. Default is 300s (5 minutes). "
         "Set to None to disable timeout (not recommended for production).",
+        json_schema_extra=field_meta(),
     )
 
     max_message_chars: int = Field(
         default=30_000,
         ge=1,
         description="Approx max chars in each event/content sent to the LLM.",
+        json_schema_extra=field_meta(),
     )
 
     temperature: float | None = Field(
@@ -335,6 +348,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "Set to 0.0 for deterministic outputs, "
             "or higher values (0.7-1.0) for more creative responses."
         ),
+        json_schema_extra=field_meta(),
     )
     top_p: float | None = Field(
         default=None,
@@ -345,8 +359,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "Defaults to None (uses provider default). "
             "Set to a value between 0 and 1 to control diversity of outputs."
         ),
+        json_schema_extra=field_meta(),
     )
-    top_k: float | None = Field(default=None, ge=0)
+    top_k: float | None = Field(default=None, ge=0, json_schema_extra=field_meta())
 
     max_input_tokens: int | None = Field(
         default=None,
@@ -354,11 +369,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         description="The maximum number of input tokens. "
         "Note that this is currently unused, and the value at runtime is actually"
         " the total tokens in OpenAI (e.g. 128,000 tokens for GPT-4).",
+        json_schema_extra=field_meta(),
     )
     max_output_tokens: int | None = Field(
         default=None,
         ge=1,
         description="The maximum number of output tokens. This is sent to the LLM.",
+        json_schema_extra=field_meta(),
     )
     model_canonical_name: str | None = Field(
         default=None,
@@ -372,23 +389,28 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "capability detection. If not provided, the 'model' field "
             "will be used for capability lookups."
         ),
+        json_schema_extra=field_meta(),
     )
     extra_headers: dict[str, str] | None = Field(
         default=None,
         description="Optional HTTP headers to forward to LiteLLM requests.",
+        json_schema_extra=field_meta(),
     )
     input_cost_per_token: float | None = Field(
         default=None,
         ge=0,
         description="The cost per input token. This will available in logs for user.",
+        json_schema_extra=field_meta(),
     )
     output_cost_per_token: float | None = Field(
         default=None,
         ge=0,
         description="The cost per output token. This will available in logs for user.",
+        json_schema_extra=field_meta(),
     )
     ollama_base_url: str | None = Field(
         default=None,
+        json_schema_extra=field_meta(),
     )
 
     stream: bool = Field(
@@ -398,42 +420,51 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "When enabled, the provided `on_token` callback in .completions "
             "and .responses will be invoked for each chunk of tokens."
         ),
+        json_schema_extra=field_meta(),
     )
-    drop_params: bool = Field(default=True)
+    drop_params: bool = Field(default=True, json_schema_extra=field_meta())
     modify_params: bool = Field(
         default=True,
         description="Modify params allows litellm to do transformations like adding"
         " a default message, when a message is empty.",
+        json_schema_extra=field_meta(),
     )
     disable_vision: bool | None = Field(
         default=None,
         description="If model is vision capable, this option allows to disable image "
         "processing (useful for cost reduction).",
+        json_schema_extra=field_meta(),
     )
     disable_stop_word: bool | None = Field(
         default=False,
         description="Disable using of stop word.",
+        json_schema_extra=field_meta(),
     )
     caching_prompt: bool = Field(
         default=True,
         description="Enable caching of prompts.",
+        json_schema_extra=field_meta(),
     )
     log_completions: bool = Field(
         default=False,
         description="Enable logging of completions.",
+        json_schema_extra=field_meta(),
     )
     log_completions_folder: str = Field(
         default=os.path.join(ENV_LOG_DIR, "completions"),
         description="The folder to log LLM completions to. "
         "Required if log_completions is True.",
+        json_schema_extra=field_meta(),
     )
     custom_tokenizer: str | None = Field(
         default=None,
         description="A custom tokenizer to use for token counting.",
+        json_schema_extra=field_meta(),
     )
     native_tool_calling: bool = Field(
         default=True,
         description="Whether to use native tool calling.",
+        json_schema_extra=field_meta(),
     )
     force_string_serializer: bool | None = Field(
         default=None,
@@ -443,6 +474,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "Useful for providers that do not support list content, "
             "like HuggingFace and Groq."
         ),
+        json_schema_extra=field_meta(),
     )
     inline_image_urls: bool | None = Field(
         default=None,
@@ -459,6 +491,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "litellm — otherwise images are not sent at all and there is "
             "nothing to inline."
         ),
+        json_schema_extra=field_meta(),
     )
     reasoning_effort: Literal["low", "medium", "high", "xhigh", "none"] | None = Field(
         default="high",
@@ -466,17 +499,20 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         "This is a string that can be one of 'low', 'medium', 'high', 'xhigh', "
         "or 'none'. "
         "Can apply to all reasoning models.",
+        json_schema_extra=field_meta(),
     )
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = Field(
         default=None,
         description="The level of detail for reasoning summaries. "
         "This is a string that can be one of 'auto', 'concise', or 'detailed'. "
         "Requires verified OpenAI organization. Only sent when explicitly set.",
+        json_schema_extra=field_meta(),
     )
     enable_encrypted_reasoning: bool = Field(
         default=True,
         description="If True, ask for ['reasoning.encrypted_content'] "
         "in Responses API include.",
+        json_schema_extra=field_meta(),
     )
     # Prompt cache retention is filtered per model features in chat options.
     prompt_cache_retention: str | None = Field(
@@ -486,15 +522,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "(GPT-5+ and GPT-4.1, excluding Azure deployments); explicitly "
             "stripped for all others."
         ),
+        json_schema_extra=field_meta(),
     )
     extended_thinking_budget: int | None = Field(
         default=200_000,
         description="The budget tokens for extended thinking, "
         "supported by Anthropic models.",
+        json_schema_extra=field_meta(),
     )
     seed: int | None = Field(
         default=None,
         description="The seed to use for random number generation.",
+        json_schema_extra=field_meta(),
     )
     usage_id: str = Field(
         default="default",
@@ -503,6 +542,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "Unique usage identifier for the LLM. Used for registry lookups, "
             "telemetry, and spend tracking."
         ),
+        json_schema_extra=field_meta(),
     )
     litellm_extra_body: dict[str, Any] = Field(
         default_factory=dict,
@@ -520,6 +560,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "- Proxy routing: {'trace_version': '1.0.0', 'tags': ['agent:my-agent']} "
             "- vLLM features: {'return_token_ids': True}"
         ),
+        json_schema_extra=field_meta(),
     )
 
     fallback_strategy: FallbackStrategy | None = Field(

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -196,6 +196,7 @@ class LLMSummarizingCondenserSettings(CondenserSettings):
             "Discriminator for the condenser settings union. ``'llm_summarizing'`` "
             "selects the default LLM summarizing condenser."
         ),
+        json_schema_extra={SETTINGS_METADATA_KEY: SettingsFieldMetadata().model_dump()},
     )
     max_tokens: int | None = Field(
         default=None,
@@ -295,6 +296,7 @@ class NoOpCondenserSettings(CondenserSettings):
             "Discriminator for the condenser settings union. ``'no_op'`` selects "
             "a condenser that leaves conversation views unchanged."
         ),
+        json_schema_extra={SETTINGS_METADATA_KEY: SettingsFieldMetadata().model_dump()},
     )
 
     def build_condenser(self, llm: LLM) -> CondenserBase | None:  # noqa: ARG002
@@ -1266,6 +1268,13 @@ class OpenHandsAgentSettings(AgentSettingsBase):
     agent_context: AgentContext = Field(
         default_factory=AgentContext,
         description="Context for the agent (skills, secrets, message suffixes).",
+        json_schema_extra={
+            SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
+                key="agent_context",
+                label="Memory",
+                variant="openhands",
+            ).model_dump()
+        },
     )
     condenser: CondenserSettingsConfig = Field(
         default_factory=LLMSummarizingCondenserSettings,
@@ -2084,6 +2093,9 @@ def export_settings_schema(model: type[BaseModel]) -> SettingsSchema:
                 for nested_key, nested_field in nested_model.model_fields.items():
                     if nested_field.exclude:
                         continue
+                    metadata = settings_metadata(nested_field)
+                    if metadata is None:
+                        continue
                     existing_field = seen_nested_fields.get(nested_key)
                     if existing_field is not None:
                         existing_choice_values = {
@@ -2094,7 +2106,6 @@ def export_settings_schema(model: type[BaseModel]) -> SettingsSchema:
                                 existing_field.choices.append(choice)
                                 existing_choice_values.add(choice.value)
                         continue
-                    metadata = settings_metadata(nested_field)
                     default_value = None
                     if isinstance(section_default, BaseModel) and hasattr(
                         section_default, nested_key
@@ -2104,7 +2115,7 @@ def export_settings_schema(model: type[BaseModel]) -> SettingsSchema:
                         key=f"{explicit_section_metadata.key}.{nested_key}",
                         label=(
                             metadata.label
-                            if metadata is not None and metadata.label is not None
+                            if metadata.label is not None
                             else _humanize_name(nested_key)
                         ),
                         description=nested_field.description,
@@ -2112,26 +2123,17 @@ def export_settings_schema(model: type[BaseModel]) -> SettingsSchema:
                         section_label=section.label,
                         value_type=_infer_value_type(nested_field.annotation),
                         default=_normalize_default(default_value),
-                        prominence=(
-                            metadata.prominence
-                            if metadata is not None
-                            else SettingProminence.MINOR
-                        ),
+                        prominence=metadata.prominence,
                         depends_on=[
                             f"{explicit_section_metadata.key}.{dependency}"
-                            for dependency in (
-                                metadata.depends_on if metadata is not None else ()
-                            )
+                            for dependency in metadata.depends_on
                         ],
                         secret=_contains_secret(nested_field.annotation),
                         choices=_extract_choices(nested_field.annotation),
                         # Field-level variant falls back to the enclosing
                         # section's variant — nested fields inherit their
                         # parent section's variant by default.
-                        variant=(
-                            (metadata.variant if metadata is not None else None)
-                            or section.variant
-                        ),
+                        variant=metadata.variant or section.variant,
                     )
                     seen_nested_fields[nested_key] = field_schema
                     section.fields.append(field_schema)

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -99,6 +99,13 @@ def test_get_agent_settings_schema():
     assert "confirmation_mode" not in verification_field_keys
     assert "security_analyzer" not in verification_field_keys
 
+    agent_context_section = next(
+        section for section in body["sections"] if section["key"] == "agent_context"
+    )
+    assert [field["key"] for field in agent_context_section["fields"]] == [
+        "agent_context.load_memory"
+    ]
+
 
 def test_get_conversation_settings_schema():
     client = TestClient(create_app(Config(static_files_path=None, session_api_keys=[])))
@@ -1012,6 +1019,19 @@ def test_patch_settings_deep_merges(client_with_settings):
     body = response.json()
     assert body["agent_settings"]["llm"]["model"] == "gpt-4o"
     assert body["llm_api_key_is_set"] is True
+
+
+def test_patch_settings_agent_context_load_memory_round_trips(client_with_settings):
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"agent_context": {"load_memory": True}}},
+    )
+
+    assert response.status_code == 200
+
+    fetched = client_with_settings.get("/api/settings")
+    assert fetched.status_code == 200
+    assert fetched.json()["agent_settings"]["agent_context"]["load_memory"] is True
 
 
 # ── JSON Merge Patch (RFC 7386) unset semantics ─────────────────────────

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -56,6 +56,7 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     assert section_keys == [
         "general",
         "llm",
+        "agent_context",
         "condenser",
         "verification",
     ]
@@ -111,6 +112,16 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     # Excluded fields must not appear
     assert "llm.fallback_strategy" not in llm_fields
     assert "llm.retry_listener" not in llm_fields
+
+    # -- agent_context section --
+    assert sections["agent_context"].label == "Memory"
+    agent_context_fields = {f.key: f for f in sections["agent_context"].fields}
+    assert set(agent_context_fields) == {"agent_context.load_memory"}
+    load_memory = agent_context_fields["agent_context.load_memory"]
+    assert load_memory.label == "Persistent memory"
+    assert load_memory.value_type == "boolean"
+    assert load_memory.default is False
+    assert load_memory.prominence is SettingProminence.MAJOR
 
     # -- condenser section --
     condenser_fields = {f.key: f for f in sections["condenser"].fields}
@@ -358,6 +369,9 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
     assert ("llm", "openhands") in by_keyvariant
     assert ("condenser", "openhands") in by_keyvariant
     assert ("verification", "openhands") in by_keyvariant
+
+    assert ("agent_context", "openhands") in by_keyvariant
+    assert ("agent_context", "acp") not in by_keyvariant
 
     # ACP-variant sections.
     acp_section = by_keyvariant.get(("acp", "acp"))


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The settings-schema exporter used different inclusion rules by depth: top-level
fields were opt-in through settings metadata, while every non-excluded field in
a nested section was exported automatically. PR #4205 exposed that inconsistency
by adding a per-section `fields_opt_in` mode to safely surface only
`AgentContext.load_memory`.

This change removes the need for a second mode. Settings fields are now
explicitly curated at every depth, preventing internal fields added to nested
runtime models from silently becoming user-facing settings.

## Summary

- Require settings metadata for nested fields, matching the existing top-level
  rule.
- Explicitly annotate every currently exported LLM field and condenser
  discriminator, preserving the existing schema exactly.
- Expose only `agent_context.load_memory` in a new OpenHands Memory section and
  retain its PATCH/GET settings path.

## Issue Number

Replacement implementation for #4205; supports the schema-driven settings work
in OpenHands/agent-canvas#1887.

## How to Test

```bash
make build
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/context/agent_context.py \
  openhands-sdk/openhands/sdk/llm/llm.py \
  openhands-sdk/openhands/sdk/settings/model.py \
  tests/sdk/test_settings.py \
  tests/agent_server/test_settings_router.py
OPENHANDS_SUPPRESS_BANNER=1 uv run pytest \
  tests/sdk/test_settings.py tests/agent_server/test_settings_router.py
```

Observed:

```text
187 passed, 8 warnings in 52.20s
Ruff format, Ruff lint, pycodestyle, pyright, import rules, and tool registration: Passed
```

I also created a detached `origin/main` worktree, exported
`export_agent_settings_schema()` from both revisions, removed only the new
`agent_context` section from the changed result, and compared the complete JSON
structures:

```text
schema_compatibility=exact_match_except_agent_context
```

Live end-to-end verification used an inline Python probe
(`OPENHANDS_SUPPRESS_BANNER=1 uv run python -`) that launched a real
`agent-server` with an isolated temporary `OH_PERSISTENCE_DIR`, requested
`/api/settings/agent-schema`, PATCHed `agent_context.load_memory`, and read
`/api/settings` back:

```text
schema_http=200 memory_fields=agent_context.load_memory
patch_http=200 settings_http=200 load_memory=true
```

## Video/Screenshots

N/A — API/schema change verified against a live server process.

## Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The generated schema remains compatible outside the intentionally added Memory
section. The larger annotation diff is a one-time migration from implicit nested
exposure to an explicit, uniform contract.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:383bbe0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-383bbe0-python \
  ghcr.io/openhands/agent-server:383bbe0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:383bbe0-golang-amd64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-golang-amd64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-golang-amd64
ghcr.io/openhands/agent-server:383bbe0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:383bbe0-golang-arm64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-golang-arm64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-golang-arm64
ghcr.io/openhands/agent-server:383bbe0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:383bbe0-java-amd64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-java-amd64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-java-amd64
ghcr.io/openhands/agent-server:383bbe0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:383bbe0-java-arm64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-java-arm64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-java-arm64
ghcr.io/openhands/agent-server:383bbe0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:383bbe0-python-amd64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-python-amd64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-python-amd64
ghcr.io/openhands/agent-server:383bbe0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:383bbe0-python-arm64
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-python-arm64
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-python-arm64
ghcr.io/openhands/agent-server:383bbe0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:383bbe0-golang
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-golang
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-golang
ghcr.io/openhands/agent-server:383bbe0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:383bbe0-java
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-java
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-java
ghcr.io/openhands/agent-server:383bbe0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:383bbe0-python
ghcr.io/openhands/agent-server:383bbe042828ba6af37f47b74fedb819b9cfa154-python
ghcr.io/openhands/agent-server:agent-simplify-settings-schema-curation-python
ghcr.io/openhands/agent-server:383bbe0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `383bbe0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `383bbe0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->