### PR TITLE
fix(git): demote expected command failures to debug

### DIFF
--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -69,6 +69,8 @@ def run_git_command(
     args: list[str],
     cwd: str | Path | None = None,
     timeout: int = 30,
+    *,
+    expected_failure: bool = False,
 ) -> str:
     """Run a git command safely without shell injection vulnerabilities.
 
@@ -76,6 +78,8 @@ def run_git_command(
         args: List of command arguments (e.g., ['git', 'status', '--porcelain'])
         cwd: Working directory to run the command in (optional for commands like clone)
         timeout: Timeout in seconds (default: 30)
+        expected_failure: Log a non-zero exit at debug level when the caller
+            intentionally probes for a fallback condition.
 
     Returns:
         Command output as string
@@ -94,7 +98,8 @@ def run_git_command(
             # stderr can echo the remote URL (with embedded credentials on some
             # git versions / error paths), so redact before logging and storing.
             redacted_stderr = redact_url_credentials_in_text(result.stderr)
-            logger.debug(
+            log = logger.debug if expected_failure else logger.error
+            log(
                 f"{error_msg}. Exit code: {result.returncode}. "
                 f"Stderr: {redacted_stderr}"
             )
@@ -154,7 +159,9 @@ def _rev_parse(repo_dir: str | Path, ref: str) -> str | None:
     """Resolve ``ref`` to a commit SHA, or None if it doesn't resolve."""
     try:
         result = run_git_command(
-            ["git", "--no-pager", "rev-parse", "--verify", ref], repo_dir
+            ["git", "--no-pager", "rev-parse", "--verify", ref],
+            repo_dir,
+            expected_failure=True,
         )
         return result or None
     except GitCommandError:
@@ -166,7 +173,9 @@ def _merge_base(repo_dir: str | Path, ref_a: str, ref_b: str) -> str | None:
     (e.g. unrelated histories, shallow clone)."""
     try:
         result = run_git_command(
-            ["git", "--no-pager", "merge-base", ref_a, ref_b], repo_dir
+            ["git", "--no-pager", "merge-base", ref_a, ref_b],
+            repo_dir,
+            expected_failure=True,
         )
         return result or None
     except GitCommandError:
@@ -177,7 +186,9 @@ def _get_current_branch(repo_dir: str | Path) -> str | None:
     """Return the current branch name, or None when detached/unborn."""
     try:
         branch = run_git_command(
-            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"], repo_dir
+            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"],
+            repo_dir,
+            expected_failure=True,
         )
         if branch and branch != "HEAD":
             return branch
@@ -197,6 +208,7 @@ def _get_remote_default_branch(repo_dir: str | Path) -> str | None:
         symref = run_git_command(
             ["git", "--no-pager", "rev-parse", "--abbrev-ref", "origin/HEAD"],
             repo_dir,
+            expected_failure=True,
         )
         prefix = "origin/"
         if symref.startswith(prefix) and len(symref) > len(prefix):
@@ -378,6 +390,7 @@ def get_valid_ref(
                     f"{override}^{{commit}}",
                 ],
                 repo_dir,
+                expected_failure=override == "HEAD",
             )
         except GitCommandError:
             # ``HEAD`` is the canonical "current branch tip"; if it doesn't
@@ -413,7 +426,9 @@ def get_valid_ref(
     # Try current branch's origin
     try:
         current_branch = run_git_command(
-            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"], repo_dir
+            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"],
+            repo_dir,
+            expected_failure=True,
         )
         if current_branch and current_branch != "HEAD":  # Not in detached HEAD state
             refs_to_try.append(f"origin/{current_branch}")
@@ -446,6 +461,7 @@ def get_valid_ref(
                                 f"origin/{default_branch}",
                             ],
                             repo_dir,
+                            expected_failure=True,
                         )
                         if merge_base:
                             refs_to_try.append(merge_base)
@@ -460,7 +476,9 @@ def get_valid_ref(
     for ref in refs_to_try:
         try:
             result = run_git_command(
-                ["git", "--no-pager", "rev-parse", "--verify", ref], repo_dir
+                ["git", "--no-pager", "rev-parse", "--verify", ref],
+                repo_dir,
+                expected_failure=True,
             )
             if result:
                 logger.debug(f"Using valid reference: {ref} -> {result}")

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -94,7 +94,7 @@ def run_git_command(
             # stderr can echo the remote URL (with embedded credentials on some
             # git versions / error paths), so redact before logging and storing.
             redacted_stderr = redact_url_credentials_in_text(result.stderr)
-            logger.error(
+            logger.debug(
                 f"{error_msg}. Exit code: {result.returncode}. "
                 f"Stderr: {redacted_stderr}"
             )

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -316,18 +316,29 @@ class TestRunGitCommandCredentialRedaction:
         assert "SUPERSECRET" not in exc_info.value.stderr
         assert REDACTED_URL in exc_info.value.stderr
 
-    def test_stderr_credentials_redacted_in_debug_log(self, caplog):
-        """Credentials echoed in stderr must not leak into the debug log line."""
+    def test_stderr_credentials_redacted_in_error_log_by_default(self, caplog):
+        """Credentials echoed in stderr must not leak into the error log line."""
         leaky_stderr = f"fatal: Authentication failed for '{CREDENTIAL_URL}/'"
         completed = subprocess.CompletedProcess(
             args=self._args(), returncode=128, stdout="", stderr=leaky_stderr
         )
         with patch("subprocess.run", return_value=completed):
-            with caplog.at_level(logging.DEBUG):
+            with caplog.at_level(logging.ERROR):
                 with pytest.raises(GitCommandError):
                     run_git_command(self._args())
         assert "SUPERSECRET" not in caplog.text
         assert REDACTED_URL in caplog.text
+        assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+    def test_expected_failure_is_logged_at_debug(self, caplog):
+        completed = subprocess.CompletedProcess(
+            args=self._args(), returncode=128, stdout="", stderr="fatal: repo not found"
+        )
+        with patch("subprocess.run", return_value=completed):
+            with caplog.at_level(logging.DEBUG):
+                with pytest.raises(GitCommandError):
+                    run_git_command(self._args(), expected_failure=True)
+        assert "Git command failed" in caplog.text
         assert all(record.levelno < logging.ERROR for record in caplog.records)
 
 

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -316,18 +316,19 @@ class TestRunGitCommandCredentialRedaction:
         assert "SUPERSECRET" not in exc_info.value.stderr
         assert REDACTED_URL in exc_info.value.stderr
 
-    def test_stderr_credentials_redacted_in_log(self, caplog):
-        """Credentials echoed in stderr must not leak into the error log line."""
+    def test_stderr_credentials_redacted_in_debug_log(self, caplog):
+        """Credentials echoed in stderr must not leak into the debug log line."""
         leaky_stderr = f"fatal: Authentication failed for '{CREDENTIAL_URL}/'"
         completed = subprocess.CompletedProcess(
             args=self._args(), returncode=128, stdout="", stderr=leaky_stderr
         )
         with patch("subprocess.run", return_value=completed):
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.DEBUG):
                 with pytest.raises(GitCommandError):
                     run_git_command(self._args())
         assert "SUPERSECRET" not in caplog.text
         assert REDACTED_URL in caplog.text
+        assert all(record.levelno < logging.ERROR for record in caplog.records)
 
 
 def test_run_git_command_replaces_undecodable_stdout_bytes():


### PR DESCRIPTION
HUMAN:

I have carefully read the code and it looks fine. I don't think this is complex enough to warrant testing.

---

AGENT:

## Why

Datadog is receiving high-volume error-level logs from Git fallback probes, such as unresolved remote refs and merge-base lookups. Those probe failures are expected and caught by the SDK, while other Git command failures can represent real operational problems.

## Summary

- keep error logging as the default for Git command failures
- log only explicit fallback probes at debug level
- preserve exceptions, credential redaction, and error-level logging for real operational failures

## Issue Number

Closes #4340

## How to Test

```bash
uv run pytest tests/sdk/git/test_url_redaction.py -q
# 40 passed
uv run pre-commit run --files openhands-sdk/openhands/sdk/git/utils.py tests/sdk/git/test_url_redaction.py
# passed
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Among 1,000 sampled Datadog records, 807 were expected missing-ref or merge-base fallback probes. Repository validation and remote-access failures remain error-level.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1b45d9c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1b45d9c-python \
  ghcr.io/openhands/agent-server:1b45d9c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1b45d9c-golang-amd64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-golang-amd64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-golang-amd64
ghcr.io/openhands/agent-server:1b45d9c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1b45d9c-golang-arm64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-golang-arm64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-golang-arm64
ghcr.io/openhands/agent-server:1b45d9c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1b45d9c-java-amd64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-java-amd64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-java-amd64
ghcr.io/openhands/agent-server:1b45d9c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1b45d9c-java-arm64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-java-arm64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-java-arm64
ghcr.io/openhands/agent-server:1b45d9c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1b45d9c-python-amd64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-python-amd64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-python-amd64
ghcr.io/openhands/agent-server:1b45d9c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1b45d9c-python-arm64
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-python-arm64
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-python-arm64
ghcr.io/openhands/agent-server:1b45d9c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1b45d9c-golang
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-golang
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-golang
ghcr.io/openhands/agent-server:1b45d9c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1b45d9c-java
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-java
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-java
ghcr.io/openhands/agent-server:1b45d9c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1b45d9c-python
ghcr.io/openhands/agent-server:1b45d9c1eda12213d8fede6c5f914a53132e827e-python
ghcr.io/openhands/agent-server:fix-git-command-failures-debug-python
ghcr.io/openhands/agent-server:1b45d9c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1b45d9c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1b45d9c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->