### PR TITLE
fix(sdk): reject switch_llm/switch_profile on ACP conversations

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1539,7 +1539,21 @@ class LocalConversation(BaseConversation):
 
         Args:
             llm: LLM to install on the agent.
+
+        Raises:
+            ValueError: If the conversation's agent is an :class:`ACPAgent`.
+                Swapping OpenHands' own LLM object has no effect on an ACP
+                subprocess, which owns its own model. Persisting the swap would
+                leave base_state.json and the live session disagreeing (#4158);
+                use :meth:`switch_acp_model` for ACP conversations instead.
         """
+        if isinstance(self.agent, ACPAgent):
+            raise ValueError(
+                "switch_llm/switch_profile is not supported for ACP conversations. "
+                "The ACP server owns its own model, so switching the OpenHands LLM "
+                "would not take effect on the live session. Use switch_acp_model to "
+                "change the model of an ACP conversation."
+            )
         try:
             new_llm = self.llm_registry.get(llm.usage_id)
         except KeyError:

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -258,6 +258,34 @@ def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     assert switched._atexit_callback is None
 
 
+def test_switch_llm_rejects_acp_agent(tmp_path):
+    """Regression for #4158: switch_llm must reject ACP conversations.
+
+    Swapping the OpenHands LLM has no effect on the ACP subprocess (which owns
+    its own model), so persisting the swap would leave base_state.json and the
+    live session disagreeing. It must fail loudly instead of half-applying.
+    """
+    conv, agent = _make_acp_conversation(tmp_path)
+    with pytest.raises(ValueError, match="not supported for ACP"):
+        conv.switch_llm(_make_llm("kimi", "kimi"))
+    # The agent is untouched — still the ACP agent, and no LLM swap occurred.
+    assert conv.agent is agent
+    assert isinstance(conv.state.agent, ACPAgent)
+
+
+def test_switch_profile_rejects_acp_agent(tmp_path, profile_store):
+    """Regression for #4158: switch_profile must reject ACP conversations.
+
+    The persisted state must not be rewritten to the profile's OpenHands LLM
+    while the live ACP session keeps the old agent.
+    """
+    conv, agent = _make_acp_conversation(tmp_path)
+    with pytest.raises(ValueError, match="not supported for ACP"):
+        conv.switch_profile("fast")
+    assert conv.agent is agent
+    assert isinstance(conv.state.agent, ACPAgent)
+
+
 def test_switch_profile(profile_store):
     """switch_profile switches the agent's LLM."""
     conv = _make_conversation()


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Fixes #4158. On an ACP conversation, `switch_profile` (and the underlying `switch_llm`) half-applied: `base_state.json` was rewritten to the new OpenHands LLM while the live ACP session kept running the old ACP agent/model. The caller (agent-canvas UI / REST endpoint / `switch_llm` tool) was told the switch **succeeded**, so persisted state and the running agent disagreed.

The root cause is that an ACP conversation runs its model inside the ACP subprocess, which owns its own model. `switch_llm` only swaps OpenHands' own `LLM` object, which has no effect on an ACP subprocess — but it still persisted the swap, producing the inconsistency.

## Summary

- Guard `LocalConversation.switch_llm` to raise `ValueError` when the conversation's agent is an `ACPAgent`, pointing callers at `switch_acp_model` instead. `switch_profile` delegates to `switch_llm`, so it is covered too.
- Both existing callers already surface `ValueError` as a 4xx (`POST /switch_profile` → 400) or an error observation (`SwitchLLM` tool), so the half-applied path is now rejected loudly rather than silently succeeding.
- Added regression tests for both `switch_llm` and `switch_profile` against an ACP conversation.

This matches the issue's suggested fix: "cross-agent-kind switching is out of scope, so `switch_profile` should validate agent_kind compatibility and return 4xx."

## Issue Number

Fixes #4158

## How to Test

Run the targeted tests:

```bash
uv run pytest tests/sdk/conversation/test_switch_model.py -q
uv run pytest tests/agent_server/test_conversation_router.py -q -k switch
```

Both suites pass (26 and 15 tests respectively). New tests:

- `test_switch_llm_rejects_acp_agent` — `switch_llm` on an ACP conversation raises `ValueError` and leaves the agent/state untouched.
- `test_switch_profile_rejects_acp_agent` — `switch_profile` on an ACP conversation raises `ValueError`; persisted state is not rewritten.

Pre-commit (ruff, pyright, import rules) passes on the changed files.

## Video/Screenshots

N/A — SDK-level behavior change covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is intentionally a "reject loudly" fix rather than "tear down and re-provision the ACP agent from updated state," matching the out-of-scope guidance in the issue. Cross-agent-kind live switching can be a follow-up if desired. Downstream UIs should also avoid offering incompatible profiles mid-conversation, but that is outside this repo.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6e13c614-034b-449d-99c7-0a2d1daf0c41)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e77cd7f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e77cd7f-python \
  ghcr.io/openhands/agent-server:e77cd7f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e77cd7f-golang-amd64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-golang-amd64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-golang-amd64
ghcr.io/openhands/agent-server:e77cd7f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e77cd7f-golang-arm64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-golang-arm64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-golang-arm64
ghcr.io/openhands/agent-server:e77cd7f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e77cd7f-java-amd64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-java-amd64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-java-amd64
ghcr.io/openhands/agent-server:e77cd7f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e77cd7f-java-arm64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-java-arm64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-java-arm64
ghcr.io/openhands/agent-server:e77cd7f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e77cd7f-python-amd64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-python-amd64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-python-amd64
ghcr.io/openhands/agent-server:e77cd7f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e77cd7f-python-arm64
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-python-arm64
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-python-arm64
ghcr.io/openhands/agent-server:e77cd7f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e77cd7f-golang
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-golang
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-golang
ghcr.io/openhands/agent-server:e77cd7f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e77cd7f-java
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-java
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-java
ghcr.io/openhands/agent-server:e77cd7f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e77cd7f-python
ghcr.io/openhands/agent-server:e77cd7f2d6876c4d9860a74677ac9a063bc5f960-python
ghcr.io/openhands/agent-server:openhands-fix-4158-switch-profile-acp-guard-python
ghcr.io/openhands/agent-server:e77cd7f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e77cd7f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e77cd7f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->