### PR TITLE
test(sdk): stabilize MCP stdio integration tests

### DIFF
--- a/tests/sdk/mcp/stdio_test_server.py
+++ b/tests/sdk/mcp/stdio_test_server.py
@@ -1,0 +1,26 @@
+"""Run the deterministic stdio MCP test server."""
+
+from typing import Annotated
+
+from fastmcp import FastMCP
+from pydantic import Field
+
+
+mcp = FastMCP("stdio-test-server")
+
+
+@mcp.tool()
+def fetch(
+    url: Annotated[str, Field(description="URL to fetch.")],
+    max_length: Annotated[
+        int,
+        Field(description="Maximum number of characters to return."),
+    ] = 5000,
+) -> str:
+    """Fetch a URL."""
+    result = f"Fetched {url}"
+    return result[:max_length]
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio", show_banner=False)

--- a/tests/sdk/mcp/test_create_mcp_tool.py
+++ b/tests/sdk/mcp/test_create_mcp_tool.py
@@ -3,9 +3,11 @@
 import asyncio
 import logging
 import socket
+import sys
 import threading
 import time
 from collections.abc import Generator
+from pathlib import Path
 from typing import Literal
 from unittest.mock import MagicMock, patch
 
@@ -38,6 +40,19 @@ MCPTransport = Literal["http", "streamable-http", "sse"]
 
 def native_mcp_config(config: dict) -> dict:
     return coerce_mcp_config(config["mcpServers"])
+
+
+def stdio_fetch_mcp_config() -> dict:
+    repo_root = Path(__file__).resolve().parents[3]
+    return {
+        "mcpServers": {
+            "fetch": {
+                "command": sys.executable,
+                "args": ["-m", "tests.sdk.mcp.stdio_test_server"],
+                "cwd": str(repo_root),
+            }
+        }
+    }
 
 
 @pytest.mark.parametrize(
@@ -583,12 +598,9 @@ def test_create_mcp_tools_connection_to_nonexistent_server():
 
 def test_create_mcp_tools_stdio_server():
     """Test creating MCP tools from a native server map."""
-    mcp_config = {
-        "mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}
-    }
+    mcp_config = stdio_fetch_mcp_config()
 
-    # Use longer timeout for CI environments where uvx may need to download packages
-    tools = create_mcp_tools(native_mcp_config(mcp_config), timeout=120.0)
+    tools = create_mcp_tools(native_mcp_config(mcp_config), timeout=10.0)
     assert len(tools) == 1
     assert tools[0].name == "fetch"
 

--- a/tests/sdk/mcp/test_mcp_tool_kind_field.py
+++ b/tests/sdk/mcp/test_mcp_tool_kind_field.py
@@ -4,6 +4,9 @@ This test reproduces issue #886 where the 'kind' field from DiscriminatedUnionMi
 is incorrectly included in the MCP tool arguments, causing validation errors.
 """
 
+import sys
+from pathlib import Path
+
 import pytest
 
 from openhands.sdk.mcp import create_mcp_tools
@@ -12,12 +15,18 @@ from openhands.sdk.mcp.config import coerce_mcp_config
 
 @pytest.fixture
 def fetch_tool():
-    """Create a real MCP fetch tool using the mcp-server-fetch package."""
+    """Create a real MCP fetch tool using a local stdio server."""
+    repo_root = Path(__file__).resolve().parents[3]
     mcp_config = {
-        "mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}
+        "mcpServers": {
+            "fetch": {
+                "command": sys.executable,
+                "args": ["-m", "tests.sdk.mcp.stdio_test_server"],
+                "cwd": str(repo_root),
+            }
+        }
     }
-    # Use longer timeout for CI environments where uvx may need to download packages
-    tools = create_mcp_tools(coerce_mcp_config(mcp_config["mcpServers"]), timeout=120.0)
+    tools = create_mcp_tools(coerce_mcp_config(mcp_config["mcpServers"]), timeout=10.0)
     assert len(tools) == 1
     return tools[0]
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix CI failure with MCP stdio 

---

AGENT:

## Why

The SDK test suite installs `mcp-server-fetch` at runtime through `uvx`. MCP SDK 2.0.0 removed the old `McpError` symbol while the fetch server still imports it, so five stdio integration tests began failing without an SDK code change.

## Summary

- Add a deterministic in-repository FastMCP stdio server with the same `fetch` input shape used by the affected tests.
- Run it with the active Python interpreter instead of resolving and downloading a floating external package.
- Keep real subprocess, stdio handshake, tool discovery, schema, and tool-call coverage while reducing the setup timeout from 120 seconds to 10 seconds.

## Issue Number

N/A — external dependency CI regression after MCP SDK 2.0.0.

## How to Test

The focused integration path launches the local server in a real subprocess and exercises MCP discovery and execution over stdio.

`uv run pytest -q tests/sdk/mcp/test_create_mcp_tool.py::test_create_mcp_tools_stdio_server tests/sdk/mcp/test_mcp_tool_kind_field.py`

Result: `5 passed in 3.12s`

`CI=true uv run python -m pytest -q -n auto tests/sdk/mcp`

Result: `122 passed in 8.75s`

`uv run pre-commit run --files tests/sdk/mcp/stdio_test_server.py tests/sdk/mcp/test_create_mcp_tool.py tests/sdk/mcp/test_mcp_tool_kind_field.py`

Result: all checks passed.

## Video/Screenshots

N/A — test-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This extracts the MCP stdio test stabilization already validated in #3948 into a focused PR. It changes no production code and includes no Windows-related changes.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bb62891-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bb62891-python \
  ghcr.io/openhands/agent-server:bb62891-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bb62891-golang-amd64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-golang-amd64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-golang-amd64
ghcr.io/openhands/agent-server:bb62891-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bb62891-golang-arm64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-golang-arm64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-golang-arm64
ghcr.io/openhands/agent-server:bb62891-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bb62891-java-amd64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-java-amd64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-java-amd64
ghcr.io/openhands/agent-server:bb62891-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bb62891-java-arm64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-java-arm64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-java-arm64
ghcr.io/openhands/agent-server:bb62891-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bb62891-python-amd64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-python-amd64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-python-amd64
ghcr.io/openhands/agent-server:bb62891-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bb62891-python-arm64
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-python-arm64
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-python-arm64
ghcr.io/openhands/agent-server:bb62891-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bb62891-golang
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-golang
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-golang
ghcr.io/openhands/agent-server:bb62891-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bb62891-java
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-java
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-java
ghcr.io/openhands/agent-server:bb62891-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bb62891-python
ghcr.io/openhands/agent-server:bb62891b152ceb905f8a488764e92d6d9b8bb0d0-python
ghcr.io/openhands/agent-server:fix-mcp-stdio-tests-python
ghcr.io/openhands/agent-server:bb62891-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bb62891-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bb62891-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->