### PR TITLE
fix(agent-server): handle non-ASCII filenames in Git endpoints

### DIFF
--- a/openhands-sdk/openhands/sdk/git/git_changes.py
+++ b/openhands-sdk/openhands/sdk/git/git_changes.py
@@ -14,6 +14,7 @@ from openhands.sdk.git.models import GitChange, GitChangeStatus
 from openhands.sdk.git.utils import (
     get_valid_ref,
     run_git_command,
+    unquote_git_path,
     validate_git_repository,
 )
 
@@ -67,8 +68,8 @@ def _parse_name_status(changed_files: list[str]) -> list[GitChange]:
         # by similarity percentage)
         if status.startswith("R") and len(parts) == 3:
             # Rename: convert to delete (old path) + add (new path)
-            old_path = parts[1].strip()
-            new_path = parts[2].strip()
+            old_path = unquote_git_path(parts[1].strip())
+            new_path = unquote_git_path(parts[2].strip())
             changes.append(
                 GitChange(
                     status=GitChangeStatus.DELETED,
@@ -88,7 +89,7 @@ def _parse_name_status(changed_files: list[str]) -> list[GitChange]:
         # similarity percentage)
         elif status.startswith("C") and len(parts) == 3:
             # Copy: only add the new path (original remains)
-            new_path = parts[2].strip()
+            new_path = unquote_git_path(parts[2].strip())
             changes.append(
                 GitChange(
                     status=GitChangeStatus.ADDED,
@@ -100,7 +101,7 @@ def _parse_name_status(changed_files: list[str]) -> list[GitChange]:
 
         # Handle regular operations (M, A, D, etc.)
         elif len(parts) == 2:
-            path = parts[1].strip()
+            path = unquote_git_path(parts[1].strip())
         else:
             logger.error(f"Unexpected git diff line format: {line}")
             raise GitCommandError(
@@ -203,10 +204,11 @@ def get_changes_in_repo(
         untracked_files = []
     for path in untracked_files:
         if path.strip():
+            clean_untracked_path = unquote_git_path(path.strip())
             changes.append(
                 GitChange(
                     status=GitChangeStatus.ADDED,
-                    path=Path(path.strip()),
+                    path=Path(clean_untracked_path),
                 )
             )
             logger.debug(f"Found untracked file: {path}")

--- a/openhands-sdk/openhands/sdk/git/git_commits.py
+++ b/openhands-sdk/openhands/sdk/git/git_commits.py
@@ -23,11 +23,13 @@ from openhands.sdk.git.utils import (
     GIT_EMPTY_TREE_HASH,
     _rev_parse,
     run_git_command,
+    unquote_git_path,
     validate_git_repository,
 )
 
 
 logger = logging.getLogger(__name__)
+
 
 DEFAULT_COMMIT_LIMIT = 50
 
@@ -200,7 +202,8 @@ def get_commit_file_diff(file_path: str | Path, commit: str) -> GitDiff:
         GitRepositoryError: If the path is not inside a git repository.
         GitCommandError: If ``commit`` does not resolve.
     """
-    path = Path(os.getcwd(), file_path).resolve()
+    clean_file_path = unquote_git_path(str(file_path))
+    path = Path(os.getcwd(), clean_file_path).resolve()
 
     closest_git_repo = get_closest_git_repo(path)
     if not closest_git_repo:

--- a/openhands-sdk/openhands/sdk/git/git_diff.py
+++ b/openhands-sdk/openhands/sdk/git/git_diff.py
@@ -16,6 +16,7 @@ from openhands.sdk.git.models import GitDiff
 from openhands.sdk.git.utils import (
     get_valid_ref,
     run_git_command,
+    unquote_git_path,
     validate_git_repository,
 )
 
@@ -68,7 +69,8 @@ def get_git_diff(relative_file_path: str | Path, ref: str | None = None) -> GitD
         GitCommandError: If git commands fail (including when ``ref`` is
             provided but does not resolve in the repository).
     """
-    path = Path(os.getcwd(), relative_file_path).resolve()
+    clean_file_path = unquote_git_path(str(relative_file_path))
+    path = Path(os.getcwd(), clean_file_path).resolve()
 
     # Check if file exists
     if not path.exists():

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -1,3 +1,4 @@
+import codecs
 import logging
 import re
 import shlex
@@ -20,6 +21,24 @@ logger = logging.getLogger(__name__)
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
+def unquote_git_path(path_str: str) -> str:
+    """Unquote C-style double-quoted and octal-escaped Git path if needed."""
+    if not path_str or '"' not in path_str:
+        return path_str
+    parts = path_str.split("/")
+    unquoted_parts: list[str] = []
+    for part in parts:
+        if len(part) >= 2 and part.startswith('"') and part.endswith('"'):
+            try:
+                raw_bytes, _ = codecs.escape_decode(part[1:-1].encode("ascii"))
+                unquoted_parts.append(raw_bytes.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                unquoted_parts.append(part[1:-1])
+        else:
+            unquoted_parts.append(part)
+    return "/".join(unquoted_parts)
+
+
 def _run_git_subprocess(
     args: list[str],
     cwd: str | Path | None,
@@ -39,7 +58,8 @@ def _run_git_subprocess(
 
 def _run_git_probe(args: list[str], cwd: str | Path) -> str:
     try:
-        result = _run_git_subprocess(["git", "--no-pager", *args], cwd, timeout=30)
+        cmd = ["git", "-c", "core.quotePath=false", "--no-pager", *args]
+        result = _run_git_subprocess(cmd, cwd, timeout=30)
     except (OSError, subprocess.SubprocessError):
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -83,6 +103,8 @@ def run_git_command(
     Raises:
         GitCommandError: If the git command fails
     """
+    if args and args[0] == "git" and not any("core.quotePath" in a for a in args):
+        args = ["git", "-c", "core.quotePath=false", *args[1:]]
     redacted_args = [redact_url_credentials(a) for a in args]
     cmd_str = shlex.join(redacted_args)
 

--- a/tests/agent_server/test_git_router.py
+++ b/tests/agent_server/test_git_router.py
@@ -564,3 +564,72 @@ def test_git_commit_endpoints_in_openapi(client):
     assert commit_param is not None
     assert commit_param["in"] == "query"
     assert commit_param.get("required", False) is False
+
+
+def test_git_non_ascii_unicode_filename(tmp_path, client):
+    """Non-ASCII filenames (e.g. äfile.txt, 测试.txt) should return clean UTF-8 paths
+    in /changes and work in /diff.
+    """
+    repo_dir = tmp_path / "unicode_repo"
+    repo_dir.mkdir()
+
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_dir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo_dir, check=True
+    )
+    subprocess.run(
+        ["git", "config", "core.quotePath", "true"], cwd=repo_dir, check=True
+    )
+
+    non_ascii_file = repo_dir / "äfile_测试.txt"
+    non_ascii_file.write_text("initial content\n", encoding="utf-8")
+
+    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=repo_dir, check=True)
+
+    # Modify the file so it shows in diff/changes
+    non_ascii_file.write_text("initial content\nmodified content\n", encoding="utf-8")
+
+    rel_path_str = "äfile_测试.txt"
+    abs_path_str = str(non_ascii_file)
+
+    # 1. Test /api/git/changes returns unescaped UTF-8 paths
+    changes_resp = client.get("/api/git/changes", params={"path": str(repo_dir)})
+    assert changes_resp.status_code == 200
+    changes = changes_resp.json()
+    assert len(changes) == 1
+    assert changes[0]["path"] == rel_path_str
+    assert changes[0]["status"] == "UPDATED"
+
+    # 2. Test /api/git/diff with UTF-8 path parameter
+    diff_resp = client.get("/api/git/diff", params={"path": abs_path_str})
+    assert diff_resp.status_code == 200
+    diff_data = diff_resp.json()
+    assert "initial content" in diff_data["original"]
+    assert "modified content" in diff_data["modified"]
+
+    # 3. Test /api/git/diff with defensive octal-escaped path parameter
+    octal_escaped_path = str(
+        repo_dir / '"\\303\\244file_\\346\\265\\213\\350\\257\\225.txt"'
+    )
+    diff_resp_octal = client.get("/api/git/diff", params={"path": octal_escaped_path})
+    assert diff_resp_octal.status_code == 200
+    assert "modified content" in diff_resp_octal.json()["modified"]
+
+    # 4. Test /api/git/commits/{sha}/changes
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    commit_changes_resp = client.get(
+        f"/api/git/commits/{head_sha}/changes", params={"path": str(repo_dir)}
+    )
+    assert commit_changes_resp.status_code == 200
+    commit_changes = commit_changes_resp.json()
+    assert len(commit_changes) == 1
+    assert commit_changes[0]["path"] == rel_path_str


### PR DESCRIPTION
## Summary

Fix handling of non-ASCII filenames across the Git endpoints used by the agent server.

Git's default `core.quotePath=true` configuration causes commands such as `git diff --name-status` and `git ls-files` to return non-ASCII paths as C-style octal-escaped strings (for example, `"\303\244file.txt"`). These escaped paths could propagate through the API and cause `/api/git/diff` to fail when resolving files on disk.

This change ensures Git commands return UTF-8 paths and adds defensive handling for octal-escaped paths when they are received.

## Changes

- Configure Git commands to use `core.quotePath=false` when executed by the SDK.
- Add a helper to decode quoted octal-escaped Git paths.
- Apply defensive path decoding in:
  - Git change parsing
  - Git diff endpoint
  - Commit diff endpoint
- Add a regression test covering repositories with non-ASCII filenames.

## Testing

Added a regression test for Unicode filenames that verifies:

- `/api/git/changes` returns UTF-8 filenames.
- `/api/git/diff` works with Unicode filenames.
- Octal-escaped path inputs are handled correctly.
- `/api/git/commits/{sha}/changes` returns UTF-8 filenames.

Executed:

```bash
poetry run pytest software-agent-sdk/tests/agent_server/test_git_router.py
```

Result:

```
28 passed
```

## Fixes

Fixes #16215