### PR TITLE
fix(acp): surface Claude Opus 5 in Claude Code model picker

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -297,21 +297,19 @@ class ACPProviderInfo:
 # select claude-agent-acp reports at ``session/new`` (the short aliases the CLI's
 # own ``/model`` menu offers, switched via ``set_config_option``).
 # ``opus[1m]`` is the SDK-documented version-agnostic 1M-context alias and the
-# CLI's own default (``currentValue``); as of Claude Code ≥ 2.1.219 / Opus 5 GA
-# it resolves to Opus 5 on the Anthropic API (previously Opus 4.8). ``default``
-# is the CLI's recommended tier for the account. ``claude-opus-5`` is the
-# explicit full model pin for users who want to force Opus 5 rather than track
-# the version-agnostic alias. The ``/model`` menu is dynamic/account-dependent
-# and the CLI validates ``set_config_option(model)`` against the live select —
-# it rejects an absent id (e.g. ``sonnet`` on accounts without it), so these are
-# pre-session suggestions, not ground truth; a rejected id degrades to the
-# server default.
+# CLI's own default (``currentValue``); ``default`` is the CLI's recommended tier
+# for the account. ``claude-opus-5`` is the explicit full model pin for users who
+# want Opus 5 rather than the provider-dependent alias. The ``/model`` menu is
+# dynamic/account-dependent and the CLI validates ``set_config_option(model)``
+# against the live select — it rejects an absent id (e.g. ``sonnet`` on accounts
+# without it), so these are pre-session suggestions, not ground truth; a rejected
+# id degrades to the server default.
 _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="default", label="Default (recommended)"),
-    ACPModelOption(id="opus[1m]", label="Claude Opus 5 (1M)"),
-    ACPModelOption(id="claude-opus-5", label="Claude Opus 5 (pinned)"),
-    ACPModelOption(id="sonnet", label="Claude Sonnet 5"),
-    ACPModelOption(id="haiku", label="Claude Haiku 4.5"),
+    ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
+    ACPModelOption(id="claude-opus-5", label="Claude Opus 5"),
+    ACPModelOption(id="sonnet", label="Claude Sonnet"),
+    ACPModelOption(id="haiku", label="Claude Haiku"),
 )
 
 # Bare preset ids advertised by the Codex app server through

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -294,18 +294,23 @@ class ACPProviderInfo:
 # ---------------------------------------------------------------------------
 
 # Model IDs the Claude Code CLI accepts, mirroring the ``model`` configOptions
-# select claude-agent-acp 0.44.0 reports at ``session/new`` (the short aliases
-# the CLI's own ``/model`` menu offers, switched via ``set_config_option``).
+# select claude-agent-acp reports at ``session/new`` (the short aliases the CLI's
+# own ``/model`` menu offers, switched via ``set_config_option``).
 # ``opus[1m]`` is the SDK-documented version-agnostic 1M-context alias and the
-# CLI's own default (``currentValue``); ``default`` is the CLI's recommended
-# tier (Opus 4.8 · 1M). The ``/model`` menu is dynamic/account-dependent and the
-# CLI validates ``set_config_option(model)`` against the live select — it rejects
-# an absent id (e.g. ``sonnet`` on accounts without it), so these are pre-session
-# suggestions, not ground truth; a rejected id degrades to the server default.
+# CLI's own default (``currentValue``); as of Claude Code ≥ 2.1.219 / Opus 5 GA
+# it resolves to Opus 5 on the Anthropic API (previously Opus 4.8). ``default``
+# is the CLI's recommended tier for the account. ``claude-opus-5`` is the
+# explicit full model pin for users who want to force Opus 5 rather than track
+# the version-agnostic alias. The ``/model`` menu is dynamic/account-dependent
+# and the CLI validates ``set_config_option(model)`` against the live select —
+# it rejects an absent id (e.g. ``sonnet`` on accounts without it), so these are
+# pre-session suggestions, not ground truth; a rejected id degrades to the
+# server default.
 _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="default", label="Default (recommended)"),
-    ACPModelOption(id="opus[1m]", label="Claude Opus 4.8 (1M)"),
-    ACPModelOption(id="sonnet", label="Claude Sonnet 4.6"),
+    ACPModelOption(id="opus[1m]", label="Claude Opus 5 (1M)"),
+    ACPModelOption(id="claude-opus-5", label="Claude Opus 5 (pinned)"),
+    ACPModelOption(id="sonnet", label="Claude Sonnet 5"),
     ACPModelOption(id="haiku", label="Claude Haiku 4.5"),
 )
 

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -43,6 +43,10 @@ class TestACPProviderInfo:
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "opus[1m]"
         assert any(m.id == "opus[1m]" for m in info.available_models)
+        # Opus 5 GA: version-agnostic opus[1m] label + explicit pin for picker.
+        opus_1m = next(m for m in info.available_models if m.id == "opus[1m]")
+        assert "Opus 5" in opus_1m.label
+        assert any(m.id == "claude-opus-5" for m in info.available_models)
         # Pinned binary exposed by the agent-server image wrappers.
         assert info.binary_name == "claude-agent-acp"
         assert info.data_dir_env_var == "CLAUDE_CONFIG_DIR"

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -42,11 +42,11 @@ class TestACPProviderInfo:
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "opus[1m]"
-        assert any(m.id == "opus[1m]" for m in info.available_models)
-        # Opus 5 GA: version-agnostic opus[1m] label + explicit pin for picker.
-        opus_1m = next(m for m in info.available_models if m.id == "opus[1m]")
-        assert "Opus 5" in opus_1m.label
-        assert any(m.id == "claude-opus-5" for m in info.available_models)
+        models = {model.id: model.label for model in info.available_models}
+        assert models["opus[1m]"] == "Claude Opus (1M)"
+        assert models["claude-opus-5"] == "Claude Opus 5"
+        assert models["sonnet"] == "Claude Sonnet"
+        assert models["haiku"] == "Claude Haiku"
         # Pinned binary exposed by the agent-server image wrappers.
         assert info.binary_name == "claude-agent-acp"
         assert info.data_dir_env_var == "CLAUDE_CONFIG_DIR"


### PR DESCRIPTION
HUMAN:


Hit this in Agent Canvas: Claude Code model picker still only shows Opus 4.8 after Opus 5 shipped.

---

AGENT:

## Why

Agent Canvas Settings → Agent → Model for the Claude Code provider still lists **Claude Opus 4.8 (1M)** after Claude Opus 5 GA (2026-07-24). The curated list lives in `openhands.sdk.settings.acp_providers._CLAUDE_MODELS` and is mirrored into `@openhands/typescript-client` for the Canvas picker. Users reasonably conclude OpenHands does not support Opus 5.

`opus[1m]`, `sonnet`, and `haiku` are provider- and account-dependent Claude Code aliases, so versioned labels can be inaccurate and go stale. The picker also lacked an explicit `claude-opus-5` pin.

## Summary

- Relabel rolling aliases with stable names: **Claude Opus (1M)**, **Claude Sonnet**, and **Claude Haiku**
- Add explicit pin **`claude-opus-5`** / **Claude Opus 5**
- Keep `default_model="opus[1m]"` so existing profiles keep working
- Extend unit tests for the alias labels and explicit Opus 5 pin
- No agent-loop / protocol / `claude-agent-acp` version changes

## Issue Number

N/A (found via local Agent Canvas 1.8.0 usage)

## How to Test

```bash
uv run pytest tests/sdk/settings/test_acp_providers.py -q
```

Evidence (local run on this branch):

```
collected 45 items
tests/sdk/settings/test_acp_providers.py ............................... [ 68%]
..............                                                           [100%]
============================== 45 passed in 0.05s ==============================
```

Also inspect `openhands-sdk/openhands/sdk/settings/acp_providers.py` `_CLAUDE_MODELS` for the updated entries.

End-to-end UI verification requires the typescript-client mirror (https://github.com/OpenHands/typescript-client/pull/320) + Agent Canvas client bump. Until then, Custom model `claude-opus-5` works as a workaround.

## Video/Screenshots

Problem (local Agent Canvas 1.8.0 — Claude Code preset model dropdown):

- Available models: Default, Claude Opus 4.8 (1M), Claude Sonnet 4.6, Claude Haiku 4.5 — no Opus 5

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Follow-up mirror: https://github.com/OpenHands/typescript-client/pull/320
- References: https://www.anthropic.com/news/claude-opus-5 · https://code.claude.com/docs/en/model-config
- OpenHands monorepo tests that hardcode `"Claude Opus 4.8 (1M)"` will need a label update when Canvas bumps `@openhands/typescript-client`

