### PR TITLE
chore(ruff): enable safe line-reducing rules and apply autofixes

### DIFF
--- a/.github/scripts/check_approval_drift.py
+++ b/.github/scripts/check_approval_drift.py
@@ -187,9 +187,7 @@ def main() -> int:
     errors = 0
     for number, _subject in prs:
         status, detail = audit_pr(repo, number, token, trusted_bots)
-        if status == "ok":
-            ok += 1
-        elif status == "trusted-bot":
+        if status == "ok" or status == "trusted-bot":
             ok += 1
         elif status == "error":
             errors += 1

--- a/.github/scripts/check_docstrings.py
+++ b/.github/scripts/check_docstrings.py
@@ -181,11 +181,9 @@ def get_docstrings_from_file(file: Path) -> list[tuple[str, str, int]]:
             docstring = ast.get_docstring(node)
             name = file.stem
             lineno = 1
-        elif isinstance(node, ast.ClassDef):
-            docstring = ast.get_docstring(node)
-            name = node.name
-            lineno = node.lineno
-        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        elif isinstance(node, ast.ClassDef) or isinstance(
+            node, ast.FunctionDef | ast.AsyncFunctionDef
+        ):
             docstring = ast.get_docstring(node)
             name = node.name
             lineno = node.lineno

--- a/examples/03_github_workflows/04_datadog_debugging/datadog_debugging.py
+++ b/examples/03_github_workflows/04_datadog_debugging/datadog_debugging.py
@@ -263,9 +263,8 @@ def create_unique_identifier(query: str, errors_data: dict) -> str:
     if examples and examples[0].get("issue_id"):
         issue_id = examples[0]["issue_id"]
         return f"error-id: {issue_id}"
-    else:
-        # Use query as identifier
-        return f"query: {query}"
+    # Use query as identifier
+    return f"query: {query}"
 
 
 def search_existing_issue(
@@ -304,9 +303,8 @@ def search_existing_issue(
             issue_number = items_sorted[0]["number"]
             print(f"✅ Found existing issue #{issue_number} (oldest of {len(items)})")
             return issue_number
-        else:
-            print("❌ No existing issue found")
-            return None
+        print("❌ No existing issue found")
+        return None
     except (
         requests.exceptions.RequestException,
         json.JSONDecodeError,

--- a/examples/03_github_workflows/05_posthog_debugging/posthog_debugging.py
+++ b/examples/03_github_workflows/05_posthog_debugging/posthog_debugging.py
@@ -470,9 +470,8 @@ def create_unique_identifier(query: str, events_data: dict) -> str:
     if examples and examples[0].get("event_id"):
         event_id = examples[0]["event_id"]
         return f"event-id: {event_id}"
-    else:
-        # Use query as identifier
-        return f"query: {query}"
+    # Use query as identifier
+    return f"query: {query}"
 
 
 def search_existing_issue(
@@ -516,9 +515,8 @@ def search_existing_issue(
                 f"✅ Found existing open issue #{issue_number} (oldest of {len(items)})"
             )
             return issue_number
-        else:
-            print("📭 No open issue found - will create new one")
-            return None
+        print("📭 No open issue found - will create new one")
+        return None
     except (
         requests.exceptions.RequestException,
         json.JSONDecodeError,

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -498,8 +498,7 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
         index_path = config.static_files_path / "index.html"
         if index_path.exists():
             return RedirectResponse(url="/static/index.html", status_code=302)
-        else:
-            return RedirectResponse(url="/static/", status_code=302)
+        return RedirectResponse(url="/static/", status_code=302)
 
 
 def _sanitize_validation_errors(errors: Sequence[Any]) -> list[dict]:

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -507,10 +507,9 @@ class BuildOptions(BaseModel):
         base = f"buildcache-{self.target}-{self.base_image_slug}"
         if self.git_ref in ("main", "refs/heads/main"):
             return f"{base}-main", base
-        elif self.git_ref != "unknown":
+        if self.git_ref != "unknown":
             return f"{base}-{_sanitize_branch(self.git_ref)}", base
-        else:
-            return base, base
+        return base, base
 
     @property
     def all_tags(self) -> list[str]:

--- a/openhands-agent-server/openhands/agent_server/event_router.py
+++ b/openhands-agent-server/openhands/agent_server/event_router.py
@@ -57,9 +57,8 @@ def normalize_datetime_to_server_timezone(dt: datetime) -> datetime:
     if dt.tzinfo is not None:
         # Timezone-aware: convert to server native timezone, then make naive
         return dt.astimezone(None).replace(tzinfo=None)
-    else:
-        # Naive datetime: assume it's already in server timezone
-        return dt
+    # Naive datetime: assume it's already in server timezone
+    return dt
 
 
 @event_router.get("/search", responses={404: {"description": "Conversation not found"}})

--- a/openhands-agent-server/openhands/agent_server/openai/service.py
+++ b/openhands-agent-server/openhands/agent_server/openai/service.py
@@ -237,16 +237,16 @@ async def _wait_for_completion(
         )
         if last_status == ConversationExecutionStatus.RUNNING:
             observed_run = True
-        elif last_status.is_terminal() and (
-            allow_existing_response or observed_run or enough_new_events
-        ):
-            return last_status
-        elif observed_run and enough_new_events:
-            return last_status
         elif (
-            allow_existing_response
+            last_status.is_terminal()
+            and (allow_existing_response or observed_run or enough_new_events)
+            or observed_run
             and enough_new_events
-            and await event_service.get_agent_final_response()
+            or (
+                allow_existing_response
+                and enough_new_events
+                and await event_service.get_agent_final_response()
+            )
         ):
             return last_status
 

--- a/openhands-agent-server/openhands/agent_server/pub_sub.py
+++ b/openhands-agent-server/openhands/agent_server/pub_sub.py
@@ -68,11 +68,10 @@ class PubSub[T]:
             del self._subscribers[subscriber_id]
             logger.debug(f"Unsubscribed subscriber with ID: {subscriber_id}")
             return True
-        else:
-            logger.warning(
-                f"Attempted to unsubscribe unknown subscriber ID: {subscriber_id}"
-            )
-            return False
+        logger.warning(
+            f"Attempted to unsubscribe unknown subscriber ID: {subscriber_id}"
+        )
+        return False
 
     def subscriber_ids(self) -> set[UUID]:
         """Return the ids of all currently-registered subscribers."""

--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -109,9 +109,8 @@ async def ready(response: Response) -> dict[str, str]:
     """
     if _initialization_complete.is_set():
         return {"status": "ready"}
-    else:
-        response.status_code = 503
-        return {"status": "initializing", "message": "Server is still initializing"}
+    response.status_code = 503
+    return {"status": "initializing", "message": "Server is still initializing"}
 
 
 @server_details_router.get("/server_info")

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -477,8 +477,7 @@ def sync_public_skills() -> tuple[bool, str]:
         if result:
             _invalidate_public_skills_cache()
             return (True, "Skills repository synced successfully")
-        else:
-            return (False, "Failed to sync skills repository")
+        return (False, "Failed to sync skills repository")
     except Exception as e:
         logger.warning(f"Failed to sync skills repository: {e}")
         return (False, f"Sync failed: {str(e)}")

--- a/openhands-agent-server/openhands/agent_server/telemetry/subscriber.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/subscriber.py
@@ -194,13 +194,13 @@ class TelemetrySubscriber(Subscriber[Event]):
         try:
             value = getattr(event, "value", None)
             if not isinstance(value, dict):
-                return None
+                return
             stats = value.get("stats")
             if not isinstance(stats, dict):
-                return None
+                return
             per_usage = stats.get("usage_to_metrics")
             if not isinstance(per_usage, dict):
-                return None
+                return
 
             tokens = 0
             cost = 0.0

--- a/openhands-agent-server/openhands/agent_server/vscode_service.py
+++ b/openhands-agent-server/openhands/agent_server/vscode_service.py
@@ -233,13 +233,12 @@ def get_vscode_service() -> VSCodeService | None:
         if not config.enable_vscode:
             logger.info("VSCode is disabled in configuration")
             return None
-        else:
-            connection_token = None
-            if config.session_api_keys:
-                connection_token = config.session_api_keys[0]
-            _vscode_service = VSCodeService(
-                port=config.vscode_port,
-                connection_token=connection_token,
-                server_base_path=config.vscode_base_path,
-            )
+        connection_token = None
+        if config.session_api_keys:
+            connection_token = config.session_api_keys[0]
+        _vscode_service = VSCodeService(
+            port=config.vscode_port,
+            connection_token=connection_token,
+            server_base_path=config.vscode_base_path,
+        )
     return _vscode_service

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -1205,7 +1205,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                     thinking_blocks=thinking_blocks,
                     responses_reasoning_item=responses_reasoning_item,
                 )
-                return
+                return None
 
             arguments = fix_malformed_tool_arguments(arguments, tool.action_type)
             normalized_tool_call = tool_call.model_copy(
@@ -1261,7 +1261,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 thinking_blocks=thinking_blocks,
                 responses_reasoning_item=responses_reasoning_item,
             )
-            return
+            return None
 
         # Create initial action event
         action_event = ActionEvent(

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -987,4 +987,3 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
 
         No-op by default; ACPAgent overrides to terminate subprocess.
         """
-        pass

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -641,14 +641,13 @@ def make_llm_completion(
             on_token=on_token,
             call_context=call_context,
         )
-    else:
-        return llm.completion(
-            messages=messages,
-            tools=tools or [],
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
+    return llm.completion(
+        messages=messages,
+        tools=tools or [],
+        add_security_risk_prediction=True,
+        on_token=on_token,
+        call_context=call_context,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -704,11 +703,10 @@ async def amake_llm_completion(
             on_token=on_token,
             call_context=call_context,
         )
-    else:
-        return await llm.acompletion(
-            messages=messages,
-            tools=tools or [],
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
+    return await llm.acompletion(
+        messages=messages,
+        tools=tools or [],
+        add_security_risk_prediction=True,
+        on_token=on_token,
+        call_context=call_context,
+    )

--- a/openhands-sdk/openhands/sdk/context/condenser/base.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/base.py
@@ -173,7 +173,7 @@ class RollingCondenser(PipelinableCondenserBase, ABC):
                     # we do so immediately.
                     return view
 
-                elif request == CondensationRequirement.HARD:
+                if request == CondensationRequirement.HARD:
                     # The agent has found itself in a situation where it cannot proceed
                     # without condensation, but the condenser cannot provide one. We'll
                     # try to recover from this situation by performing a hard context
@@ -217,7 +217,7 @@ class RollingCondenser(PipelinableCondenserBase, ABC):
                 if request == CondensationRequirement.SOFT:
                     return view
 
-                elif request == CondensationRequirement.HARD:
+                if request == CondensationRequirement.HARD:
                     try:
                         hard_reset_condensation = await self.ahard_context_reset(
                             view, agent_llm=agent_llm

--- a/openhands-sdk/openhands/sdk/context/view/manipulation_indices.py
+++ b/openhands-sdk/openhands/sdk/context/view/manipulation_indices.py
@@ -46,7 +46,7 @@ class ManipulationIndices(set[int]):
         """
         manipulation_indices = ManipulationIndices()
 
-        manipulation_indices.update(range(0, len(events)))
+        manipulation_indices.update(range(len(events)))
         manipulation_indices.add(len(events))
 
         return manipulation_indices

--- a/openhands-sdk/openhands/sdk/context/view/view.py
+++ b/openhands-sdk/openhands/sdk/context/view/view.py
@@ -66,10 +66,9 @@ class View(BaseModel):
         if isinstance(key, slice):
             start, stop, step = key.indices(len(self))
             return [self[i] for i in range(start, stop, step)]
-        elif isinstance(key, int):
+        if isinstance(key, int):
             return self.events[key]
-        else:
-            raise ValueError(f"Invalid key type: {type(key)}")
+        raise ValueError(f"Invalid key type: {type(key)}")
 
     def enforce_properties(
         self,

--- a/openhands-sdk/openhands/sdk/conversation/response_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/response_utils.py
@@ -32,10 +32,9 @@ def get_agent_final_response(events: Sequence[Event]) -> str:
             # Extract message from finish tool call
             if event.action is not None and isinstance(event.action, FinishAction):
                 return event.action.message
-            else:
-                break
+            break
         # Case 2: text message with no tool calls (MessageEvent)
-        elif isinstance(event, MessageEvent) and event.source == "agent":
+        if isinstance(event, MessageEvent) and event.source == "agent":
             text_parts = content_to_str(event.llm_message.content)
             return "".join(text_parts)
     return ""

--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -136,9 +136,8 @@ def generate_title_with_llm(message: str, llm: LLM, max_length: int = 50) -> str
                 title = title[: max_length - 3] + "..."
 
             return title
-        else:
-            logger.warning("LLM returned empty response for title generation")
-            return None
+        logger.warning("LLM returned empty response for title generation")
+        return None
 
     except Exception as e:
         logger.warning(f"Error generating conversation title with LLM: {e}")

--- a/openhands-sdk/openhands/sdk/conversation/visualizer/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/base.py
@@ -64,7 +64,6 @@ class ConversationVisualizerBase(ABC):
         Args:
             event: The event to visualize
         """
-        pass
 
     def create_sub_visualizer(
         self,

--- a/openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/taxonomy.py
@@ -159,7 +159,7 @@ def categorize_features(
         if category == "general_context":
             # Skip general context features for now
             continue
-        elif category == "agent_behavioral_issues":
+        if category == "agent_behavioral_issues":
             result["agent_behavioral_issues"].append(feature_entry)
         elif category == "user_followup_patterns":
             result["user_followup_patterns"].append(feature_entry)

--- a/openhands-sdk/openhands/sdk/critic/result.py
+++ b/openhands-sdk/openhands/sdk/critic/result.py
@@ -44,10 +44,9 @@ class CriticResult(BaseModel):
         """Get the style for the star rating based on score."""
         if score >= 0.6:
             return "green"
-        elif score >= 0.4:
+        if score >= 0.4:
             return "yellow"
-        else:
-            return "red"
+        return "red"
 
     @property
     def visualize(self) -> Text:

--- a/openhands-sdk/openhands/sdk/event/base.py
+++ b/openhands-sdk/openhands/sdk/event/base.py
@@ -98,8 +98,7 @@ class LLMConvertibleEvent(Event, ABC):
                 if len(content_preview) > N_CHAR_PREVIEW:
                     content_preview = content_preview[: N_CHAR_PREVIEW - 3] + "..."
                 return f"{base_str}\n  {llm_message.role}: {content_preview}"
-            else:
-                return f"{base_str}\n  {llm_message.role}: [no text content]"
+            return f"{base_str}\n  {llm_message.role}: [no text content]"
         except Exception:
             # Fallback to base representation if LLM message conversion fails
             return base_str

--- a/openhands-sdk/openhands/sdk/event/llm_convertible/action.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/action.py
@@ -155,10 +155,9 @@ class ActionEvent(LLMConvertibleEvent):
         if self.action:
             action_name = self.action.__class__.__name__
             return f"{base_str}\n  Thought: {thought_preview}\n  Action: {action_name}"
-        else:
-            # When action is None (non-executable), show the tool call
-            call = f"{self.tool_call.name}:{self.tool_call.id}"
-            return (
-                f"{base_str}\n  Thought: {thought_preview}\n  Action: (not executed)"
-                f"\n  Call: {call}"
-            )
+        # When action is None (non-executable), show the tool call
+        call = f"{self.tool_call.name}:{self.tool_call.id}"
+        return (
+            f"{base_str}\n  Thought: {thought_preview}\n  Action: (not executed)"
+            f"\n  Call: {call}"
+        )

--- a/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
@@ -148,5 +148,4 @@ class MessageEvent(LLMConvertibleEvent):
                 f"{base_str}\n  {message.role}: "
                 f"{content_preview}{skill_info}{thinking_info}"
             )
-        else:
-            return f"{base_str}\n  {message.role}: [no text content]"
+        return f"{base_str}\n  {message.role}: [no text content]"

--- a/openhands-sdk/openhands/sdk/git/exceptions.py
+++ b/openhands-sdk/openhands/sdk/git/exceptions.py
@@ -4,8 +4,6 @@
 class GitError(Exception):
     """Base exception for git-related errors."""
 
-    pass
-
 
 class GitRepositoryError(GitError):
     """Exception raised when git repository operations fail."""
@@ -39,5 +37,3 @@ class GitCommandError(GitError):
 
 class GitPathError(GitError):
     """Exception raised when git path operations fail."""
-
-    pass

--- a/openhands-sdk/openhands/sdk/git/git_changes.py
+++ b/openhands-sdk/openhands/sdk/git/git_changes.py
@@ -86,7 +86,7 @@ def _parse_name_status(changed_files: list[str]) -> list[GitChange]:
 
         # Handle copy operations (status starts with 'C' followed by
         # similarity percentage)
-        elif status.startswith("C") and len(parts) == 3:
+        if status.startswith("C") and len(parts) == 3:
             # Copy: only add the new path (original remains)
             new_path = parts[2].strip()
             changes.append(
@@ -99,7 +99,7 @@ def _parse_name_status(changed_files: list[str]) -> list[GitChange]:
             continue
 
         # Handle regular operations (M, A, D, etc.)
-        elif len(parts) == 2:
+        if len(parts) == 2:
             path = parts[1].strip()
         else:
             logger.error(f"Unexpected git diff line format: {line}")

--- a/openhands-sdk/openhands/sdk/io/cache.py
+++ b/openhands-sdk/openhands/sdk/io/cache.py
@@ -39,18 +39,17 @@ class MemoryLRUCache(LRUCache):
             # For strings, len() gives character count which is what we care about
             # This is much more accurate than sys.getsizeof for our use case
             return len(value)
-        elif isinstance(value, bytes):
+        if isinstance(value, bytes):
             return len(value)
-        else:
-            # For other types, fall back to sys.getsizeof
-            # This is mainly for edge cases and won't be accurate for nested
-            # structures, but it's better than nothing
-            try:
-                import sys
+        # For other types, fall back to sys.getsizeof
+        # This is mainly for edge cases and won't be accurate for nested
+        # structures, but it's better than nothing
+        try:
+            import sys
 
-                return sys.getsizeof(value)
-            except Exception:
-                return 0
+            return sys.getsizeof(value)
+        except Exception:
+            return 0
 
     def __setitem__(self, key: Any, value: Any) -> None:
         new_size = self._get_size(value)

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -230,9 +230,8 @@ def _extract_chatgpt_account_id(access_token: str) -> str | None:
         if account_id:
             logger.debug(f"Extracted chatgpt_account_id: {account_id}")
             return account_id
-        else:
-            logger.warning("chatgpt_account_id not found in JWT payload")
-            return None
+        logger.warning("chatgpt_account_id not found in JWT payload")
+        return None
 
     except JoseError as e:
         logger.warning(f"JWT signature verification failed: {e}")

--- a/openhands-sdk/openhands/sdk/llm/router/impl/multimodal.py
+++ b/openhands-sdk/openhands/sdk/llm/router/impl/multimodal.py
@@ -57,9 +57,8 @@ class MultimodalRouter(RouterLLM):
         if route_to_primary:
             logger.info("Routing to the primary model...")
             return self.PRIMARY_MODEL_KEY
-        else:
-            logger.info("Routing to the secondary model...")
-            return self.SECONDARY_MODEL_KEY
+        logger.info("Routing to the secondary model...")
+        return self.SECONDARY_MODEL_KEY
 
     @model_validator(mode="after")
     def _validate_llms_for_routing(self) -> "MultimodalRouter":

--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -62,7 +62,7 @@ def _serialize_secret_map(
     if value is None:
         return None
     if resolve_expose_mode(info.context) == "redact":
-        return {key: REDACTED_SECRET_VALUE for key in value}
+        return dict.fromkeys(value, REDACTED_SECRET_VALUE)
     return {
         key: cast(str | None, serialize_secret(secret, info))
         for key, secret in value.items()

--- a/openhands-sdk/openhands/sdk/mcp/exceptions.py
+++ b/openhands-sdk/openhands/sdk/mcp/exceptions.py
@@ -4,8 +4,6 @@
 class MCPError(Exception):
     """Base exception for MCP-related errors."""
 
-    pass
-
 
 class MCPTimeoutError(MCPError):
     """Exception raised when MCP operations timeout."""

--- a/openhands-sdk/openhands/sdk/observability/utils.py
+++ b/openhands-sdk/openhands/sdk/observability/utils.py
@@ -14,7 +14,6 @@ def extract_action_name(action_event: ActionEvent) -> str:
     try:
         if action_event.action is not None and hasattr(action_event.action, "kind"):
             return action_event.action.kind
-        else:
-            return action_event.tool_name
+        return action_event.tool_name
     except Exception:
         return "agent.execute_action"

--- a/openhands-sdk/openhands/sdk/security/analyzer.py
+++ b/openhands-sdk/openhands/sdk/security/analyzer.py
@@ -36,7 +36,6 @@ class SecurityAnalyzerBase(DiscriminatedUnionMixin, ABC):
         Returns:
             ActionSecurityRisk enum indicating the risk level
         """
-        pass
 
     def analyze_event(self, event: Event) -> SecurityRisk | None:
         """Analyze an event for security risks.
@@ -72,15 +71,14 @@ class SecurityAnalyzerBase(DiscriminatedUnionMixin, ABC):
         if risk == SecurityRisk.HIGH:
             # HIGH risk actions always require confirmation
             return True
-        elif risk == SecurityRisk.UNKNOWN and not confirmation_mode:
+        if risk == SecurityRisk.UNKNOWN and not confirmation_mode:
             # UNKNOWN risk requires confirmation if no security analyzer is configured
             return True
-        elif confirmation_mode:
+        if confirmation_mode:
             # In confirmation mode, all actions require confirmation
             return True
-        else:
-            # LOW and MEDIUM risk actions don't require confirmation by default
-            return False
+        # LOW and MEDIUM risk actions don't require confirmation by default
+        return False
 
     def analyze_pending_actions(
         self, pending_actions: list[ActionEvent]

--- a/openhands-sdk/openhands/sdk/security/grayswan/analyzer.py
+++ b/openhands-sdk/openhands/sdk/security/grayswan/analyzer.py
@@ -138,9 +138,7 @@ class GraySwanAnalyzer(SecurityAnalyzerBase):
     def _get_client(self) -> httpx.Client:
         """Get or create HTTP client."""
         # Split condition to avoid AttributeError when _client is None
-        if self._client is None:
-            self._client = self._create_client()
-        elif self._client.is_closed:
+        if self._client is None or self._client.is_closed:
             self._client = self._create_client()
         return self._client
 
@@ -155,10 +153,9 @@ class GraySwanAnalyzer(SecurityAnalyzerBase):
         """
         if violation_score <= self.low_threshold:
             return SecurityRisk.LOW
-        elif violation_score <= self.medium_threshold:
+        if violation_score <= self.medium_threshold:
             return SecurityRisk.MEDIUM
-        else:
-            return SecurityRisk.HIGH
+        return SecurityRisk.HIGH
 
     def _call_grayswan_api(self, messages: list[dict[str, Any]]) -> SecurityRisk:
         """Call GraySwan API with formatted messages.
@@ -213,11 +210,8 @@ class GraySwanAnalyzer(SecurityAnalyzerBase):
                     f"(violation_score: {violation_score:.2f})"
                 )
                 return risk_level
-            else:
-                logger.error(
-                    f"GraySwan API error {response.status_code}: {response.text}"
-                )
-                return SecurityRisk.UNKNOWN
+            logger.error(f"GraySwan API error {response.status_code}: {response.text}")
+            return SecurityRisk.UNKNOWN
 
         except httpx.TimeoutException:
             logger.error("GraySwan API request timed out")

--- a/openhands-sdk/openhands/sdk/skills/exceptions.py
+++ b/openhands-sdk/openhands/sdk/skills/exceptions.py
@@ -1,8 +1,6 @@
 class SkillError(Exception):
     """Base exception for all skill errors."""
 
-    pass
-
 
 class SkillValidationError(SkillError):
     """Raised when there's a validation error in skill metadata."""

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -385,8 +385,7 @@ class Skill(BaseModel):
             return cls._load_agentskills_skill(
                 path, file_content, strict=strict, skip_mcp=skip_mcp
             )
-        else:
-            return cls._load_legacy_openhands_skill(path, file_content, skill_base_dir)
+        return cls._load_legacy_openhands_skill(path, file_content, skill_base_dir)
 
     @classmethod
     def _load_agentskills_skill(
@@ -584,7 +583,7 @@ class Skill(BaseModel):
                 is_agentskills_format=is_agentskills_format,
                 **agentskills_fields,
             )
-        elif "inputs" in metadata_dict:
+        if "inputs" in metadata_dict:
             # Add a trigger for the agent name if not already present
             trigger_keyword = f"/{agent_name}"
             if trigger_keyword not in keywords:
@@ -607,7 +606,7 @@ class Skill(BaseModel):
                 **agentskills_fields,
             )
 
-        elif metadata_dict.get("triggers", None):
+        if metadata_dict.get("triggers", None):
             return Skill(
                 name=agent_name,
                 content=content,
@@ -618,18 +617,17 @@ class Skill(BaseModel):
                 is_agentskills_format=is_agentskills_format,
                 **agentskills_fields,
             )
-        else:
-            # No triggers, default to None (always active)
-            return Skill(
-                name=agent_name,
-                content=content,
-                source=to_posix_path(path),
-                trigger=None,
-                mcp_tools=mcp_tools,
-                resources=resources,
-                is_agentskills_format=is_agentskills_format,
-                **agentskills_fields,
-            )
+        # No triggers, default to None (always active)
+        return Skill(
+            name=agent_name,
+            content=content,
+            source=to_posix_path(path),
+            trigger=None,
+            mcp_tools=mcp_tools,
+            resources=resources,
+            is_agentskills_format=is_agentskills_format,
+            **agentskills_fields,
+        )
 
     @classmethod
     def _handle_third_party(cls, path: Path, file_content: str) -> Union["Skill", None]:
@@ -791,10 +789,9 @@ class Skill(BaseModel):
         """
         if self.is_agentskills_format:
             return "agentskills"
-        elif self.trigger is None:
+        if self.trigger is None:
             return "repo"
-        else:
-            return "knowledge"
+        return "knowledge"
 
     def get_triggers(self) -> list[str]:
         """Extract trigger keywords from this skill.
@@ -804,7 +801,7 @@ class Skill(BaseModel):
         """
         if isinstance(self.trigger, KeywordTrigger):
             return self.trigger.keywords
-        elif isinstance(self.trigger, TaskTrigger):
+        if isinstance(self.trigger, TaskTrigger):
             return self.trigger.triggers
         return []
 

--- a/openhands-sdk/openhands/sdk/skills/trigger.py
+++ b/openhands-sdk/openhands/sdk/skills/trigger.py
@@ -13,8 +13,6 @@ from pydantic import BaseModel
 class BaseTrigger(BaseModel, ABC):
     """Base class for all trigger types."""
 
-    pass
-
 
 class KeywordTrigger(BaseTrigger):
     """Trigger for keyword-based skills.

--- a/openhands-sdk/openhands/sdk/testing/test_llm.py
+++ b/openhands-sdk/openhands/sdk/testing/test_llm.py
@@ -56,8 +56,6 @@ __all__ = ["TestLLM", "TestLLMExhaustedError"]
 class TestLLMExhaustedError(Exception):
     """Raised when TestLLM has no more scripted responses."""
 
-    pass
-
 
 class TestLLM(LLM):
     """A mock LLM for testing that returns scripted responses.

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -162,7 +162,6 @@ class ToolExecutor[ActionT, ObservationT](ABC):
         this method to perform cleanup (e.g., closing connections,
         terminating processes, etc.).
         """
-        pass
 
     def interrupt(self) -> None:
         """Interrupt any in-flight execution (e.g., send Ctrl+C).
@@ -174,7 +173,6 @@ class ToolExecutor[ActionT, ObservationT](ABC):
         The default is a no-op; tools with long-running operations
         (terminal subprocesses, browser navigations, …) should override.
         """
-        pass
 
 
 class ExecutableTool(Protocol):
@@ -377,17 +375,16 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
             if isinstance(result, self.observation_type):
                 return result
             return self.observation_type.model_validate(result)
-        else:
-            # When no output schema is defined, wrap the result in Observation
-            if isinstance(result, Observation):
-                return result
-            elif isinstance(result, BaseModel):
-                return Observation.model_validate(result.model_dump())
-            elif isinstance(result, dict):
-                return Observation.model_validate(result)
-            raise TypeError(
-                "Output must be dict or BaseModel when no output schema is defined"
-            )
+        # When no output schema is defined, wrap the result in Observation
+        if isinstance(result, Observation):
+            return result
+        if isinstance(result, BaseModel):
+            return Observation.model_validate(result.model_dump())
+        if isinstance(result, dict):
+            return Observation.model_validate(result)
+        raise TypeError(
+            "Output must be dict or BaseModel when no output schema is defined"
+        )
 
     async def acall(
         self, action: ActionT, conversation: "LocalConversation | None" = None

--- a/openhands-sdk/openhands/sdk/utils/async_executor.py
+++ b/openhands-sdk/openhands/sdk/utils/async_executor.py
@@ -94,12 +94,11 @@ class AsyncExecutor:
                     return await coro
 
             return portal.call(_with_timeout)
-        else:
 
-            async def _execute():
-                return await coro
+        async def _execute():
+            return await coro
 
-            return portal.call(_execute)
+        return portal.call(_execute)
 
     def close(self):
         with self._lock:

--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -241,7 +241,7 @@ class DiscriminatedUnionMixin(OpenHandsModel):
                 raise ValueError(
                     f"No kinds defined for {cls.__module__}.{cls.__name__}"
                 )
-            elif len(subclasses) == 1:
+            if len(subclasses) == 1:
                 # If there is ony 1 possible implementation, then we do not need
                 # to state the kind explicitly - it can only be this!
                 kind = next(iter(subclasses))

--- a/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
+++ b/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
@@ -122,8 +122,7 @@ def validate_secret(v: str | SecretStr | None, info) -> SecretStr | None:
     # Always return SecretStr
     if isinstance(v, SecretStr):
         return v
-    else:
-        return SecretStr(secret_value)
+    return SecretStr(secret_value)
 
 
 @overload

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -66,7 +66,6 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
             exc_val: Exception value if an exception occurred
             exc_tb: Exception traceback if an exception occurred
         """
-        pass
 
     @abstractmethod
     def execute_command(

--- a/openhands-tools/openhands/tools/apply_patch/core.py
+++ b/openhands-tools/openhands/tools/apply_patch/core.py
@@ -201,8 +201,7 @@ class Parser(BaseModel):
             if new_index == -1:
                 if eof:
                     raise DiffError(f"Invalid EOF Context {index}:\n{next_chunk_text}")
-                else:
-                    raise DiffError(f"Invalid Context {index}:\n{next_chunk_text}")
+                raise DiffError(f"Invalid Context {index}:\n{next_chunk_text}")
             self.fuzz += fuzz
             for ch in chunks:
                 ch.orig_index += new_index
@@ -286,7 +285,7 @@ def peek_next_section(
             break
         if s == "***":
             break
-        elif s.startswith("***"):
+        if s.startswith("***"):
             raise DiffError(f"Invalid Line: {s}")
         index += 1
         last_mode = mode

--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -143,8 +143,6 @@ class BrowserAction(Action):
     enabling proper type hierarchy and eliminating the need for union types.
     """
 
-    pass
-
 
 # ============================================
 # `go_to_url`
@@ -432,8 +430,6 @@ class BrowserScrollTool(ToolDefinition[BrowserScrollAction, BrowserObservation])
 class BrowserGoBackAction(BrowserAction):
     """Schema for going back in browser history."""
 
-    pass
-
 
 BROWSER_GO_BACK_DESCRIPTION = """Go back to the previous page in browser history.
 
@@ -469,8 +465,6 @@ class BrowserGoBackTool(ToolDefinition[BrowserGoBackAction, BrowserObservation])
 # ============================================
 class BrowserListTabsAction(BrowserAction):
     """Schema for listing browser tabs."""
-
-    pass
 
 
 BROWSER_LIST_TABS_DESCRIPTION = """List all open browser tabs.
@@ -593,8 +587,6 @@ class BrowserCloseTabTool(ToolDefinition[BrowserCloseTabAction, BrowserObservati
 class BrowserGetStorageAction(BrowserAction):
     """Schema for getting browser storage (cookies, local storage, session storage)."""
 
-    pass
-
 
 BROWSER_GET_STORAGE_DESCRIPTION = """Get browser storage data including cookies,
 local storage, and session storage.
@@ -682,8 +674,6 @@ class BrowserSetStorageTool(
 class BrowserStartRecordingAction(BrowserAction):
     """Schema for starting browser session recording."""
 
-    pass
-
 
 BROWSER_START_RECORDING_DESCRIPTION = f"""Start recording the browser session.
 
@@ -731,8 +721,6 @@ class BrowserStartRecordingTool(
 # ============================================
 class BrowserStopRecordingAction(BrowserAction):
     """Schema for stopping browser session recording."""
-
-    pass
 
 
 BROWSER_STOP_RECORDING_DESCRIPTION = f"""Stop recording the browser session.

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -245,9 +245,8 @@ def _install_chromium() -> bool:
         if result.returncode == 0:
             logger.info("Chromium installation completed successfully")
             return True
-        else:
-            logger.error(f"Chromium installation failed: {result.stderr}")
-            return False
+        logger.error(f"Chromium installation failed: {result.stderr}")
+        return False
     except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
         logger.error(f"Error during Chromium installation: {e}")
         return False

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -73,17 +73,16 @@ class DelegateExecutor(ToolExecutor):
         # Route to appropriate handler based on command
         if action.command == "spawn":
             return self._spawn_agents(action)
-        elif action.command == "delegate":
+        if action.command == "delegate":
             return self._delegate_tasks(action)
-        else:
-            return DelegateObservation.from_text(
-                text=(
-                    f"Unsupported command: {action.command}. "
-                    "Available commands: spawn, delegate"
-                ),
-                command=action.command,
-                is_error=True,
-            )
+        return DelegateObservation.from_text(
+            text=(
+                f"Unsupported command: {action.command}. "
+                "Available commands: spawn, delegate"
+            ),
+            command=action.command,
+            is_error=True,
+        )
 
     @staticmethod
     def _format_agent_label(agent_id: str, agent_type: str) -> str:

--- a/openhands-tools/openhands/tools/delegate/visualizer.py
+++ b/openhands-tools/openhands/tools/delegate/visualizer.py
@@ -155,7 +155,7 @@ class DelegationVisualizer(DefaultConversationVisualizer):
                     title=title,
                     title_color=_SYSTEM_COLOR,
                 )
-            elif isinstance(event, ActionEvent):
+            if isinstance(event, ActionEvent):
                 # Check if action is None (non-executable)
                 if event.action is None:
                     title = f"{agent_name} Agent Action (Not Executed)"
@@ -171,13 +171,13 @@ class DelegationVisualizer(DefaultConversationVisualizer):
                         event, force_totals=not self._claim_batch_primary(event)
                     ),
                 )
-            else:  # ObservationEvent
-                title = f"{agent_name} Agent Observation"
-                return build_event_block(
-                    content=content,
-                    title=title,
-                    title_color=_OBSERVATION_COLOR,
-                )
+            # ObservationEvent
+            title = f"{agent_name} Agent Observation"
+            return build_event_block(
+                content=content,
+                title=title,
+                title_color=_OBSERVATION_COLOR,
+            )
 
         # For all other event types, use the parent implementation
         return super()._create_event_block(event)

--- a/openhands-tools/openhands/tools/file_editor/editor.py
+++ b/openhands-tools/openhands/tools/file_editor/editor.py
@@ -119,7 +119,7 @@ class FileEditor:
         self.validate_path(command, _path)
         if command == "view":
             return self.view(_path, view_range)
-        elif command == "create":
+        if command == "create":
             if file_text is None:
                 raise EditorToolParameterMissingError(command, "file_text")
             self.write_file(_path, file_text)
@@ -131,7 +131,7 @@ class FileEditor:
                 new_content=file_text,
                 prev_exist=False,
             )
-        elif command == "str_replace":
+        if command == "str_replace":
             if old_str is None:
                 raise EditorToolParameterMissingError(command, "old_str")
             if new_str is None:
@@ -144,13 +144,13 @@ class FileEditor:
                     "different.",
                 )
             return self.str_replace(_path, old_str, new_str)
-        elif command == "insert":
+        if command == "insert":
             if insert_line is None:
                 raise EditorToolParameterMissingError(command, "insert_line")
             if new_str is None:
                 raise EditorToolParameterMissingError(command, "new_str")
             return self.insert(_path, insert_line, new_str)
-        elif command == "undo_edit":
+        if command == "undo_edit":
             return self.undo_edit(_path)
 
         raise ToolError(
@@ -763,14 +763,13 @@ class FileEditor:
                         if i >= start_line:
                             lines.append(line)
                 return "".join(lines)
-            elif start_line is not None or end_line is not None:
+            if start_line is not None or end_line is not None:
                 raise ValueError(
                     "Both start_line and end_line must be provided together"
                 )
-            else:
-                # Use line-by-line reading to avoid loading entire file into memory
-                with open(path, encoding=encoding) as f:
-                    return "".join(f)
+            # Use line-by-line reading to avoid loading entire file into memory
+            with open(path, encoding=encoding) as f:
+                return "".join(f)
         except Exception as e:
             raise ToolError(f"Ran into {e} while trying to read {path}") from None
 

--- a/openhands-tools/openhands/tools/task_tracker/definition.py
+++ b/openhands-tools/openhands/tools/task_tracker/definition.py
@@ -184,7 +184,7 @@ class TaskTrackerExecutor(ToolExecutor[TaskTrackerAction, TaskTrackerObservation
                 command=action.command,
                 task_list=self._task_list,
             )
-        elif action.command == "view":
+        if action.command == "view":
             # Return the current task list
             if not self._task_list:
                 return TaskTrackerObservation.from_text(
@@ -198,16 +198,15 @@ class TaskTrackerExecutor(ToolExecutor[TaskTrackerAction, TaskTrackerObservation
                 command=action.command,
                 task_list=self._task_list,
             )
-        else:
-            return TaskTrackerObservation.from_text(
-                text=(
-                    f"Unknown command: {action.command}. "
-                    'Supported commands are "view" and "plan".'
-                ),
-                is_error=True,
-                command=action.command,
-                task_list=[],
-            )
+        return TaskTrackerObservation.from_text(
+            text=(
+                f"Unknown command: {action.command}. "
+                'Supported commands are "view" and "plan".'
+            ),
+            is_error=True,
+            command=action.command,
+            task_list=[],
+        )
 
     def _format_task_list(self, task_list: list[TaskItem]) -> str:
         """Format the task list for display."""
@@ -263,7 +262,6 @@ class TaskTrackerExecutor(ToolExecutor[TaskTrackerAction, TaskTrackerObservation
                 json.dump([task.model_dump() for task in self._task_list], f, indent=2)
         except OSError as e:
             logger.warning(f"Failed to save tasks to {tasks_file}: {e}")
-            pass
 
 
 # Tool definition with detailed description

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -575,8 +575,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
 
         if self._pool is not None:
             return self._execute_pooled(action, conversation)
-        else:
-            return self._execute_single_session(action, conversation)
+        return self._execute_single_session(action, conversation)
 
     def interrupt(self) -> None:
         """Send Ctrl+C to all active terminal sessions.

--- a/openhands-tools/openhands/tools/terminal/terminal/interface.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/interface.py
@@ -47,9 +47,7 @@ def parse_ctrl_key(text: str) -> str | None:
     key: str | None = None
     if upper.startswith("C-"):
         key = upper[2:]
-    elif upper.startswith("CTRL-"):
-        key = upper[5:]
-    elif upper.startswith("CTRL+"):
+    elif upper.startswith("CTRL-") or upper.startswith("CTRL+"):
         key = upper[5:]
     if key and len(key) == 1 and "A" <= key <= "Z":
         return f"C-{key.lower()}"

--- a/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
@@ -383,10 +383,9 @@ class TerminalSession(TerminalSessionBase):
             if get_content_before_last_match:
                 # The command output is the content before the last PS1 prompt
                 return terminal_content[: ps1_matches[0].start()]
-            else:
-                # The command output is the content after the last PS1 prompt
-                return terminal_content[ps1_matches[0].end() + 1 :]
-        elif len(ps1_matches) == 0:
+            # The command output is the content after the last PS1 prompt
+            return terminal_content[ps1_matches[0].end() + 1 :]
+        if len(ps1_matches) == 0:
             return terminal_content
         combined_output = ""
         for i in range(len(ps1_matches) - 1):

--- a/openhands-tools/openhands/tools/tom_consult/definition.py
+++ b/openhands-tools/openhands/tools/tom_consult/definition.py
@@ -55,8 +55,6 @@ class SleeptimeComputeAction(Action):
     conversation history to build and update the user model.
     """
 
-    pass
-
 
 # ==================== Observation Schemas ====================
 

--- a/openhands-tools/openhands/tools/tom_consult/executor.py
+++ b/openhands-tools/openhands/tools/tom_consult/executor.py
@@ -99,8 +99,7 @@ class TomConsultExecutor(
         """
         if isinstance(action, SleeptimeComputeAction):
             return self._sleeptime_compute(conversation)
-        else:
-            return self._consult_tom(action, conversation)
+        return self._consult_tom(action, conversation)
 
     def _format_events(
         self,
@@ -141,23 +140,20 @@ class TomConsultExecutor(
         if conversation is not None:
             # Skip system message (first message)
             return conversation.state.agent.llm.format_messages_for_llm(messages)[1:]
-        else:
-            # If no conversation, format messages directly from events
-            from openhands.sdk.llm import TextContent
+        # If no conversation, format messages directly from events
+        from openhands.sdk.llm import TextContent
 
-            formatted_messages = []
-            for msg in messages:
-                if msg.role != "system":  # Skip system messages
-                    text_contents = [
-                        {"text": c.text}
-                        for c in msg.content
-                        if isinstance(c, TextContent)
-                    ]
-                    if text_contents:
-                        formatted_messages.append(
-                            {"role": msg.role, "content": text_contents}
-                        )
-            return formatted_messages
+        formatted_messages = []
+        for msg in messages:
+            if msg.role != "system":  # Skip system messages
+                text_contents = [
+                    {"text": c.text} for c in msg.content if isinstance(c, TextContent)
+                ]
+                if text_contents:
+                    formatted_messages.append(
+                        {"role": msg.role, "content": text_contents}
+                    )
+        return formatted_messages
 
     def _consult_tom(
         self, action: ConsultTomAction, conversation: "BaseConversation | None" = None
@@ -234,11 +230,10 @@ class TomConsultExecutor(
                     confidence=getattr(result, "confidence", None),
                     reasoning=getattr(result, "reasoning", None),
                 )
-            else:
-                logger.warning("⚠️ Tom: No consultation result received")
-                return ConsultTomObservation(
-                    suggestions="[CRITICAL] Tom agent cannot provide consultation for this user message. Do not consult ToM agent again for this message and use other actions instead."  # noqa: E501
-                )
+            logger.warning("⚠️ Tom: No consultation result received")
+            return ConsultTomObservation(
+                suggestions="[CRITICAL] Tom agent cannot provide consultation for this user message. Do not consult ToM agent again for this message and use other actions instead."  # noqa: E501
+            )
 
         except Exception as e:
             logger.error(f"❌ Tom: Error in consultation: {e}")

--- a/openhands-tools/openhands/tools/utils/timeout.py
+++ b/openhands-tools/openhands/tools/utils/timeout.py
@@ -4,8 +4,6 @@ from func_timeout import FunctionTimedOut, func_timeout
 class TimeoutError(Exception):
     """Generic SDK Tool TimeoutError (wraps func-timeout)."""
 
-    pass
-
 
 def run_with_timeout(func, timeout, *args, **kwargs):
     try:

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -399,21 +399,20 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
                 self._check_agent_server_health(agent_server_url)
             return
 
-        elif status == "STARTING":
+        if status == "STARTING":
             raise RuntimeError("Sandbox still starting")
 
-        elif status in ("ERROR", "MISSING"):
+        if status in ("ERROR", "MISSING"):
             raise ValueError(f"Sandbox failed with status: {status}")
 
-        elif status == "PAUSED":
+        if status == "PAUSED":
             # Try to resume the sandbox
             logger.info("Sandbox is paused, attempting to resume...")
             self._resume_sandbox()
             raise RuntimeError("Sandbox resuming, waiting for RUNNING status")
 
-        else:
-            logger.warning(f"Unknown sandbox status: {status}")
-            raise RuntimeError(f"Unknown sandbox status: {status}")
+        logger.warning(f"Unknown sandbox status: {status}")
+        raise RuntimeError(f"Unknown sandbox status: {status}")
 
     def _check_agent_server_health(self, agent_server_url: str) -> None:
         """Check if the agent server is healthy."""

--- a/openhands-workspace/openhands/workspace/docker/dev_workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/dev_workspace.py
@@ -116,8 +116,7 @@ class DockerDevWorkspace(DockerWorkspace):
                 target=self.target,
                 platform=self.platform,
             )
-        elif self.server_image:
+        if self.server_image:
             # Use pre-built image
             return self.server_image
-        else:
-            raise ValueError("Either base_image or server_image must be set")
+        raise ValueError("Either base_image or server_image must be set")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,23 @@ select = [
 # - B008: function-call-in-default-argument
 # - B039: mutable-contextvar-default
 # - RUF012: mutable-class-default
-extend-select = ["B006", "B008", "B039", "RUF012"]
+extend-select = [
+    "B006",
+    "B008",
+    "B039",
+    "RUF012",
+    # Line-reducing rules
+    "RET501",  # unnecessary-return-none
+    "RET502",  # implicit-return-value
+    "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
+    "RET507",  # superfluous-else-continue
+    "RET508",  # superfluous-else-break
+    "SIM114",  # if-with-same-arms
+    "PIE790",  # unnecessary-placeholder
+    "PIE808",  # unnecessary-range-start
+    "C420",  # unnecessary-dict-comprehension-for-iterable
+]
 
 [tool.ruff.lint.per-file-ignores]
 # Test files often have unused arguments (fixtures, mocks, interface implementations)

--- a/scripts/check_tool_registration.py
+++ b/scripts/check_tool_registration.py
@@ -57,9 +57,9 @@ class ToolChecker(ast.NodeVisitor):
         """Extract name from an AST node (handles Name, Attribute, Subscript)."""
         if isinstance(node, ast.Name):
             return node.id
-        elif isinstance(node, ast.Attribute):
+        if isinstance(node, ast.Attribute):
             return f"{self._get_name(node.value)}.{node.attr}"
-        elif isinstance(node, ast.Subscript):
+        if isinstance(node, ast.Subscript):
             return self._get_name(node.value)
         return ""
 

--- a/tests/agent_server/test_desktop_service.py
+++ b/tests/agent_server/test_desktop_service.py
@@ -294,7 +294,7 @@ class TestDesktopService:
             wait_calls += 1
             if wait_calls == 1:
                 raise TimeoutError()
-            return None
+            return
 
         mock_proc.wait = mock_wait
         service._proc = mock_proc

--- a/tests/agent_server/test_event_router_websocket.py
+++ b/tests/agent_server/test_event_router_websocket.py
@@ -196,7 +196,7 @@ async def test_websocket_general_exception_continues_loop(
         call_count += 1
         if call_count == 1:
             raise ValueError("Some error")
-        elif call_count == 2:
+        if call_count == 2:
             raise WebSocketDisconnect()
 
     mock_websocket.receive_json.side_effect = side_effect
@@ -236,8 +236,7 @@ async def test_websocket_successful_message_processing(
         call_count += 1
         if call_count == 1:
             return message_data
-        else:
-            raise WebSocketDisconnect()
+        raise WebSocketDisconnect()
 
     mock_websocket.receive_json.side_effect = side_effect
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -797,7 +797,7 @@ class TestEventServiceSendMessage:
 
     async def _mock_executor(self, *args):
         """Helper to create a mock coroutine for run_in_executor."""
-        return None
+        return
 
     @pytest.mark.asyncio
     async def test_send_message_inactive_service(self, event_service):

--- a/tests/agent_server/test_pub_sub.py
+++ b/tests/agent_server/test_pub_sub.py
@@ -76,11 +76,10 @@ class PubSubForTesting:
             del self._subscribers[subscriber_id]
             self._logger.debug(f"Unsubscribed subscriber with ID: {subscriber_id}")
             return True
-        else:
-            self._logger.warning(
-                f"Attempted to unsubscribe unknown subscriber ID: {subscriber_id}"
-            )
-            return False
+        self._logger.warning(
+            f"Attempted to unsubscribe unknown subscriber ID: {subscriber_id}"
+        )
+        return False
 
     async def __call__(self, event) -> None:
         """Invoke all registered callbacks with the given event."""

--- a/tests/cross/test_agent_secrets_integration.py
+++ b/tests/cross/test_agent_secrets_integration.py
@@ -377,9 +377,8 @@ def test_masking_persists(
             self.counter += 1
             if self.counter == 1:
                 return f"changing-secret-{self.counter}"
-            else:
-                self.raised_on_second = True
-                raise Exception("Blip occured, failed to refresh token")
+            self.raised_on_second = True
+            raise Exception("Blip occured, failed to refresh token")
 
     dynamic_secret = MyChangingFailingDynamicSecretSource()
     conversation.update_secrets(

--- a/tests/cross/test_hello_world.py
+++ b/tests/cross/test_hello_world.py
@@ -331,9 +331,8 @@ class TestHelloWorld:
                 }
                 logged_completions.append(logged_data)
                 return response
-            else:
-                # No more responses available
-                raise StopIteration("No more mock responses available")
+            # No more responses available
+            raise StopIteration("No more mock responses available")
 
         mock_completion.side_effect = capture_completion_call
 

--- a/tests/integration/api_compliance/base.py
+++ b/tests/integration/api_compliance/base.py
@@ -70,13 +70,11 @@ class BaseAPIComplianceTest(ABC):
     @abstractmethod
     def pattern_name(self) -> str:
         """Unique identifier for the malformed pattern being tested."""
-        pass
 
     @property
     @abstractmethod
     def pattern_description(self) -> str:
         """Human-readable description of the malformed pattern."""
-        pass
 
     @abstractmethod
     def build_malformed_messages(self) -> list[Message]:
@@ -85,7 +83,6 @@ class BaseAPIComplianceTest(ABC):
         Returns:
             List of Message objects representing the malformed conversation.
         """
-        pass
 
     def needs_tools(self) -> bool:
         """Whether this test needs tool definitions sent to the API.
@@ -190,23 +187,22 @@ class BaseAPIComplianceTest(ABC):
         model_lower = model.lower()
         if "claude" in model_lower or "anthropic" in model_lower:
             return "anthropic"
-        elif "gpt" in model_lower or "openai" in model_lower:
+        if "gpt" in model_lower or "openai" in model_lower:
             return "openai"
-        elif "gemini" in model_lower or "google" in model_lower:
+        if "gemini" in model_lower or "google" in model_lower:
             return "google"
-        elif "deepseek" in model_lower:
+        if "deepseek" in model_lower:
             return "deepseek"
-        elif "kimi" in model_lower or "moonshot" in model_lower:
+        if "kimi" in model_lower or "moonshot" in model_lower:
             return "moonshot"
-        elif "qwen" in model_lower or "dashscope" in model_lower:
+        if "qwen" in model_lower or "dashscope" in model_lower:
             return "alibaba"
-        elif "glm" in model_lower:
+        if "glm" in model_lower:
             return "zhipu"
-        elif "minimax" in model_lower:
+        if "minimax" in model_lower:
             return "minimax"
-        else:
-            # Return the first part of the model name
-            return model.split("/")[0] if "/" in model else "unknown"
+        # Return the first part of the model name
+        return model.split("/")[0] if "/" in model else "unknown"
 
 
 def create_test_llm(llm_config: dict[str, Any]) -> LLM:

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -74,8 +74,6 @@ class SkipTest(Exception):
     that may not be available in all LLMs.
     """
 
-    pass
-
 
 class TestResult(BaseModel):
     """Result of an integration test."""
@@ -294,7 +292,6 @@ class BaseIntegrationTest(ABC):
         This method should create any files, directories, or other
         resources needed for the test.
         """
-        pass
 
     def skip_if_model_matches(self, pattern: str | list[str], reason: str) -> None:
         """Skip test if the model name matches the given pattern(s).
@@ -343,7 +340,6 @@ class BaseIntegrationTest(ABC):
         Returns:
             TestResult: The result of the verification
         """
-        pass
 
     def add_judge_usage(
         self, prompt_tokens: int, completion_tokens: int, cost: float

--- a/tests/integration/early_stopper.py
+++ b/tests/integration/early_stopper.py
@@ -43,7 +43,6 @@ class EarlyStopperBase(ABC):
         Returns:
             EarlyStopResult indicating whether to stop and why
         """
-        pass
 
 
 class FileEditPruner(EarlyStopperBase):

--- a/tests/integration/tests/b01_no_premature_implementation.py
+++ b/tests/integration/tests/b01_no_premature_implementation.py
@@ -126,12 +126,11 @@ implementing?
                     f"(confidence={judgment.confidence:.2f})"
                 ),
             )
-        else:
-            return TestResult(
-                success=False,
-                reason=(
-                    "Agent behavior was inappropriate according to LLM judge. "
-                    f"Judge reasoning: {judgment.reasoning} "
-                    f"(confidence={judgment.confidence:.2f})"
-                ),
-            )
+        return TestResult(
+            success=False,
+            reason=(
+                "Agent behavior was inappropriate according to LLM judge. "
+                f"Judge reasoning: {judgment.reasoning} "
+                f"(confidence={judgment.confidence:.2f})"
+            ),
+        )

--- a/tests/integration/tests/t01_fix_simple_typo.py
+++ b/tests/integration/tests/t01_fix_simple_typo.py
@@ -56,8 +56,7 @@ class TypoFixTest(BaseIntegrationTest):
         )
         if are_typos_fixed:
             return TestResult(success=True, reason="Successfully fixed all typos")
-        else:
-            return TestResult(
-                success=False,
-                reason=f"Typos were not fully corrected:\n{corrected_content}",
-            )
+        return TestResult(
+            success=False,
+            reason=f"Typos were not fully corrected:\n{corrected_content}",
+        )

--- a/tests/integration/tests/t05_simple_browsing.py
+++ b/tests/integration/tests/t05_simple_browsing.py
@@ -162,14 +162,12 @@ class SimpleBrowsingTest(BaseIntegrationTest):
                     f"Response contained the expected content about OpenHands."
                 ),
             )
-        else:
-            return TestResult(
-                success=False,
-                reason=(
-                    "Agent did not find the answer. "
-                    f"Response: {agent_response[:200]}..."
-                ),
-            )
+        return TestResult(
+            success=False,
+            reason=(
+                f"Agent did not find the answer. Response: {agent_response[:200]}..."
+            ),
+        )
 
     def teardown(self):
         """Turn down the web server and close the conversation."""

--- a/tests/integration/tests/t06_github_pr_browsing.py
+++ b/tests/integration/tests/t06_github_pr_browsing.py
@@ -53,12 +53,11 @@ class GitHubPRBrowsingTest(BaseIntegrationTest):
                 success=True,
                 reason="Agent's final answer contains information about the PR content",
             )
-        else:
-            return TestResult(
-                success=False,
-                reason=(
-                    "Agent's final answer does not contain the expected information "
-                    "about the PR content. "
-                    f"Final answer preview: {agent_answer[:200]}..."
-                ),
-            )
+        return TestResult(
+            success=False,
+            reason=(
+                "Agent's final answer does not contain the expected information "
+                "about the PR content. "
+                f"Final answer preview: {agent_answer[:200]}..."
+            ),
+        )

--- a/tests/integration/tests/t08_image_file_viewing.py
+++ b/tests/integration/tests/t08_image_file_viewing.py
@@ -59,11 +59,10 @@ class ImageFileViewingTest(BaseIntegrationTest):
                 success=True,
                 reason="Agent successfully identified yellow color in the icon",
             )
-        else:
-            return TestResult(
-                success=False,
-                reason=(
-                    f"Agent did not identify yellow color in the icon. "
-                    f"Response: {final_response[:500]}"
-                ),
-            )
+        return TestResult(
+            success=False,
+            reason=(
+                f"Agent did not identify yellow color in the icon. "
+                f"Response: {final_response[:500]}"
+            ),
+        )

--- a/tests/integration/utils/consolidate_json_results.py
+++ b/tests/integration/utils/consolidate_json_results.py
@@ -123,10 +123,9 @@ def find_artifact_url(run_suffix: str, artifacts_dir: str) -> str | None:
                 # Create a URL that points to the GitHub Actions run page
                 # Users can download the specific artifact from there
                 return f"{server_url}/{repository}/actions/runs/{run_id}"
-            else:
-                # Fallback: if environment variables not available, return None
-                # This will prevent showing broken links
-                return None
+            # Fallback: if environment variables not available, return None
+            # This will prevent showing broken links
+            return None
 
     return None
 

--- a/tests/integration/utils/format_costs.py
+++ b/tests/integration/utils/format_costs.py
@@ -18,12 +18,11 @@ def format_cost(value: float) -> str:
     if value == 0.0:
         # Handle zero as a special case
         return "$0.00"
-    elif abs(value) >= 0.01:
+    if abs(value) >= 0.01:
         # Normal rounding for typical amounts
         return f"${value:.2f}"
-    elif abs(value) >= 0.001:
+    if abs(value) >= 0.001:
         # Round small numbers to 2 significant figures
         return f"${value:.2g}"
-    else:
-        # Use scientific notation for very small numbers
-        return f"${value:.1e}"
+    # Use scientific notation for very small numbers
+    return f"${value:.1e}"

--- a/tests/integration/utils/llm_judge.py
+++ b/tests/integration/utils/llm_judge.py
@@ -35,8 +35,6 @@ class SubmitJudgmentAction(Action):
 class SubmitJudgmentObservation(Observation):
     """Observation returned after submitting judgment."""
 
-    pass
-
 
 class SubmitJudgmentExecutor(
     ToolExecutor[SubmitJudgmentAction, SubmitJudgmentObservation]
@@ -209,16 +207,15 @@ the information available, assuming the agent's behavior is correct afterward.
                 total_tokens=total_tokens,
                 cost=cost,
             )
-        else:
-            logger.error(
-                "LLM did not call the judgment tool. Response message: %s",
-                response.message.model_dump(),
-            )
-            return JudgmentResult(
-                approved=False,
-                reasoning="LLM failed to call the judgment tool",
-                confidence=0.0,
-            )
+        logger.error(
+            "LLM did not call the judgment tool. Response message: %s",
+            response.message.model_dump(),
+        )
+        return JudgmentResult(
+            approved=False,
+            reasoning="LLM failed to call the judgment tool",
+            confidence=0.0,
+        )
 
     except Exception as exc:
         logger.exception("Error during tool-based LLM judgment")

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2139,7 +2139,7 @@ class TestACPAgentAstep:
             # — proves we actually crossed the loop boundary.
             prompt_thread_id.append(threading.get_ident())
             mock_client.accumulated_text.append("answer")
-            return None
+            return
 
         _agent_conn(agent).prompt = _fake_prompt
         agent._session_id = "test-session"
@@ -2192,7 +2192,7 @@ class TestACPAgentAstep:
 
         async def _fake_prompt(session_id, prompt):  # noqa: ARG001
             mock_client.accumulated_text.append("answer")
-            return None
+            return
 
         _agent_conn(agent).prompt = _fake_prompt
 
@@ -2269,7 +2269,7 @@ class TestACPAgentAstep:
                 chunk.content = MagicMock(spec=TextContentBlock)
                 chunk.content.text = "tick"
                 await mock_client.session_update(session_id, chunk)
-            return None
+            return
 
         _agent_conn(agent).prompt = _fake_prompt
 
@@ -2486,7 +2486,7 @@ class TestACPAgentAstep:
                 # failed ACP tool-call events.
                 released = await asyncio.to_thread(prompt_released.wait, 10.0)
                 assert released
-                return None
+                return
 
             async def _fake_cancel(session_id):
                 assert session_id == "test-session"
@@ -2574,7 +2574,7 @@ class TestACPAgentAstep:
                         content=TextContentBlock(type="text", text="done"),
                     ),
                 )
-                return None
+                return
 
             async def _fake_cancel(session_id):
                 assert session_id == "test-session"
@@ -2706,7 +2706,7 @@ class TestACPAgentAstep:
                 caller_loop.call_soon_threadsafe(prompt_entered.set)
                 released = await asyncio.to_thread(prompt_released.wait, 10.0)
                 assert released
-                return None
+                return
 
             async def _fake_cancel(session_id):
                 assert session_id == "test-session"
@@ -2767,7 +2767,7 @@ class TestACPAgentAstep:
                 caller_loop.call_soon_threadsafe(prompt_entered.set)
                 released = await asyncio.to_thread(prompt_released.wait, 10.0)
                 assert released
-                return None
+                return
 
             async def _raise_during_cancel_send(self):  # noqa: ARG001
                 raise asyncio.CancelledError
@@ -2912,7 +2912,7 @@ class TestACPAgentAstep:
                 caller_loop.call_soon_threadsafe(prompt_entered.set)
                 released = await asyncio.to_thread(prompt_released.wait, 10.0)
                 assert released
-                return None
+                return
 
             async def _fake_cancel(session_id):
                 assert session_id == "test-session"
@@ -2980,7 +2980,7 @@ class TestACPAgentAstep:
 
         async def _fake_prompt(session_id, prompt):  # noqa: ARG001
             mock_client.accumulated_text.append("done")
-            return None
+            return
 
         _agent_conn(agent).prompt = _fake_prompt
         agent._session_id = "test-session"

--- a/tests/sdk/agent/test_message_while_finishing.py
+++ b/tests/sdk/agent/test_message_while_finishing.py
@@ -204,7 +204,7 @@ class TestMessageWhileFinishing:
                 object="chat.completion",
             )
 
-        elif self.step_count == 2:
+        if self.step_count == 2:
             # Step 2: Final step - sleep AND finish (multiple tool calls)
             # Record timestamp BEFORE setting flag to avoid race with butterfly thread
             self.timestamps.append(("final_step_start", time.time()))
@@ -261,28 +261,27 @@ class TestMessageWhileFinishing:
                 model="test-model",
                 object="chat.completion",
             )
-        else:
-            # Step 3: This happens because butterfly message reset FINISHED status
-            # This demonstrates the bug: messages sent during final step reset status
-            response_content = "I see the butterfly message"
-            if has_butterfly:
-                response_content += " with butterfly"
+        # Step 3: This happens because butterfly message reset FINISHED status
+        # This demonstrates the bug: messages sent during final step reset status
+        response_content = "I see the butterfly message"
+        if has_butterfly:
+            response_content += " with butterfly"
 
-            # Return a simple message response (no tool calls)
-            return ModelResponse(
-                id=f"response_step_{self.step_count}",
-                choices=[
-                    Choices(
-                        message=LiteLLMMessage(
-                            role="assistant",
-                            content=response_content,
-                        )
+        # Return a simple message response (no tool calls)
+        return ModelResponse(
+            id=f"response_step_{self.step_count}",
+            choices=[
+                Choices(
+                    message=LiteLLMMessage(
+                        role="assistant",
+                        content=response_content,
                     )
-                ],
-                created=0,
-                model="test-model",
-                object="chat.completion",
-            )
+                )
+            ],
+            created=0,
+            model="test-model",
+            object="chat.completion",
+        )
 
     def test_message_processing_fix_verification(self):
         """

--- a/tests/sdk/agent/test_nonexistent_tool_handling.py
+++ b/tests/sdk/agent/test_nonexistent_tool_handling.py
@@ -231,37 +231,36 @@ def test_conversation_continues_after_tool_error():
                 model="test-model",
                 object="chat.completion",
             )
-        else:
-            # Second call: respond with finish tool
-            return ModelResponse(
-                id="mock-response-2",
-                choices=[
-                    Choices(
-                        index=0,
-                        message=LiteLLMMessage(
-                            role="assistant",
-                            content=None,
-                            tool_calls=[
-                                ChatCompletionMessageToolCall(
-                                    id="finish-call-1",
-                                    type="function",
-                                    function=Function(
-                                        name="finish",
-                                        arguments=(
-                                            '{"message": "I see there '
-                                            'was an error. Task completed."}'
-                                        ),
+        # Second call: respond with finish tool
+        return ModelResponse(
+            id="mock-response-2",
+            choices=[
+                Choices(
+                    index=0,
+                    message=LiteLLMMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="finish-call-1",
+                                type="function",
+                                function=Function(
+                                    name="finish",
+                                    arguments=(
+                                        '{"message": "I see there '
+                                        'was an error. Task completed."}'
                                     ),
-                                )
-                            ],
-                        ),
-                        finish_reason="tool_calls",
-                    )
-                ],
-                created=0,
-                model="test-model",
-                object="chat.completion",
-            )
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            created=0,
+            model="test-model",
+            object="chat.completion",
+        )
 
     collected_events = []
 

--- a/tests/sdk/agent/test_reasoning_only_responses.py
+++ b/tests/sdk/agent/test_reasoning_only_responses.py
@@ -40,27 +40,26 @@ class ReasoningOnlyLLM(LLM):
                 ),
                 raw_response=MagicMock(spec=ModelResponse, id="r1"),
             )
-        else:
-            # Second call: return finish action
-            message = Message(role="assistant")
-            message.tool_calls = [
-                MessageToolCall(
-                    id="finish-call-1",
-                    name="finish",
-                    arguments='{"message": "Task completed"}',
-                    origin="completion",
-                )
-            ]
-            return LLMResponse(
-                message=message,
-                metrics=MetricsSnapshot(
-                    model_name="test",
-                    accumulated_cost=0.0,
-                    max_budget_per_task=0.0,
-                    accumulated_token_usage=TokenUsage(model="test"),
-                ),
-                raw_response=MagicMock(spec=ModelResponse, id="r2"),
+        # Second call: return finish action
+        message = Message(role="assistant")
+        message.tool_calls = [
+            MessageToolCall(
+                id="finish-call-1",
+                name="finish",
+                arguments='{"message": "Task completed"}',
+                origin="completion",
             )
+        ]
+        return LLMResponse(
+            message=message,
+            metrics=MetricsSnapshot(
+                model_name="test",
+                accumulated_cost=0.0,
+                max_budget_per_task=0.0,
+                accumulated_token_usage=TokenUsage(model="test"),
+            ),
+            raw_response=MagicMock(spec=ModelResponse, id="r2"),
+        )
 
 
 def test_agent_continues_after_reasoning_only_response():
@@ -163,27 +162,26 @@ class EmptyResponseLLM(LLM):
                 ),
                 raw_response=MagicMock(spec=ModelResponse, id="r1"),
             )
-        else:
-            # Second call: return finish action
-            message = Message(role="assistant")
-            message.tool_calls = [
-                MessageToolCall(
-                    id="finish-call-3",
-                    name="finish",
-                    arguments='{"message": "Done"}',
-                    origin="completion",
-                )
-            ]
-            return LLMResponse(
-                message=message,
-                metrics=MetricsSnapshot(
-                    model_name="test",
-                    accumulated_cost=0.0,
-                    max_budget_per_task=0.0,
-                    accumulated_token_usage=TokenUsage(model="test"),
-                ),
-                raw_response=MagicMock(spec=ModelResponse, id="r2"),
+        # Second call: return finish action
+        message = Message(role="assistant")
+        message.tool_calls = [
+            MessageToolCall(
+                id="finish-call-3",
+                name="finish",
+                arguments='{"message": "Done"}',
+                origin="completion",
             )
+        ]
+        return LLMResponse(
+            message=message,
+            metrics=MetricsSnapshot(
+                model_name="test",
+                accumulated_cost=0.0,
+                max_budget_per_task=0.0,
+                accumulated_token_usage=TokenUsage(model="test"),
+            ),
+            raw_response=MagicMock(spec=ModelResponse, id="r2"),
+        )
 
 
 def test_agent_handles_empty_response():

--- a/tests/sdk/agent/test_tool_execution_error_handling.py
+++ b/tests/sdk/agent/test_tool_execution_error_handling.py
@@ -189,37 +189,36 @@ def test_conversation_continues_after_tool_execution_error():
                 model="test-model",
                 object="chat.completion",
             )
-        else:
-            # Second call: respond with finish tool
-            return ModelResponse(
-                id="mock-response-2",
-                choices=[
-                    Choices(
-                        index=0,
-                        message=LiteLLMMessage(
-                            role="assistant",
-                            content=None,
-                            tool_calls=[
-                                ChatCompletionMessageToolCall(
-                                    id="finish-call-1",
-                                    type="function",
-                                    function=Function(
-                                        name="finish",
-                                        arguments=(
-                                            '{"message": "I see there '
-                                            'was an error. Task completed."}'
-                                        ),
+        # Second call: respond with finish tool
+        return ModelResponse(
+            id="mock-response-2",
+            choices=[
+                Choices(
+                    index=0,
+                    message=LiteLLMMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="finish-call-1",
+                                type="function",
+                                function=Function(
+                                    name="finish",
+                                    arguments=(
+                                        '{"message": "I see there '
+                                        'was an error. Task completed."}'
                                     ),
-                                )
-                            ],
-                        ),
-                        finish_reason="tool_calls",
-                    )
-                ],
-                created=0,
-                model="test-model",
-                object="chat.completion",
-            )
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            created=0,
+            model="test-model",
+            object="chat.completion",
+        )
 
     collected_events = []
 

--- a/tests/sdk/conversation/conftest.py
+++ b/tests/sdk/conversation/conftest.py
@@ -33,14 +33,13 @@ def create_mock_http_client(conversation_id: str | None = None):
     def mock_request(method, url, **kwargs):
         if method == "POST":
             return mock_post_response
-        elif method == "GET":
+        if method == "GET":
             return mock_get_response
-        else:
-            # Default response
-            response = Mock()
-            response.raise_for_status.return_value = None
-            response.json.return_value = {}
-            return response
+        # Default response
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {}
+        return response
 
     mock_client.request = Mock(side_effect=mock_request)
     mock_client.post = Mock(return_value=mock_post_response)

--- a/tests/sdk/conversation/local/test_rerun_actions.py
+++ b/tests/sdk/conversation/local/test_rerun_actions.py
@@ -409,8 +409,6 @@ class FailingAction(Action):
 class FailingObservation(Observation):
     """Observation from failing tool."""
 
-    pass
-
 
 class FailingExecutor(ToolExecutor[FailingAction, FailingObservation]):
     """Executor that always raises an exception."""

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -58,9 +58,9 @@ class TestRemoteConversation:
         def request_side_effect(method, url, **kwargs):
             if method == "POST" and url == "/api/conversations":
                 return mock_conv_response
-            elif method == "GET" and "/api/conversations/" in url and "/events" in url:
+            if method == "GET" and "/api/conversations/" in url and "/events" in url:
                 return mock_events_response
-            elif method == "GET" and url.startswith("/api/conversations/"):
+            if method == "GET" and url.startswith("/api/conversations/"):
                 # Return conversation info response with finished status
                 # (needed for run() polling to complete)
                 response = Mock()
@@ -70,32 +70,31 @@ class TestRemoteConversation:
                 conv_info["execution_status"] = "finished"
                 response.json.return_value = conv_info
                 return response
-            elif method == "POST" and "/events" in url:
+            if method == "POST" and "/events" in url:
                 # POST to events endpoint (send_message)
                 response = Mock()
                 response.status_code = 200
                 response.raise_for_status.return_value = None
                 response.json.return_value = {}
                 return response
-            elif method == "POST" and "/run" in url:
+            if method == "POST" and "/run" in url:
                 # POST to run endpoint
                 response = Mock()
                 response.raise_for_status.return_value = None
                 response.status_code = 200
                 response.json.return_value = {}
                 return response
-            elif method == "POST" or method == "PUT":
+            if method == "POST" or method == "PUT":
                 # Default success response for other POST/PUT requests
                 response = Mock()
                 response.status_code = 200
                 response.raise_for_status.return_value = None
                 response.json.return_value = {}
                 return response
-            else:
-                response = Mock()
-                response.status_code = 200
-                response.raise_for_status.return_value = None
-                return response
+            response = Mock()
+            response.status_code = 200
+            response.raise_for_status.return_value = None
+            return response
 
         mock_client_instance.request.side_effect = request_side_effect
         return mock_client_instance
@@ -528,11 +527,11 @@ class TestRemoteConversation:
                 response.status_code = 404
                 response.raise_for_status.side_effect = None
                 return response
-            elif method == "POST" and url == "/api/conversations":
+            if method == "POST" and url == "/api/conversations":
                 return mock_conv_response
-            elif method == "GET" and "/events/search" in url:
+            if method == "GET" and "/events/search" in url:
                 return mock_events_response
-            elif method == "GET" and url.startswith("/api/conversations/"):
+            if method == "GET" and url.startswith("/api/conversations/"):
                 response = Mock()
                 response.status_code = 200
                 response.raise_for_status.return_value = None
@@ -540,12 +539,11 @@ class TestRemoteConversation:
                 conv_info["execution_status"] = "finished"
                 response.json.return_value = conv_info
                 return response
-            else:
-                response = Mock()
-                response.status_code = 200
-                response.raise_for_status.return_value = None
-                response.json.return_value = {}
-                return response
+            response = Mock()
+            response.status_code = 200
+            response.raise_for_status.return_value = None
+            response.json.return_value = {}
+            return response
 
         mock_client_instance.request.side_effect = request_side_effect
 

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -65,7 +65,6 @@ class MockConversation(BaseConversation):
 
     def condense(self) -> None:
         """Mock implementation of condense method."""
-        pass
 
     def execute_tool(self, tool_name: str, action: Action) -> Observation:
         """Mock implementation of execute_tool method."""

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -106,8 +106,6 @@ class VisualizerCustomAction(Action):
 class VisualizerMockObservation(Observation):
     """Mock observation for testing."""
 
-    pass
-
 
 class VisualizerMockExecutor(ToolExecutor):
     """Mock executor for testing."""

--- a/tests/sdk/critic/test_critic.py
+++ b/tests/sdk/critic/test_critic.py
@@ -21,8 +21,6 @@ from openhands.sdk.tool.schema import Action
 class DummyAction(Action):
     """A simple dummy action for testing purposes."""
 
-    pass
-
 
 def test_critic_result_success_threshold():
     """Test that CriticResult determines success based on threshold."""

--- a/tests/sdk/event/test_event_serialization.py
+++ b/tests/sdk/event/test_event_serialization.py
@@ -39,8 +39,6 @@ class EventsSerializationMockAction(Action):
 class EventsSerializationMockObservation(Observation):
     """Mock observation for testing."""
 
-    pass
-
 
 def test_event_base_serialization() -> None:
     """Test basic Event serialization/deserialization."""

--- a/tests/sdk/event/test_system_prompt_event_visualize.py
+++ b/tests/sdk/event/test_system_prompt_event_visualize.py
@@ -17,13 +17,9 @@ if TYPE_CHECKING:
 class SimpleAction(Action):
     """Simple test action."""
 
-    pass
-
 
 class SimpleObservation(Observation):
     """Simple test observation."""
-
-    pass
 
 
 class SimpleExecutor(ToolExecutor):

--- a/tests/sdk/test_apply_agent_settings_diff.py
+++ b/tests/sdk/test_apply_agent_settings_diff.py
@@ -160,7 +160,7 @@ def test_apply_diff_on_llm_tagged_base_returns_openhands() -> None:
 
 
 def test_validate_never_returns_llm_subclass() -> None:
-    for version in range(0, AGENT_SETTINGS_SCHEMA_VERSION + 1):
+    for version in range(AGENT_SETTINGS_SCHEMA_VERSION + 1):
         result = validate_agent_settings(
             {"agent_kind": "llm", "schema_version": version, "llm": {"model": "m"}}
         )

--- a/tests/sdk/utils/test_discriminated_union.py
+++ b/tests/sdk/utils/test_discriminated_union.py
@@ -44,7 +44,7 @@ class Wolf(Canine):
     def _remove_genus(cls, data):
         # Remove the genus from input as it is generated
         if not isinstance(data, dict):
-            return
+            return None
         data = dict(data)
         data.pop("genus", None)
         return data
@@ -69,7 +69,7 @@ class AnimalPack(BaseModel):
     def _remove_alpha(cls, data):
         # Remove the genus from input as it is generated
         if not isinstance(data, dict):
-            return
+            return None
         data = dict(data)
         data.pop("alpha", None)
         return data

--- a/tests/tools/file_editor/test_basic_operations.py
+++ b/tests/tools/file_editor/test_basic_operations.py
@@ -307,7 +307,7 @@ def test_view_with_a_specific_range(editor):
         old_str="This is a test file.\nThis file is for testing purposes.",
         new_str="",
     )
-    for i in range(0, 200):
+    for i in range(200):
         _ = editor(
             command="insert",
             path=str(test_file),
@@ -860,7 +860,7 @@ def test_str_replace_and_insert_snippet_output_on_a_large_file(editor):
         old_str="This is a test file.\nThis file is for testing purposes.",
         new_str="",
     )
-    for i in range(0, 700):
+    for i in range(700):
         _ = editor(
             command="insert",
             path=str(test_file),

--- a/tests/tools/terminal/conftest.py
+++ b/tests/tools/terminal/conftest.py
@@ -38,10 +38,10 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     )
     for item in items:
         module_name = Path(str(item.fspath)).name
-        if module_name in _WINDOWS_UNSUPPORTED_BACKEND_TEST_MODULES:
-            item.add_marker(skip_backend)
-        elif module_name == "test_escape_filter.py" and item.name.startswith(
-            "test_session_"
+        if (
+            module_name in _WINDOWS_UNSUPPORTED_BACKEND_TEST_MODULES
+            or module_name == "test_escape_filter.py"
+            and item.name.startswith("test_session_")
         ):
             item.add_marker(skip_backend)
 

--- a/tests/tools/terminal/test_terminal_session.py
+++ b/tests/tools/terminal/test_terminal_session.py
@@ -500,12 +500,10 @@ def test_command_output_continuation(terminal_type):
                     "[The command completed with exit code 0.]" in obs.metadata.suffix
                 )
                 break
-            else:
-                assert (
-                    "[The command has no new output after 1 seconds."
-                    in obs.metadata.suffix
-                )
-                assert session.prev_status == TerminalCommandStatus.NO_CHANGE_TIMEOUT
+            assert (
+                "[The command has no new output after 1 seconds." in obs.metadata.suffix
+            )
+            assert session.prev_status == TerminalCommandStatus.NO_CHANGE_TIMEOUT
 
         # Verify we've seen all numbers
         assert numbers_seen == {1, 2, 3, 4, 5}, (


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Adding some Ruff rules to reduce verbosity of the code.

---

AGENT:

## Why

Issue #4224 lists, among its cleanups, applying ruff's line-reducing rules that are
not enabled yet — `RET5xx`, `SIM103/110/114/118`, `PIE790/808`, `C4xx` — and adding
them to `pyproject.toml` so the codebase does not regress. This PR implements that
mechanical portion.

## Summary

- Enable the line-reducing rules whose violations ruff resolves with **safe**
  autofixes, so the pre-commit gate `ruff check --fix --exit-non-zero-on-fix` stays
  green: `RET501/502/505/506/507/508`, `SIM114`, `PIE790`, `PIE808`, `C420`.
- Apply those safe autofixes across the repo — **97 files, net −120 lines**
  (462 insertions, 582 deletions). Purely mechanical; no behavior change.

## Issue Number

#4224

## How to Test

From the repo root, with the ruff version pinned in `uv.lock` (0.13.1):

```
uv sync
uv run ruff check .                                # passes with the new rules enabled
uv run ruff check --fix --exit-non-zero-on-fix .   # no-op, exit 0 (fixes already applied)
uv run ruff format --check .                       # formatting clean
uv run pyright                                     # 0 errors
uv run pytest tests/sdk tests/tools tests/workspace tests/cross -m "not stress"
```

Verified locally: `ruff check` / `ruff check --fix --exit-non-zero-on-fix` /
`ruff format --check` are all clean and idempotent, and `pyright` reports 0 errors
project-wide. The unit suites are being validated in CI (a local run was still in
progress at PR-open time). The diff is entirely ruff safe autofixes (removing
superfluous `else` after `return`/`raise`, dropping redundant `return None`/`pass`,
collapsing duplicate `if`/`elif` arms, dropping `range(0, ...)` starts), each of which
is a provably behavior-preserving rewrite.

## Video/Screenshots

N/A — lint-only change; command output above is the evidence.

## Type

- [x] Docs / chore

## Notes

- Ruff is pinned to **0.13.1** via `uv.lock`. Under that version the `RET505`–`RET508`
  fixes are classified **safe**, which is why the net (−120 lines / 97 files) is larger
  than the issue's −70 / 58-file estimate.
- Only rules that reach **zero** remaining violations under safe autofix are enabled,
  so CI's `--exit-non-zero-on-fix` stays green. The remaining rules from the issue only
  have `--unsafe-fixes` and would leave 126 violations if enabled naively:
  `RET503/504`, `SIM103/110/118`, `C401/408/413/416/417`. Enabling those (via
  `--unsafe-fixes` with manual review) is a sensible follow-up and is intentionally
  out of scope here to keep this change safe and minimal.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:70c2c64-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-70c2c64-python \
  ghcr.io/openhands/agent-server:70c2c64-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:70c2c64-golang-amd64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-golang-amd64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-golang-amd64
ghcr.io/openhands/agent-server:70c2c64-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:70c2c64-golang-arm64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-golang-arm64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-golang-arm64
ghcr.io/openhands/agent-server:70c2c64-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:70c2c64-java-amd64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-java-amd64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-java-amd64
ghcr.io/openhands/agent-server:70c2c64-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:70c2c64-java-arm64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-java-arm64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-java-arm64
ghcr.io/openhands/agent-server:70c2c64-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:70c2c64-python-amd64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-python-amd64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-python-amd64
ghcr.io/openhands/agent-server:70c2c64-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:70c2c64-python-arm64
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-python-arm64
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-python-arm64
ghcr.io/openhands/agent-server:70c2c64-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:70c2c64-golang
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-golang
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-golang
ghcr.io/openhands/agent-server:70c2c64-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:70c2c64-java
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-java
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-java
ghcr.io/openhands/agent-server:70c2c64-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:70c2c64-python
ghcr.io/openhands/agent-server:70c2c64d103a6834c4e9153d53c47dd67b28fda3-python
ghcr.io/openhands/agent-server:vasco-ruff-line-reducing-rules-4224-python
ghcr.io/openhands/agent-server:70c2c64-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `70c2c64-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `70c2c64-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->