### PR TITLE
test(settings): reject unversioned persisted shape changes

### DIFF
--- a/.github/scripts/check_persisted_settings_compat.py
+++ b/.github/scripts/check_persisted_settings_compat.py
@@ -516,12 +516,56 @@ def _assert_expected_paths(
             )
 
 
+def _find_unpreserved_path(
+    expected: Any,
+    actual: Any,
+    *,
+    path: str = "",
+) -> str | None:
+    """Return the first historical path missing or changed in ``actual``.
+
+    New mapping keys are compatible, but every value already emitted under the
+    current schema version must survive a load/dump round-trip unchanged.
+    """
+    if isinstance(expected, Mapping):
+        if not isinstance(actual, Mapping):
+            return path
+        for key, expected_value in expected.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            if key not in actual:
+                return child_path
+            changed_path = _find_unpreserved_path(
+                expected_value,
+                actual[key],
+                path=child_path,
+            )
+            if changed_path is not None:
+                return changed_path
+        return None
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(expected) != len(actual):
+            return path
+        for index, expected_value in enumerate(expected):
+            changed_path = _find_unpreserved_path(
+                expected_value,
+                actual[index],
+                path=f"{path}[{index}]",
+            )
+            if changed_path is not None:
+                return changed_path
+        return None
+    if expected != actual:
+        return path
+    return None
+
+
 def _validate_single_payload(
     *,
     payload: Mapping[str, Any],
     surface: SurfaceConfig,
     origin: str,
     expected_paths: Mapping[str, Any] | None = None,
+    require_same_version_preservation: bool = False,
 ) -> None:
     raw_payload = _copy_payload(payload)
     raw_version = raw_payload.get("schema_version")
@@ -547,6 +591,20 @@ def _validate_single_payload(
         raise PersistedSettingsCompatError(
             f"{surface.display_name} payload from {origin} round-tripped with "
             f"schema_version {roundtrip_version}, expected {surface.current_version}."
+        )
+    unpreserved_path = None
+    if (
+        require_same_version_preservation
+        and type(raw_version) is int
+        and raw_version == surface.current_version
+    ):
+        unpreserved_path = _find_unpreserved_path(raw_payload, roundtrip)
+    if unpreserved_path is not None:
+        raise PersistedSettingsCompatError(
+            f"{surface.display_name} payload from {origin} did not preserve persisted "
+            f"field {unpreserved_path!r} without advancing schema_version "
+            f"{raw_version}. "
+            f"{surface.migration_guidance}"
         )
     if expected_paths:
         _assert_expected_paths(
@@ -678,6 +736,7 @@ def validate_baseline_payload_cases(
             payload=case.payload,
             surface=surface,
             origin=f"{case.source} ({case.key})",
+            require_same_version_preservation=True,
         )
 
 

--- a/tests/cross/test_check_persisted_settings_compat.py
+++ b/tests/cross/test_check_persisted_settings_compat.py
@@ -8,8 +8,10 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 
 os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
@@ -28,11 +30,59 @@ def _load_script_module(name: str):
 
 _prod = _load_script_module("check_persisted_settings_compat")
 PersistedSettingsCompatError = _prod.PersistedSettingsCompatError
+BaselinePayloadCase = _prod.BaselinePayloadCase
 FixtureCase = _prod.FixtureCase
 SURFACES = _prod.SURFACES
+SurfaceConfig = _prod.SurfaceConfig
 collect_fixture_cases = _prod.collect_fixture_cases
 get_pypi_baseline_version = _prod.get_pypi_baseline_version
+validate_baseline_payload_cases = _prod.validate_baseline_payload_cases
 validate_fixture_cases = _prod.validate_fixture_cases
+
+
+class _FlattenedMCPSettings(BaseModel):
+    schema_version: int
+    mcp_config: dict[str, Any]
+
+
+class _AdditiveItem(BaseModel):
+    existing: str
+    added: str | None = None
+
+
+class _AdditiveSettings(BaseModel):
+    schema_version: int
+    items: list[_AdditiveItem]
+
+
+def _load_and_flatten_mcp_settings(data: Any) -> _FlattenedMCPSettings:
+    payload = dict(data)
+    payload["schema_version"] = 1
+    mcp_config = payload["mcp_config"]
+    if "mcpServers" in mcp_config:
+        payload["mcp_config"] = mcp_config["mcpServers"]
+    return _FlattenedMCPSettings.model_validate(payload)
+
+
+def _load_additive_settings(data: Any) -> _AdditiveSettings:
+    return _AdditiveSettings.model_validate(data)
+
+
+_SHAPE_CHANGING_SURFACE = SurfaceConfig(
+    key="agent_settings",
+    display_name="AgentSettings",
+    current_version=1,
+    loader=_load_and_flatten_mcp_settings,
+    migration_guidance="Bump the schema version and add a migration.",
+)
+
+_ADDITIVE_SURFACE = SurfaceConfig(
+    key="agent_settings",
+    display_name="AgentSettings",
+    current_version=1,
+    loader=_load_additive_settings,
+    migration_guidance="Bump the schema version and add a migration.",
+)
 
 
 def _mock_pypi_releases(monkeypatch, releases: dict[str, list[dict[str, str]]]) -> None:
@@ -203,6 +253,78 @@ def test_get_pypi_baseline_version_raises_on_metadata_failure(monkeypatch) -> No
         match="Failed to fetch PyPI metadata for openhands-sdk",
     ):
         get_pypi_baseline_version("openhands-sdk", "1.2.0")
+
+
+def test_validate_baseline_rejects_shape_change_without_version_bump() -> None:
+    case = BaselinePayloadCase(
+        source="PyPI baseline openhands-sdk==1.0.0",
+        key="agent_settings/populated",
+        surface_key="agent_settings",
+        payload={
+            "schema_version": 1,
+            "mcp_config": {
+                "mcpServers": {
+                    "shttp": {
+                        "url": "https://example.com/mcp",
+                        "timeout": 60,
+                    }
+                }
+            },
+        },
+    )
+
+    with pytest.raises(
+        PersistedSettingsCompatError,
+        match=(
+            "did not preserve persisted field 'mcp_config.mcpServers' "
+            "without advancing schema_version 1"
+        ),
+    ):
+        validate_baseline_payload_cases(
+            [case],
+            surfaces={"agent_settings": _SHAPE_CHANGING_SURFACE},
+        )
+
+
+def test_validate_baseline_allows_shape_change_with_version_bump() -> None:
+    case = BaselinePayloadCase(
+        source="PyPI baseline openhands-sdk==0.9.0",
+        key="agent_settings/populated",
+        surface_key="agent_settings",
+        payload={
+            "schema_version": 0,
+            "mcp_config": {
+                "mcpServers": {
+                    "shttp": {
+                        "url": "https://example.com/mcp",
+                        "timeout": 60,
+                    }
+                }
+            },
+        },
+    )
+
+    validate_baseline_payload_cases(
+        [case],
+        surfaces={"agent_settings": _SHAPE_CHANGING_SURFACE},
+    )
+
+
+def test_validate_baseline_allows_additive_same_version_fields() -> None:
+    case = BaselinePayloadCase(
+        source="PyPI baseline openhands-sdk==1.0.0",
+        key="agent_settings/default",
+        surface_key="agent_settings",
+        payload={
+            "schema_version": 1,
+            "items": [{"existing": "preserved"}],
+        },
+    )
+
+    validate_baseline_payload_cases(
+        [case],
+        surfaces={"agent_settings": _ADDITIVE_SURFACE},
+    )
 
 
 def test_generate_baseline_payloads_uses_uv_with_release_cutoff(monkeypatch) -> None:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

This is a testing-only change, so no human verification is needed.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The persisted-settings compatibility check proved that payloads from older
releases still loaded, but it did not reject removal, relocation, or rewriting
of existing fields when the schema version stayed unchanged. That allowed the
schema-v4 MCP shape to change from `mcp_config.mcpServers.<name>` to
`mcp_config.<name>` without a version bump.

## Summary

- Require every path and value emitted by a same-version PyPI baseline to
  survive the current load/dump round-trip.
- Continue allowing additive mapping fields and shape changes backed by a
  schema-version migration.
- Add a regression reproducing the legacy wrapped-to-flat MCP rewrite.

## Issue Number

N/A

## How to Test

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run pytest -q tests/cross/test_check_persisted_settings_compat.py
```

Result: `13 passed`.

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run python .github/scripts/check_persisted_settings_compat.py
```

Result:

```text
Validated 9 persisted settings fixture(s) under tests/sdk/persisted_settings_baselines
Validated 7 baseline payload(s) from PyPI release openhands-sdk==1.38.0, openhands-agent-server==1.38.0
```

```bash
uv run pre-commit run --files .github/scripts/check_persisted_settings_compat.py tests/cross/test_check_persisted_settings_compat.py
```

Result: Ruff format/lint, pycodestyle, pyright, import rules, and tool
registration all passed.

## Video/Screenshots

Not applicable; this changes a CI compatibility check.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Additive fields remain compatible. Existing fields may only be removed, moved,
or changed after advancing the relevant schema version and adding a migration.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8cbe162-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8cbe162-python \
  ghcr.io/openhands/agent-server:8cbe162-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8cbe162-golang-amd64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-golang-amd64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-golang-amd64
ghcr.io/openhands/agent-server:8cbe162-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8cbe162-golang-arm64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-golang-arm64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-golang-arm64
ghcr.io/openhands/agent-server:8cbe162-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8cbe162-java-amd64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-java-amd64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-java-amd64
ghcr.io/openhands/agent-server:8cbe162-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8cbe162-java-arm64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-java-arm64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-java-arm64
ghcr.io/openhands/agent-server:8cbe162-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8cbe162-python-amd64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-python-amd64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-python-amd64
ghcr.io/openhands/agent-server:8cbe162-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8cbe162-python-arm64
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-python-arm64
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-python-arm64
ghcr.io/openhands/agent-server:8cbe162-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8cbe162-golang
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-golang
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-golang
ghcr.io/openhands/agent-server:8cbe162-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8cbe162-java
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-java
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-java
ghcr.io/openhands/agent-server:8cbe162-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8cbe162-python
ghcr.io/openhands/agent-server:8cbe162569b6dda50a215f1732a8a51f7665a898-python
ghcr.io/openhands/agent-server:agent-enforce-persisted-settings-version-shape-python
ghcr.io/openhands/agent-server:8cbe162-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8cbe162-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8cbe162-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->