### PR TITLE
chore: remove verified dead code

### DIFF
--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -8,7 +8,6 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
 
-from openhands.sdk import LLM
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.conversation_stats import ConversationStats
@@ -399,11 +398,6 @@ ACPConversationInfo: TypeAlias = ConversationInfo  # noqa: UP040
 ACPConversationPage: TypeAlias = ConversationPage  # noqa: UP040
 
 
-class ConversationResponse(BaseModel):
-    conversation_id: str
-    state: ConversationExecutionStatus
-
-
 class ConfirmationResponseRequest(BaseModel):
     """Payload to accept or reject a pending action."""
 
@@ -545,23 +539,6 @@ class NavigateConversationRequest(BaseModel):
             "conversation. ``None`` selects the empty tree."
         ),
     )
-
-
-class GenerateTitleRequest(BaseModel):
-    """Payload to generate a title for a conversation."""
-
-    max_length: int = Field(
-        default=50, ge=1, le=200, description="Maximum length of the generated title"
-    )
-    llm: LLM | None = Field(
-        default=None, description="Optional LLM to use for title generation"
-    )
-
-
-class GenerateTitleResponse(BaseModel):
-    """Response containing the generated conversation title."""
-
-    title: str = Field(description="The generated title for the conversation")
 
 
 class AskAgentRequest(BaseModel):

--- a/openhands-sdk/openhands/sdk/agent/response_dispatch.py
+++ b/openhands-sdk/openhands/sdk/agent/response_dispatch.py
@@ -9,7 +9,7 @@ Contains:
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.event import MessageEvent
@@ -82,55 +82,11 @@ def classify_response(message: Message) -> LLMResponseType:
 # ---------------------------------------------------------------------------
 
 
-@runtime_checkable
-class _AgentProtocol(Protocol):
-    """Subset of ``Agent`` that ``ResponseDispatchMixin`` depends on."""
-
-    critic: CriticBase | None
-
-    def _get_action_event(
-        self,
-        tool_call: MessageToolCall,
-        conversation: LocalConversation,
-        llm_response_id: str,
-        on_event: ConversationCallbackType,
-        security_analyzer: SecurityAnalyzerBase | None = None,
-        thought: list[TextContent] | None = None,
-        reasoning_content: str | None = None,
-        thinking_blocks: list[ThinkingBlock | RedactedThinkingBlock] | None = None,
-        responses_reasoning_item: ReasoningItemModel | None = None,
-    ) -> ActionEvent | None: ...
-
-    def _execute_actions(
-        self,
-        conversation: LocalConversation,
-        action_events: list[ActionEvent],
-        on_event: ConversationCallbackType,
-    ) -> None: ...
-
-    def _requires_user_confirmation(
-        self,
-        state: ConversationState,
-        action_events: list[ActionEvent],
-    ) -> bool: ...
-
-    def _maybe_emit_vllm_tokens(
-        self,
-        llm_response: LLMResponse,
-        on_event: ConversationCallbackType,
-    ) -> None: ...
-
-    def _evaluate_with_critic(
-        self,
-        conversation: LocalConversation,
-        event: ActionEvent | MessageEvent,
-    ) -> CriticResult | None: ...
-
-
 class ResponseDispatchMixin:
     """Handler methods for each ``LLMResponseType``. Mixed into ``Agent``.
 
-    Expects the host class to satisfy :class:`_AgentProtocol`.
+    Expects the host class (``Agent``) to provide the members declared in the
+    ``TYPE_CHECKING`` block below.
     """
 
     # Declared for pyright — the actual implementations live on Agent.

--- a/openhands-sdk/openhands/sdk/critic/impl/api/client.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/client.py
@@ -330,6 +330,3 @@ class CriticClient(BaseModel):
 
         mapping = {lbl: probs[i] for i, lbl in enumerate(self.all_labels)}
         return LabelProbMap(probs=mapping, order=list(self.all_labels))
-
-    def predict_labels(self, probs: list[float], threshold: float = 0.5) -> list[int]:
-        return [1 if p > threshold else 0 for p in probs]

--- a/openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py
@@ -47,18 +47,6 @@ CATEGORY_DISPLAY_NAMES: dict[str, str] = {
 }
 
 
-def get_category(feature_name: str) -> str | None:
-    """Get the category for a feature.
-
-    Args:
-        feature_name: Name of the feature
-
-    Returns:
-        Category name or None if not found
-    """
-    return FEATURE_CATEGORIES.get(feature_name)
-
-
 def _softmax_normalize(probs: dict[str, float]) -> dict[str, float]:
     """Apply softmax normalization to convert logits to probabilities.
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small PR to delete some dead-code

---

AGENT:

## Why

Several symbols in the SDK and agent-server are defined but never used anywhere in the tree. They add maintenance surface (imports to keep valid, type-checking, docs) for no benefit. This removes the dead-code items from #4224 (the duplication, simplification, and `model_dump_succint()` items in that issue are intentionally **not** part of this PR).

Each symbol was verified unreferenced before removal: whole-tree `git grep` shows only the definition site, none appear in any `__all__`, and no module does `from ... import *` on them.

## Summary

- Remove `_AgentProtocol` from `openhands-sdk/openhands/sdk/agent/response_dispatch.py` (its only reference was a docstring, which now points at the mixin's `TYPE_CHECKING` block instead) and drop the now-unused `Protocol`/`runtime_checkable` imports.
- Remove `ConversationResponse`, `GenerateTitleRequest`, and `GenerateTitleResponse` from `openhands-agent-server/openhands/agent_server/models.py` (none are wired to a route) and drop the now-unused `from openhands.sdk import LLM` import.
- Remove `get_category()` from `openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py` (a thin wrapper over `FEATURE_CATEGORIES.get()`, which `categorize_features()` already calls directly).
- Remove `predict_labels()` from `openhands-sdk/openhands/sdk/critic/impl/api/client.py`.

Net change: **−82 lines** across 4 files, no behavior change.

## Issue Number

Refs #4224 (dead-code items only; other items in the issue are out of scope for this PR).

## How to Test

From the repo root:

```bash
# 1. Confirm each symbol has no remaining reference anywhere in the tree
git grep -n "_AgentProtocol\|ConversationResponse\|GenerateTitleRequest\|GenerateTitleResponse\|get_category\|predict_labels"
# (only the definition sites existed before this PR; nothing after)

# 2. Lint + type-check the changed files
uv run ruff check openhands-sdk openhands-agent-server
uv run ruff format --check openhands-sdk openhands-agent-server
uv run pyright openhands-sdk/openhands/sdk/agent/response_dispatch.py \
  openhands-sdk/openhands/sdk/critic/impl/api/client.py \
  openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py \
  openhands-agent-server/openhands/agent_server/models.py

# 3. Run the affected test suites
uv run pytest tests/sdk/critic tests/sdk/agent/test_response_dispatch.py \
  tests/agent_server/test_models.py tests/agent_server/test_openapi_discriminator.py \
  tests/agent_server/test_conversation_response.py -q
```

Results in this branch:

- `ruff check` / `ruff format --check`: pass, all files formatted.
- `pyright`: `0 errors, 0 warnings, 0 informations`.
- `pytest`: **87 passed**.
- The agent-server OpenAPI schema is unchanged — the three removed models never appeared in it (`api.openapi()` reports 404 components, none of them the removed models), so the HTTP API surface is untouched.
- Pre-commit (ruff, pycodestyle, pyright, import-dependency and Tool-registration checks) passes on the commit.

## Video/Screenshots

N/A — internal dead-code removal with no runtime or UI behavior change; evidence is the command output above.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `predict_labels()` and `get_category()` live under the internal `critic/impl/api/` package and are not exported via any `__all__`, so this is not a public-API change.
- The `_AgentProtocol` removal is safe because `ResponseDispatchMixin` already re-declares the same members under its own `if TYPE_CHECKING:` block, which is what pyright actually uses.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2382870-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2382870-python \
  ghcr.io/openhands/agent-server:2382870-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2382870-golang-amd64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-golang-amd64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-golang-amd64
ghcr.io/openhands/agent-server:2382870-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2382870-golang-arm64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-golang-arm64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-golang-arm64
ghcr.io/openhands/agent-server:2382870-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2382870-java-amd64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-java-amd64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-java-amd64
ghcr.io/openhands/agent-server:2382870-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2382870-java-arm64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-java-arm64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-java-arm64
ghcr.io/openhands/agent-server:2382870-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2382870-python-amd64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-python-amd64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-python-amd64
ghcr.io/openhands/agent-server:2382870-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2382870-python-arm64
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-python-arm64
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-python-arm64
ghcr.io/openhands/agent-server:2382870-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2382870-golang
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-golang
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-golang
ghcr.io/openhands/agent-server:2382870-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2382870-java
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-java
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-java
ghcr.io/openhands/agent-server:2382870-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2382870-python
ghcr.io/openhands/agent-server:23828702504b3a74b0410c75018ca3e928dfb02f-python
ghcr.io/openhands/agent-server:vasco-cleanup-dead-code-4224-python
ghcr.io/openhands/agent-server:2382870-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2382870-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2382870-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->