### PR TITLE
feat(agent-server): add MCP settings CRUD endpoints

### DIFF
--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from functools import lru_cache
 from typing import cast
 
@@ -19,6 +20,7 @@ from openhands.agent_server.persistence import (
 from openhands.agent_server.persistence.models import SettingsUpdatePayload
 from openhands.agent_server.telemetry import notify_misc_settings_changed
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.settings import (
     ConversationSettings,
     SecretCreateRequest,
@@ -29,6 +31,7 @@ from openhands.sdk.settings import (
     SettingsUpdateRequest,
     export_agent_settings_schema,
 )
+from openhands.sdk.settings.api_models import MCPServerPatch
 
 
 logger = get_logger(__name__)
@@ -40,6 +43,7 @@ logger = get_logger(__name__)
 # while this router uses relative paths. The paths are intentionally separate
 # to match their respective contexts (router prefix vs full URL path).
 SETTINGS_PATH = ""  # -> /api/settings
+MCP_SERVER_PATH = "/mcp/{settings_key:path}"  # -> /api/settings/mcp/{settings_key}
 SECRETS_PATH = "/secrets"  # -> /api/settings/secrets
 SECRET_VALUE_PATH = "/secrets/{name}"  # -> /api/settings/secrets/{name}
 
@@ -198,9 +202,6 @@ async def update_settings(
     Raises:
         HTTPException: 400 if the update payload contains invalid values.
     """
-    config = get_config(request)
-    store = get_settings_store(config)
-
     update_data = payload.model_dump(exclude_none=True)
     # exclude_none drops an explicit null, so re-add nullable pointers when the
     # client set them (including to None) to allow clearing.
@@ -219,12 +220,27 @@ async def update_settings(
             ),
         )
 
+    return _apply_settings_update(
+        request,
+        cast(SettingsUpdatePayload, update_data),
+    )
+
+
+def _apply_settings_update(
+    request: Request,
+    update_data: SettingsUpdatePayload,
+    before_update: Callable[[PersistedSettings], None] | None = None,
+) -> SettingsResponse:
     # Apply updates atomically with file locking
     def apply_update(settings: PersistedSettings) -> PersistedSettings:
+        if before_update is not None:
+            before_update(settings)
         context = {"cipher": config.cipher} if config.cipher is not None else None
-        settings.update(cast(SettingsUpdatePayload, update_data), context=context)
+        settings.update(update_data, context=context)
         return settings
 
+    config = get_config(request)
+    store = get_settings_store(config)
     client_host = request.client.host if request.client else "unknown"
     try:
         settings = store.update(apply_update)
@@ -272,7 +288,7 @@ async def update_settings(
         logger.error("Settings update failed - file I/O error")
         raise HTTPException(status_code=500, detail="Failed to update settings")
 
-    # Don't expose secrets in PATCH response (consistent with GET behavior)
+    # Don't expose secrets in mutation responses (consistent with GET behavior)
     return SettingsResponse(
         agent_settings=settings.agent_settings.model_dump(mode="json"),
         conversation_settings=settings.conversation_settings.model_dump(mode="json"),
@@ -280,6 +296,87 @@ async def update_settings(
         active_profile=settings.active_profile,
         active_agent_profile_id=settings.active_agent_profile_id,
         misc_settings=settings.misc_settings,
+    )
+
+
+def _require_mcp_server_absent(settings: PersistedSettings, settings_key: str) -> None:
+    if settings_key in settings.agent_settings.mcp_config:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"MCP server '{settings_key}' already exists",
+        )
+
+
+def _require_mcp_server_present(settings: PersistedSettings, settings_key: str) -> None:
+    if settings_key not in settings.agent_settings.mcp_config:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"MCP server '{settings_key}' was not found",
+        )
+
+
+@settings_router.post(
+    MCP_SERVER_PATH,
+    response_model=SettingsResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_mcp_server(
+    request: Request,
+    settings_key: str,
+    server: MCPServer,
+) -> SettingsResponse:
+    """Create one named MCP server without replacing an existing map entry."""
+    server_data = server.model_dump(
+        mode="python",
+        context={"expose_secrets": "plaintext"},
+        exclude_none=True,
+        exclude_defaults=True,
+    )
+    update_data = cast(
+        SettingsUpdatePayload,
+        {"agent_settings_diff": {"mcp_config": {settings_key: server_data}}},
+    )
+    return _apply_settings_update(
+        request,
+        update_data,
+        lambda settings: _require_mcp_server_absent(settings, settings_key),
+    )
+
+
+@settings_router.patch(MCP_SERVER_PATH, response_model=SettingsResponse)
+async def patch_mcp_server(
+    request: Request,
+    settings_key: str,
+    patch: MCPServerPatch,
+) -> SettingsResponse:
+    """Sparsely update one existing named MCP server."""
+    patch_data = patch.model_dump(
+        mode="python",
+        context={"expose_secrets": "plaintext"},
+        exclude_unset=True,
+    )
+    update_data = cast(
+        SettingsUpdatePayload,
+        {"agent_settings_diff": {"mcp_config": {settings_key: patch_data}}},
+    )
+    return _apply_settings_update(
+        request,
+        update_data,
+        lambda settings: _require_mcp_server_present(settings, settings_key),
+    )
+
+
+@settings_router.delete(MCP_SERVER_PATH, response_model=SettingsResponse)
+async def delete_mcp_server(request: Request, settings_key: str) -> SettingsResponse:
+    """Delete one existing named MCP server without altering sibling entries."""
+    update_data = cast(
+        SettingsUpdatePayload,
+        {"agent_settings_diff": {"mcp_config": {settings_key: None}}},
+    )
+    return _apply_settings_update(
+        request,
+        update_data,
+        lambda settings: _require_mcp_server_present(settings, settings_key),
     )
 
 

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -43,7 +43,7 @@ logger = get_logger(__name__)
 # while this router uses relative paths. The paths are intentionally separate
 # to match their respective contexts (router prefix vs full URL path).
 SETTINGS_PATH = ""  # -> /api/settings
-MCP_SERVER_PATH = "/mcp/{settings_key:path}"  # -> /api/settings/mcp/{settings_key}
+MCP_SERVER_PATH = "/mcp/{settings_key}"  # -> /api/settings/mcp/{settings_key}
 SECRETS_PATH = "/secrets"  # -> /api/settings/secrets
 SECRET_VALUE_PATH = "/secrets/{name}"  # -> /api/settings/secrets/{name}
 

--- a/tests/agent_server/telemetry/test_telemetry_concurrency.py
+++ b/tests/agent_server/telemetry/test_telemetry_concurrency.py
@@ -213,7 +213,7 @@ def test_consent_is_never_read_from_inside_a_settings_lock():
     """
     import openhands.agent_server.settings_router as router_mod
 
-    src = inspect.getsource(router_mod.update_settings)
+    src = inspect.getsource(router_mod._apply_settings_update)
     update_at = src.index("store.update(")
     notify_at = src.index("notify_misc_settings_changed(")
     assert update_at < notify_at, (

--- a/tests/agent_server/test_openapi_contract.py
+++ b/tests/agent_server/test_openapi_contract.py
@@ -101,6 +101,33 @@ def test_settings_contract_exposes_typed_mcp_response_and_patch() -> None:
     ]["anyOf"]
 
 
+def test_mcp_server_crud_operations_use_canonical_contract_types() -> None:
+    document = build_public_openapi()
+    operations = document["paths"]["/api/settings/mcp/{settings_key}"]
+
+    create = operations["post"]
+    assert create["requestBody"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/MCPServer-Input"
+    }
+    assert create["responses"]["201"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/SettingsResponse"
+    }
+
+    patch = operations["patch"]
+    assert patch["requestBody"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/MCPServerPatch"
+    }
+    assert patch["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/SettingsResponse"
+    }
+
+    delete = operations["delete"]
+    assert "requestBody" not in delete
+    assert delete["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/SettingsResponse"
+    }
+
+
 def test_mcp_server_patch_tracks_every_canonical_server_field() -> None:
     """Keep the sparse patch contract in lock-step with the persisted model."""
     assert set(MCPServerPatch.model_fields) == set(MCPServer.model_fields)

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -915,6 +915,32 @@ def test_mcp_server_crud_endpoints_enforce_key_preconditions(client_with_setting
     assert plaintext["github"]["url"] == "https://github.example/mcp"
 
 
+def test_mcp_server_crud_endpoints_normalize_key_paths(client_with_settings):
+    server = {"transport": "http", "url": "https://github.example/mcp"}
+    created = client_with_settings.post("/api/settings/mcp/github", json=server)
+    assert created.status_code == 201, created.text
+
+    trailing_slash = client_with_settings.post(
+        "/api/settings/mcp/github/",
+        json=server,
+        follow_redirects=False,
+    )
+    assert trailing_slash.status_code == 307
+    assert trailing_slash.headers["location"].endswith("/api/settings/mcp/github")
+
+    empty_key = client_with_settings.post(
+        "/api/settings/mcp/",
+        json=server,
+        follow_redirects=False,
+    )
+    assert empty_key.status_code == 404
+
+    mcp_config = client_with_settings.get("/api/settings").json()["agent_settings"][
+        "mcp_config"
+    ]
+    assert set(mcp_config) == {"github"}
+
+
 def test_patch_settings_empty_payload_returns_400(client_with_settings):
     """PATCH /api/settings with empty payload returns 400."""
     response = client_with_settings.patch("/api/settings", json={})

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -831,6 +831,90 @@ def test_patch_settings_encrypts_mcp_env_and_headers_on_disk(
     assert servers["remote"]["headers"] == {"X-Api-Key": "tok-router-secret"}
 
 
+def test_mcp_server_crud_endpoints_preserve_sibling_credentials(client_with_settings):
+    github = client_with_settings.post(
+        "/api/settings/mcp/github",
+        json={
+            "transport": "http",
+            "url": "https://github.example/mcp",
+            "auth": {"strategy": "bearer", "value": "github-secret"},
+        },
+    )
+    assert github.status_code == 201, github.text
+    assert github.json()["agent_settings"]["mcp_config"]["github"]["auth"] == {
+        "strategy": "bearer",
+        "value": "**********",
+    }
+
+    docs = client_with_settings.post(
+        "/api/settings/mcp/docs",
+        json={"transport": "http", "url": "https://docs.example/mcp"},
+    )
+    assert docs.status_code == 201, docs.text
+
+    updated_docs = client_with_settings.patch(
+        "/api/settings/mcp/docs",
+        json={"description": "Documentation"},
+    )
+    assert updated_docs.status_code == 200, updated_docs.text
+
+    plaintext = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()["agent_settings"]["mcp_config"]
+    assert plaintext["github"]["auth"]["value"] == "github-secret"
+    assert plaintext["docs"]["description"] == "Documentation"
+
+    deleted_docs = client_with_settings.delete("/api/settings/mcp/docs")
+    assert deleted_docs.status_code == 200, deleted_docs.text
+    assert set(deleted_docs.json()["agent_settings"]["mcp_config"]) == {"github"}
+
+    replaced_auth = client_with_settings.patch(
+        "/api/settings/mcp/github",
+        json={"auth": {"strategy": "bearer", "value": "new-github-secret"}},
+    )
+    assert replaced_auth.status_code == 200, replaced_auth.text
+    plaintext = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()["agent_settings"]["mcp_config"]
+    assert plaintext["github"]["auth"]["value"] == "new-github-secret"
+
+    cleared_auth = client_with_settings.patch(
+        "/api/settings/mcp/github",
+        json={"auth": None},
+    )
+    assert cleared_auth.status_code == 200, cleared_auth.text
+    assert "auth" not in cleared_auth.json()["agent_settings"]["mcp_config"]["github"]
+
+
+def test_mcp_server_crud_endpoints_enforce_key_preconditions(client_with_settings):
+    created = client_with_settings.post(
+        "/api/settings/mcp/github",
+        json={"transport": "http", "url": "https://github.example/mcp"},
+    )
+    assert created.status_code == 201, created.text
+
+    duplicate = client_with_settings.post(
+        "/api/settings/mcp/github",
+        json={"transport": "http", "url": "https://replacement.example/mcp"},
+    )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "MCP server 'github' already exists"
+
+    missing_patch = client_with_settings.patch(
+        "/api/settings/mcp/missing",
+        json={"description": "Missing"},
+    )
+    assert missing_patch.status_code == 404
+
+    missing_delete = client_with_settings.delete("/api/settings/mcp/missing")
+    assert missing_delete.status_code == 404
+
+    plaintext = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()["agent_settings"]["mcp_config"]
+    assert plaintext["github"]["url"] == "https://github.example/mcp"
+
+
 def test_patch_settings_empty_payload_returns_400(client_with_settings):
     """PATCH /api/settings with empty payload returns 400."""
     response = client_with_settings.patch("/api/settings", json={})

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -2115,6 +2115,7 @@ def test_settings_and_secrets_api_with_live_server(server_env):
     Validates the full REST API for settings and secrets management
     through the live agent-server, including:
     - GET/PATCH settings
+    - POST/PATCH/DELETE MCP servers
     - GET/PUT/DELETE secrets
     - Secret name validation
     - Encryption/decryption round-trip
@@ -2137,6 +2138,26 @@ def test_settings_and_secrets_api_with_live_server(server_env):
         assert patch_resp.status_code == 200
         patched = patch_resp.json()
         assert patched["agent_settings"]["llm"]["model"] == "gpt-4o"
+
+        create_mcp_resp = client.post(
+            "/api/settings/mcp/docs",
+            json={"transport": "http", "url": "https://docs.example/mcp"},
+        )
+        assert create_mcp_resp.status_code == 201
+
+        patch_mcp_resp = client.patch(
+            "/api/settings/mcp/docs",
+            json={"description": "Documentation"},
+        )
+        assert patch_mcp_resp.status_code == 200
+        assert (
+            patch_mcp_resp.json()["agent_settings"]["mcp_config"]["docs"]["description"]
+            == "Documentation"
+        )
+
+        delete_mcp_resp = client.delete("/api/settings/mcp/docs")
+        assert delete_mcp_resp.status_code == 200
+        assert "docs" not in delete_mcp_resp.json()["agent_settings"]["mcp_config"]
 
         # ── Test secrets CRUD endpoints ────────────────────────────────────
         # List secrets (should be empty initially)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

As part of this stack of 3 PRs, I have verified that adding two consecutive MCPs works:

1. [software-agent-sdk #4294 — Add MCP settings CRUD endpoints](https://github.com/OpenHands/software-agent-sdk/pull/4294)  
2. [typescript-client #302 — Add canonical MCP settings operations](https://github.com/OpenHands/typescript-client/pull/302)  
3. [OpenHands #16144 — Preserve MCP credentials during Canvas mutations](https://github.com/OpenHands/OpenHands/pull/16144)  

<img width="624" height="171" alt="Screenshot 2026-07-28 at 6 34 41 PM" src="https://github.com/user-attachments/assets/d4522fc9-33e6-44b0-8686-a156e90bf9e5" />
<img width="291" height="411" alt="Screenshot 2026-07-28 at 6 39 07 PM" src="https://github.com/user-attachments/assets/e3d66513-da48-4659-a911-793e380280c6" />


<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Agent Server already owns canonical MCP settings, secrets, locking, and RFC 7386 merge behavior, but clients must currently construct the enclosing `PATCH /api/settings` payload themselves. First-class one-server operations make create, sparse update, and delete intent discoverable in OpenAPI and keep key preconditions atomic with persistence.

## Summary

- Add `POST /api/settings/mcp/{settings_key}` for create-only semantics with `409` collision handling.
- Add `PATCH` and `DELETE` operations on the same path for existing servers, returning `404` when the key is absent.
- Reuse the existing settings-store lock and merge implementation; add unit, OpenAPI contract, and real live-server coverage.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `1f9f0b1aa035` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -6,0 +7 @@
+operation DELETE /api/settings/mcp/{settings_key} operationId=delete_mcp_server_api_settings_mcp__settings_key__delete
@@ -63,0 +65 @@
+operation PATCH /api/settings/mcp/{settings_key} operationId=patch_mcp_server_api_settings_mcp__settings_key__patch
@@ -106,0 +109 @@
+operation POST /api/settings/mcp/{settings_key} operationId=create_mcp_server_api_settings_mcp__settings_key__post
@@ -118,0 +122 @@
+parameter DELETE /api/settings/mcp/{settings_key} path:settings_key required=true schema=type="string"
@@ -196,0 +201 @@
+parameter PATCH /api/settings/mcp/{settings_key} path:settings_key required=true schema=type="string"
@@ -229,0 +235 @@
+parameter POST /api/settings/mcp/{settings_key} path:settings_key required=true schema=type="string"
@@ -235,0 +242 @@
+requestBody PATCH /api/settings/mcp/{settings_key} application/json required=true schema=MCPServerPatch
@@ -265,0 +273 @@
+requestBody POST /api/settings/mcp/{settings_key} application/json required=true schema=MCPServer-Input
@@ -283,0 +292,2 @@
+response DELETE /api/settings/mcp/{settings_key} 200 application/json schema=SettingsResponse
+response DELETE /api/settings/mcp/{settings_key} 422 application/json schema=HTTPValidationError
@@ -392,0 +403,2 @@
+response PATCH /api/settings/mcp/{settings_key} 200 application/json schema=SettingsResponse
+response PATCH /api/settings/mcp/{settings_key} 422 application/json schema=HTTPValidationError
@@ -506,0 +519,2 @@
+response POST /api/settings/mcp/{settings_key} 201 application/json schema=SettingsResponse
+response POST /api/settings/mcp/{settings_key} 422 application/json schema=HTTPValidationError
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Fixes #4293

## How to Test

- `uv run pytest tests/agent_server/test_settings_router.py tests/agent_server/test_openapi_contract.py -q` — 74 passed.
- With ambient OpenHands configuration variables removed, `uv run pytest tests/cross/test_remote_conversation_live_server.py::test_settings_and_secrets_api_with_live_server -q` — 1 passed against a real FastAPI/uvicorn server.
- `make test-server-schema` — deterministic export, OpenAPI type-quality check, and schema validation passed.
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/settings_router.py tests/agent_server/test_openapi_contract.py tests/agent_server/test_settings_router.py tests/cross/test_remote_conversation_live_server.py` — all hooks passed.

The stateful route test creates a bearer-authenticated GitHub MCP server, adds and edits a sibling, confirms the GitHub credential survives, deletes the sibling, replaces and clears auth, and verifies create/update/delete key preconditions.

## Video/Screenshots

Not applicable: this is an Agent Server REST API change with no UI.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The operations are additive. Mutation responses remain redacted, and all persistence still flows through the canonical settings update implementation under the existing store lock. The generated TypeScript contract and client wrappers will be updated after this Agent Server change lands in a release.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7dabdc1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7dabdc1-python \
  ghcr.io/openhands/agent-server:7dabdc1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7dabdc1-golang-amd64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-golang-amd64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-golang-amd64
ghcr.io/openhands/agent-server:7dabdc1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7dabdc1-golang-arm64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-golang-arm64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-golang-arm64
ghcr.io/openhands/agent-server:7dabdc1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7dabdc1-java-amd64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-java-amd64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-java-amd64
ghcr.io/openhands/agent-server:7dabdc1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7dabdc1-java-arm64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-java-arm64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-java-arm64
ghcr.io/openhands/agent-server:7dabdc1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7dabdc1-python-amd64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-python-amd64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-python-amd64
ghcr.io/openhands/agent-server:7dabdc1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7dabdc1-python-arm64
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-python-arm64
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-python-arm64
ghcr.io/openhands/agent-server:7dabdc1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7dabdc1-golang
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-golang
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-golang
ghcr.io/openhands/agent-server:7dabdc1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7dabdc1-java
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-java
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-java
ghcr.io/openhands/agent-server:7dabdc1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7dabdc1-python
ghcr.io/openhands/agent-server:7dabdc1d2e82d5575d2ba036273559a044d2ccca-python
ghcr.io/openhands/agent-server:agent-mcp-settings-endpoints-python
ghcr.io/openhands/agent-server:7dabdc1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7dabdc1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7dabdc1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
