### PR TITLE
fix(agent-server): include server_base_path in the advertised VSCode URL

### DIFF
--- a/openhands-agent-server/openhands/agent_server/vscode_service.py
+++ b/openhands-agent-server/openhands/agent_server/vscode_service.py
@@ -94,6 +94,12 @@ class VSCodeService:
     ) -> str | None:
         """Get the VSCode URL with authentication token.
 
+        When ``server_base_path`` is configured, the server only answers under
+        that prefix (it is passed to openvscode-server as
+        ``--server-base-path``), so the prefix is included in the returned URL.
+        Without it, path-based-routing deployments are advertised a root URL
+        that the server does not serve.
+
         Args:
             base_url: Base URL for the VSCode server
             workspace_dir: Path to workspace directory
@@ -107,7 +113,11 @@ class VSCodeService:
         if base_url is None:
             base_url = f"http://localhost:{self.port}"
 
-        return f"{base_url}/?tkn={self.connection_token}&folder={workspace_dir}"
+        base = base_url.rstrip("/")
+        if self.server_base_path:
+            base = f"{base}/{self.server_base_path.strip('/')}"
+
+        return f"{base}/?tkn={self.connection_token}&folder={workspace_dir}"
 
     def is_running(self) -> bool:
         """Check if VSCode server is running.

--- a/tests/agent_server/test_vscode_service.py
+++ b/tests/agent_server/test_vscode_service.py
@@ -199,6 +199,66 @@ def test_get_vscode_url_with_custom_port():
     assert url == "http://localhost:9001/?tkn=test-token-456&folder=workspace"
 
 
+def test_get_vscode_url_includes_server_base_path():
+    """Test that a configured server_base_path appears in the URL.
+
+    The base path is passed to openvscode-server as ``--server-base-path``, so
+    the server only answers under that prefix — a root URL would not resolve.
+    """
+    service = VSCodeService(port=19000, server_base_path="/vscode")
+    service.connection_token = "test-token-789"
+
+    assert (
+        service.get_vscode_url()
+        == "http://localhost:19000/vscode/?tkn=test-token-789&folder=workspace"
+    )
+
+
+def test_get_vscode_url_base_path_with_caller_supplied_base_url():
+    """Test that the base path is appended to a caller-supplied base_url.
+
+    Callers behind a reverse proxy pass their own public origin; they still
+    cannot know the server's base path, so it must be applied here. Base paths
+    are normalized so '/vscode', 'vscode' and a trailing-slash base_url all
+    produce the same single-slash URL.
+    """
+    service = VSCodeService(port=19000, server_base_path="vscode")
+    service.connection_token = "test-token-789"
+
+    expected = "https://example.com/vscode/?tkn=test-token-789&folder=%2Fsrv%2Fwork"
+    assert (
+        service.get_vscode_url(
+            base_url="https://example.com", workspace_dir="%2Fsrv%2Fwork"
+        )
+        == expected
+    )
+    assert (
+        service.get_vscode_url(
+            base_url="https://example.com/", workspace_dir="%2Fsrv%2Fwork"
+        )
+        == expected
+    )
+
+
+def test_get_vscode_url_without_base_path_is_unchanged():
+    """Test that URLs are byte-identical when no base path is configured.
+
+    Downstream clients (OpenHands-CLI, app-server, Enterprise) that do not set
+    ``vscode_base_path`` must see exactly the previous output.
+    """
+    service = VSCodeService(port=8001)
+    service.connection_token = "test-token-000"
+
+    assert (
+        service.get_vscode_url()
+        == "http://localhost:8001/?tkn=test-token-000&folder=workspace"
+    )
+    assert (
+        service.get_vscode_url(base_url="http://example.com:9000")
+        == "http://example.com:9000/?tkn=test-token-000&folder=workspace"
+    )
+
+
 def test_is_running_false(vscode_service):
     """Test is_running when no process."""
     assert not vscode_service.is_running()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

A setup behind a single-hostname path router hits this — a Mac mini on a Cloudflare Tunnel or tailnet, where you can't just expose another port for VSCode, so it has to live under /vscode. The server honors vscode_base_path when launching but /api/vscode/url drops the prefix, so the returned link doesn't load. Follow-up to my #4181 (port half).

---

AGENT:

## Why

`VSCodeService` uses `server_base_path` when it **launches** the server but ignores it when it **advertises** the URL:

```python
# _start_vscode_process — uses it
base_path_arg = (
    f"--server-base-path {self.server_base_path} " if self.server_base_path else ""
)

# get_vscode_url — ignored
return f"{base_url}/?tkn={self.connection_token}&folder={workspace_dir}"
```

openvscode-server only answers under that prefix, so with `vscode_base_path` configured, `GET /api/vscode/url` hands out a root URL the server does not serve. The setting is honored for launching the process and ignored for advertising it.

**Who this affects.** Any deployment that reaches agent-server through a single hostname routed by path, rather than giving VSCode its own publicly reachable port. That is the ordinary self-hosting shape, not an exotic one:

- **Cloudflare Tunnel** — ingress rules map hostname + path to a local service. HTTP is served over the standard web ports, so a second port for VSCode means a second hostname, DNS record, and tunnel rule; routing `/vscode` on the hostname you already have is the natural setup.
- **Tailscale Serve** — mounting a local port under a path on the node's existing name is the idiom, and Funnel only exposes a small fixed set of ports, so an arbitrary VSCode port isn't an option.
- **Reverse proxies and identity-aware load balancers** — the case I hit it on, where only 443 is open and everything is dispatched by path.

In all of these, `vscode_base_path` is the correct and only mechanism, and in all of them the URL from `/api/vscode/url` currently fails to load. `config.py` also documents `'/{runtime_id}/vscode'` as an intended value, so the multi-tenant runtime case has the same problem.

This is the path counterpart to #4181, which fixed the *port* half of the same "advertise where the server really binds" problem.

## Summary

- `get_vscode_url()` now appends `server_base_path` to the returned URL, for both the default and caller-supplied `base_url`.
- Base paths are normalized (`strip("/")` on the prefix, `rstrip("/")` on `base_url`) so `/vscode`, `vscode`, and a trailing-slash `base_url` all produce the same single-slash URL.
- Three tests: base path with the default `base_url`, base path with a caller-supplied `base_url` (incl. both normalization forms), and a no-base-path case asserting the previous output byte-for-byte.

## Issue Number

None. Related: #4181 (merged, port half of the same defect).

## How to Test

**1. Unit tests** — from the repo root:

```
uv run pytest tests/agent_server/test_vscode_service.py tests/agent_server/test_vscode_router.py -q
# 45 passed
uv run pytest tests/agent_server/ -q
# 1819 passed, 13 deselected
```

The two new base-path tests fail without the source change (`git stash` the `vscode_service.py` edit and re-run `-k base_path`), showing precisely the missing prefix:

```
- http://localhost:19000/vscode/?tkn=test-token-789&folder=workspace
?                       -------
+ http://localhost:19000/?tkn=test-token-789&folder=workspace
```

The third test passes with and without the change — that is intentional; it is the no-regression guard for clients that leave `vscode_base_path` unset.

**2. End-to-end, on a real deployment.** Agent-server 1.37.1 behind a reverse proxy, `vscode_base_path=/vscode` (`OH_VSCODE_BASE_PATH=/vscode`), VSCode bound on :19000, proxy forwarding `/vscode` → `localhost:19000` without path rewriting.

The launched process does honor the base path:

```
$ pgrep -af openvscode-server
.../bin/openvscode-server --host 0.0.0.0 --connection-token <redacted> \
  --port 19000 --extensions-dir ... --server-base-path /vscode --disable-workspace-trust
```

And the prefixed URL is the one that works — 302 setting the token cookie, then the workbench:

```
$ curl -sD - -o /dev/null "http://localhost:8000/vscode/?tkn=$KEY"
HTTP/1.1 302 Found
set-cookie: vscode-tkn=<redacted>; Max-Age=604800; SameSite=Lax
location: /vscode?folder=...

$ curl -sL -o /dev/null -w '%{http_code}\n' "http://localhost:8000/vscode/?tkn=$KEY"
200
```

But **before this change** the API advertised the unprefixed URL:

```
$ curl -s "$SERVER/api/vscode/url" -H "X-Session-API-Key: $KEY"
{"url":"http://localhost:19000/?tkn=<redacted>&folder=workspace"}   # no /vscode → not served
```

**after** this change:

```
{"url":"http://localhost:19000/vscode/?tkn=<redacted>&folder=workspace"}   # matches the working entrypoint
```

With a caller-supplied origin (`?base_url=https://<public-host>`), the response likewise becomes `https://<public-host>/vscode/?tkn=…`, which is the URL that actually loads through the proxy.

## Video/Screenshots

No GUI change — this is a URL-construction fix. The `curl` transcripts above are the equivalent evidence: the advertised URL now matches the entrypoint that returns the workbench, and a WebSocket upgrade through the same prefixed path completes (`101 Switching Protocols`), confirming the prefixed URL is fully functional and the unprefixed one is not.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Compatibility.** Output is byte-identical when `server_base_path` is `None`, which is the default and the case for every client that does not opt in — so OpenHands-CLI, app-server, and Enterprise are unaffected unless they set `vscode_base_path`, and if they do, they were previously receiving a URL that did not resolve. No config, migration, or deprecation is needed.

**Scope.** This only makes the server advertise its own routing correctly. A client that passes `base_url` still cannot know the deployment's *external* path prefix if it differs from the server's base path; that is a separate frontend concern (see OpenHands/OpenHands#15434).
