### PR TITLE
fix(security): authenticate WebSockets outside URLs

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections.abc import Callable, Mapping
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, SupportsIndex, overload
+from typing import TYPE_CHECKING, Final, SupportsIndex, overload
 from urllib.parse import urlparse
 
 import httpx
@@ -65,8 +65,8 @@ logger = get_logger(__name__)
 
 LEGACY_CONVERSATIONS_PATH = "/api/conversations"
 FATAL_WS_CLOSE_CODES = frozenset({4001, 4004})
-_WEBSOCKET_AUTH_TYPE = "auth"
-_WEBSOCKET_SESSION_API_KEY_FIELD = "session_api_key"
+_WEBSOCKET_AUTH_TYPE: Final = "auth"
+_WEBSOCKET_SESSION_API_KEY_FIELD: Final = "session_api_key"
 
 
 def _agent_kind_mismatch_message(conversation_id: ConversationID) -> str:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -8,7 +8,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, SupportsIndex, overload
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import httpx
 import websockets
@@ -65,6 +65,8 @@ logger = get_logger(__name__)
 
 LEGACY_CONVERSATIONS_PATH = "/api/conversations"
 FATAL_WS_CLOSE_CODES = frozenset({4001, 4004})
+_WEBSOCKET_AUTH_TYPE = "auth"
+_WEBSOCKET_SESSION_API_KEY_FIELD = "session_api_key"
 
 
 def _agent_kind_mismatch_message(conversation_id: ConversationID) -> str:
@@ -214,15 +216,20 @@ class WebSocketCallbackClient:
         base = f"{ws_scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
         ws_url = f"{base}/sockets/events/{self.conversation_id}"
 
-        # Add API key as query parameter if provided
-        if self.api_key:
-            ws_url += f"?session_api_key={quote(self.api_key, safe='')}"
-
         delay = 1.0
         has_connected = False
         while not self._stop.is_set():
             try:
                 async with websockets.connect(ws_url) as ws:
+                    if self.api_key:
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "type": _WEBSOCKET_AUTH_TYPE,
+                                    _WEBSOCKET_SESSION_API_KEY_FIELD: self.api_key,
+                                }
+                            )
+                        )
                     delay = 1.0
                     connection_ready = False
                     async for message in ws:

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -57,6 +57,7 @@ def live_server_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     import_modules: str | None = None,
+    session_api_keys: list[str] | None = None,
 ) -> Generator[dict]:
     """Launch a real FastAPI server backed by temp workspace and conversations.
 
@@ -97,7 +98,7 @@ def live_server_env(
     )
 
     cfg = {
-        "session_api_keys": [],  # disable auth for tests
+        "session_api_keys": session_api_keys or [],
         "conversations_path": str(conversations_path),
         "workspace_path": str(workspace_path),
     }
@@ -203,6 +204,20 @@ def server_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[dic
 
 
 @pytest.fixture
+def authenticated_server_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[dict]:
+    api_key = "test-websocket-auth-key"
+    with live_server_env(
+        tmp_path,
+        monkeypatch,
+        session_api_keys=[api_key],
+    ) as env:
+        env["api_key"] = api_key
+        yield env
+
+
+@pytest.fixture
 def patched_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch LLM.completion to a deterministic assistant message response."""
 
@@ -256,6 +271,28 @@ def patched_llm(monkeypatch: pytest.MonkeyPatch) -> None:
         return fake_completion(self, messages, tools, **kwargs)
 
     monkeypatch.setattr(LLM, "acompletion", fake_acompletion, raising=True)
+
+
+def test_remote_conversation_websocket_first_message_auth(
+    authenticated_server_env,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("OPENHANDS_REMOTE_WS_READY_TIMEOUT", "2")
+    agent = Agent(
+        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")),
+        tools=[],
+    )
+    workspace = RemoteWorkspace(
+        host=authenticated_server_env["host"],
+        working_dir="/tmp/workspace/project",
+        api_key=authenticated_server_env["api_key"],
+    )
+
+    conversation: RemoteConversation = Conversation(agent=agent, workspace=workspace)
+    try:
+        assert conversation.id
+    finally:
+        conversation.close()
 
 
 def test_preloaded_custom_tool_resolves_in_live_server(

--- a/tests/sdk/conversation/remote/test_websocket_client.py
+++ b/tests/sdk/conversation/remote/test_websocket_client.py
@@ -131,7 +131,25 @@ def test_websocket_client_callback_invocation(mock_event):
     assert callback_events[0].id == mock_event.id
 
 
-def test_websocket_client_sends_api_key_in_first_frame():
+@pytest.mark.parametrize(
+    ("api_key", "expected_messages"),
+    [
+        pytest.param(
+            "sk-oh-" + "a" * 64,
+            [
+                json.dumps(
+                    {
+                        "type": "auth",
+                        "session_api_key": "sk-oh-" + "a" * 64,
+                    }
+                )
+            ],
+            id="with-api-key",
+        ),
+        pytest.param(None, [], id="without-api-key"),
+    ],
+)
+def test_websocket_client_authenticates_outside_url(api_key, expected_messages):
     captured_urls = []
     sent_messages = []
 
@@ -165,7 +183,7 @@ def test_websocket_client_sends_api_key_in_first_frame():
         host="http://localhost:8000",
         conversation_id="test-conv-id",
         callback=lambda event: None,
-        api_key="sk-oh-" + "a" * 64,
+        api_key=api_key,
     )
 
     with patch(
@@ -176,14 +194,7 @@ def test_websocket_client_sends_api_key_in_first_frame():
 
     assert len(captured_urls) == 1
     assert captured_urls[0] == ("ws://localhost:8000/sockets/events/test-conv-id")
-    assert sent_messages == [
-        json.dumps(
-            {
-                "type": "auth",
-                "session_api_key": client.api_key,
-            }
-        )
-    ]
+    assert sent_messages == expected_messages
 
 
 def _state_update_payload(event_id: str) -> str:
@@ -208,9 +219,13 @@ def _connection_closed(code: int) -> websockets.exceptions.ConnectionClosed:
 
 
 class _MockWebSocket:
-    def __init__(self, messages, close_code: int):
+    def __init__(self, messages, close_code: int, sent_messages=None):
         self._messages = list(messages)
         self._close_code = close_code
+        self._sent_messages = sent_messages if sent_messages is not None else []
+
+    async def send(self, message):
+        self._sent_messages.append(message)
 
     def __aiter__(self):
         return self
@@ -236,6 +251,8 @@ def test_websocket_client_retries_after_retryable_connection_closed():
     """Test that transient WebSocket closures reconnect instead of exiting."""
     connect_calls = 0
     callback_events = []
+    sent_per_connection = []
+    retry_delays = []
 
     def callback(event):
         callback_events.append(event)
@@ -246,10 +263,13 @@ def test_websocket_client_retries_after_retryable_connection_closed():
         def __call__(self, url, *args, **kwargs):
             nonlocal connect_calls
             connect_calls += 1
+            sent_messages = []
+            sent_per_connection.append(sent_messages)
             return _MockWebSocketContext(
                 _MockWebSocket(
                     [_state_update_payload(f"state-{connect_calls}")],
                     close_code=1000,
+                    sent_messages=sent_messages,
                 )
             )
 
@@ -257,9 +277,11 @@ def test_websocket_client_retries_after_retryable_connection_closed():
         host="http://localhost:8000",
         conversation_id="test-conv-id",
         callback=callback,
+        api_key="sk-oh-" + "b" * 64,
     )
 
     async def no_sleep(delay):
+        retry_delays.append(delay)
         return None
 
     client._sleep_before_retry = no_sleep
@@ -272,6 +294,14 @@ def test_websocket_client_retries_after_retryable_connection_closed():
 
     assert connect_calls == 2
     assert [event.id for event in callback_events] == ["state-1", "state-2"]
+    expected_auth = json.dumps(
+        {
+            "type": "auth",
+            "session_api_key": client.api_key,
+        }
+    )
+    assert sent_per_connection == [[expected_auth], [expected_auth]]
+    assert retry_delays == [1.0, 1.0]
 
 
 @pytest.mark.parametrize("close_code", [4001, 4004])

--- a/tests/sdk/conversation/remote/test_websocket_client.py
+++ b/tests/sdk/conversation/remote/test_websocket_client.py
@@ -131,9 +131,20 @@ def test_websocket_client_callback_invocation(mock_event):
     assert callback_events[0].id == mock_event.id
 
 
-def test_websocket_client_url_encodes_api_key():
-    """Test that API key special characters are URL-encoded in the WebSocket URL."""
+def test_websocket_client_sends_api_key_in_first_frame():
     captured_urls = []
+    sent_messages = []
+
+    class _MockWebSocket:
+        async def send(self, message):
+            sent_messages.append(message)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            client._stop.set()
+            raise StopAsyncIteration
 
     class _MockAsyncContextManager:
         def __init__(self, url):
@@ -141,11 +152,7 @@ def test_websocket_client_url_encodes_api_key():
 
         async def __aenter__(self):
             captured_urls.append(self.url)
-            raise websockets.exceptions.ConnectionClosed(
-                rcvd=websockets.frames.Close(4001, "test"),
-                sent=websockets.frames.Close(4001, "test"),
-                rcvd_then_sent=False,
-            )
+            return _MockWebSocket()
 
         async def __aexit__(self, exc_type, exc, tb):
             return False
@@ -158,7 +165,7 @@ def test_websocket_client_url_encodes_api_key():
         host="http://localhost:8000",
         conversation_id="test-conv-id",
         callback=lambda event: None,
-        api_key="1+FYh/SRE=ds 8Q",
+        api_key="sk-oh-" + "a" * 64,
     )
 
     with patch(
@@ -168,7 +175,15 @@ def test_websocket_client_url_encodes_api_key():
         asyncio.run(client._client_loop())
 
     assert len(captured_urls) == 1
-    assert "session_api_key=1%2BFYh%2FSRE%3Dds%208Q" in captured_urls[0]
+    assert captured_urls[0] == ("ws://localhost:8000/sockets/events/test-conv-id")
+    assert sent_messages == [
+        json.dumps(
+            {
+                "type": "auth",
+                "session_api_key": client.api_key,
+            }
+        )
+    ]
 
 
 def _state_update_payload(event_id: str) -> str:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Remove session_api_key from Python SDK WebSocket URLs.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Session API keys in WebSocket query strings are copied into reverse-proxy and access logs. Production log review confirmed credential-bearing event-socket URLs.

## Summary

- Remove session_api_key from Python SDK WebSocket URLs.
- Send the existing first-message auth payload immediately after connection.
- Verify the URL is clean and the auth payload is the first client frame.

## Issue Number

N/A

## How to Test

- uv run pytest tests/sdk/conversation/remote/test_websocket_client.py tests/agent_server/test_agent_server_wsproto.py::test_agent_server_websocket_first_message_auth_accepted -q
  - 10 passed.
  - This covers both the updated client frame and a real agent-server WebSocket accepting first-message authentication.
- uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py tests/sdk/conversation/remote/test_websocket_client.py
  - All hooks passed.

## Video/Screenshots

N/A. This is a wire-protocol security change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Agent-server first-message authentication is already available on main from #2790. The server retains its deprecated query fallback for older clients.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0a7e7ea-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0a7e7ea-python \
  ghcr.io/openhands/agent-server:0a7e7ea-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0a7e7ea-golang-amd64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-golang-amd64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-golang-amd64
ghcr.io/openhands/agent-server:0a7e7ea-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0a7e7ea-golang-arm64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-golang-arm64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-golang-arm64
ghcr.io/openhands/agent-server:0a7e7ea-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0a7e7ea-java-amd64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-java-amd64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-java-amd64
ghcr.io/openhands/agent-server:0a7e7ea-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0a7e7ea-java-arm64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-java-arm64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-java-arm64
ghcr.io/openhands/agent-server:0a7e7ea-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0a7e7ea-python-amd64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-python-amd64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-python-amd64
ghcr.io/openhands/agent-server:0a7e7ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0a7e7ea-python-arm64
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-python-arm64
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-python-arm64
ghcr.io/openhands/agent-server:0a7e7ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0a7e7ea-golang
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-golang
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-golang
ghcr.io/openhands/agent-server:0a7e7ea-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0a7e7ea-java
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-java
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-java
ghcr.io/openhands/agent-server:0a7e7ea-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0a7e7ea-python
ghcr.io/openhands/agent-server:0a7e7ea0234f9fd69c28814dd363e863e63683fe-python
ghcr.io/openhands/agent-server:fix-websocket-auth-frame-python
ghcr.io/openhands/agent-server:0a7e7ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0a7e7ea-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0a7e7ea-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->