### PR TITLE
fix(sdk): nudge before hard-terminating on a repeating action-error pattern

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -649,16 +649,7 @@ class LocalConversation(BaseConversation):
         )
 
     def _check_stuck_or_nudge(self) -> bool:
-        """Run stuck-pattern detection for the current run loop iteration.
-
-        A repeating action-error pattern gets one explicit corrective nudge
-        (naming the repeated action and its error) before the conversation is
-        hard-terminated, mirroring how an EMPTY/reasoning-only LLM response
-        already gets `_send_corrective_nudge()` instead of an immediate stop
-        (#4331). The nudge is injected and the loop is left free to run
-        another `agent.step()` this same iteration so the model can react to
-        it; only a pattern that persists past that nudge, or any other stuck
-        pattern, sets STUCK.
+        """Nudge once on a repeating action-error streak, else apply is_stuck().
 
         Returns True if STUCK was set and the run loop should stop.
         """

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -648,6 +648,40 @@ class LocalConversation(BaseConversation):
             ConversationErrorEvent(source="environment", code=code, detail=detail)
         )
 
+    def _check_stuck_or_nudge(self) -> bool:
+        """Run stuck-pattern detection for the current run loop iteration.
+
+        A repeating action-error pattern gets one explicit corrective nudge
+        (naming the repeated action and its error) before the conversation is
+        hard-terminated, mirroring how an EMPTY/reasoning-only LLM response
+        already gets `_send_corrective_nudge()` instead of an immediate stop
+        (#4331). The nudge is injected and the loop is left free to run
+        another `agent.step()` this same iteration so the model can react to
+        it; only a pattern that persists past that nudge, or any other stuck
+        pattern, sets STUCK.
+
+        Returns True if STUCK was set and the run loop should stop.
+        """
+        if not self._stuck_detector:
+            return False
+
+        nudge = self._stuck_detector.get_action_error_nudge()
+        if nudge is not None:
+            self._on_event(
+                MessageEvent(
+                    source="environment",
+                    llm_message=Message(role="user", content=[TextContent(text=nudge)]),
+                )
+            )
+            return False
+
+        if self._stuck_detector.is_stuck():
+            logger.warning("Stuck pattern detected.")
+            self._state.execution_status = ConversationExecutionStatus.STUCK
+            return True
+
+        return False
+
     @property
     def stuck_detector(self) -> StuckDetector | None:
         """Get the stuck detector instance if enabled."""
@@ -1869,15 +1903,8 @@ class LocalConversation(BaseConversation):
                         break
 
                     # Check for stuck patterns if enabled
-                    if self._stuck_detector:
-                        is_stuck = self._stuck_detector.is_stuck()
-
-                        if is_stuck:
-                            logger.warning("Stuck pattern detected.")
-                            self._state.execution_status = (
-                                ConversationExecutionStatus.STUCK
-                            )
-                            continue
+                    if self._check_stuck_or_nudge():
+                        continue
 
                     # clear the flag before calling agent.step() (user approved)
                     if (
@@ -2069,14 +2096,8 @@ class LocalConversation(BaseConversation):
                                 continue
                         break
 
-                    if self._stuck_detector:
-                        is_stuck = self._stuck_detector.is_stuck()
-                        if is_stuck:
-                            logger.warning("Stuck pattern detected.")
-                            self._state.execution_status = (
-                                ConversationExecutionStatus.STUCK
-                            )
-                            continue
+                    if self._check_stuck_or_nudge():
+                        continue
 
                     if (
                         self._state.execution_status

--- a/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
+++ b/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
@@ -60,14 +60,7 @@ class StuckDetector:
         return self.thresholds.alternating_pattern
 
     def _events_since_last_user_message(self) -> list[Event]:
-        """Events in the scan window, after the last user message (if any).
-
-        To avoid materializing potentially large file-backed event histories,
-        only the last MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION events of the active
-        branch are analyzed (abandoned branches are excluded). If a user message
-        exists within this window, only events after it are returned. Otherwise,
-        all events in the window are returned.
-        """
+        """Events in the scan window, after the last user message (if any)."""
         events = self.state.active_branch(limit=MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION)
 
         last_user_msg_index = next(
@@ -118,10 +111,8 @@ class StuckDetector:
             f"Events after last user message: {[type(e).__name__ for e in events]}"
         )
 
-        # Collect enough actions and observations for detection. The action-error
-        # scan needs one extra pair beyond its threshold to tell a fresh streak
-        # (nudge-eligible, see get_action_error_nudge()) apart from one that
-        # continued past the nudge (hard stuck).
+        # action_error needs one extra pair to tell a fresh streak from one
+        # that already continued past the nudge (see get_action_error_nudge)
         max_needed = max(
             self.action_observation_threshold, self.action_error_threshold + 1
         )
@@ -193,12 +184,7 @@ class StuckDetector:
     def _action_error_streak(
         self, last_actions: list[Event], last_observations: list[Event]
     ) -> int:
-        """Length of the trailing run of one action repeatedly erroring.
-
-        Counts, from the most recent pair backwards, how many consecutive
-        (action, observation) pairs have an action equal to the most recent
-        one and an observation that is an :class:`AgentErrorEvent`.
-        """
+        """Length of the trailing run of one action repeatedly erroring."""
         if not last_actions or not last_observations:
             return 0
         reference = last_actions[0]
@@ -214,10 +200,7 @@ class StuckDetector:
     def _is_stuck_repeating_action_error(
         self, last_actions: list[Event], last_observations: list[Event]
     ) -> bool:
-        # scenario 2: same action, errors. Requires one repeat *beyond* the
-        # threshold: the streak reaching the threshold itself is handled by
-        # get_action_error_nudge(), which gives the model one explicit chance
-        # to self-correct before this reports the pattern as terminal.
+        # scenario 2: same action, errors — one repeat past the threshold
         if self._action_error_streak(last_actions, last_observations) > (
             self.action_error_threshold
         ):
@@ -226,16 +209,7 @@ class StuckDetector:
         return False
 
     def get_action_error_nudge(self) -> str | None:
-        """Corrective nudge for a repeating action-error streak, once.
-
-        Returns a message naming the repeated action and its error the first
-        time the identical-action streak reaches ``action_error_threshold``,
-        so the caller can inject it and give the model one explicit,
-        higher-salience chance to self-correct before ``is_stuck()`` reports
-        the pattern as terminal. Returns ``None`` before the threshold is
-        reached, and again once the streak continues past it — at that point
-        the nudge already failed and ``is_stuck()`` takes over.
-        """
+        """Nudge text once an action-error streak first hits the threshold."""
         events = self._events_since_last_user_message()
         threshold = self.action_error_threshold
         last_actions, last_observations = self._collect_actions_and_observations(

--- a/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
+++ b/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
@@ -59,18 +59,17 @@ class StuckDetector:
     def alternating_pattern_threshold(self) -> int:
         return self.thresholds.alternating_pattern
 
-    def is_stuck(self) -> bool:
-        """Check if the agent is currently stuck.
+    def _events_since_last_user_message(self) -> list[Event]:
+        """Events in the scan window, after the last user message (if any).
 
-        Note: To avoid materializing potentially large file-backed event histories,
+        To avoid materializing potentially large file-backed event histories,
         only the last MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION events of the active
         branch are analyzed (abandoned branches are excluded). If a user message
-        exists within this window, only events after it are checked. Otherwise, all
-        events in the window are analyzed.
+        exists within this window, only events after it are returned. Otherwise,
+        all events in the window are returned.
         """
         events = self.state.active_branch(limit=MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION)
 
-        # Only look at history after the last user message
         last_user_msg_index = next(
             (
                 i
@@ -81,6 +80,29 @@ class StuckDetector:
         )
         if last_user_msg_index != -1:
             events = events[last_user_msg_index + 1 :]
+        return events
+
+    def _collect_actions_and_observations(
+        self, events: list[Event], max_needed: int
+    ) -> tuple[list[Event], list[Event]]:
+        """The last ``max_needed`` actions and observations, most recent first."""
+        last_actions: list[Event] = []
+        last_observations: list[Event] = []
+        for event in reversed(events):
+            if isinstance(event, ActionEvent) and len(last_actions) < max_needed:
+                last_actions.append(event)
+            elif (
+                isinstance(event, ObservationBaseEvent)
+                and len(last_observations) < max_needed
+            ):
+                last_observations.append(event)
+            if len(last_actions) >= max_needed and len(last_observations) >= max_needed:
+                break
+        return last_actions, last_observations
+
+    def is_stuck(self) -> bool:
+        """Check if the agent is currently stuck."""
+        events = self._events_since_last_user_message()
 
         # Determine minimum events needed
         min_threshold = min(
@@ -96,22 +118,16 @@ class StuckDetector:
             f"Events after last user message: {[type(e).__name__ for e in events]}"
         )
 
-        # Collect enough actions and observations for detection
-        max_needed = max(self.action_observation_threshold, self.action_error_threshold)
-        last_actions: list[Event] = []
-        last_observations: list[Event] = []
-
-        # Retrieve the last N actions and observations from the end of history
-        for event in reversed(events):
-            if isinstance(event, ActionEvent) and len(last_actions) < max_needed:
-                last_actions.append(event)
-            elif (
-                isinstance(event, ObservationBaseEvent)
-                and len(last_observations) < max_needed
-            ):
-                last_observations.append(event)
-            if len(last_actions) >= max_needed and len(last_observations) >= max_needed:
-                break
+        # Collect enough actions and observations for detection. The action-error
+        # scan needs one extra pair beyond its threshold to tell a fresh streak
+        # (nudge-eligible, see get_action_error_nudge()) apart from one that
+        # continued past the nudge (hard stuck).
+        max_needed = max(
+            self.action_observation_threshold, self.action_error_threshold + 1
+        )
+        last_actions, last_observations = self._collect_actions_and_observations(
+            events, max_needed
+        )
 
         # Check all stuck patterns
         # scenario 1: same action, same observation
@@ -174,29 +190,71 @@ class StuckDetector:
 
         return False
 
+    def _action_error_streak(
+        self, last_actions: list[Event], last_observations: list[Event]
+    ) -> int:
+        """Length of the trailing run of one action repeatedly erroring.
+
+        Counts, from the most recent pair backwards, how many consecutive
+        (action, observation) pairs have an action equal to the most recent
+        one and an observation that is an :class:`AgentErrorEvent`.
+        """
+        if not last_actions or not last_observations:
+            return 0
+        reference = last_actions[0]
+        streak = 0
+        for action, observation in zip(last_actions, last_observations):
+            if not self._event_eq(reference, action):
+                break
+            if not isinstance(observation, AgentErrorEvent):
+                break
+            streak += 1
+        return streak
+
     def _is_stuck_repeating_action_error(
         self, last_actions: list[Event], last_observations: list[Event]
     ) -> bool:
-        # scenario 2: same action, errors
-        threshold = self.action_error_threshold
-        if len(last_actions) < threshold or len(last_observations) < threshold:
-            return False
-
-        # are the last N actions the "same"?
-        if all(
-            self._event_eq(last_actions[0], action)
-            for action in last_actions[:threshold]
+        # scenario 2: same action, errors. Requires one repeat *beyond* the
+        # threshold: the streak reaching the threshold itself is handled by
+        # get_action_error_nudge(), which gives the model one explicit chance
+        # to self-correct before this reports the pattern as terminal.
+        if self._action_error_streak(last_actions, last_observations) > (
+            self.action_error_threshold
         ):
-            # and the last N observations are all errors?
-            if all(
-                isinstance(obs, AgentErrorEvent)
-                for obs in last_observations[:threshold]
-            ):
-                logger.warning("Action, Error loop detected")
-                return True
-
-        # Check if observations are errors
+            logger.warning("Action, Error loop detected")
+            return True
         return False
+
+    def get_action_error_nudge(self) -> str | None:
+        """Corrective nudge for a repeating action-error streak, once.
+
+        Returns a message naming the repeated action and its error the first
+        time the identical-action streak reaches ``action_error_threshold``,
+        so the caller can inject it and give the model one explicit,
+        higher-salience chance to self-correct before ``is_stuck()`` reports
+        the pattern as terminal. Returns ``None`` before the threshold is
+        reached, and again once the streak continues past it — at that point
+        the nudge already failed and ``is_stuck()`` takes over.
+        """
+        events = self._events_since_last_user_message()
+        threshold = self.action_error_threshold
+        last_actions, last_observations = self._collect_actions_and_observations(
+            events, threshold + 1
+        )
+        if self._action_error_streak(last_actions, last_observations) != threshold:
+            return None
+
+        action = last_actions[0]
+        error = last_observations[0]
+        assert isinstance(action, ActionEvent)
+        assert isinstance(error, AgentErrorEvent)
+        return (
+            f"You've called `{action.tool_name}` with the same arguments "
+            f"{threshold} times in a row and gotten the same error each "
+            f"time: {error.error!r}. Repeating the exact same call again "
+            "will not work — review the error message and either correct "
+            "the arguments or try a different approach."
+        )
 
     def _is_stuck_monologue(self, events: list[Event]) -> bool:
         # scenario 3: monologue

--- a/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
+++ b/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
@@ -42,6 +42,10 @@ class StuckDetector:
     ):
         self.state = state
         self.thresholds = thresholds or StuckDetectionThresholds()
+        # Id of the AgentErrorEvent already nudged for, so a frozen streak
+        # (e.g. an empty/reasoning-only response that adds no new action)
+        # doesn't re-emit the same nudge every iteration.
+        self._last_nudged_error_event_id: str | None = None
 
     @property
     def action_observation_threshold(self) -> int:
@@ -212,7 +216,12 @@ class StuckDetector:
         return False
 
     def get_action_error_nudge(self) -> str | None:
-        """Nudge text once an action-error streak first hits the threshold."""
+        """Nudge text once an action-error streak first hits the threshold.
+
+        Nudges once per streak: if the streak is still frozen on the same
+        error event (e.g. an empty/reasoning-only response added no new
+        action) we've already nudged for it, so we don't re-fire.
+        """
         events = self._events_since_last_user_message()
         threshold = self.action_error_threshold
         last_actions, last_observations = self._collect_actions_and_observations(
@@ -225,10 +234,15 @@ class StuckDetector:
         error = last_observations[0]
         assert isinstance(action, ActionEvent)
         assert isinstance(error, AgentErrorEvent)
+
+        if error.id == self._last_nudged_error_event_id:
+            return None
+        self._last_nudged_error_event_id = error.id
+
         return (
             f"You've called `{action.tool_name}` with the same arguments "
             f"{threshold} times in a row and gotten the same error each "
-            f"time: {error.error!r}. Repeating the exact same call again "
+            f"time: {error.error}. Repeating the exact same call again "
             "will not work — review the error message and either correct "
             "the arguments or try a different approach."
         )

--- a/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
+++ b/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
@@ -60,7 +60,11 @@ class StuckDetector:
         return self.thresholds.alternating_pattern
 
     def _events_since_last_user_message(self) -> list[Event]:
-        """Events in the scan window, after the last user message (if any)."""
+        """Events in the scan window, after the last user message (if any).
+
+        Windowed rather than full-history to avoid materializing large
+        file-backed event logs.
+        """
         events = self.state.active_branch(limit=MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION)
 
         last_user_msg_index = next(
@@ -201,9 +205,8 @@ class StuckDetector:
         self, last_actions: list[Event], last_observations: list[Event]
     ) -> bool:
         # scenario 2: same action, errors — one repeat past the threshold
-        if self._action_error_streak(last_actions, last_observations) > (
-            self.action_error_threshold
-        ):
+        threshold = self.action_error_threshold
+        if self._action_error_streak(last_actions, last_observations) > threshold:
             logger.warning("Action, Error loop detected")
             return True
         return False

--- a/tests/cross/test_stuck_detector.py
+++ b/tests/cross/test_stuck_detector.py
@@ -376,11 +376,7 @@ def test_repeating_action_observation_stuck():
 
 
 def test_repeating_action_error_nudges_before_stuck():
-    """A repeating action-error pattern gets one corrective nudge before
-    ``is_stuck()`` reports it as terminal (#4331): reaching the threshold
-    (3 by default) is nudge-eligible, not yet stuck; only a further repeat
-    of the identical action-error pair is a hard stuck.
-    """
+    """Reaching the threshold nudges once; a further repeat is a hard stuck."""
     llm = LLM(model="gpt-4o-mini", usage_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(
@@ -426,28 +422,26 @@ def test_repeating_action_error_nudges_before_stuck():
         state.events.append(action)
         state.events.append(error)
 
-    # Should not be stuck (nor nudge-eligible) with only 2 identical pairs
+    # 2 pairs: not stuck, no nudge yet
     assert stuck_detector.is_stuck() is False
     assert stuck_detector.get_action_error_nudge() is None
 
-    # Add 1 more identical action-error pair to reach the threshold (3)
+    # 3rd pair reaches the threshold: nudge, not yet stuck
     action, error = create_action_and_error(2)
     state.events.append(action)
     state.events.append(error)
 
-    # Threshold reached: nudge-eligible, but not yet a hard stuck
     assert stuck_detector.is_stuck() is False
     nudge = stuck_detector.get_action_error_nudge()
     assert nudge is not None
     assert "terminal" in nudge
     assert "Command 'invalid_command' not found" in nudge
 
-    # Model repeats the exact same action-error again despite the nudge
+    # 4th pair despite the nudge: hard stuck
     action, error = create_action_and_error(3)
     state.events.append(action)
     state.events.append(error)
 
-    # Now it's a hard stuck, and there's no further nudge to give
     assert stuck_detector.is_stuck() is True
     assert stuck_detector.get_action_error_nudge() is None
 

--- a/tests/cross/test_stuck_detector.py
+++ b/tests/cross/test_stuck_detector.py
@@ -375,8 +375,12 @@ def test_repeating_action_observation_stuck():
     assert stuck_detector.is_stuck() is True
 
 
-def test_repeating_action_error_stuck():
-    """Test detection of repeating action-error cycles."""
+def test_repeating_action_error_nudges_before_stuck():
+    """A repeating action-error pattern gets one corrective nudge before
+    ``is_stuck()`` reports it as terminal (#4331): reaching the threshold
+    (3 by default) is nudge-eligible, not yet stuck; only a further repeat
+    of the identical action-error pair is a hard stuck.
+    """
     llm = LLM(model="gpt-4o-mini", usage_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(
@@ -422,16 +426,30 @@ def test_repeating_action_error_stuck():
         state.events.append(action)
         state.events.append(error)
 
-    # Should not stuck with 2 identical action-error pairs
+    # Should not be stuck (nor nudge-eligible) with only 2 identical pairs
     assert stuck_detector.is_stuck() is False
+    assert stuck_detector.get_action_error_nudge() is None
 
-    # Add 1 more identical action-error pair to trigger stuck detection
+    # Add 1 more identical action-error pair to reach the threshold (3)
     action, error = create_action_and_error(2)
     state.events.append(action)
     state.events.append(error)
 
-    # Should be stuck with 3 identical action-error pairs
+    # Threshold reached: nudge-eligible, but not yet a hard stuck
+    assert stuck_detector.is_stuck() is False
+    nudge = stuck_detector.get_action_error_nudge()
+    assert nudge is not None
+    assert "terminal" in nudge
+    assert "Command 'invalid_command' not found" in nudge
+
+    # Model repeats the exact same action-error again despite the nudge
+    action, error = create_action_and_error(3)
+    state.events.append(action)
+    state.events.append(error)
+
+    # Now it's a hard stuck, and there's no further nudge to give
     assert stuck_detector.is_stuck() is True
+    assert stuck_detector.get_action_error_nudge() is None
 
 
 def test_agent_monologue_stuck():

--- a/tests/sdk/conversation/local/test_stuck_detector_nudge.py
+++ b/tests/sdk/conversation/local/test_stuck_detector_nudge.py
@@ -1,12 +1,4 @@
-"""Integration tests for the repeating action-error corrective nudge (#4331).
-
-Before this fix, a repeating action-error pattern (same malformed tool call,
-same validation error, N times in a row) went straight to a terminal STUCK
-status. These tests drive a real `Conversation.run()` loop with a tool that
-always errors, verifying the run loop now gives the model one explicit
-corrective nudge before hard-terminating, and that it only terminates if the
-identical action-error pair continues past that nudge.
-"""
+"""Integration tests for the repeating action-error corrective nudge (#4331)."""
 
 from collections.abc import Sequence
 from typing import ClassVar
@@ -29,8 +21,6 @@ from openhands.sdk.tool import (
 
 
 class _AlwaysErrorAction(Action):
-    """Mock action for a tool call that always fails validation/execution."""
-
     command: str
 
 
@@ -43,8 +33,6 @@ class _AlwaysErrorObservation(Observation):
 
 
 class _AlwaysErrorExecutor(ToolExecutor[_AlwaysErrorAction, _AlwaysErrorObservation]):
-    """Executor that always raises, mirroring a missing-required-arg error."""
-
     def __call__(self, action: _AlwaysErrorAction, conversation=None):
         raise ValueError("`file_text` is required for command: create.")
 
@@ -123,7 +111,6 @@ def test_run_nudges_before_going_stuck_on_repeating_action_error():
     assert "always_error_tool" in nudge_text.text
     assert "file_text" in nudge_text.text
 
-    # The nudge must land right after the 3rd error and before the 4th action.
     events = list(conversation.state.events)
     nudge_index = events.index(nudges[0])
     preceding_errors = [

--- a/tests/sdk/conversation/local/test_stuck_detector_nudge.py
+++ b/tests/sdk/conversation/local/test_stuck_detector_nudge.py
@@ -1,0 +1,166 @@
+"""Integration tests for the repeating action-error corrective nudge (#4331).
+
+Before this fix, a repeating action-error pattern (same malformed tool call,
+same validation error, N times in a row) went straight to a terminal STUCK
+status. These tests drive a real `Conversation.run()` loop with a tool that
+always errors, verifying the run loop now gives the model one explicit
+corrective nudge before hard-terminating, and that it only terminates if the
+identical action-error pair continues past that nudge.
+"""
+
+from collections.abc import Sequence
+from typing import ClassVar
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import AgentErrorEvent, MessageEvent
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.testing import TestLLM
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    Tool,
+    ToolDefinition,
+    ToolExecutor,
+    register_tool,
+)
+
+
+class _AlwaysErrorAction(Action):
+    """Mock action for a tool call that always fails validation/execution."""
+
+    command: str
+
+
+class _AlwaysErrorObservation(Observation):
+    result: str
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        return [TextContent(text=self.result)]
+
+
+class _AlwaysErrorExecutor(ToolExecutor[_AlwaysErrorAction, _AlwaysErrorObservation]):
+    """Executor that always raises, mirroring a missing-required-arg error."""
+
+    def __call__(self, action: _AlwaysErrorAction, conversation=None):
+        raise ValueError("`file_text` is required for command: create.")
+
+
+class _AlwaysErrorTool(ToolDefinition[_AlwaysErrorAction, _AlwaysErrorObservation]):
+    name: ClassVar[str] = "always_error_tool"
+
+    @classmethod
+    def create(cls, conv_state=None, *, executor: ToolExecutor, **params):
+        return [
+            cls(
+                description="A tool that always errors",
+                action_type=_AlwaysErrorAction,
+                observation_type=_AlwaysErrorObservation,
+                executor=executor,
+            )
+        ]
+
+
+def _bad_tool_call(call_id: str) -> MessageToolCall:
+    return MessageToolCall(
+        id=call_id,
+        name="always_error_tool",
+        arguments='{"command": "create"}',
+        origin="completion",
+    )
+
+
+def _bad_tool_call_message(call_id: str) -> Message:
+    return Message(
+        role="assistant",
+        content=[TextContent(text="")],
+        tool_calls=[_bad_tool_call(call_id)],
+    )
+
+
+def _make_conversation(
+    scripted_messages: list[Message | Exception],
+) -> LocalConversation:
+    register_tool(
+        "always_error_tool", _AlwaysErrorTool.create(executor=_AlwaysErrorExecutor())[0]
+    )
+    llm = TestLLM.from_messages(scripted_messages)
+    agent = Agent(llm=llm, tools=[Tool(name="always_error_tool")])
+    conversation = Conversation(agent=agent)
+    assert isinstance(conversation, LocalConversation)
+    return conversation
+
+
+def test_run_nudges_before_going_stuck_on_repeating_action_error():
+    """4 identical failing calls: nudge after the 3rd, hard STUCK after the 4th."""
+    scripted_messages: list[Message | Exception] = [
+        _bad_tool_call_message(f"call_{i}") for i in range(4)
+    ]
+    conversation = _make_conversation(scripted_messages)
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Create /tmp/foo.py")])
+    )
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.STUCK
+
+    error_events = [
+        e for e in conversation.state.events if isinstance(e, AgentErrorEvent)
+    ]
+    assert len(error_events) == 4
+
+    nudges = [
+        e
+        for e in conversation.state.events
+        if isinstance(e, MessageEvent) and e.source == "environment"
+    ]
+    assert len(nudges) == 1
+    nudge_text = nudges[0].llm_message.content[0]
+    assert isinstance(nudge_text, TextContent)
+    assert "always_error_tool" in nudge_text.text
+    assert "file_text" in nudge_text.text
+
+    # The nudge must land right after the 3rd error and before the 4th action.
+    events = list(conversation.state.events)
+    nudge_index = events.index(nudges[0])
+    preceding_errors = [
+        e for e in events[:nudge_index] if isinstance(e, AgentErrorEvent)
+    ]
+    following_errors = [
+        e for e in events[nudge_index:] if isinstance(e, AgentErrorEvent)
+    ]
+    assert len(preceding_errors) == 3
+    assert len(following_errors) == 1
+
+
+def test_run_recovers_after_nudge_when_model_self_corrects():
+    """3 identical failing calls then a different response: no STUCK at all."""
+    scripted_messages: list[Message | Exception] = [
+        *[_bad_tool_call_message(f"call_{i}") for i in range(3)],
+        Message(
+            role="assistant",
+            content=[TextContent(text="I see the issue, stopping here.")],
+        ),
+    ]
+    conversation = _make_conversation(scripted_messages)
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Create /tmp/foo.py")])
+    )
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+    error_events = [
+        e for e in conversation.state.events if isinstance(e, AgentErrorEvent)
+    ]
+    assert len(error_events) == 3
+
+    nudges = [
+        e
+        for e in conversation.state.events
+        if isinstance(e, MessageEvent) and e.source == "environment"
+    ]
+    assert len(nudges) == 1

--- a/tests/sdk/conversation/local/test_stuck_detector_nudge.py
+++ b/tests/sdk/conversation/local/test_stuck_detector_nudge.py
@@ -151,3 +151,49 @@ def test_run_recovers_after_nudge_when_model_self_corrects():
         if isinstance(e, MessageEvent) and e.source == "environment"
     ]
     assert len(nudges) == 1
+
+
+def test_run_does_not_renudge_action_error_while_streak_is_frozen():
+    """An empty response after the nudge must not re-fire the same nudge.
+
+    3 identical failing calls hit the nudge threshold and emit one nudge.
+    The model then stalls with an empty response, which adds no new
+    action/observation, so the action-error streak stays frozen at the
+    threshold. The unrelated EMPTY corrective nudge fires for that, but
+    the action-error nudge must not re-fire on the frozen streak.
+    """
+    scripted_messages: list[Message | Exception] = [
+        *[_bad_tool_call_message(f"call_{i}") for i in range(3)],
+        Message(role="assistant", content=[]),
+        Message(
+            role="assistant",
+            content=[TextContent(text="I see the issue, stopping here.")],
+        ),
+    ]
+    conversation = _make_conversation(scripted_messages)
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Create /tmp/foo.py")])
+    )
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+    error_events = [
+        e for e in conversation.state.events if isinstance(e, AgentErrorEvent)
+    ]
+    assert len(error_events) == 3
+
+    nudges = [
+        e
+        for e in conversation.state.events
+        if isinstance(e, MessageEvent) and e.source == "environment"
+    ]
+    # One action-error nudge plus the unrelated EMPTY corrective nudge —
+    # not a second action-error nudge for the already-nudged, frozen streak.
+    assert len(nudges) == 2
+    action_error_nudge = nudges[0].llm_message.content[0]
+    empty_corrective_nudge = nudges[1].llm_message.content[0]
+    assert isinstance(action_error_nudge, TextContent)
+    assert isinstance(empty_corrective_nudge, TextContent)
+    assert "always_error_tool" in action_error_nudge.text
+    assert "did not include a function call" in empty_corrective_nudge.text


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix stuck detection for GLM models

---

AGENT:

## Why

`StuckDetector._is_stuck_repeating_action_error()` already detects the pattern where the model repeats the *same* tool call and gets the *same* error back `action_error` times in a row (default threshold: 3). But once detected, the run loop (`local_conversation.py`, both `run()` and `arun()`) went straight from "pattern detected" to a terminal `STUCK` status with no attempt at self-correction.

This is asymmetric with how the SDK already treats a different weak-model failure mode: an `EMPTY`/reasoning-only LLM response gets `_send_corrective_nudge()` — an injected message telling the model what it needs to do — and the loop continues. A model that instead keeps emitting a malformed tool call got zero equivalent chance: it only ever saw the tool's own validation-error text repeated back to it, and if it didn't self-correct within 3 tries, the conversation was killed unconditionally.

## Summary

- `StuckDetector.get_action_error_nudge()`: when the repeating action-error streak first reaches `action_error_threshold`, returns a message naming the repeated action and its error instead of leaving the caller to only find out via a bare `is_stuck()` bool.
- `StuckDetector._is_stuck_repeating_action_error()` now requires the streak to continue *one repeat past* the threshold before reporting a hard stuck — the streak reaching the threshold itself is nudge-eligible, not yet terminal.
- `LocalConversation._check_stuck_or_nudge()` (used by both `run()` and `arun()`): injects the nudge as an `environment`-sourced `MessageEvent` and lets the loop run another `agent.step()` so the model can react to it, only setting `STUCK` if the identical action-error pair persists past that one nudge (or for any other stuck pattern, unchanged).

## Issue Number

Fixes #4331

## How to Test

- Unit: `uv run pytest tests/cross/test_stuck_detector.py tests/cross/test_stuck_detector_config.py` — covers `get_action_error_nudge()` returning `None` before the threshold, a message at the threshold, and `None` again (with `is_stuck()` now `True`) once the streak continues past it.
- Integration (drives a real `Conversation.run()` loop with `TestLLM` + a tool whose executor always raises): `uv run pytest tests/sdk/conversation/local/test_stuck_detector_nudge.py`
  - `test_run_nudges_before_going_stuck_on_repeating_action_error`: 4 identical failing tool calls → exactly one `environment` nudge event lands between the 3rd and 4th error, final status is `STUCK`.
  - `test_run_recovers_after_nudge_when_model_self_corrects`: 3 identical failing calls then a different response → one nudge, conversation reaches `FINISHED`, never goes `STUCK`.
- Also ran the full `tests/cross` + `tests/sdk` suites; all pass except a pre-existing, unrelated cipher/secrets test-pollution issue that reproduces identically on unmodified `main` (confirmed by re-running the same subset with these changes stashed).
- Ran `uv run ruff format --check`, `uv run ruff check`, and `uv run pre-commit run --files <changed>` on all touched files — all pass.

## Video/Screenshots



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Behavior change: `is_stuck()` for the action-error pattern now trips one repeat later than before (e.g. 4 identical action-error pairs instead of 3 with default thresholds), since the repeat at the threshold is now used for the nudge. `action_error_threshold` still configures the same detector via `StuckDetectionThresholds`.
- Scoped to the `repeating_action_error` pattern only, per the issue's title/reproduction; the `repeating_action_observation` pattern (non-error, identical observation) is unchanged.
- Doesn't add typed stuck-reason codes (issue mentions #3565) — kept this change minimal and focused on the recovery gap.
