### PR TITLE
fix(ci): bind release smoke container port

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -372,8 +372,8 @@ jobs:
                   echo "Starting container ..."
                   docker run --platform="linux/${ARCH}" -d --rm \
                       --name "$CONTAINER" \
-                      -p 8000:8000 \
-                      "$TAG_FQN"
+                      -p 127.0.0.1:8000:8000 \
+                      "$TAG_FQN" --host 0.0.0.0
 
                   cleanup() {
                       docker logs "$CONTAINER" 2>&1 | tail -100 || true


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

CI seems to be passing after this.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The `v1.39.0` release artifact workflow published its assets successfully, but
all six Docker smoke jobs timed out on `/health`. The containers started normally
but defaulted to `127.0.0.1` inside the container, so the runner could not reach
them through Docker's published port.

## Summary

- Publish port 8000 only on the runner's loopback interface.
- Explicitly bind agent-server to `0.0.0.0` inside the container, matching the
  existing TypeScript integration-test pattern.

## Issue Number

N/A

## How to Test

- `uv run pre-commit run --files .github/workflows/release-binaries.yml` — passed.
- Ran `ghcr.io/openhands/agent-server:1.39.0-python` locally with
  `-p 127.0.0.1:18081:8000` and `--host 0.0.0.0`; `/health` returned HTTP 200
  after seven polling attempts.

## Video/Screenshots

N/A — CI-only workflow fix. The failure is visible in the
[v1.39.0 artifact workflow](https://github.com/OpenHands/software-agent-sdk/actions/runs/30451843656).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The release assets, PyPI packages, and container images were already published
successfully; this fixes the post-publish Docker reachability check.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:eaef0cf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-eaef0cf-python \
  ghcr.io/openhands/agent-server:eaef0cf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:eaef0cf-golang-amd64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-golang-amd64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-golang-amd64
ghcr.io/openhands/agent-server:eaef0cf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:eaef0cf-golang-arm64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-golang-arm64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-golang-arm64
ghcr.io/openhands/agent-server:eaef0cf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:eaef0cf-java-amd64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-java-amd64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-java-amd64
ghcr.io/openhands/agent-server:eaef0cf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:eaef0cf-java-arm64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-java-arm64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-java-arm64
ghcr.io/openhands/agent-server:eaef0cf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:eaef0cf-python-amd64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-python-amd64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-python-amd64
ghcr.io/openhands/agent-server:eaef0cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:eaef0cf-python-arm64
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-python-arm64
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-python-arm64
ghcr.io/openhands/agent-server:eaef0cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:eaef0cf-golang
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-golang
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-golang
ghcr.io/openhands/agent-server:eaef0cf-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:eaef0cf-java
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-java
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-java
ghcr.io/openhands/agent-server:eaef0cf-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:eaef0cf-python
ghcr.io/openhands/agent-server:eaef0cf0c3780ea894fcc66ae0d4160e53122dcc-python
ghcr.io/openhands/agent-server:agent-fix-release-smoke-bind-python
ghcr.io/openhands/agent-server:eaef0cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `eaef0cf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `eaef0cf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->