### PR TITLE
Share the Gemini edit/write_file diff rendering

### DIFF
--- a/openhands-tools/openhands/tools/gemini/edit/definition.py
+++ b/openhands-tools/openhands/tools/gemini/edit/definition.py
@@ -4,17 +4,16 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pydantic import Field, PrivateAttr
-from rich.text import Text
+from pydantic import Field
 
 from openhands.sdk.tool import (
     Action,
     DeclaredResources,
-    Observation,
     ToolAnnotations,
     ToolDefinition,
     register_tool,
 )
+from openhands.tools.gemini.file_change import FileChangeObservation
 
 
 if TYPE_CHECKING:
@@ -43,7 +42,7 @@ class EditAction(Action):
     )
 
 
-class EditObservation(Observation):
+class EditObservation(FileChangeObservation):
     """Observation from editing a file."""
 
     file_path: str | None = Field(
@@ -62,45 +61,8 @@ class EditObservation(Observation):
         default=None, description="The content after the edit."
     )
 
-    _diff_cache: Text | None = PrivateAttr(default=None)
-
-    @property
-    def visualize(self) -> Text:
-        """Return Rich Text representation of this observation."""
-        text = Text()
-
-        if self.is_error:
-            text.append("❌ ", style="red bold")
-            text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
-            return super().visualize
-
-        if self.file_path:
-            if self.is_new_file:
-                text.append("✨ ", style="green bold")
-                text.append(f"Created: {self.file_path}\n", style="green")
-            else:
-                text.append("✏️  ", style="yellow bold")
-                text.append(
-                    (
-                        f"Edited: {self.file_path} "
-                        f"({self.replacements_made} replacement(s))\n"
-                    ),
-                    style="yellow",
-                )
-
-            if self.old_content is not None and self.new_content is not None:
-                from openhands.tools.file_editor.utils.diff import visualize_diff
-
-                if not self._diff_cache:
-                    self._diff_cache = visualize_diff(
-                        self.file_path,
-                        self.old_content,
-                        self.new_content,
-                        n_context_lines=2,
-                        change_applied=True,
-                    )
-                text.append(self._diff_cache)
-        return text
+    def change_summary(self) -> str:
+        return f"Edited: {self.file_path} ({self.replacements_made} replacement(s))\n"
 
 
 TOOL_DESCRIPTION = """Replaces text within a file.

--- a/openhands-tools/openhands/tools/gemini/file_change.py
+++ b/openhands-tools/openhands/tools/gemini/file_change.py
@@ -1,0 +1,65 @@
+"""Shared observation behaviour for the Gemini tools that write files.
+
+``edit`` and ``write_file`` both report a file that was either created or
+changed, and both render the result as a diff. The only part that differs is
+the line announcing a change to an existing file, so the rendering lives here
+and each tool supplies that one line.
+"""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from pydantic import PrivateAttr
+from rich.text import Text
+
+from openhands.sdk.tool import Observation
+
+
+class FileChangeObservation(Observation, ABC):
+    """Base for observations reporting a created or rewritten file.
+
+    Subclasses declare ``file_path``, ``is_new_file``, ``old_content`` and
+    ``new_content`` themselves so that each tool keeps its own field
+    descriptions, and implement :meth:`change_summary`.
+    """
+
+    if TYPE_CHECKING:
+        file_path: str | None
+        is_new_file: bool
+        old_content: str | None
+        new_content: str | None
+
+    _diff_cache: Text | None = PrivateAttr(default=None)
+
+    @abstractmethod
+    def change_summary(self) -> str:
+        """Return the line shown when an existing file was changed."""
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation of this observation."""
+        if self.is_error:
+            return super().visualize
+
+        text = Text()
+        if self.file_path:
+            if self.is_new_file:
+                text.append("✨ ", style="green bold")
+                text.append(f"Created: {self.file_path}\n", style="green")
+            else:
+                text.append("✏️  ", style="yellow bold")
+                text.append(self.change_summary(), style="yellow")
+
+            if self.old_content is not None and self.new_content is not None:
+                from openhands.tools.file_editor.utils.diff import visualize_diff
+
+                if not self._diff_cache:
+                    self._diff_cache = visualize_diff(
+                        self.file_path,
+                        self.old_content,
+                        self.new_content,
+                        n_context_lines=2,
+                        change_applied=True,
+                    )
+                text.append(self._diff_cache)
+        return text

--- a/openhands-tools/openhands/tools/gemini/write_file/definition.py
+++ b/openhands-tools/openhands/tools/gemini/write_file/definition.py
@@ -4,17 +4,16 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pydantic import Field, PrivateAttr
-from rich.text import Text
+from pydantic import Field
 
 from openhands.sdk.tool import (
     Action,
     DeclaredResources,
-    Observation,
     ToolAnnotations,
     ToolDefinition,
     register_tool,
 )
+from openhands.tools.gemini.file_change import FileChangeObservation
 
 
 if TYPE_CHECKING:
@@ -28,7 +27,7 @@ class WriteFileAction(Action):
     content: str = Field(description="The content to write to the file.")
 
 
-class WriteFileObservation(Observation):
+class WriteFileObservation(FileChangeObservation):
     """Observation from writing a file."""
 
     file_path: str | None = Field(
@@ -44,39 +43,8 @@ class WriteFileObservation(Observation):
         default=None, description="The new content written to the file."
     )
 
-    _diff_cache: Text | None = PrivateAttr(default=None)
-
-    @property
-    def visualize(self) -> Text:
-        """Return Rich Text representation of this observation."""
-        text = Text()
-
-        if self.is_error:
-            text.append("❌ ", style="red bold")
-            text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
-            return super().visualize
-
-        if self.file_path:
-            if self.is_new_file:
-                text.append("✨ ", style="green bold")
-                text.append(f"Created: {self.file_path}\n", style="green")
-            else:
-                text.append("✏️  ", style="yellow bold")
-                text.append(f"Updated: {self.file_path}\n", style="yellow")
-
-            if self.old_content is not None and self.new_content is not None:
-                from openhands.tools.file_editor.utils.diff import visualize_diff
-
-                if not self._diff_cache:
-                    self._diff_cache = visualize_diff(
-                        self.file_path,
-                        self.old_content,
-                        self.new_content,
-                        n_context_lines=2,
-                        change_applied=True,
-                    )
-                text.append(self._diff_cache)
-        return text
+    def change_summary(self) -> str:
+        return f"Updated: {self.file_path}\n"
 
 
 TOOL_DESCRIPTION = """Writes content to a specified file in the local filesystem.


### PR DESCRIPTION
HUMAN:

Third one from #4224, the Gemini `visualize` bullet. This one needed a bit of care because these observations are in the discriminated union and end up in the public OpenAPI schema, so a naive base class would have added a component and shuffled the field order. I built it so the schema comes out byte identical and checked that. Evidence below.

---

AGENT:

## Why

`EditObservation` and `WriteFileObservation` had the same `visualize` body: the error branch, the "Created:" line for a new file, the `visualize_diff` call with the same arguments, and the same `_diff_cache` private attr. The only real difference is the wording of the line for an existing file:

```python
# edit
f"Edited: {self.file_path} ({self.replacements_made} replacement(s))\n"
# write_file
f"Updated: {self.file_path}\n"
```

## Summary

- New `openhands/tools/gemini/file_change.py` with `FileChangeObservation`, holding `_diff_cache` and the shared `visualize`.
- Each tool implements `change_summary()` for its one line.
- Both observations keep declaring their own fields, so their descriptions and their order in the schema are untouched.

## Two things I had to design around

**The discriminated union.** `get_known_concrete_subclasses` in `sdk/utils/models.py` walks every subclass and keeps the ones `_is_abstract` says no to. A plain intermediate class would therefore have joined the union and shown up as a new component in the spec. `_is_abstract` returns true when `ABC in type_.__bases__`, so the base is declared `class FileChangeObservation(Observation, ABC)` and has an `@abstractmethod`. That keeps it out. `Observation` itself is declared the same way, so this follows what is already there.

**Field descriptions and order.** If the base declared the shared fields, the two tools would have lost their own wording ("The content before the edit." vs "The previous content of the file (if it existed).") and `replacements_made` would have moved in the property order. So the base declares no fields at all. It only needs to know those attributes exist for type checking, which it does under `if TYPE_CHECKING`, so pydantic never sees them and the subclasses stay exactly as they were.

## Issue Number

Part of #4224

## How to Test

**1. The OpenAPI schema is byte identical.** Generated on `upstream/main` and again with this change:

```
uv run python -c 'import json; from openhands.agent_server.api import api; print(json.dumps(api.openapi(), indent=2))'
```

```
before: 26905 lines, after: 26905 lines
IDENTICAL
FileChangeObservation in schema? False
```

**2. The rendering is identical.** A throwaway script builds both observations across every branch of `visualize`: new file, existing file with a real diff, existing file with no content to diff, no `file_path` at all, and the error case, for both tools. It prints `text.plain` and `text.spans` so styling is compared too, then reads `visualize` a second time to exercise the `_diff_cache` path. It also prints which observations are in the union. Ran it before and after:

```
before: 32 lines, after: 32 lines
IDENTICAL
```

and from that output:

```
gemini-observations-in-union: ['EditObservation', 'FileEditorObservation', 'ReadFileObservation', 'WriteFileObservation']
FileChangeObservation-in-union: False
```

<details>
<summary>The script</summary>

```python
from openhands.sdk.tool import Observation
from openhands.sdk.utils.models import get_known_concrete_subclasses
from openhands.tools.gemini.edit.definition import EditObservation
from openhands.tools.gemini.write_file.definition import WriteFileObservation

OLD = "line one\nline two\nline three\n"
NEW = "line one\nline TWO changed\nline three\n"

CASES: list[tuple[str, Observation]] = [
    ("edit/new-file", EditObservation(file_path="/ws/new.py", is_new_file=True, replacements_made=0, old_content="", new_content=NEW)),
    ("edit/updated", EditObservation(file_path="/ws/existing.py", is_new_file=False, replacements_made=3, old_content=OLD, new_content=NEW)),
    ("edit/updated-no-content", EditObservation(file_path="/ws/existing.py", is_new_file=False, replacements_made=1)),
    ("edit/no-path", EditObservation(file_path=None, old_content=OLD, new_content=NEW)),
    ("edit/error", EditObservation(file_path="/ws/existing.py", is_error=True)),
    ("write/new-file", WriteFileObservation(file_path="/ws/new.py", is_new_file=True, old_content="", new_content=NEW)),
    ("write/updated", WriteFileObservation(file_path="/ws/existing.py", is_new_file=False, old_content=OLD, new_content=NEW)),
    ("write/updated-no-content", WriteFileObservation(file_path="/ws/existing.py", is_new_file=False)),
    ("write/no-path", WriteFileObservation(file_path=None, old_content=OLD, new_content=NEW)),
    ("write/error", WriteFileObservation(file_path="/ws/existing.py", is_error=True)),
]

for name, obs in CASES:
    text = obs.visualize
    print(f"{name}/plain: {text.plain!r}")
    print(f"{name}/spans: {text.spans!r}")
    print(f"{name}/cached: {obs.visualize.plain!r}")

names = sorted(c.__name__ for c in get_known_concrete_subclasses(Observation))
print(f"gemini-observations-in-union: {[n for n in names if 'File' in n or 'Edit' in n]}")
print(f"FileChangeObservation-in-union: {'FileChangeObservation' in names}")
```

</details>

**3. Tests.**

```
uv run pytest tests/tools/gemini tests/sdk/tool tests/sdk/utils/test_discriminated_union.py
```

```
240 passed in 2.09s
```

**4. Hooks.** `ruff check`, `ruff format --check`, `pyright` and `scripts/check_import_rules.py` are clean on all three files.

## Video/Screenshots

No UI. The rendering comparison above covers it, spans included.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

One small thing I changed on purpose. The old error branch did this:

```python
if self.is_error:
    text.append("❌ ", style="red bold")
    text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
    return super().visualize
```

Those two appends went into a `Text` that was then thrown away, since the branch returns `super().visualize` instead of `text`. I did not want to carry that into the shared version, so the base just returns `super().visualize`. The output is unchanged, which the `edit/error` and `write/error` cases above confirm.

This is the third of the four "Duplication to reuse" bullets. The other two are #4276 and #4277. The remaining one is the port resolution block, which I flagged on the issue as needing a decision first.