### PR TITLE
Move duplicated LLM option blocks into common.py

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from openhands.sdk.llm.options.common import apply_defaults_if_absent
+from openhands.sdk.llm.options.common import (
+    apply_call_context,
+    apply_defaults_if_absent,
+    apply_extra_body,
+    apply_extra_headers,
+)
 from openhands.sdk.llm.utils.model_features import get_features
 
 
@@ -36,17 +41,7 @@ def select_chat_options(
         if "max_completion_tokens" in out:
             out["max_tokens"] = out.pop("max_completion_tokens")
 
-    # If user didn't set extra_headers, propagate from llm config
-    if llm.extra_headers is not None and "extra_headers" not in out:
-        out["extra_headers"] = dict(llm.extra_headers)
-
-    # Inject OpenRouter HTTP-Referer / X-Title via extra_headers so we don't
-    # have to mutate os.environ (which would leak across conversations in a
-    # multi-tenant server; see issue #3138). User-supplied headers win.
-    openrouter_headers = llm._openrouter_headers()
-    if openrouter_headers:
-        existing = out.get("extra_headers") or {}
-        out["extra_headers"] = {**openrouter_headers, **existing}
+    out = apply_extra_headers(out, llm)
 
     # Reasoning-model quirks
     supports_reasoning_effort = get_features(llm.model).supports_reasoning_effort
@@ -99,21 +94,7 @@ def select_chat_options(
     ):
         out["prompt_cache_retention"] = llm.prompt_cache_retention
 
-    # Pass through user-provided extra_body unchanged
-    if llm.litellm_extra_body:
-        out["extra_body"] = llm.litellm_extra_body
-
-    # Inject per-conversation state from call context (#3443).
-    # Prefer explicitly threaded context; fall back to PrivateAttr for
-    # callers that don't thread (e.g. condenser's dedicated LLM).
-    ctx = call_context or llm._call_context
-    if ctx.prompt_cache_key:
-        out["prompt_cache_key"] = ctx.prompt_cache_key
-    if ctx.session_id:
-        existing = out.get("extra_headers") or {}
-        out["extra_headers"] = {
-            **existing,
-            "x-litellm-session-id": ctx.session_id,
-        }
+    out = apply_extra_body(out, llm)
+    out = apply_call_context(out, llm, call_context)
 
     return out

--- a/openhands-sdk/openhands/sdk/llm/options/common.py
+++ b/openhands-sdk/openhands/sdk/llm/options/common.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.llm.llm import LLM, LLMCallContext
 
 
 def apply_defaults_if_absent(
@@ -16,4 +20,66 @@ def apply_defaults_if_absent(
     for key, value in defaults.items():
         if key not in out and value is not None:
             out[key] = value
+    return out
+
+
+def apply_extra_headers(user_kwargs: dict[str, Any], llm: LLM) -> dict[str, Any]:
+    """Return a new dict with the LLM's extra headers applied.
+
+    Propagates ``llm.extra_headers`` when the caller did not set its own, then
+    merges the OpenRouter attribution headers. These go through ``extra_headers``
+    rather than ``os.environ`` so they don't leak across conversations in a
+    multi-tenant server (see issue #3138). User-supplied headers win.
+
+    - Pure and deterministic; does not mutate inputs
+    """
+    out = dict(user_kwargs)
+
+    if llm.extra_headers is not None and "extra_headers" not in out:
+        out["extra_headers"] = dict(llm.extra_headers)
+
+    openrouter_headers = llm._openrouter_headers()
+    if openrouter_headers:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {**openrouter_headers, **existing}
+
+    return out
+
+
+def apply_extra_body(user_kwargs: dict[str, Any], llm: LLM) -> dict[str, Any]:
+    """Return a new dict with the user-provided ``extra_body`` passed through.
+
+    - Pure and deterministic; does not mutate inputs
+    """
+    out = dict(user_kwargs)
+    if llm.litellm_extra_body:
+        out["extra_body"] = llm.litellm_extra_body
+    return out
+
+
+def apply_call_context(
+    user_kwargs: dict[str, Any],
+    llm: LLM,
+    call_context: LLMCallContext | None,
+) -> dict[str, Any]:
+    """Return a new dict with per-conversation call context applied (#3443).
+
+    Prefers the explicitly threaded context and falls back to the LLM's own
+    PrivateAttr for callers that don't thread one (e.g. the condenser's
+    dedicated LLM).
+
+    - Pure and deterministic; does not mutate inputs
+    """
+    out = dict(user_kwargs)
+
+    ctx = call_context or llm._call_context
+    if ctx.prompt_cache_key:
+        out["prompt_cache_key"] = ctx.prompt_cache_key
+    if ctx.session_id:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {
+            **existing,
+            "x-litellm-session-id": ctx.session_id,
+        }
+
     return out

--- a/openhands-sdk/openhands/sdk/llm/options/responses_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/responses_options.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from openhands.sdk.llm.options.common import apply_defaults_if_absent
+from openhands.sdk.llm.options.common import (
+    apply_call_context,
+    apply_defaults_if_absent,
+    apply_extra_body,
+    apply_extra_headers,
+)
 from openhands.sdk.llm.utils.model_features import get_features
 
 
@@ -32,17 +37,7 @@ def select_responses_options(
         out["temperature"] = 1.0
     out["tool_choice"] = "auto"
 
-    # If user didn't set extra_headers, propagate from llm config
-    if llm.extra_headers is not None and "extra_headers" not in out:
-        out["extra_headers"] = dict(llm.extra_headers)
-
-    # Inject OpenRouter HTTP-Referer / X-Title via extra_headers so we don't
-    # have to mutate os.environ (which would leak across conversations in a
-    # multi-tenant server; see issue #3138). User-supplied headers win.
-    openrouter_headers = llm._openrouter_headers()
-    if openrouter_headers:
-        existing = out.get("extra_headers") or {}
-        out["extra_headers"] = {**openrouter_headers, **existing}
+    out = apply_extra_headers(out, llm)
 
     # Store defaults to False (stateless) unless explicitly provided
     if store is not None:
@@ -86,21 +81,7 @@ def select_responses_options(
     ):
         out["prompt_cache_retention"] = llm.prompt_cache_retention
 
-    # Pass through user-provided extra_body unchanged
-    if llm.litellm_extra_body:
-        out["extra_body"] = llm.litellm_extra_body
-
-    # Inject per-conversation state from call context (#3443).
-    # Prefer explicitly threaded context; fall back to PrivateAttr for
-    # callers that don't thread (e.g. condenser's dedicated LLM).
-    ctx = call_context or llm._call_context
-    if ctx.prompt_cache_key:
-        out["prompt_cache_key"] = ctx.prompt_cache_key
-    if ctx.session_id:
-        existing = out.get("extra_headers") or {}
-        out["extra_headers"] = {
-            **existing,
-            "x-litellm-session-id": ctx.session_id,
-        }
+    out = apply_extra_body(out, llm)
+    out = apply_call_context(out, llm, call_context)
 
     return out


### PR DESCRIPTION
HUMAN:

I picked one item off #4224. While I was in there I found a third block that is duplicated in the same way but is not listed in the issue, so I did that one too. Since this is a refactor and unit tests on their own do not prove much, I also diffed the real output of both functions before and after. Details below.

---

AGENT:

## Why

`select_chat_options` and `select_responses_options` each carried three blocks of logic that were the same in both files, line for line:

1. propagate `extra_headers` from the LLM config, then merge the OpenRouter `HTTP-Referer` / `X-Title` headers
2. pass `litellm_extra_body` through as `extra_body`
3. inject the call context, so `prompt_cache_key` and the `x-litellm-session-id` header

The issue points at 2 and 3 (`chat_options.py:103-119` and `responses_options.py:90-106`). Block 1 sits a bit higher up in both files and is duplicated in exactly the same way, so I pulled that one out as well.

The risk with copies like this is the usual one. Someone fixes a header ordering bug in the chat path, the Responses path keeps the old behaviour, and it only turns up later as a bug report.

## Summary

- Added `apply_extra_headers`, `apply_extra_body` and `apply_call_context` to `llm/options/common.py`, right next to the existing `apply_defaults_if_absent`. They follow the contract that file already documents: pure, deterministic, returns a new dict, does not mutate the input.
- `select_chat_options` and `select_responses_options` now call those helpers instead of each keeping a copy.
- No behaviour change. The merge order is untouched, so user supplied headers still win over the OpenRouter ones (`{**openrouter_headers, **existing}`) and the session id header is still merged last (`{**existing, "x-litellm-session-id": ...}`).

## Issue Number

Part of #4224

## How to Test

**1. Tests.** Everything that touches these code paths passes:

```
uv run pytest tests/sdk/llm \
  tests/sdk/conversation/local/test_call_context_isolation.py \
  tests/sdk/context/condenser/test_llm_summarizing_condenser.py \
  tests/sdk/config/test_llm_config.py \
  tests/sdk/test_settings.py \
  tests/tools/task/test_task_manager.py
```

```
1115 passed, 30 warnings in 71.24s (0:01:11)
```

**2. Output comparison.** This is the part that actually shows nothing changed. I wrote a throwaway script that builds 11 `LLM` configs covering every branch in the three blocks: config headers only, user headers overriding config headers, OpenRouter with and without user headers, OpenRouter where the config also sets `X-Title`, `extra_body`, call context with and without a cache key, a context session id landing on top of headers the user already set, and all of it at once. For each config it dumps `select_chat_options` with `has_tools` both ways and `select_responses_options` with `store` as `None`, `True` and `False`, then prints the input dict again to confirm nothing got mutated. That is 66 lines of output.

I ran it on this branch, then ran the exact same script against the old code with `git checkout upstream/main -- openhands-sdk/openhands/sdk/llm/options/`, and compared the two:

```
before lines: 66
after lines : 66
IDENTICAL
before sha: 1560105955F1FD772905BC262A3228B217996BE732B2215D45C238C9A4252FE9
after  sha: 1560105955F1FD772905BC262A3228B217996BE732B2215D45C238C9A4252FE9
```

<details>
<summary>The script, if you want to run it yourself</summary>

```python
import json

from pydantic import SecretStr

from openhands.sdk.llm.llm import LLM, LLMCallContext
from openhands.sdk.llm.options.chat_options import select_chat_options
from openhands.sdk.llm.options.responses_options import select_responses_options


def llm(**overrides):
    base = dict(
        model="gpt-4o",
        api_key=SecretStr("test_key"),
        usage_id="equiv-check",
    )
    base.update(overrides)
    return LLM(**base)


CASES = [
    ("plain", llm(), {}, None),
    ("llm_extra_headers", llm(extra_headers={"X-From-Config": "1"}), {}, None),
    (
        "user_headers_beat_config",
        llm(extra_headers={"X-From-Config": "1"}),
        {"extra_headers": {"X-From-User": "2"}},
        None,
    ),
    (
        "openrouter_both",
        llm(
            model="openrouter/anthropic/claude-3.5-sonnet",
            openrouter_site_url="https://example.test",
            openrouter_app_name="EquivCheck",
        ),
        {},
        None,
    ),
    (
        "openrouter_user_headers_win",
        llm(
            model="openrouter/anthropic/claude-3.5-sonnet",
            openrouter_site_url="https://example.test",
            openrouter_app_name="EquivCheck",
        ),
        {"extra_headers": {"HTTP-Referer": "https://user.test", "X-Own": "keep"}},
        None,
    ),
    (
        "openrouter_plus_config_headers",
        llm(
            model="openrouter/anthropic/claude-3.5-sonnet",
            openrouter_site_url="https://example.test",
            openrouter_app_name="EquivCheck",
            extra_headers={"X-From-Config": "1", "X-Title": "config-wins"},
        ),
        {},
        None,
    ),
    ("extra_body", llm(litellm_extra_body={"custom": {"nested": [1, 2]}}), {}, None),
    (
        "ctx_cache_key_and_session",
        llm(),
        {},
        LLMCallContext(prompt_cache_key="cache-abc", session_id="sess-xyz"),
    ),
    (
        "ctx_session_merges_after_headers",
        llm(extra_headers={"X-From-Config": "1"}),
        {},
        LLMCallContext(prompt_cache_key="", session_id="sess-xyz"),
    ),
    (
        "ctx_overwrites_existing_session_header",
        llm(),
        {"extra_headers": {"x-litellm-session-id": "user-set"}},
        LLMCallContext(prompt_cache_key=None, session_id="sess-xyz"),
    ),
    (
        "everything_at_once",
        llm(
            model="openrouter/anthropic/claude-3.5-sonnet",
            openrouter_site_url="https://example.test",
            openrouter_app_name="EquivCheck",
            extra_headers={"X-From-Config": "1"},
            litellm_extra_body={"custom": True},
        ),
        {"extra_headers": {"X-From-User": "2"}},
        LLMCallContext(prompt_cache_key="cache-abc", session_id="sess-xyz"),
    ),
]


def render(value):
    try:
        return json.dumps(value, sort_keys=True, default=repr)
    except TypeError:
        return repr(value)


for name, model, user_kwargs, ctx in CASES:
    for has_tools in (True, False):
        out = select_chat_options(
            model, dict(user_kwargs), has_tools=has_tools, call_context=ctx
        )
        print(f"chat/{name}/tools={has_tools}: {render(out)}")

    for store in (None, True, False):
        out = select_responses_options(
            model, dict(user_kwargs), include=None, store=store, call_context=ctx
        )
        print(f"responses/{name}/store={store}: {render(out)}")

    print(f"input-not-mutated/{name}: {render(user_kwargs)}")
```

</details>

**3. Hooks.** `ruff check`, `ruff format --check`, `pyright` and `scripts/check_import_rules.py` are all clean on the three changed files.

## Video/Screenshots

Nothing to show, there is no UI here. The output comparison above is the evidence instead.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The diff is +85/-57, so the line count goes up a little. That is because the helpers carry docstrings and I kept the existing comments that explain #3138 and #3443. Happy to trim them if you would rather keep it tight, the point of this one was removing the copies rather than the line count.

Two items from #4224 I left alone on purpose:

- The port resolution block shared by `docker/workspace.py` and `apptainer/workspace.py`. The tests patch `check_port_available` and `find_available_tcp_port` at both module paths, so moving the block behind a shared helper would quietly stop those patches from applying. Hanging it off `RemoteWorkspace` would also mean sdk importing from `openhands.workspace`, which is the wrong direction for the package layering. That one needs its own PR and a decision on where the helper should live.
- Dropping `model_dump_succint()`, since that is a public API removal and should be your call rather than mine.

Happy to take either of those next if you tell me which shape you want.