### PR TITLE
feat: add MCPServer.enabled to switch a server off without removing it

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -563,6 +563,10 @@ def _mcp_config_to_acp_servers(
     these are *not* turned into in-process SDK MCP tools — the ACP server owns
     the MCP connection and exposes the tools through its own turn.
 
+    Servers with ``enabled=False`` are skipped entirely -- the ACP subprocess
+    owns the connection, so withholding the entry is the only way to keep a
+    disabled server out of its reach.
+
     Each entry maps by transport:
 
     - ``command`` present → :class:`McpServerStdio` (always forwarded; the
@@ -583,6 +587,8 @@ def _mcp_config_to_acp_servers(
     sse_ok = bool(getattr(mcp_capabilities, "sse", False))
     result: list[_ACPMcpServer] = []
     for name, server in mcp_config.items():
+        if not server.enabled:
+            continue
         if server.command:
             env = [
                 EnvVariable(name=name, value=value.get_secret_value())

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -58,7 +58,12 @@ from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace.registry import MarketplaceRegistry
-from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config, dump_mcp_config
+from openhands.sdk.mcp.config import (
+    MCPServer,
+    coerce_mcp_config,
+    dump_mcp_config,
+    enabled_mcp_servers,
+)
 from openhands.sdk.mcp.utils import (
     DefaultMCPToolProvider,
     MCPToolProvider,
@@ -1247,6 +1252,10 @@ class LocalConversation(BaseConversation):
         *,
         on_tools_changed: ToolsChangedCallback | None = None,
     ) -> list[ToolDefinition]:
+        # Servers the user switched off stay in the settings map but must not
+        # be connected to. Filter before the emptiness check so an all-disabled
+        # config is a plain no-op rather than a zero-server MCP client.
+        mcp_config = enabled_mcp_servers(mcp_config)
         if not mcp_config:
             return []
         client = self._mcp_tool_provider.create_tools(

--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -511,6 +511,15 @@ class MCPServer(_MCPBaseModel):
     keep_alive: bool | None = None
     headers: dict[str, SecretStr] | None = None
     auth: MCPAuthCredential | None = None
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Whether this server is exposed to the agent. A disabled server "
+            "stays fully configured -- including its secrets -- but is skipped "
+            "when MCP tools are created and when servers are forwarded to an "
+            "ACP subprocess."
+        ),
+    )
 
     @field_validator("env", "headers", mode="after")
     @classmethod
@@ -645,6 +654,12 @@ def _normalize_server_for_fastmcp(
     server: Mapping[str, Any],
 ) -> dict[str, Any]:
     server = copy.deepcopy(dict(server))
+    # ``enabled`` is an OpenHands-side flag; FastMCP server models are
+    # ``extra="allow"``, so leaving it in would be silently absorbed rather
+    # than rejected. Callers are expected to have dropped disabled servers
+    # already (see ``enabled_mcp_servers``) -- this only keeps the key from
+    # leaking through the public ``to_fastmcp_mcp_config`` boundary.
+    server.pop("enabled", None)
     auth = server.pop("auth", None)
     raw_headers = server.get("headers")
     headers = dict(raw_headers) if isinstance(raw_headers, Mapping) else {}
@@ -706,6 +721,19 @@ def dump_mcp_config(
         )
         for name, server in mcp_config.items()
     }
+
+
+def enabled_mcp_servers(
+    mcp_config: Mapping[str, MCPServer],
+) -> dict[str, MCPServer]:
+    """Drop servers the user has switched off.
+
+    Disabled servers stay in the settings map (so their configuration and
+    secrets survive) but must never reach a live MCP connection, whether the
+    agent turns them into SDK tools or an ACP subprocess connects to them
+    itself.
+    """
+    return {name: server for name, server in mcp_config.items() if server.enabled}
 
 
 def to_fastmcp_mcp_config(

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -18,6 +18,7 @@ from openhands.sdk.mcp.config import (
     MCPOAuthAuthCredential,
     MCPOAuthAuthentication,
     MCPServer,
+    enabled_mcp_servers,
     to_fastmcp_mcp_config,
 )
 from openhands.sdk.mcp.exceptions import MCPTimeoutError
@@ -293,6 +294,14 @@ def create_mcp_tools(
     callers must ensure it is thread-safe (e.g. ``Agent.add_runtime_tools``).
     """
     mcp_config = _require_native_mcp_config(mcp_config)
+    requested = mcp_config
+    mcp_config = enabled_mcp_servers(mcp_config)
+    if requested and not mcp_config:
+        raise ValueError(
+            "All configured MCP servers are disabled: "
+            f"{', '.join(sorted(requested))}. Enable at least one, or skip "
+            "the call entirely."
+        )
     config = _prepare_mcp_config(
         mcp_config,
         mcp_oauth_token_storage=mcp_oauth_token_storage,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8409,6 +8409,20 @@ class TestMcpConfigToAcpServers:
         assert len(out) == 1
         assert isinstance(out[0], HttpMcpServer)
 
+    def test_disabled_servers_not_forwarded(self):
+        cfg = {
+            "mcpServers": {
+                "fetch": {"command": "uvx"},
+                "switched_off": {"command": "uvx", "enabled": False},
+            }
+        }
+        # The subprocess owns the connection, so withholding the entry is the
+        # only way to keep a disabled server out of its reach.
+        out = _mcp_config_to_acp_servers(
+            self._config(cfg), self._caps(http=True, sse=True)
+        )
+        assert [s.name for s in out] == ["fetch"]
+
     def test_empty_configs(self):
         caps = self._caps(http=True, sse=True)
         assert _mcp_config_to_acp_servers({}, caps) == []

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -1,0 +1,49 @@
+"""Tests for how LocalConversation wires MCP servers into a running agent."""
+
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.mcp.client import MCPClient
+from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
+
+
+class RecordingMCPToolProvider:
+    """Records every attempt to open an MCP connection."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, MCPServer]] = []
+
+    def create_tools(
+        self,
+        mcp_config: dict[str, MCPServer],
+        timeout: float = 30.0,
+        *,
+        on_tools_changed: Any = None,
+    ) -> MCPClient:
+        self.calls.append(mcp_config)
+        return cast(MCPClient, type("EmptyMCPClient", (), {"tools": []})())
+
+
+def test_disabling_every_server_skips_the_mcp_connection(tmp_path: Path) -> None:
+    """The agent still starts; it just has no MCP servers to reach."""
+    provider = RecordingMCPToolProvider()
+    agent = Agent(
+        llm=LLM(model="test-model", api_key=SecretStr("test-key")),
+        tools=[],
+        mcp_config=coerce_mcp_config({"fetch": {"command": "uvx", "enabled": False}}),
+    )
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        mcp_tool_provider=provider,
+    )
+
+    conversation._ensure_agent_ready()
+
+    assert provider.calls == []
+    conversation.close()

--- a/tests/sdk/mcp/test_create_mcp_tool.py
+++ b/tests/sdk/mcp/test_create_mcp_tool.py
@@ -28,6 +28,7 @@ from openhands.sdk.mcp.config import (
     MCPNoneAuthCredential,
     MCPOAuthAuthCredential,
     coerce_mcp_config,
+    to_fastmcp_mcp_config,
 )
 from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
 from openhands.sdk.mcp.utils import _prepare_mcp_config
@@ -246,6 +247,58 @@ def test_create_mcp_tools_rejects_external_config_shapes():
     fastmcp_config = FastMCPConfig.model_validate(config)
     with pytest.raises(TypeError, match="dict\\[str, MCPServer\\]"):
         create_mcp_tools(fastmcp_config)  # type: ignore[arg-type]
+
+
+def test_create_mcp_tools_skips_disabled_servers():
+    """A server the user switched off is never connected to."""
+    config = {
+        "mcpServers": {
+            "kept": {"url": "https://kept.example.com/mcp"},
+            "switched_off": {
+                "url": "https://switched-off.example.com/mcp",
+                "enabled": False,
+            },
+        }
+    }
+
+    with patch("openhands.sdk.mcp.utils.MCPClient") as mock_client_class:
+        create_mcp_tools(native_mcp_config(config))
+
+    prepared = mock_client_class.call_args.args[0]
+    assert list(prepared.mcpServers) == ["kept"]
+
+
+def test_create_mcp_tools_all_servers_disabled():
+    """Disabling every server is reported by name, not as "no servers defined"."""
+    config = {
+        "mcpServers": {
+            "switched_off": {
+                "url": "https://switched-off.example.com/mcp",
+                "enabled": False,
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="switched_off"):
+        create_mcp_tools(native_mcp_config(config))
+
+
+def test_to_fastmcp_mcp_config_strips_enabled():
+    """``enabled`` is OpenHands-side only, and FastMCP would absorb it silently."""
+    config = native_mcp_config(
+        {
+            "mcpServers": {
+                "switched_off": {
+                    "url": "https://switched-off.example.com/mcp",
+                    "enabled": False,
+                }
+            }
+        }
+    )
+
+    prepared = to_fastmcp_mcp_config(config)
+
+    assert "enabled" not in prepared["mcpServers"]["switched_off"]
 
 
 def test_prepare_mcp_config_converts_bare_oauth_credential():

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -896,7 +896,7 @@ def test_llm_agent_settings_validates_mcp_config_as_typed_model() -> None:
 
     assert isinstance(settings.mcp_config["fetch"], MCPServer)
     assert settings.model_dump()["mcp_config"] == {
-        "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}
+        "fetch": {"command": "uvx", "args": ["mcp-server-fetch"], "enabled": True}
     }
 
 
@@ -911,6 +911,26 @@ def test_llm_create_agent_serializes_typed_mcp_config_compactly() -> None:
     assert dump_mcp_config(agent.mcp_config) == {
         "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}
     }
+
+
+def test_disabled_mcp_server_survives_settings_round_trip() -> None:
+    """A switched-off server stays off, and keeps its config, across reloads."""
+    settings = OpenHandsAgentSettings.model_validate(
+        {
+            "mcp_config": {
+                "fetch": {
+                    "command": "uvx",
+                    "args": ["mcp-server-fetch"],
+                    "enabled": False,
+                }
+            }
+        }
+    )
+
+    reloaded = OpenHandsAgentSettings.model_validate(settings.model_dump(mode="json"))
+
+    assert reloaded.mcp_config["fetch"].enabled is False
+    assert reloaded.mcp_config["fetch"].command == "uvx"
 
 
 def test_llm_create_agent_builds_condenser_when_enabled() -> None:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

I have verified the changes.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

`agent_settings.mcp_config` could only express two states for a server: present (the agent gets it) or absent (deleted, credentials and all). There was no representation of "configured but inactive" anywhere in the stack.

That is the root cause behind OSS-5182 — a user who wants to temporarily stop the agent from reaching an MCP server has to delete the entry and re-enter its credential to bring it back.

The flag has to live on the server object rather than in a GUI-side deny-list. MCP servers are resolved server-side on two of the three launch paths (local named agent profiles and cloud both send only `{ agent_profile_id }`), so a frontend filter would be a no-op there. Moving disabled servers out of `mcp_config` into frontend storage would work on all paths but destroys secrets on cloud, where settings are only ever readable redacted (`**********`).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `enabled: bool = True` to `MCPServer` plus an `enabled_mcp_servers()` helper; the entry never moves, so a disabled server keeps its configuration and its encrypted secrets.
- Filter on it at the three points a server becomes reachable: `create_mcp_tools` (all SDK tool consumers), `LocalConversation`'s runtime MCP tools (so an all-disabled config is a no-op, not an error), and `_mcp_config_to_acp_servers` (ACP forwards to a subprocess that owns the connection).
- Drop the key defensively in `_normalize_server_for_fastmcp` — FastMCP server models are `extra="allow"` and would silently absorb it at the public `to_fastmcp_mcp_config` boundary.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `6387406b99db` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1797,0 +1798 @@
+schema MCPServer-Input property enabled optional schema=type="boolean" default=true
@@ -1811,0 +1813 @@
+schema MCPServer-Output property enabled optional schema=type="boolean" default=true
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

**1. Real MCP servers — a disabled server contributes no tools**

```python
# e2e_enabled.py
from openhands.sdk.mcp import create_mcp_tools
from openhands.sdk.mcp.config import coerce_mcp_config


def tool_names(fetch_enabled: bool, time_enabled: bool) -> list[str]:
    cfg = coerce_mcp_config({
        "fetch": {"command": "uvx", "args": ["mcp-server-fetch"],
                  "enabled": fetch_enabled},
        "time": {"command": "uvx", "args": ["mcp-server-time"],
                 "enabled": time_enabled},
    })
    client = create_mcp_tools(cfg, timeout=180.0)
    try:
        return sorted(t.name for t in client.tools)
    finally:
        client.sync_close()


print("both enabled  :", tool_names(True, True))
print("time disabled :", tool_names(True, False))
print("fetch disabled:", tool_names(False, True))
try:
    tool_names(False, False)
except ValueError as exc:
    print("all disabled  : ValueError:", exc)

```

```console
$ uv run python e2e_enabled.py
INFO  Created 3 MCP tools    utils.py:347
INFO  Created 1 MCP tools    utils.py:347
INFO  Created 2 MCP tools    utils.py:347
both enabled  : ['fetch_fetch', 'time_convert_time', 'time_get_current_time']
time disabled : ['fetch']
fetch disabled: ['convert_time', 'get_current_time']
all disabled  : ValueError: All configured MCP servers are disabled: fetch, time. Enable at least one, or skip the call entirely.

```

Real subprocesses were launched for the enabled servers only; the disabled one is never connected to.

**2. Real agent-server HTTP API — the flag persists, and secrets survive**

```python
# e2e_settings_http.py — PATCH/GET against a live app built by create_app()
client.patch("/api/settings", json={"agent_settings_diff": {"mcp_config": {
    "fetch": {"command": "uvx", "args": ["mcp-server-fetch"],
              "env": {"API_TOKEN": "super-secret"}, "enabled": False}}}})
client.get("/api/settings")
# then the GUI's "re-enable" write: pre-clear to null, then re-PATCH
# with `enabled` omitted

```

```console
$ uv run python e2e_settings_http.py
PATCH disable       -> 200
GET after disable   -> {"fetch": {"args": ["mcp-server-fetch"], "command": "uvx", "enabled": false, "env": {"API_TOKEN": "**********"}}}
PATCH re-enable     -> 200
GET after re-enable -> {"fetch": {"args": ["mcp-server-fetch"], "command": "uvx", "enabled": true, "env": {"API_TOKEN": "**********"}}}

```

The secret is still there (redacted on read) across both writes — disabling is not deleting, and re-enabling needs no re-configuration.

**3. Test suites**

```console
$ uv run pytest tests/sdk/mcp tests/sdk/test_settings.py \
    tests/sdk/conversation/test_local_conversation_mcp.py \
    tests/sdk/agent/test_acp_agent.py::TestMcpConfigToAcpServers \
    tests/agent_server/test_mcp_router.py tests/agent_server/test_mcp_oauth_store.py \
    tests/sdk/profiles/test_resolver.py tests/sdk/plugin -q
462 passed, 5 warnings in 23.93s

$ uv run ruff check <changed files>   # All checks passed!
$ uv run ruff format --check <changed files>   # already formatted
$ uv run pyright <changed files>      # 0 errors, 0 warnings

```

Each new test was also confirmed to fail against unmodified `openhands-sdk/` (4 of 5 fail red; the `to_fastmcp_mcp_config` one passes vacuously there because the field does not exist yet — it guards against the strip being removed later).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

Console transcripts above. No UI in this repo — the user-facing toggle ships in `agent-server-gui`.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4140de1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4140de1-python \
  ghcr.io/openhands/agent-server:4140de1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4140de1-golang-amd64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-golang-amd64
ghcr.io/openhands/agent-server:hieptl-oss-8627-golang-amd64
ghcr.io/openhands/agent-server:4140de1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4140de1-golang-arm64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-golang-arm64
ghcr.io/openhands/agent-server:hieptl-oss-8627-golang-arm64
ghcr.io/openhands/agent-server:4140de1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4140de1-java-amd64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-java-amd64
ghcr.io/openhands/agent-server:hieptl-oss-8627-java-amd64
ghcr.io/openhands/agent-server:4140de1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4140de1-java-arm64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-java-arm64
ghcr.io/openhands/agent-server:hieptl-oss-8627-java-arm64
ghcr.io/openhands/agent-server:4140de1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4140de1-python-amd64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-python-amd64
ghcr.io/openhands/agent-server:hieptl-oss-8627-python-amd64
ghcr.io/openhands/agent-server:4140de1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4140de1-python-arm64
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-python-arm64
ghcr.io/openhands/agent-server:hieptl-oss-8627-python-arm64
ghcr.io/openhands/agent-server:4140de1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4140de1-golang
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-golang
ghcr.io/openhands/agent-server:hieptl-oss-8627-golang
ghcr.io/openhands/agent-server:4140de1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4140de1-java
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-java
ghcr.io/openhands/agent-server:hieptl-oss-8627-java
ghcr.io/openhands/agent-server:4140de1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4140de1-python
ghcr.io/openhands/agent-server:4140de18be565384272d105568b243b2bc14a402-python
ghcr.io/openhands/agent-server:hieptl-oss-8627-python
ghcr.io/openhands/agent-server:4140de1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4140de1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4140de1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->