### PR TITLE
chore(sdk): deprecate AgentBase.model_dump_succint

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -41,6 +41,7 @@ from openhands.sdk.tool.builtins.vision_inspect import (
     VisionInspectTool,
     has_vision_profile_available,
 )
+from openhands.sdk.utils.deprecation import deprecated
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 
@@ -731,6 +732,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
 
         return self
 
+    @deprecated(
+        deprecated_in="1.40.0",
+        removed_in="1.45.0",
+        details="Use model_dump(exclude_none=True) instead.",
+    )
     def model_dump_succint(self, **kwargs):
         """Like model_dump, but excludes None fields by default."""
         if "exclude_none" not in kwargs:

--- a/tests/sdk/agent/test_model_dump_succint_deprecation.py
+++ b/tests/sdk/agent/test_model_dump_succint_deprecation.py
@@ -1,0 +1,39 @@
+"""Deprecation coverage for AgentBase.model_dump_succint (issue #4224)."""
+
+import pytest
+from deprecation import DeprecatedWarning
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.llm import LLM
+
+
+def _agent() -> Agent:
+    return Agent(llm=LLM(model="test-model", usage_id="test-llm"), tools=[])
+
+
+def test_model_dump_succint_emits_deprecation_warning() -> None:
+    """The method warns with the scheduled 1.40.0 -> 1.45.0 runway."""
+    with pytest.warns(DeprecatedWarning, match="model_dump_succint") as caught:
+        _agent().model_dump_succint()
+
+    message = str(caught[0].message)
+    assert "deprecated as of 1.40.0" in message
+    assert "removed in 1.45.0" in message
+
+
+def test_model_dump_succint_matches_model_dump_exclude_none() -> None:
+    """The only documented difference from model_dump is exclude_none=True."""
+    agent = _agent()
+    with pytest.warns(DeprecatedWarning):
+        dumped = agent.model_dump_succint()
+
+    assert dumped == agent.model_dump(exclude_none=True)
+
+
+def test_model_dump_succint_honors_explicit_exclude_none_false() -> None:
+    """Callers can still override the exclude_none default."""
+    agent = _agent()
+    with pytest.warns(DeprecatedWarning):
+        dumped = agent.model_dump_succint(exclude_none=False)
+
+    assert dumped == agent.model_dump()


### PR DESCRIPTION
HUMAN:

For #4224 I picked up the `model_dump_succint` item. I went with a deprecation rather than a deletion — removing it outright would pull a public method out from under anyone still using it with no warning period, and that isn't how this repo treats public API.

---

AGENT:

## Why

`AgentBase.model_dump_succint()` is the last unchecked dead-code item on #4224. It has no callers anywhere in the tree — `git grep` finds only the definition.

It cannot be deleted in a single PR, which is presumably why #4225 cleared the other five items and left this one. `AgentBase` is exported via `openhands.sdk.__all__`, so `check_sdk_api_breakage.py` governs its public members, and the deprecation scan runs against the **baseline** tree rather than the PR:

```
:1382   old_root = _load_prev_from_pypi(griffe_module, baseline, cfg)
:1278   source_root = _get_source_root(old_root)   # deprecation scan
```

So the `@deprecated` marker has to exist in an already-published release before removal is permitted. A PR that adds the marker and deletes the method together still fails, because the baseline it is compared against has no marker. Deleting it today gives:

```
Removed 'AgentBase.model_dump_succint' without prior deprecation.
```

This PR therefore starts the runway instead of removing.

**Question for maintainers — the reason this is worth a look rather than a rubber stamp.** The issue says "remove", and this PR does not remove. There is an escape hatch: `_ACCEPTED_REMOVED_MEMBERS` in `check_sdk_api_breakage.py` already allowlists two removals (`DockerWorkspace.mount_dir` / `DockerDevWorkspace.mount_dir`, from #3822, shipped with `release-note-required`). If you would rather allowlist this one and take the deletion now, say so and I will swap this PR for the removal. If you would rather leave the method alone entirely, that is a fine answer too and I will close this. I picked the deprecation route because adding an entry to that allowlist is accepting a breaking change on behalf of downstream clients, which felt like your call and not mine.

## Summary

- Adds `@deprecated(deprecated_in="1.40.0", removed_in="1.45.0", ...)` to `AgentBase.model_dump_succint`, using the canonical helper in `openhands.sdk.utils.deprecation`.
- `1.45.0` is exactly the minimum legal target: `_minimum_removed_in("1.40.0")` returns `"1.45.0"` for `DEPRECATION_RUNWAY_MINOR_RELEASES = 5`.
- `deprecated_in="1.40.0"` rather than `1.41.0` because the decorator only warns when `current_version >= deprecated_in`, so anchoring ahead of the current version leaves it untestable in-tree. This matches existing entries, which anchor at or below the version current when they were written.
- **No runtime behavior change.** The method body is byte-identical; only a decorator and a one-line docstring were added. The diff is additive-only.
- The `succint` typo is deliberately left alone — correcting it would add a new public symbol rather than remove one.
- Three tests covering warning emission with both version strings asserted, equivalence to `model_dump(exclude_none=True)`, and the explicit `exclude_none=False` override.
- I did not hand-write a `.. deprecated::` docstring block: the `deprecation` package injects its own at decoration time, so a manual one renders twice.

Follow-up note for whoever does the deletion: `check_deprecations.py` goes red on every PR once `pyproject` reaches 1.45.0, while the api-breakage gate rejects the removal until then. So the deletion has to ride in the 1.45.0 release PR itself. That is pre-existing behavior — the four existing `1.36.0 → 1.41.0` deprecations hit the same wall at the next release — not something introduced here.

## Issue Number

Part of #4224

## How to Test

Full SDK suite (baseline on `main` before this change was 5650 passed / 9 skipped / 13 xfailed — the delta is exactly the three new tests):

```
uv run pytest tests/sdk/ -q
5653 passed, 9 skipped, 13 xfailed, 61 warnings in 333.40s (0:05:33)
```

Focused tests:

```
uv run pytest tests/sdk/agent/test_model_dump_succint_deprecation.py -v
3 passed
```

Both policy gates:

```
uv run python .github/scripts/check_deprecations.py
# exit 0 — openhands-sdk: checked 5 deprecation metadata entries against version 1.40.0

uv run python .github/scripts/check_sdk_api_breakage.py
# exit 0 — No breaking changes detected
```

Lint:

```
make lint
# All checks passed!
```

The warning and docstring, confirmed at runtime:

```
>>> AgentBase.model_dump_succint.__doc__
'Like model_dump, but excludes None fields by default.\n\n.. deprecated:: 1.40.0\n   This will be removed in 1.45.0. Use model_dump(exclude_none=True) instead.'
```

Exactly one `.. deprecated::` directive, and the emitted `DeprecatedWarning` reads:

```
model_dump_succint is deprecated as of 1.40.0 and will be removed in 1.45.0. Use model_dump(exclude_none=True) instead.
```
