### PR TITLE
chore(release): remove OpenHands Index checklist item

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -127,7 +127,6 @@ These PRs will:
 
 - [ ] Merge the release PR to main
 - [ ] Review and merge the auto-created version bump PRs in OpenHands, OpenHands-CLI, automation, and typescript-client (merging the automation PR triggers its release-please release PR; merge that too to publish the pinned `openhands-automation`)
-- [ ] Run evaluation on OpenHands Index (manual step)
 - [ ] Announce the release
 
 ## Manual PyPI Release (If Needed)
@@ -192,6 +191,5 @@ For reference, the previous manual release checklist was:
 - [ ] Tag "test-examples" and make sure example checks all pass
 - [ ] Draft a new release
 - [ ] Use workflow to publish to PyPI on tag `v1.X.X`
-- [ ] Evaluation on OpenHands Index
 
 Most of these steps are now automated!

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -99,7 +99,6 @@ jobs:
                   - [ ] Behavior tests pass (tagged with `behavior-test`)
                   - [ ] Example tests pass (tagged with `test-examples`)
                   - [ ] Security scan passes (tagged with `security-scan`)
-                  - [ ] Evaluation on OpenHands Index
                   - [ ] Confirm any `release-note-required` PRs are accurately called out in the final release notes
 
                   ### What happens on merge


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I, as a human, confirm this change.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

OpenHands Index evaluation is no longer a release requirement, but the automated release PR template and release documentation still present it as a checklist item.

## Summary

- Remove the OpenHands Index evaluation item from generated release PR checklists.
- Remove the same item from current and historical release documentation checklists.

## Issue Number

N/A

## How to Test

Run:

```bash
uv run pre-commit run --files .github/workflows/prepare-release.yml
uv run pre-commit run --files .github/workflows/README-RELEASE.md
```

Both commands pass. A repository search confirms neither release checklist retains the OpenHands Index item.

## Video/Screenshots

Not applicable; this changes release automation text only.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The current v1.39.0 release PR was updated separately so this obsolete item is ignored immediately.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4ba7664-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4ba7664-python \
  ghcr.io/openhands/agent-server:4ba7664-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4ba7664-golang-amd64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-golang-amd64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-golang-amd64
ghcr.io/openhands/agent-server:4ba7664-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4ba7664-golang-arm64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-golang-arm64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-golang-arm64
ghcr.io/openhands/agent-server:4ba7664-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4ba7664-java-amd64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-java-amd64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-java-amd64
ghcr.io/openhands/agent-server:4ba7664-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4ba7664-java-arm64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-java-arm64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-java-arm64
ghcr.io/openhands/agent-server:4ba7664-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4ba7664-python-amd64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-python-amd64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-python-amd64
ghcr.io/openhands/agent-server:4ba7664-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4ba7664-python-arm64
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-python-arm64
ghcr.io/openhands/agent-server:agent-remove-index-release-check-python-arm64
ghcr.io/openhands/agent-server:4ba7664-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4ba7664-golang
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-golang
ghcr.io/openhands/agent-server:agent-remove-index-release-check-golang
ghcr.io/openhands/agent-server:4ba7664-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4ba7664-java
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-java
ghcr.io/openhands/agent-server:agent-remove-index-release-check-java
ghcr.io/openhands/agent-server:4ba7664-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4ba7664-python
ghcr.io/openhands/agent-server:4ba7664d440930bb2897a4fc4ef658b61bcbbbd8-python
ghcr.io/openhands/agent-server:agent-remove-index-release-check-python
ghcr.io/openhands/agent-server:4ba7664-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4ba7664-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4ba7664-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->