### PR TITLE
Import SkillInfo from the SDK instead of redefining it in skills_router

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -28,6 +28,7 @@ from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     SkillFetchError,
+    SkillInfo,
     SkillValidationError,
 )
 from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
@@ -127,19 +128,6 @@ class SkillsRequest(BaseModel):
     sandbox_config: SandboxConfig | None = Field(
         default=None, description="Sandbox skills configuration"
     )
-
-
-class SkillInfo(BaseModel):
-    """Skill information returned by the API."""
-
-    name: str
-    type: Literal["repo", "knowledge", "agentskills"]
-    content: str
-    triggers: list[str] = Field(default_factory=list)
-    source: str | None = None
-    description: str | None = None
-    is_agentskills_format: bool = False
-    disable_model_invocation: bool = False
 
 
 class SkillsResponse(BaseModel):
@@ -328,20 +316,7 @@ def get_skills(request: SkillsRequest, http_request: Request) -> SkillsResponse:
         registered_marketplaces=registered_marketplaces,
     )
 
-    # Convert Skill objects to SkillInfo for response
-    skills_info = [
-        SkillInfo(
-            name=info.name,
-            type=info.type,
-            content=info.content,
-            triggers=info.triggers,
-            source=info.source,
-            description=info.description,
-            is_agentskills_format=info.is_agentskills_format,
-            disable_model_invocation=info.disable_model_invocation,
-        )
-        for info in (skill.to_skill_info() for skill in result.skills)
-    ]
+    skills_info = [skill.to_skill_info() for skill in result.skills]
 
     return SkillsResponse(skills=skills_info, sources=result.sources)
 


### PR DESCRIPTION
HUMAN:

Second one off #4224. The issue says the OpenAPI schema comes out unchanged here. That is almost true but not quite, so I generated the schema before and after and checked. One line moves. I wrote up exactly what it is below so you can decide if you are happy with it.

---

AGENT:

## Why

`skills_router.py` declared its own `SkillInfo` model with the same eight fields as `openhands.sdk.skills.SkillInfo`. The SDK class has no extra validators, methods or config, so the local one was a straight copy.

The handler made it worse than a plain duplicate. `skill.to_skill_info()` already returns the SDK `SkillInfo`, and `get_skills` then copied all eight fields out of it one at a time into the local class:

```python
skills_info = [
    SkillInfo(
        name=info.name,
        type=info.type,
        content=info.content,
        ...
    )
    for info in (skill.to_skill_info() for skill in result.skills)
]
```

So the router was converting the SDK model into an identical copy of itself. Add a field to the SDK class and you have to remember to add it in two more places here, otherwise it silently never reaches the response.

## Summary

- `skills_router.py` imports `SkillInfo` from `openhands.sdk.skills` and the local class is gone.
- `get_skills` returns what `to_skill_info()` already produced instead of rebuilding it field by field.
- Net 25 lines removed, one file touched.

## Issue Number

Part of #4224

## How to Test

**1. The OpenAPI schema, since that is the risky part.** I generated it on `upstream/main`, then again with this change, using the same command the Makefile uses:

```
uv run python -c 'import json; from openhands.agent_server.api import api; print(json.dumps(api.openapi(), indent=2))'
```

Both are 26905 lines. Exactly one line differs:

```
before:  "description": "Skill information returned by the API."
after:   "description": "Lightweight representation of a skill's essential information.\n\nThis class provides a standardized, serializable format for skill metadata that can be used across different components of the system."
```

That is the component description, which FastAPI takes from the model docstring, so it now reads from the SDK class instead of the local one. Everything else is byte for byte the same: the `SkillInfo` properties, their types, defaults, the `required` list, and every path that references it. Nothing structural moved, so `oasdiff` has nothing to flag, but I did not want to claim "no schema change" when a string does in fact change. If you would rather the old wording stayed, the SDK docstring is the place to change it and I am happy to do that instead.

**2. Tests.**

```
uv run pytest tests/agent_server/test_skills_router.py tests/agent_server/test_skills_service.py \
  tests/agent_server/test_conversation_router_skill_trim.py \
  tests/agent_server/test_openapi_discriminator.py tests/sdk/skills
```

```
467 passed, 5 skipped, 7 warnings in 70.86s
```

I also ran the whole `tests/agent_server` package: `1783 passed, 10 failed`. The 10 are all environment ones on my Windows box, nothing to do with skills. I checked by stashing the change and running just those 10 against unmodified `main`, and they fail exactly the same way:

```
10 failed, 1 warning in 2.55s
```

They are the symlink tests (`WinError 1314`, needs admin on Windows), the SIGTERM trap test, the conversation lease PID test, the `$HOME` resolution tests, a non ASCII branch name test that trips on my code page, and two plugin catalog tests.

**3. Hooks.** `ruff check`, `ruff format --check`, `pyright` and `scripts/check_import_rules.py` are all clean on the changed file.

## Video/Screenshots

No UI here. The schema comparison above is the evidence.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is the second item from the "Duplication to reuse" list. The first one is #4276.