### PR TITLE
fix: honor the stored memory preference on profile launches

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -286,6 +286,7 @@ def _resolve_agent_from_profile(
     profile_id: "UUID",
     cipher: "Cipher | None",
     mcp_config: "dict[str, MCPServer]",
+    load_memory: bool = False,
 ) -> "tuple[AgentBase, LaunchedAgentProfile]":
     """Load and resolve an agent profile by id, returning the built agent + provenance.
 
@@ -296,6 +297,11 @@ def _resolve_agent_from_profile(
             server's cipher.  Passed explicitly so this free function never
             touches the settings-store singleton (which may not have been
             initialised with the correct cipher yet).
+        load_memory: The user's global persistent-memory preference
+            (``agent_settings.agent_context.load_memory``).  An ``AgentProfile``
+            has no ``agent_context`` field, so the preference cannot ride the
+            profile — it is stamped onto the resolved agent below, else a
+            profile-launched conversation would silently ignore the setting.
 
     Raises:
         ProfileNotFound: No stored profile has ``profile_id``.
@@ -371,6 +377,15 @@ def _resolve_agent_from_profile(
     ):
         agent = agent.model_copy(
             update={"tools": [*agent.tools, Tool(name=BROWSER_TOOL_NAME)]}
+        )
+    # Persistent memory is a global user preference, not a profile field, so it
+    # is carried across the profile-resolution boundary the same way the global
+    # ``mcp_config`` is. Left untouched when off, so the resolved agent stays
+    # byte-identical for everyone who hasn't opted in.
+    if load_memory:
+        context = agent.agent_context or AgentContext()
+        agent = agent.model_copy(
+            update={"agent_context": context.model_copy(update={"load_memory": True})}
         )
     launched = LaunchedAgentProfile(
         agent_profile_id=profile.id,
@@ -1320,11 +1335,14 @@ class ConversationService:
 
             settings = get_settings_store().load() or PersistedSettings()
             mcp_config = settings.agent_settings.mcp_config
+            # ``ACPAgentSettings.agent_context`` is nullable, hence the guard.
+            stored_context = settings.agent_settings.agent_context
             resolved_agent, launched_agent_profile = await asyncio.to_thread(
                 _resolve_agent_from_profile,
                 request.agent_profile_id,
                 self.cipher,
                 mcp_config,
+                load_memory=bool(stored_context and stored_context.load_memory),
             )
             request = request.model_copy(update={"agent": resolved_agent})
 

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -30,7 +30,8 @@ from openhands.agent_server.models import (
     StartConversationRequest,
     StoredConversation,
 )
-from openhands.sdk import LLM, Agent
+from openhands.agent_server.persistence import PersistedSettings
+from openhands.sdk import LLM, Agent, AgentContext
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
@@ -43,6 +44,7 @@ from openhands.sdk.profiles.resolver import (
     DanglingMcpServerRef,
     ProfileNotFound,
 )
+from openhands.sdk.settings.model import ACPAgentSettings, OpenHandsAgentSettings
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -158,6 +160,9 @@ _RESOLVE_PATH = "openhands.sdk.profiles.resolver.resolve_agent_profile"
 # (load_all_skills loads public skills from GitHub). conversation_service imports
 # discover_profile_skills directly, so patch it in that namespace.
 _DISCOVER_PATH = "openhands.agent_server.conversation_service.discover_profile_skills"
+# The profile branch of start_conversation reads the persisted settings through a
+# local import too, so patch the package-level name it binds.
+_SETTINGS_STORE_PATH = "openhands.agent_server.persistence.get_settings_store"
 
 
 class TestResolveAgentFromProfile:
@@ -504,6 +509,98 @@ class TestResolveAgentFromProfile:
 # ---------------------------------------------------------------------------
 
 
+def _resolved_settings_for(
+    agent_kind: str,
+) -> tuple[
+    OpenHandsAgentProfile | ACPAgentProfile, OpenHandsAgentSettings | ACPAgentSettings
+]:
+    """A profile plus the settings the SDK resolver builds from it.
+
+    Mirrors ``profiles/resolver.py``: both variants always get an
+    ``AgentContext``, and neither ``AgentProfile`` variant has a field that
+    could carry the user's memory preference.
+    """
+    if agent_kind == "acp":
+        return _make_acp_profile(), ACPAgentSettings(
+            acp_command=["echo", "acp"],
+            agent_context=AgentContext(skills=[], current_datetime=None),
+        )
+    return _make_openhands_profile(), OpenHandsAgentSettings(
+        llm=LLM(model="gpt-4o", usage_id="agent"),
+        agent_context=AgentContext(skills=[]),
+    )
+
+
+async def _start_from_profile(
+    tmp_path,
+    profile: OpenHandsAgentProfile | ACPAgentProfile,
+    resolved_settings: OpenHandsAgentSettings | ACPAgentSettings,
+    persisted_settings: PersistedSettings,
+) -> StoredConversation:
+    """Launch from ``profile`` and return the captured ``StoredConversation``.
+
+    Only the stores are stubbed, so ``_resolve_agent_from_profile`` and the
+    settings read that feeds it both run for real — this is the path a client
+    reaches by sending ``agent_profile_id`` alone, with no ``agent_settings``.
+    """
+    request = StartConversationRequest(
+        agent_profile_id=profile.id,
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+    )
+    captured: dict[str, Any] = {}
+
+    async def capture_start(stored, **_kwargs):
+        captured["stored"] = stored
+        event_service = AsyncMock(spec=EventService)
+        event_service.get_state.return_value = ConversationState(
+            id=uuid4(),
+            agent=stored.agent,
+            workspace=request.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+        )
+        event_service.stored = MagicMock(
+            launched_agent_profile=None,
+            client_tools=[],
+            title=None,
+            metrics=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            forked_from_conversation_id=None,
+            forked_from_event_id=None,
+            parent_conversation_id=None,
+        )
+        return event_service
+
+    service = ConversationService(conversations_dir=tmp_path)
+    service._event_services = {}
+
+    with (
+        patch(_SETTINGS_STORE_PATH) as MockSettingsStore,
+        patch(_STORE_PATH) as MockStore,
+        patch(_LLM_STORE_PATH),
+        patch(_RESOLVE_PATH, return_value=resolved_settings),
+        patch(_DISCOVER_PATH, return_value=[]),
+        # Pin the environment probe: browser injection is covered by its own
+        # tests above and would otherwise vary with the host.
+        patch(
+            "openhands.agent_server.conversation_service.is_tool_usable",
+            return_value=False,
+        ),
+        patch.object(
+            service,
+            "_start_event_service",
+            new_callable=AsyncMock,
+            side_effect=capture_start,
+        ),
+    ):
+        MockSettingsStore.return_value.load.return_value = persisted_settings
+        MockStore.return_value.name_for_id.return_value = profile.name
+        MockStore.return_value.load.return_value = profile
+        await service.start_conversation(request)
+
+    return captured["stored"]
+
+
 class TestConversationServiceStartFromProfile:
     @pytest.mark.asyncio
     async def test_start_from_profile_stamps_launched_agent_profile_on_stored(
@@ -602,6 +699,62 @@ class TestConversationServiceStartFromProfile:
             with pytest.raises(DanglingMcpServerRef) as exc_info:
                 await service.start_conversation(request)
         assert "mcp-server-x" in exc_info.value.missing
+
+    @pytest.mark.parametrize("agent_kind", ["openhands", "acp"])
+    @pytest.mark.asyncio
+    async def test_profile_launch_inherits_the_stored_memory_preference(
+        self, tmp_path, agent_kind
+    ):
+        """Persistent memory is a global preference the profile cannot carry.
+
+        A profile launch sends no ``agent_settings``, so without this the
+        Settings → Memory toggle would read as enabled while every conversation
+        started from a named OpenHands profile or an ACP profile ignored it.
+        """
+        profile, resolved_settings = _resolved_settings_for(agent_kind)
+        persisted = PersistedSettings(
+            agent_settings=OpenHandsAgentSettings(
+                agent_context=AgentContext(load_memory=True)
+            )
+        )
+
+        stored = await _start_from_profile(
+            tmp_path, profile, resolved_settings, persisted
+        )
+
+        assert stored.agent.agent_context is not None
+        assert stored.agent.agent_context.load_memory is True
+
+    @pytest.mark.parametrize(
+        "persisted_settings",
+        [
+            pytest.param(
+                PersistedSettings(
+                    agent_settings=OpenHandsAgentSettings(agent_context=AgentContext())
+                ),
+                id="preference-off",
+            ),
+            # An ACP-kind settings record leaves ``agent_context`` null until
+            # something writes to it, so the read must tolerate its absence
+            # rather than breaking every profile launch.
+            pytest.param(
+                PersistedSettings(agent_settings=ACPAgentSettings()),
+                id="stored-settings-without-agent-context",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_profile_launch_leaves_memory_off_without_the_preference(
+        self, tmp_path, persisted_settings
+    ):
+        profile, resolved_settings = _resolved_settings_for("openhands")
+
+        stored = await _start_from_profile(
+            tmp_path, profile, resolved_settings, persisted_settings
+        )
+
+        assert stored.agent.agent_context is not None
+        assert stored.agent.agent_context.load_memory is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

AgentContext.load_memory is a global user preference persisted in agent_settings, but a conversation started with agent_profile_id builds its agent purely from the stored AgentProfile — and neither profile variant has an agent_context field that could carry it. The Settings -> Memory toggle therefore read as enabled while every conversation launched from a named OpenHands profile or an ACP profile ran without memory. Only the inline agent_settings path worked.

Carry the preference across the profile-resolution boundary the same way the global mcp_config already is: create_conversation reads agent_settings.agent_context.load_memory from the settings store it already loads in that branch, and \_resolve_agent_from_profile stamps it onto the resolved agent's context. The stamp is skipped entirely when the preference is off, so an un-opted resolution is unchanged, and the start-conversation wire payload is untouched — no client change and no compatibility break with older servers.

The read guards a null agent_context, which is the default for an ACP-kind settings record; without it every profile launch for those users would raise.

Reported on OpenHands/agent-canvas#1887.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

`AgentContext.load_memory` (#4178, exposed in the settings schema by #4205) is a global user preference persisted in `agent_settings`. A conversation started with `agent_profile_id` builds its agent purely from the stored `AgentProfile`, and neither `OpenHandsAgentProfile` nor `ACPAgentProfile` has an `agent_context` field (`extra="forbid"`), so the preference is dropped. Review on OpenHands/agent-canvas#1887 caught the user-visible result: Settings → Memory shows the toggle enabled while every conversation launched from a named OpenHands profile or an ACP profile runs without memory.

A client cannot fix this — `agent_profile_id` and `agent_settings` are mutually exclusive, and the cloud launch request has no agent-config field at all.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `create_conversation`'s profile branch reads `agent_settings.agent_context.load_memory` from the settings store it already loads there for `mcp_config`, and passes it to `_resolve_agent_from_profile`. The read guards a null `agent_context` — the default for an ACP-kind settings record.
- `_resolve_agent_from_profile` stamps the flag onto the resolved agent's context via `model_copy`, alongside the other agent-server-layer post-resolution adjustments (`llm.stream=True`, browser-tool injection). Skipped entirely when the preference is off, so an un-opted resolution is byte-identical.
- No wire-payload or model change: `StartConversationRequest`, `AgentProfile`, and `AgentContext` are untouched, so no client change is needed and older clients keep working.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Follow-up to #4178 / #4205 (OpenHands/software-agent-sdk#2037). Reported on OpenHands/agent-canvas#1887.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
HOME=$(mktemp -d) uv run pytest tests/agent_server/test_agent_profile_conv_start.py -q
# 32 passed

HOME=$(mktemp -d) uv run pytest tests/agent_server -q
# 1820 passed, 13 deselected  (1816 before these 4 cases)

uv run pre-commit run --files \
  openhands-agent-server/openhands/agent_server/conversation_service.py \
  tests/agent_server/test_agent_profile_conv_start.py
# ruff format/lint, pycodestyle, pyright, import rules — all pass

```

The four new cases drive `ConversationService.start_conversation` with an `agent_profile_id`-only request; only the profile/LLM/settings stores are stubbed, so `_resolve_agent_from_profile` and the settings read that feeds it both run for real. TDD red checks:

- remove the stamp in `_resolve_agent_from_profile` → `test_profile_launch_inherits_the_stored_memory_preference[openhands]` and `[acp]` fail (`assert False is True`);
- replace the guarded read with `settings.agent_settings.agent_context.load_memory` → `test_profile_launch_leaves_memory_off_without_the_preference[stored-settings-without-agent-context]` fails.

End-to-end against a live server, driving the whole path a GUI user takes:

```bash
uvx --from ./openhands-agent-server --with-editable ./openhands-sdk \
    --with-editable ./openhands-tools --with-editable ./openhands-workspace \
    agent-server --port 8317

# 1. turn the preference on, exactly as the Canvas Memory page does
curl -s -X PATCH localhost:8317/api/settings -H 'Content-Type: application/json' \
  -d '{"agent_settings_diff": {"agent_context": {"load_memory": true}}}'

# 2. launch from a stored agent profile (no agent_settings in the request)
curl -s -X POST localhost:8317/api/conversations -H 'Content-Type: application/json' \
  -d '{"agent_profile_id": "<profile-uuid>", "workspace": {"working_dir": "/tmp/ws"}}'

# 3. the started conversation's agent carries agent_context.load_memory == true,
#    and its first SystemPromptEvent contains the two-tier memory guidance
#    (plus <MEMORY_CONTEXT> once /tmp/ws/.openhands/memory/MEMORY.md exists).

```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

N/A — server-side behavior; the user-visible effect is demonstrated in OpenHands/agent-canvas#1887.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b55b200-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b55b200-python \
  ghcr.io/openhands/agent-server:b55b200-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b55b200-golang-amd64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-golang-amd64
ghcr.io/openhands/agent-server:hieptl-oss-5812-golang-amd64
ghcr.io/openhands/agent-server:b55b200-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b55b200-golang-arm64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-golang-arm64
ghcr.io/openhands/agent-server:hieptl-oss-5812-golang-arm64
ghcr.io/openhands/agent-server:b55b200-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b55b200-java-amd64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-java-amd64
ghcr.io/openhands/agent-server:hieptl-oss-5812-java-amd64
ghcr.io/openhands/agent-server:b55b200-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b55b200-java-arm64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-java-arm64
ghcr.io/openhands/agent-server:hieptl-oss-5812-java-arm64
ghcr.io/openhands/agent-server:b55b200-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b55b200-python-amd64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-python-amd64
ghcr.io/openhands/agent-server:hieptl-oss-5812-python-amd64
ghcr.io/openhands/agent-server:b55b200-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b55b200-python-arm64
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-python-arm64
ghcr.io/openhands/agent-server:hieptl-oss-5812-python-arm64
ghcr.io/openhands/agent-server:b55b200-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b55b200-golang
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-golang
ghcr.io/openhands/agent-server:hieptl-oss-5812-golang
ghcr.io/openhands/agent-server:b55b200-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b55b200-java
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-java
ghcr.io/openhands/agent-server:hieptl-oss-5812-java
ghcr.io/openhands/agent-server:b55b200-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b55b200-python
ghcr.io/openhands/agent-server:b55b2005ca511ab3b061869cdff33604d5a19a24-python
ghcr.io/openhands/agent-server:hieptl-oss-5812-python
ghcr.io/openhands/agent-server:b55b200-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b55b200-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b55b200-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->