### PR TITLE
ci: drop unmonitored nightly schedules from integration & examples workflows

### DIFF
--- a/.agents/skills/debug-test-examples-workflow/SKILL.md
+++ b/.agents/skills/debug-test-examples-workflow/SKILL.md
@@ -10,7 +10,6 @@ description: Guide for debugging failing example tests in the `test-examples` la
 The `run-examples.yml` workflow runs example scripts from `examples/` directory. Triggers:
 - Adding `test-examples` label to a PR
 - Manual workflow dispatch
-- Scheduled nightly runs
 
 ## Debugging Steps
 

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -1,7 +1,7 @@
 ---
 name: Run Integration Tests
 run-name: >-
-    Run Integration Tests ${{ inputs.reason || github.event.label.name || 'scheduled' }}
+    Run Integration Tests ${{ inputs.reason || github.event.label.name || 'manual' }}
 
 on:
     # Use pull_request_target to access secrets even on fork PRs.
@@ -44,12 +44,10 @@ on:
                     - gemini
                     - gpt5
                     - planning
-    schedule:
-        - cron: 30 22 * * * # Runs at 10:30pm UTC every day
 
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
-    # Default models for scheduled/label-triggered runs (resolved by the inline table below)
+    # Default models for label-triggered runs (resolved by the inline table below)
     DEFAULT_MODEL_IDS: gpt-5.5,deepseek-v4-flash,minimax-m2.7,gemini-3.1-pro,claude-sonnet-4-6
 
 jobs:
@@ -230,10 +228,9 @@ jobs:
                   printf '%s' "$COMMENT_BODY" | gh issue comment "$ISSUE_NUMBER" --body-file -
 
     run-integration-tests:
-        # Security: Only run when integration-related labels are present, via workflow_dispatch, or on schedule
+        # Security: Only run when integration-related labels are present or via workflow_dispatch
         # This prevents automatic execution on fork PRs without maintainer approval
-        # Note: uses always() to run even when comment jobs are skipped (e.g., for scheduled runs)
-        # Schedule trigger only runs in the main repository, not in forks
+        # Note: uses always() to run even when comment jobs are skipped
         if: |
             always() && (
                 (
@@ -242,8 +239,7 @@ jobs:
                         github.event.label.name == 'behavior-test'
                     )
                 ) ||
-                github.event_name == 'workflow_dispatch' ||
-                (github.event_name == 'schedule' && github.repository == 'OpenHands/software-agent-sdk')
+                github.event_name == 'workflow_dispatch'
             ) && needs.setup-matrix.result == 'success'
         needs: [setup-matrix, post-label-comment, post-dispatch-comment]
         runs-on: ubuntu-24.04
@@ -319,9 +315,6 @@ jobs:
                         echo "workflow_dispatch provided unknown test_type '$test_type'; defaulting to full suite."
                         ;;
                     esac
-                  elif [ "${{ github.event_name }}" = "schedule" ]; then
-                    TEST_TYPE_ARGS="--test-type integration"
-                    echo "Scheduled run; running integration tests only."
                   else
                     echo "Running full integration test suite."
                   fi
@@ -407,8 +400,7 @@ jobs:
                         github.event.label.name == 'behavior-test'
                     )
                 ) ||
-                github.event_name == 'workflow_dispatch' ||
-                (github.event_name == 'schedule' && github.repository == 'OpenHands/software-agent-sdk')
+                github.event_name == 'workflow_dispatch'
             )
         runs-on: ubuntu-24.04
         permissions:
@@ -493,25 +485,3 @@ jobs:
                   COMMENT_BODY=$(uv run python -c "from openhands.sdk.utils.github import sanitize_openhands_mentions; import sys; print(sanitize_openhands_mentions(sys.stdin.read()), end='')" < consolidated_report.md)
                   # Use GitHub CLI to create comment on the specified issue/PR
                   echo "$COMMENT_BODY" | gh issue comment "$ISSUE_NUMBER" --body-file -
-
-            - name: Read consolidated report for tracker issue
-              if: github.event_name == 'schedule'
-              id: read_report
-              run: |
-                  # Read and sanitize the report, then set as output
-                  REPORT_CONTENT=$(uv run python -c "from openhands.sdk.utils.github import sanitize_openhands_mentions; import sys; print(sanitize_openhands_mentions(sys.stdin.read()), end='')" < consolidated_report.md)
-                  echo "report<<EOF" >> $GITHUB_OUTPUT
-                  echo "$REPORT_CONTENT" >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-
-            - name: Comment with results on tracker issue
-              if: github.event_name == 'schedule'
-              uses: KeisukeYamashita/create-comment@1d95d97d7b1b73ab66e5ca931610e4e10ddc5eed # v1
-              with:
-                  number: 2078
-                  unique: false
-                  comment: |
-                      **Trigger:** Nightly Scheduled Run
-                      **Commit:** ${{ github.sha }}
-
-                      ${{ steps.read_report.outputs.report }}

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -10,8 +10,6 @@ on:
                 description: Reason for manual trigger
                 required: true
                 default: ''
-    schedule:
-        - cron: 30 22 * * * # Runs at 10:30pm UTC every day
 
 permissions:
     contents: read
@@ -20,9 +18,7 @@ permissions:
 
 jobs:
     test-examples:
-        # Schedule trigger only runs in the main repository, not in forks
-        if: github.event.label.name == 'test-examples' || github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && 
-            github.repository == 'OpenHands/software-agent-sdk')
+        if: github.event.label.name == 'test-examples' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         steps:
@@ -172,7 +168,7 @@ jobs:
                       exit $EXIT_CODE
                   fi
             - name: Read examples report for issue comment
-              if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+              if: github.event_name == 'workflow_dispatch'
               id: read_report
               shell: bash
               run: |
@@ -186,13 +182,13 @@ jobs:
                   fi
 
             - name: Comment with results on tracker issue
-              if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+              if: github.event_name == 'workflow_dispatch'
               uses: KeisukeYamashita/create-comment@1d95d97d7b1b73ab66e5ca931610e4e10ddc5eed # v1
               with:
                   number: 3950
                   unique: false
                   comment: |
-                      **Trigger:** ${{ github.event_name == 'schedule' && 'Nightly Scheduled Run' || format('Manual Trigger: {0}', github.event.inputs.reason) }}
+                      **Trigger:** ${{ format('Manual Trigger: {0}', github.event.inputs.reason) }}
                       **Commit:** ${{ github.sha }}
                       **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -70,7 +70,6 @@ Defined in `.github/workflows/integration-runner.yml`, this workflow runs integr
 **Triggers:**
 1. **Pull Request Labels**: When a PR is labeled with `integration-test` or `behavior-test`
 2. **Manual Trigger**: Via workflow dispatch with a required reason
-3. **Scheduled Runs**: Daily at 10:30 PM UTC (cron: `30 22 * * *`)
 
 **Test Coverage:** Runs across 5 LLM models (GPT-5.5, DeepSeek V4 Flash, MiniMax M2.7, Gemini 3.1 Pro, Claude Sonnet 4.6)
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
Clean up the old scheduled workflows for integration and examples runs; running them by label and on releases generally works, and if we need more signal we can figure out what an automation with them should do.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The **Run Integration Tests** (`integration-runner.yml`) and **Run Examples Scripts** (`run-examples.yml`) workflows each ran a daily `schedule:` cron (`30 22 * * *`, 22:30 UTC) that posted results to tracker issues #2078 ("Daily Integration Runs") and #3950 ("Daily Examples Run Results"). Those trackers aren't actively monitored, and the most recent scheduled examples run finished in failure with no follow-up — so the cron spends CI time and LLM-proxy budget without producing signal anyone acts on. We plan to replace this nightly coverage with OpenHands automations, so the in-repo cron can go now.

## Summary

- Remove the `schedule:` cron trigger from `integration-runner.yml` and `run-examples.yml`.
- Remove the now-dead `if: github.event_name == 'schedule'` steps/branches (the #2078 / #3950 tracker-comment steps and the schedule-only test-selection branch).
- Preserve every on-demand path: `pull_request_target` labels `integration-test` / `behavior-test`, `pull_request` label `test-examples`, and manual `workflow_dispatch` (including its tracker-issue comment on `run-examples`).

## Issue Number

N/A

## How to Test

This is a CI trigger change, so the verification is static — the scheduled path is the only behavior removed, and the label/dispatch paths are untouched.

- YAML parses cleanly:
  `python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/integration-runner.yml','.github/workflows/run-examples.yml']]"`
- Trigger set after the change (no `schedule`, all on-demand paths intact):
  - `integration-runner.yml` -> `pull_request_target`, `workflow_dispatch`
  - `run-examples.yml` -> `pull_request`, `workflow_dispatch`
- `grep -in schedule .github/workflows/integration-runner.yml .github/workflows/run-examples.yml` returns nothing.
- Behavioral confirmation once merged: applying the `integration-test` / `behavior-test` / `test-examples` labels or dispatching manually still triggers the runs; no run fires at 22:30 UTC.

## Video/Screenshots

N/A — CI-config-only change; no user-facing UI.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Removed the now-stale nightly-schedule lines from `tests/integration/README.md` and the `debug-test-examples-workflow` skill so the docs match the label/manual-only triggers (addresses review feedback). `tests/integration/BEHAVIOR_TESTS.md` only references the label path and stays accurate.
- Follow-up: stand up the replacement OpenHands automations for the nightly integration and examples coverage before/around merging this.
