### PR TITLE
Bound agent-server webhook delivery memory

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -106,9 +106,24 @@ class WebhookSpec(BaseModel):
         default=1000,
         ge=1,
         description=(
-            "Upper bound on the number of events buffered for delivery. When the "
-            "downstream is failing and events are re-queued for retry, the oldest "
+            "Upper bound on the number of events buffered for delivery. The oldest "
             "events are dropped past this bound to prevent unbounded memory growth."
+        ),
+    )
+    max_batch_bytes: int = Field(
+        default=5 * 1024 * 1024,
+        ge=1,
+        description=(
+            "Upper bound on the serialized size of each webhook request. A single "
+            "event larger than this limit is sent by itself."
+        ),
+    )
+    max_queue_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        ge=1,
+        description=(
+            "Upper bound on the serialized size of events buffered for delivery. "
+            "The oldest events are dropped when the queue exceeds this bound."
         ),
     )
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -2278,6 +2278,11 @@ class WebhookSubscriber(Subscriber):
     session_api_key: str | None = None
     queue: list[Event] = field(default_factory=list)
     _flush_timer: asyncio.Task | None = field(default=None, init=False)
+    _post_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _queue_sizes: list[int] = field(default_factory=list, init=False)
+    _queue_bytes: int = field(default=0, init=False)
+    _dropped_events: int = field(default=0, init=False)
+    _closed: bool = field(default=False, init=False)
     # Per-instance sleep seam so tests override delays without patching the
     # global asyncio.sleep. default_factory (not default) keeps it an instance
     # attribute, else the function would be descriptor-bound as a method.
@@ -2287,17 +2292,24 @@ class WebhookSubscriber(Subscriber):
 
     async def __call__(self, event: Event):
         """Add event to queue and post to webhook when buffer size is reached."""
-        self.queue.append(event)
+        self._enqueue(event)
 
-        if len(self.queue) >= self.spec.event_buffer_size:
+        if (
+            len(self.queue) >= self.spec.event_buffer_size
+            or self._queue_bytes >= self.spec.max_batch_bytes
+        ):
+            if self._post_lock.locked():
+                self._start_flush_timer()
+                return
             # Cancel timer since we're flushing due to buffer size
             self._cancel_flush_timer()
             await self._post_events()
-        elif not self._flush_timer:
-            self._flush_timer = asyncio.create_task(self._flush_after_delay())
+        elif self.queue:
+            self._start_flush_timer()
 
     async def close(self):
         """Post any remaining items in the queue to the webhook."""
+        self._closed = True
         # Cancel any pending flush timer
         self._cancel_flush_timer()
 
@@ -2305,29 +2317,25 @@ class WebhookSubscriber(Subscriber):
             await self._post_events()
 
     async def _post_events(self):
-        """Post queued events to the webhook with retry logic."""
-        if not self.queue:
-            return
+        """Post bounded batches serially until the queue is empty or a post fails."""
+        async with self._post_lock:
+            self._sync_queue_sizes()
+            self._trim_queue()
+            events_remaining = len(self.queue)
+            while events_remaining:
+                events_to_post, event_data = self._take_batch(events_remaining)
+                if not await self._post_batch(event_data):
+                    self._requeue(events_to_post)
+                    return
+                events_remaining -= len(events_to_post)
 
-        events_to_post = self.queue.copy()
-        self.queue.clear()
+    async def _post_batch(self, event_data: list[dict[str, Any]]) -> bool:
+        """Post one serialized batch with retry logic."""
 
         # Prepare headers
         headers = self.spec.headers.copy()
         if self.session_api_key:
             headers["X-Session-API-Key"] = self.session_api_key
-
-        # Convert events to a JSON-serializable format. mode="json" is required
-        # so types like set and SecretStr become JSON-safe primitives; without
-        # it httpx's encoder raises "Object of type set/SecretStr is not JSON
-        # serializable", every retry fails identically, and the events are
-        # dropped. (Mirrors ConversationWebhookSubscriber.post_conversation_info.)
-        event_data = [
-            event.model_dump(mode="json")
-            if hasattr(event, "model_dump")
-            else event.__dict__
-            for event in events_to_post
-        ]
 
         # Construct events URL
         events_url = (
@@ -2350,7 +2358,7 @@ class WebhookSubscriber(Subscriber):
                         f"Successfully posted {len(event_data)} events "
                         f"to webhook {events_url}"
                     )
-                    return
+                    return True
             except Exception as e:
                 logger.warning(f"Webhook post attempt {attempt + 1} failed: {e}")
                 if attempt < self.spec.num_retries:
@@ -2360,15 +2368,95 @@ class WebhookSubscriber(Subscriber):
                         f"Failed to post events to webhook {events_url} "
                         f"after {self.spec.num_retries + 1} attempts"
                     )
-                    self.queue.extend(events_to_post)
-                    overflow = len(self.queue) - self.spec.max_queue_size
-                    if overflow > 0:
-                        del self.queue[:overflow]
-                        logger.warning(
-                            f"Webhook queue exceeded max_queue_size="
-                            f"{self.spec.max_queue_size}; dropped {overflow} "
-                            f"oldest event(s) for {events_url}."
-                        )
+        return False
+
+    @staticmethod
+    def _event_data(event: Event) -> dict[str, Any]:
+        # mode="json" makes types such as set and SecretStr JSON-safe.
+        if hasattr(event, "model_dump"):
+            return event.model_dump(mode="json")
+        return event.__dict__
+
+    @classmethod
+    def _event_size(cls, event: Event) -> int:
+        return len(
+            json.dumps(
+                cls._event_data(event),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode()
+        )
+
+    def _sync_queue_sizes(self):
+        """Refresh size accounting after callers directly replace the public queue."""
+        if len(self._queue_sizes) != len(self.queue):
+            self._queue_sizes = [self._event_size(event) for event in self.queue]
+            self._queue_bytes = sum(self._queue_sizes)
+
+    def _enqueue(self, event: Event):
+        self._sync_queue_sizes()
+        event_size = self._event_size(event)
+        self.queue.append(event)
+        self._queue_sizes.append(event_size)
+        self._queue_bytes += event_size
+        self._trim_queue()
+
+    def _requeue(self, events: list[Event]):
+        sizes = [self._event_size(event) for event in events]
+        self.queue[:0] = events
+        self._queue_sizes[:0] = sizes
+        self._queue_bytes += sum(sizes)
+        self._trim_queue()
+
+    def _trim_queue(self):
+        dropped = 0
+        while self.queue and (
+            len(self.queue) > self.spec.max_queue_size
+            or self._queue_bytes > self.spec.max_queue_bytes
+        ):
+            del self.queue[0]
+            self._queue_bytes -= self._queue_sizes.pop(0)
+            dropped += 1
+        if dropped:
+            previous_dropped = self._dropped_events
+            self._dropped_events += dropped
+            if (
+                previous_dropped == 0
+                or self._dropped_events // 100 > previous_dropped // 100
+            ):
+                logger.warning(
+                    "Webhook queue exceeded its configured count or byte limit; "
+                    f"dropped {self._dropped_events} event(s) so far for conversation "
+                    f"{self.conversation_id.hex}."
+                )
+
+    def _take_batch(self, max_events: int) -> tuple[list[Event], list[dict[str, Any]]]:
+        self._sync_queue_sizes()
+        batch_size = 2  # JSON array brackets
+        batch_count = 0
+        event_data: list[dict[str, Any]] = []
+
+        for event, event_size in zip(self.queue, self._queue_sizes, strict=True):
+            next_size = batch_size + event_size + (1 if batch_count else 0)
+            if batch_count and next_size > self.spec.max_batch_bytes:
+                break
+            event_data.append(self._event_data(event))
+            batch_size = next_size
+            batch_count += 1
+            if batch_count >= min(self.spec.event_buffer_size, max_events):
+                break
+
+        events = self.queue[:batch_count]
+        del self.queue[:batch_count]
+        removed_sizes = self._queue_sizes[:batch_count]
+        del self._queue_sizes[:batch_count]
+        self._queue_bytes -= sum(removed_sizes)
+        return events, event_data
+
+    def _start_flush_timer(self):
+        if not self._closed and not self._flush_timer:
+            self._flush_timer = asyncio.create_task(self._flush_after_delay())
 
     def _cancel_flush_timer(self):
         """Cancel the current flush timer if it exists."""
@@ -2378,16 +2466,22 @@ class WebhookSubscriber(Subscriber):
 
     async def _flush_after_delay(self):
         """Wait for flush_delay seconds then flush events if any exist."""
+        current_task = asyncio.current_task()
+        should_reschedule = False
         try:
             await self._sleep(self.spec.flush_delay)
             # Only flush if there are events in the queue
             if self.queue:
                 await self._post_events()
+                should_reschedule = bool(self.queue)
         except asyncio.CancelledError:
             # Timer was cancelled, which is expected behavior
             pass
         finally:
-            self._flush_timer = None
+            if self._flush_timer is current_task:
+                self._flush_timer = None
+            if should_reschedule:
+                self._start_flush_timer()
 
 
 @dataclass

--- a/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
+++ b/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
@@ -269,12 +269,9 @@ async def test_telemetry_init_does_not_hijack_the_settings_store_singleton(
 ):
     """Regression: telemetry must prime the settings store WITH the config.
 
-    ``get_settings_store`` is a singleton whose persistence directory and
-    cipher are fixed by the first call. Telemetry initialises during lifespan
-    startup, before ``ConversationService.get_instance()`` makes its own
-    priming call, so a no-arg ``get_settings_store()`` here previously won the
-    race and left the whole process writing settings *and secrets* to the
-    default relative directory with encryption disabled.
+    ``get_settings_store`` is a singleton whose cipher is fixed by the first
+    call. Telemetry initialises during lifespan startup, so a no-arg call here
+    would leave the whole process writing secrets with encryption disabled.
     """
     from base64 import urlsafe_b64encode
 
@@ -292,7 +289,6 @@ async def test_telemetry_init_does_not_hijack_the_settings_store_singleton(
             pass
 
     monkeypatch.setattr(pe, "PostHogExporter", lambda *a, **k: _FakeExporter())
-    monkeypatch.delenv("OH_PERSISTENCE_DIR", raising=False)
 
     config = Config(
         static_files_path=None,
@@ -310,8 +306,6 @@ async def test_telemetry_init_does_not_hijack_the_settings_store_singleton(
             "telemetry primed the settings store without a cipher; secrets "
             "would be persisted unencrypted process-wide"
         )
-        assert temp_persistence_dir in store.persistence_dir.parents or (
-            store.persistence_dir.is_relative_to(temp_persistence_dir)
-        ), f"settings store landed outside the configured dir: {store.persistence_dir}"
+        assert store.persistence_dir == temp_persistence_dir
     finally:
         await sink.aclose()

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -6,6 +6,7 @@ without dependencies on the openhands.sdk module.
 """
 
 import asyncio
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -784,6 +785,144 @@ class TestWebhookSubscriberIntegration:
         await subscriber.close()
         assert len(subscriber.queue) == 0
         assert mock_client.request.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_event_delivery_has_one_request_in_flight(
+    mock_event_service, sample_event, sample_conversation_id
+):
+    spec = WebhookSpec(
+        base_url="https://example.com",
+        event_buffer_size=5,
+        flush_delay=3600,
+        num_retries=0,
+    )
+    subscriber = WebhookSubscriber(
+        conversation_id=sample_conversation_id,
+        service=mock_event_service,
+        spec=spec,
+    )
+
+    request_started = asyncio.Event()
+    release_requests = asyncio.Event()
+    active_requests = 0
+    peak_active_requests = 0
+    batches: list[list[dict]] = []
+
+    async def blocked_request(*args, **kwargs):
+        nonlocal active_requests, peak_active_requests
+        active_requests += 1
+        peak_active_requests = max(peak_active_requests, active_requests)
+        batches.append(kwargs["json"])
+        request_started.set()
+        await release_requests.wait()
+        active_requests -= 1
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        return response
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.request = blocked_request
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        tasks = [asyncio.create_task(subscriber(sample_event)) for _ in range(40)]
+        await asyncio.wait_for(request_started.wait(), timeout=1)
+        await asyncio.sleep(0.05)
+        try:
+            assert peak_active_requests == 1
+        finally:
+            release_requests.set()
+            await asyncio.gather(*tasks)
+
+        await subscriber.close()
+
+    assert peak_active_requests == 1
+    assert sum(len(batch) for batch in batches) == 40
+    assert all(len(batch) <= spec.event_buffer_size for batch in batches)
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_post_events_splits_batches_by_serialized_bytes(
+    mock_client_class, mock_event_service, sample_conversation_id
+):
+    spec = WebhookSpec(
+        base_url="https://example.com",
+        event_buffer_size=100,
+        flush_delay=3600,
+        num_retries=0,
+        max_batch_bytes=4096,
+    )
+    subscriber = WebhookSubscriber(
+        conversation_id=sample_conversation_id,
+        service=mock_event_service,
+        spec=spec,
+    )
+    subscriber.queue = [
+        MessageEvent(
+            source="user",
+            llm_message=Message(role="user", content=[TextContent(text="x" * 3000)]),
+        )
+        for _ in range(3)
+    ]
+
+    mock_client = AsyncMock()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    mock_client.request.return_value = response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await subscriber._post_events()
+
+    batches = [call.kwargs["json"] for call in mock_client.request.call_args_list]
+    assert len(batches) == 3
+    for batch in batches:
+        payload_bytes = len(
+            json.dumps(batch, ensure_ascii=False, separators=(",", ":")).encode()
+        )
+        assert payload_bytes <= spec.max_batch_bytes or len(batch) == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_drops_oldest_events_past_serialized_byte_limit(
+    mock_event_service, sample_conversation_id
+):
+    events = [
+        MessageEvent(
+            source="user",
+            llm_message=Message(role="user", content=[TextContent(text=f"{i}" * 1000)]),
+        )
+        for i in range(2)
+    ]
+    event_size = len(
+        json.dumps(
+            events[0].model_dump(mode="json"),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    )
+    spec = WebhookSpec(
+        base_url="https://example.com",
+        event_buffer_size=100,
+        flush_delay=3600,
+        max_batch_bytes=1024 * 1024,
+        max_queue_bytes=event_size + 1,
+    )
+    subscriber = WebhookSubscriber(
+        conversation_id=sample_conversation_id,
+        service=mock_event_service,
+        spec=spec,
+    )
+
+    try:
+        await subscriber(events[0])
+        await subscriber(events[1])
+
+        assert subscriber.queue == [events[1]]
+        assert subscriber._queue_bytes <= spec.max_queue_bytes
+        assert subscriber._dropped_events == 1
+    finally:
+        subscriber._cancel_flush_timer()
 
 
 class TestWebhookSubscriberErrorHandling:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:


I reviewed this change and its validation results.


---

AGENT:

## Why

Concurrent event publication could enter `WebhookSubscriber._post_events` multiple times. Each invocation copied and serialized its own batch and opened another HTTP request. A slow or rate-limiting downstream therefore multiplied in-flight event objects, serialized payloads, HTTP buffers, and retry work.

The existing count limit only applied after a failed batch was requeued. It did not bound payload bytes or work already in flight, so it could not prevent memory exhaustion during a request burst.

Webhook delivery is now single-flight for each subscriber. Requests and queued backlogs have explicit serialized-byte bounds while retaining the existing count and retry behavior. A single event larger than the request limit is still sent alone; queue overflow drops the oldest events.

## Summary

- Serialize event-webhook delivery per subscriber so only one HTTP request can be in flight at a time.
- Cap each serialized webhook request at 5 MiB by default.
- Cap the serialized delivery queue at 50 MiB in addition to the existing 1,000-event limit.
- Drop the oldest queued events when either backlog limit is exceeded, with rate-limited warning logs.
- Add regressions for concurrent delivery, byte-bounded batching, and byte-bounded queues.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `d9f3e1675714` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -2601,0 +2602,2 @@
+schema WebhookSpec property max_batch_bytes optional schema=type="integer" default=5242880 minimum=1.0
+schema WebhookSpec property max_queue_bytes optional schema=type="integer" default=52428800 minimum=1.0
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

N/A

## How to Test

### Regression proof

The new tests were first run against the unchanged implementation:

- 40 concurrent events produced a peak of 8 simultaneous requests instead of 1.
- Three approximately 3 KiB events were sent in one aggregate request instead of three requests under a 4 KiB test limit.

The same tests pass with this change.

### Automated checks

- Pre-commit hooks passed, including Ruff, pycodestyle, Pyright, import rules, and tool registration.
- Webhook subscriber suite: 42 passed.
- Slow/failing-webhook stress suite: 2 passed.
- Full agent-server suite: 1,854 passed locally and in GitHub Actions.

### Packaged-image proof

Built the production `source-minimal` image for `linux/amd64` and ran it in an isolated namespace on a Replicated test instance against a real blocked HTTP receiver:

- Image: `ghcr.io/openhands/agent-server:8076cb2-python`.
- Peak concurrent requests: 1.
- Delivered events: 40/40.
- Requests used: 14.
- Largest request body: 786,520 bytes with a 1 MiB configured limit.
- Bounded queue: 1,572,948 bytes and 3 events with a 2 MiB configured limit.
- Overflow behavior: 76 oldest events dropped during a separate sustained-pressure phase.
- RSS increase during the bounded-queue phase: 40.9 MiB.
- Pod memory limit: 1 GiB.

The temporary namespace, validation files, and imported image were removed after the run.

## Video/Screenshots

Not applicable; this is a server-side webhook delivery change. The packaged-image results above provide end-to-end validation evidence.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The request and queue byte limits are configurable through `WebhookSpec.max_batch_bytes` and `WebhookSpec.max_queue_bytes`.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:56eadb6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-56eadb6-python \
  ghcr.io/openhands/agent-server:56eadb6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:56eadb6-golang-amd64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-golang-amd64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-golang-amd64
ghcr.io/openhands/agent-server:56eadb6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:56eadb6-golang-arm64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-golang-arm64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-golang-arm64
ghcr.io/openhands/agent-server:56eadb6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:56eadb6-java-amd64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-java-amd64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-java-amd64
ghcr.io/openhands/agent-server:56eadb6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:56eadb6-java-arm64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-java-arm64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-java-arm64
ghcr.io/openhands/agent-server:56eadb6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:56eadb6-python-amd64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-python-amd64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-python-amd64
ghcr.io/openhands/agent-server:56eadb6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:56eadb6-python-arm64
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-python-arm64
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-python-arm64
ghcr.io/openhands/agent-server:56eadb6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:56eadb6-golang
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-golang
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-golang
ghcr.io/openhands/agent-server:56eadb6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:56eadb6-java
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-java
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-java
ghcr.io/openhands/agent-server:56eadb6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:56eadb6-python
ghcr.io/openhands/agent-server:56eadb68407bc29a3a0f4d562bf8846ca75cd4da-python
ghcr.io/openhands/agent-server:alona-serialize-webhook-delivery-python
ghcr.io/openhands/agent-server:56eadb6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `56eadb6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `56eadb6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
