### PR TITLE
fix(acp): abort the turn immediately when close() lands mid-prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -3728,12 +3728,14 @@ class ACPAgent(AgentBase):
                 self.acp_prompt_timeout,
                 len(prompt_blocks),
             )
-            portal = self._require_executor().portal
-
             response: PromptResponse | None = None
             max_retries = _ACP_PROMPT_MAX_RETRIES
             for attempt in range(max_retries + 1):
                 try:
+                    # Re-read per attempt, like step() does, so a teardown
+                    # between retries surfaces as a closed agent rather than
+                    # anyio's "portal is not running".
+                    portal = self._require_executor().portal
                     # Schedule the ACP prompt on the portal loop (where the
                     # connection lives); await the future back on the caller
                     # loop.  Shield the portal task from wait_for timeout so

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -149,6 +149,16 @@ _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
 # Exception types that indicate transient connection issues worth retrying
 _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFError)
 
+
+class ACPAgentClosedError(RuntimeError):
+    """Raised when the ACP runtime is torn down while a prompt is in flight.
+
+    ``close()`` runs on whatever thread calls it, so it can land while another
+    thread is inside ``step()``/``astep()``. Subclasses ``RuntimeError`` so
+    callers that already handle the pre-session ``RuntimeError`` keep working.
+    """
+
+
 # ``npm run`` exports package/lifecycle configuration into descendants. ACP
 # providers launched through ``npx`` must not inherit that context, otherwise npm
 # can try to resolve against the parent package instead of the requested one.
@@ -1026,6 +1036,8 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
     policy refusals get their own code, credential failures map to ``ACPAuthRequired``
     (so the client can offer re-auth), everything else is a generic ``ACPPromptError``.
     """
+    if isinstance(exc, ACPAgentClosedError):
+        return "ACPAgentClosed"
     if isinstance(exc, ACPFileCredentialSyncError):
         return "ACPPromptError"
     if isinstance(exc, ACPFileCredentialNeedsReauthError):
@@ -1988,6 +2000,21 @@ class ACPAgent(AgentBase):
             and self._session_id is not None
             and self._executor is not None
         )
+
+    def _require_executor(self) -> Any:
+        """Return the live executor, or raise if teardown already started.
+
+        Reads ``_executor`` once so a concurrent :meth:`close` cannot null it
+        out between the check and the call. ``_closed`` is set before teardown
+        begins, so it catches the window where the executor is still assigned
+        but its portal is going away.
+        """
+        executor = self._executor
+        if executor is None or self._closed:
+            raise ACPAgentClosedError(
+                "ACP agent was closed while a prompt was in flight"
+            )
+        return executor
 
     def get_all_llms(self) -> Generator[LLM]:
         yield self.llm
@@ -3566,11 +3593,15 @@ class ACPAgent(AgentBase):
 
             for attempt in range(max_retries + 1):
                 try:
-                    response = self._executor.run_async(_prompt)
+                    response = self._require_executor().run_async(_prompt)
                     break
                 except TimeoutError:
                     raise
                 except _RETRIABLE_CONNECTION_ERRORS as e:
+                    if self._closed:
+                        raise ACPAgentClosedError(
+                            "ACP agent was closed while a prompt was in flight"
+                        ) from e
                     if attempt < max_retries:
                         delay = _ACP_PROMPT_RETRY_DELAYS[
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
@@ -3595,6 +3626,7 @@ class ACPAgent(AgentBase):
                     if (
                         e.code in _RETRIABLE_SERVER_ERROR_CODES
                         and attempt < max_retries
+                        and not self._closed
                     ):
                         delay = _ACP_PROMPT_RETRY_DELAYS[
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
@@ -3696,7 +3728,7 @@ class ACPAgent(AgentBase):
                 self.acp_prompt_timeout,
                 len(prompt_blocks),
             )
-            portal = self._executor.portal
+            portal = self._require_executor().portal
 
             response: PromptResponse | None = None
             max_retries = _ACP_PROMPT_MAX_RETRIES
@@ -3722,6 +3754,10 @@ class ACPAgent(AgentBase):
                 except TimeoutError:
                     raise
                 except _RETRIABLE_CONNECTION_ERRORS as e:
+                    if self._closed:
+                        raise ACPAgentClosedError(
+                            "ACP agent was closed while a prompt was in flight"
+                        ) from e
                     if attempt < max_retries:
                         delay = _ACP_PROMPT_RETRY_DELAYS[
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
@@ -3743,6 +3779,7 @@ class ACPAgent(AgentBase):
                     if (
                         e.code in _RETRIABLE_SERVER_ERROR_CODES
                         and attempt < max_retries
+                        and not self._closed
                     ):
                         delay = _ACP_PROMPT_RETRY_DELAYS[
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5953,6 +5953,50 @@ class TestACPPromptRetry:
         assert call_count == 1
         assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
 
+    def test_astep_reports_closed_agent_when_teardown_lands_between_retries(
+        self, tmp_path
+    ):
+        """The async path re-reads the executor per attempt, like ``step``.
+
+        Teardown that lands after a retriable failure leaves a dead portal
+        behind; reading it once up front would surface anyio's "portal is not
+        running" as a generic prompt error instead of a closed agent.
+        """
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        events: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+
+        call_count = 0
+
+        class _PortalTornDownAfterFirstAttempt:
+            def start_task_soon(self, fn, *args):  # noqa: ANN001, ANN202
+                nonlocal call_count
+                call_count += 1
+                agent._executor = None
+                failed: Future = Future()
+                failed.set_exception(ConnectionError("Connection reset by peer"))
+                return failed
+
+        mock_executor = MagicMock()
+        mock_executor.portal = _PortalTornDownAfterFirstAttempt()
+        agent._executor = mock_executor
+
+        with patch(
+            "openhands.sdk.agent.acp_agent._ACP_PROMPT_RETRY_DELAYS", (0.0, 0.0, 0.0)
+        ):
+            with pytest.raises(ACPAgentClosedError):
+                asyncio.run(agent.astep(conversation, on_event=events.append))
+
+        assert call_count == 1
+        assert [e.code for e in events if isinstance(e, ConversationErrorEvent)] == [
+            "ACPAgentClosed"
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Gemini-specific tests

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -26,6 +26,7 @@ import openhands.sdk.agent.acp_file_credentials as acp_file_credentials_module
 import openhands.sdk.utils.files as files_module
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
+    ACPAgentClosedError,
     _acp_error_detail,
     _acp_error_indicates_auth,
     _apply_acp_model,
@@ -5845,6 +5846,111 @@ class TestACPPromptRetry:
 
         # Default max retries is 3, so 4 total attempts
         assert call_count == 4
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_close_during_prompt_aborts_without_retry_delay(self, tmp_path):
+        """``close()`` landing mid-prompt aborts now instead of sleeping.
+
+        Killing the subprocess surfaces as a retriable connection error, so
+        without the ``_closed`` check the turn waits out a full retry delay
+        before failing — defeating the point of closing to abort the turn.
+        """
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        events: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+
+        call_count = 0
+
+        def _fake_run_async(_coro, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            # What close() does on the other thread: _closed is set before
+            # teardown, then the runtime references are dropped.
+            agent._closed = True
+            agent._executor = None
+            raise ConnectionError("Connection closed")
+
+        mock_executor = MagicMock()
+        mock_executor.run_async = _fake_run_async
+        agent._executor = mock_executor
+
+        with patch("openhands.sdk.agent.acp_agent.time.sleep") as mock_sleep:
+            with pytest.raises(ACPAgentClosedError):
+                agent.step(conversation, on_event=events.append)
+
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+        assert [e.code for e in events if isinstance(e, ConversationErrorEvent)] == [
+            "ACPAgentClosed"
+        ]
+
+    def test_step_after_teardown_reports_closed_agent(self, tmp_path):
+        """A torn-down executor is reported as a closed agent, not a None deref."""
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+
+        agent._client = _OpenHandsACPBridge()
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+        agent._executor = None
+
+        with pytest.raises(ACPAgentClosedError):
+            agent.step(conversation, on_event=lambda _: None)
+
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_astep_after_teardown_reports_closed_agent(self, tmp_path):
+        """Async path guards the executor read the same way as :meth:`step`."""
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+
+        agent._client = _OpenHandsACPBridge()
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+        agent._executor = None
+
+        with pytest.raises(ACPAgentClosedError):
+            asyncio.run(agent.astep(conversation, on_event=lambda _: None))
+
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_close_during_astep_aborts_without_retry_delay(self, tmp_path):
+        """Async retry loop also stops as soon as teardown starts."""
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        events: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+
+        call_count = 0
+
+        class _ClosingPortal:
+            def start_task_soon(self, fn, *args):  # noqa: ANN001, ANN202
+                nonlocal call_count
+                call_count += 1
+                agent._closed = True
+                agent._executor = None
+                failed: Future = Future()
+                failed.set_exception(ConnectionError("Connection closed"))
+                return failed
+
+        mock_executor = MagicMock()
+        mock_executor.portal = _ClosingPortal()
+        agent._executor = mock_executor
+
+        with pytest.raises(ACPAgentClosedError):
+            asyncio.run(agent.astep(conversation, on_event=events.append))
+
+        assert call_count == 1
         assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
 
 


### PR DESCRIPTION
HUMAN:

I addressed this because closing the agent during an active prompt could trigger unnecessary retries and eventually fail with an unrelated `AttributeError`. I verified the fix with the original reproducer and new regression tests, confirming that the turn now aborts immediately with the expected closed-agent error.

---

AGENT:

## Why

Fixes #4329.

`ACPAgent.close()` runs on whatever thread calls it and drops `_executor` / `_process`, while a `Conversation.run()` on another thread can be inside `step()` between its own `None` check and the call. Two things go wrong when that happens:

1. Killing the subprocess first surfaces as `Connection closed`, which the prompt loop treats as a **retriable** connection error. So the turn sleeps a full retry delay (5s by default on the sync path, up to 5+15+30s on the async path) before it can fail, even though a closed agent can never succeed. `close()` from another thread is the only way to abort a `step()` that is blocked for the whole turn (`pause()` / `interrupt()` only take effect between steps), so that delay defeats the entire point of calling it.
2. The retry then dereferences `self._executor`, which is now `None`, and the turn dies with `AttributeError: 'NoneType' object has no attribute 'run_async'` instead of anything a caller can act on.

One correction to the issue report, which was filed against 1.38.0: on current `main` the exception is **not** swallowed and `run()` does exit, since `step()` re-raises after `_emit_turn_error` (added in #4126), so `ConversationRunError` propagates. What the reporter measured as "run() never returned within 5s" is the retry delay landing exactly on their 5s bound. The race itself and the `AttributeError` are real, and the abort latency is the substantive part.

## Summary

- `ACPAgent._require_executor()` reads `_executor` once so a concurrent `close()` cannot null it out between the check and the call, and raises `ACPAgentClosedError` (a `RuntimeError` subclass, so existing `RuntimeError` handling still applies) when teardown has already started. Used by the sync prompt loop and by the `astep()` portal read.
- Both retry loops bail out as soon as `_closed` is set instead of sleeping through a retry delay. `_closed` is assigned before teardown begins, so it also covers the window where `_executor` is still assigned but its portal is going away.
- `astep()` re-reads `self._require_executor().portal` on every attempt instead of capturing it once before the loop, mirroring what the sync path already does with the executor. Without that, a teardown landing between two attempts reaches a stale portal and anyio raises `RuntimeError("This portal is not running")`, which is not in `_RETRIABLE_CONNECTION_ERRORS` and slips past the `_closed` guard as a generic `ACPPromptError`.
- New `ACPAgentClosed` code on the emitted `ConversationErrorEvent`, so a client can tell "someone closed this agent" apart from a generic prompt failure.

## Issue Number

Fixes #4329

## How to Test

End-to-end, using the reporter's own reproducer (stdlib-only ACP stub whose `session/prompt` sleeps forever; `close()` is called from the main thread 1.5s into a blocked turn). I widened their `future.result(timeout=5)` to 20s so the outcome is measured rather than clipped by the bound, and printed how long the abort actually took.

```
uv run python repro_close_step_race.py 3
```

Before, on `main` @ `8ce9300` (3/3):

```
[13:55:55] WARNING  ACP prompt failed with retriable error (attempt 1/4), retrying in 5s: Connection closed
[13:56:00] ERROR    ACP prompt failed (AttributeError): 'NoneType' object has no attribute 'run_async'
attempt 1: ConversationRunError propagated after 5.1s: ... 'NoneType' object has no attribute 'run_async'
attempt 2: ConversationRunError propagated after 5.0s: ... 'NoneType' object has no attribute 'run_async'
attempt 3: ConversationRunError propagated after 5.0s: ... 'NoneType' object has no attribute 'run_async'
```

After, with this branch (3/3), no retry warning and no `AttributeError`:

```
attempt 1: ConversationRunError propagated after 0.0s: ... ACP agent was closed while a prompt was in flight
attempt 2: ConversationRunError propagated after 0.0s: ... ACP agent was closed while a prompt was in flight
attempt 3: ConversationRunError propagated after 0.0s: ... ACP agent was closed while a prompt was in flight
```

Unit coverage, five new tests in `TestACPPromptRetry`:

```
uv run pytest tests/sdk/agent/test_acp_agent.py -k PromptRetry
```

- `test_close_during_prompt_aborts_without_retry_delay`, one attempt, `time.sleep` never called, `ACPAgentClosedError`, error event code `ACPAgentClosed`
- `test_close_during_astep_aborts_without_retry_delay`, same for the async loop
- `test_step_after_teardown_reports_closed_agent` / `test_astep_after_teardown_reports_closed_agent`, a torn-down executor is reported as a closed agent, not a `None` dereference
- `test_astep_reports_closed_agent_when_teardown_lands_between_retries`, the portal drops the executor after the first attempt and returns a retriable failure, so the loop reaches a second attempt against dead state. With the per-attempt read: one attempt, `ACPAgentClosedError`, code `ACPAgentClosed`. With the read hoisted back out of the loop: four attempts and a `ConnectionError`.

I checked the tests actually pin the behaviour by neutralising the guards: all of them fail (the async ones visibly sleeping 5+15+30s), and the seven pre-existing retry tests still pass.

`tests/sdk/agent` 445 passed, `tests/sdk/conversation` 764 passed / 1 skipped. Five tests were excluded as pre-existing Windows failures unrelated to this change, verified failing identically on unmodified `main`: the four `TestACPFileSecretMaterialisation` / `TestACPDataDirIsolation` cases (POSIX `0o600` expectations) and `test_conversation_large_event_handling` (disk-speed timeout on this host).

`ruff format`, `ruff check`, `pycodestyle --max-line-length=88`, and `scripts/check_import_rules.py` are clean on both touched files.

## Video/Screenshots

The before/after console output above is the evidence; this path has no UI surface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Behaviour change: a connection error raised while `_closed` is set now fails as `ACPAgentClosedError` rather than being retried. That only affects agents that are already being torn down, where every retry was doomed anyway.
- Scoped to the teardown race. The issue's alternative suggestion, a lock shared between `close()` and the whole prompt path, would make `close()` block for the duration of the turn it is trying to abort, which is the opposite of what the reporter needs.
- `ACPAgentClosed` is deliberately not added to `classify_error`'s code table, so it classifies as `unknown` / non-retryable. `ACPStartupTimeout` and `UsagePolicyRefusal` come out of the same module and are not in that table either, so adding only this one would make it the odd one out. Happy to do all three in a follow-up if that is wanted.
- Adjacent observation, left alone deliberately: `LocalConversation.run()` breaks on `PAUSED` / `STUCK` / `FINISHED` but not on `ERROR`. It does not bite here because `ACPAgent.step()` re-raises, but an agent that sets `ERROR` without raising would be stepped again. Happy to open a separate issue if that is not intentional.

<sub>Investigated and implemented with AI assistance.</sub>
