### PR TITLE
fix(observability): mark utility LLM spans (title generation, ask_agent)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -50,6 +50,7 @@ from openhands.sdk import LLM, AgentContext, Event, Message
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.agent.acp_file_credentials import CODEX_AUTH_SECRET_NAME
 from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.persistence_const import BASE_STATE
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
@@ -65,6 +66,7 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
+from openhands.sdk.observability import OPERATION_METADATA_KEY, observe
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
@@ -2193,6 +2195,22 @@ class _EventSubscriber(Subscriber):
         update_last_execution_time()
 
 
+@observe(
+    name="conversation.generate_title",
+    ignore_inputs=["conversation", "llm"],
+    metadata={OPERATION_METADATA_KEY: "title_generation"},
+)
+def _generate_title_traced(
+    # Unused, but must stay first and positional: ``observe`` re-attaches the
+    # root span it carries, and this runs on a context-less executor thread.
+    conversation: LocalConversation | None,  # noqa: ARG001
+    message: str,
+    llm: LLM | None,
+    max_length: int,
+) -> str:
+    return generate_title_from_message(message, llm, max_length)
+
+
 @dataclass
 class AutoTitleSubscriber(Subscriber):
     service: EventService
@@ -2215,9 +2233,9 @@ class AutoTitleSubscriber(Subscriber):
         # Precedence: title_llm_profile (if configured and loads) → agent.llm →
         # truncation. This keeps auto-titling non-breaking for consumers who
         # don't configure title_llm_profile.
+        conversation = self.service._conversation
         title_llm = self._load_title_llm()
         if title_llm is None:
-            conversation = self.service._conversation
             title_llm = conversation.agent.llm if conversation else None
 
         async def _generate_and_save() -> None:
@@ -2225,7 +2243,8 @@ class AutoTitleSubscriber(Subscriber):
                 loop = asyncio.get_running_loop()
                 title = await loop.run_in_executor(
                     None,
-                    generate_title_from_message,
+                    _generate_title_traced,
+                    conversation,
                     message_text,
                     title_llm,
                     50,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -70,7 +70,7 @@ from openhands.sdk.mcp.utils import (
     MCPToolProvider,
     ToolsChangedCallback,
 )
-from openhands.sdk.observability.laminar import observe
+from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY, observe
 from openhands.sdk.plugin import (
     Plugin,
     PluginSource,
@@ -2631,6 +2631,10 @@ class LocalConversation(BaseConversation):
         self._cleanup_complete = True
         atexit.unregister(self.close)
 
+    @observe(
+        name="conversation.ask_agent",
+        metadata={OPERATION_METADATA_KEY: "ask_agent"},
+    )
     def ask_agent(self, question: str) -> str:
         """Ask the agent a simple, stateless question and get a direct LLM response.
 
@@ -2706,7 +2710,11 @@ class LocalConversation(BaseConversation):
 
         raise Exception("Failed to generate summary")
 
-    @observe(name="conversation.generate_title", ignore_inputs=["llm"])
+    @observe(
+        name="conversation.generate_title",
+        ignore_inputs=["llm"],
+        metadata={OPERATION_METADATA_KEY: "title_generation"},
+    )
     def generate_title(self, llm: LLM | None = None, max_length: int = 50) -> str:
         """Generate a title for the conversation based on the first user message.
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1480,10 +1480,6 @@ class RemoteConversation(BaseConversation):
             json=payload,
         )
 
-    @observe(
-        name="conversation.ask_agent",
-        metadata={OPERATION_METADATA_KEY: "ask_agent"},
-    )
     def ask_agent(self, question: str) -> str:
         """Ask the agent a simple, stateless question and get a direct LLM response.
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -51,7 +51,7 @@ from openhands.sdk.event.types import EventID
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.logger import DEBUG, get_logger
-from openhands.sdk.observability.laminar import observe
+from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY, observe
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
@@ -1480,6 +1480,10 @@ class RemoteConversation(BaseConversation):
             json=payload,
         )
 
+    @observe(
+        name="conversation.ask_agent",
+        metadata={OPERATION_METADATA_KEY: "ask_agent"},
+    )
     def ask_agent(self, question: str) -> str:
         """Ask the agent a simple, stateless question and get a direct LLM response.
 
@@ -1507,7 +1511,11 @@ class RemoteConversation(BaseConversation):
         data = resp.json()
         return data["response"]
 
-    @observe(name="conversation.generate_title", ignore_inputs=["llm"])
+    @observe(
+        name="conversation.generate_title",
+        ignore_inputs=["llm"],
+        metadata={OPERATION_METADATA_KEY: "title_generation"},
+    )
     def generate_title(self, llm: LLM | None = None, max_length: int = 50) -> str:
         """Generate a title for the conversation based on the first user message.
 

--- a/openhands-sdk/openhands/sdk/observability/__init__.py
+++ b/openhands-sdk/openhands/sdk/observability/__init__.py
@@ -1,8 +1,14 @@
 from openhands.sdk.observability.laminar import (
+    OPERATION_METADATA_KEY,
     init_laminar_for_external,
     maybe_init_laminar,
     observe,
 )
 
 
-__all__ = ["init_laminar_for_external", "maybe_init_laminar", "observe"]
+__all__ = [
+    "OPERATION_METADATA_KEY",
+    "init_laminar_for_external",
+    "maybe_init_laminar",
+    "observe",
+]

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -33,11 +33,7 @@ _OBSERVABILITY_ENV_KEYS: Final[tuple[str, ...]] = (
 
 
 OPERATION_METADATA_KEY: Final[str] = "openhands.operation"
-"""Trace-metadata key naming the side-utility operation a span subtree belongs to.
-
-Spans without it belong to the main agent loop. Namespaced so it cannot collide
-with caller-supplied ``observability_metadata``, which shares this namespace.
-"""
+"""Metadata key naming the side-utility operation a span subtree belongs to."""
 
 
 def _get_int_env(key: str) -> int | None:

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -32,6 +32,14 @@ _OBSERVABILITY_ENV_KEYS: Final[tuple[str, ...]] = (
 )
 
 
+OPERATION_METADATA_KEY: Final[str] = "openhands.operation"
+"""Trace-metadata key naming the side-utility operation a span subtree belongs to.
+
+Spans without it belong to the main agent loop. Namespaced so it cannot collide
+with caller-supplied ``observability_metadata``, which shares this namespace.
+"""
+
+
 def _get_int_env(key: str) -> int | None:
     """Read an environment variable as an optional int."""
     val = get_env(key)

--- a/tests/agent_server/test_auto_title_span_metadata.py
+++ b/tests/agent_server/test_auto_title_span_metadata.py
@@ -1,0 +1,157 @@
+"""Auto-titling is the only title path a deployed agent-server actually runs.
+
+It calls the title helper from an executor thread, so its LLM span joins the
+conversation trace only if the root span is explicitly re-attached there.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+
+OPERATION_ATTRIBUTE = "lmnr.association.properties.metadata.openhands.operation"
+
+
+def _probe_auto_title_spans() -> dict[str, Any]:
+    """Drive AutoTitleSubscriber through a real Laminar tracer; return its spans."""
+    os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    import litellm
+    from lmnr import Instruments, Laminar
+    from lmnr.opentelemetry_lib.tracing import TracerWrapper
+    from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    from pydantic import SecretStr
+
+    from openhands.agent_server.conversation_service import AutoTitleSubscriber
+    from openhands.agent_server.event_service import EventService
+    from openhands.agent_server.models import StoredConversation
+    from openhands.sdk.agent import Agent
+    from openhands.sdk.conversation import Conversation
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.event.llm_convertible import MessageEvent
+    from openhands.sdk.llm import LLM, Message, TextContent
+    from openhands.sdk.security.confirmation_policy import NeverConfirm
+    from openhands.sdk.workspace import LocalWorkspace
+
+    Laminar.initialize(
+        project_api_key="test-key",
+        base_url="http://localhost",
+        http_port=1,
+        grpc_port=1,
+        disable_batch=True,
+        instruments={Instruments.LITELLM},
+    )
+    exporter = InMemorySpanExporter()
+    span_processor = TracerWrapper.instance._span_processor
+    assert isinstance(span_processor, LaminarSpanProcessor)
+    span_processor.instance = SimpleSpanProcessor(exporter)
+
+    instrumented_completion = litellm.completion
+
+    def mocked_completion(**kwargs: Any):
+        return instrumented_completion(**{**kwargs, "mock_response": "Fix Auth Bug"})
+
+    llm = LLM(usage_id="probe-llm", model="gpt-4o", api_key=SecretStr("test-key"))
+    agent = Agent(llm=llm, tools=[])
+    conversation = Conversation(
+        agent=agent,
+        callbacks=[],
+        observability_metadata={"repo": "OpenHands/software-agent-sdk"},
+    )
+    assert isinstance(conversation, LocalConversation)
+
+    stored = StoredConversation(
+        id=uuid4(),
+        agent=agent,
+        workspace=LocalWorkspace(working_dir="workspace/project"),
+        confirmation_policy=NeverConfirm(),
+        initial_message=None,
+        metrics=None,
+        title=None,
+    )
+    service = AsyncMock(spec=EventService)
+    service.stored = stored
+    service._conversation = conversation
+
+    event = MessageEvent(
+        id="evt-1",
+        source="user",
+        llm_message=Message(
+            role="user", content=[TextContent(text="fix the auth bug")]
+        ),
+    )
+
+    async def drive() -> None:
+        with patch(
+            "openhands.sdk.llm.llm.litellm_completion", side_effect=mocked_completion
+        ):
+            await AutoTitleSubscriber(service=service)(event)
+            for _ in range(250):
+                await asyncio.sleep(0.02)
+                if stored.title is not None:
+                    return
+
+    asyncio.run(drive())
+    Laminar.flush()
+
+    root_span = conversation._observability_root_span
+    assert root_span is not None
+    spans = exporter.get_finished_spans()
+    names_by_id = {
+        span.context.span_id: span.name for span in spans if span.context is not None
+    }
+    return {
+        "title": stored.title,
+        "conversation_trace_id": root_span.span.get_span_context().trace_id,
+        "spans": [
+            {
+                "name": span.name,
+                "parent": names_by_id.get(span.parent.span_id) if span.parent else None,
+                "trace_id": span.context.trace_id if span.context else None,
+                "attributes": dict(span.attributes or {}),
+            }
+            for span in spans
+        ],
+    }
+
+
+def test_auto_title_llm_span_joins_the_conversation_trace() -> None:
+    # Subprocess: Laminar.initialize() flips process-global tracing on for good,
+    # which would change every later test in this worker.
+    result = subprocess.run(
+        [sys.executable, __file__],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-4000:]
+    probe = json.loads(result.stdout.splitlines()[-1])
+
+    assert probe["title"] == "Fix Auth Bug"
+
+    llm_spans = [
+        span for span in probe["spans"] if span["name"] == "litellm.completion"
+    ]
+    assert len(llm_spans) == 1
+    title_llm = llm_spans[0]
+
+    assert title_llm["parent"] == "conversation.generate_title"
+    assert title_llm["trace_id"] == probe["conversation_trace_id"]
+
+    # Spelled out, not derived from OPERATION_METADATA_KEY: this exact attribute
+    # name is the wire contract downstream consumers hard-code.
+    assert title_llm["attributes"][OPERATION_ATTRIBUTE] == "title_generation"
+
+
+if __name__ == "__main__":
+    print(json.dumps(_probe_auto_title_spans()))

--- a/tests/sdk/conversation/test_utility_llm_span_metadata.py
+++ b/tests/sdk/conversation/test_utility_llm_span_metadata.py
@@ -1,0 +1,176 @@
+"""Utility LLM calls must be distinguishable from main-loop turns in a trace."""
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
+from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY
+
+
+def _record_observe_kwargs(unbound_method: Any) -> dict[str, Any]:
+    """Trigger the lazy ``observe`` build on a method and return the observe kwargs."""
+    recorded: dict[str, Any] = {}
+
+    def recorder(**kwargs: Any):
+        recorded.update(kwargs)
+        # Identity: leaves the decorated function's cached wrapper equivalent to
+        # the undecorated function for the rest of the process.
+        return lambda func: func
+
+    with (
+        patch("lmnr.observe", recorder),
+        patch(
+            "openhands.sdk.observability.laminar.should_enable_observability",
+            return_value=True,
+        ),
+    ):
+        try:
+            unbound_method(object())
+        except Exception:
+            pass
+
+    return recorded
+
+
+@pytest.mark.parametrize(
+    ("unbound_method", "expected_name", "expected_operation"),
+    [
+        (
+            LocalConversation.generate_title,
+            "conversation.generate_title",
+            "title_generation",
+        ),
+        (
+            RemoteConversation.generate_title,
+            "conversation.generate_title",
+            "title_generation",
+        ),
+        (LocalConversation.ask_agent, "conversation.ask_agent", "ask_agent"),
+        (RemoteConversation.ask_agent, "conversation.ask_agent", "ask_agent"),
+    ],
+)
+def test_utility_methods_declare_operation_metadata(
+    unbound_method: Any, expected_name: str, expected_operation: str
+) -> None:
+    kwargs = _record_observe_kwargs(unbound_method)
+
+    assert kwargs["name"] == expected_name
+    assert kwargs["metadata"] == {OPERATION_METADATA_KEY: expected_operation}
+
+
+def _probe_exported_spans() -> list[dict[str, Any]]:
+    """Drive a real Laminar tracer and return the exported spans as plain dicts."""
+    os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+
+    import litellm
+    from lmnr import Instruments, Laminar
+    from lmnr.opentelemetry_lib.tracing import TracerWrapper
+    from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    from pydantic import SecretStr
+
+    from openhands.sdk.agent import Agent
+    from openhands.sdk.conversation import Conversation
+    from openhands.sdk.llm import LLM, Message, TextContent
+
+    Laminar.initialize(
+        project_api_key="test-key",
+        base_url="http://localhost",
+        http_port=1,
+        grpc_port=1,
+        disable_batch=True,
+        instruments={Instruments.LITELLM},
+    )
+    exporter = InMemorySpanExporter()
+    span_processor = TracerWrapper.instance._span_processor
+    assert isinstance(span_processor, LaminarSpanProcessor)
+    span_processor.instance = SimpleSpanProcessor(exporter)
+
+    instrumented_completion = litellm.completion
+
+    def mocked_completion(**kwargs: Any):
+        return instrumented_completion(**{**kwargs, "mock_response": "Fix Auth Bug"})
+
+    llm = LLM(usage_id="probe-llm", model="gpt-4o", api_key=SecretStr("test-key"))
+    conversation = Conversation(
+        agent=Agent(llm=llm, tools=[]),
+        callbacks=[],
+        observability_metadata={"repo": "OpenHands/software-agent-sdk"},
+    )
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion", side_effect=mocked_completion
+    ):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="fix the auth bug")])
+        )
+        conversation.run()
+        conversation.generate_title()
+        conversation.ask_agent("what did you do?")
+
+    Laminar.flush()
+
+    spans = exporter.get_finished_spans()
+    names_by_id = {
+        span.context.span_id: span.name for span in spans if span.context is not None
+    }
+    return [
+        {
+            "name": span.name,
+            "parent": names_by_id.get(span.parent.span_id) if span.parent else None,
+            "metadata": {
+                key.removeprefix("lmnr.association.properties.metadata."): value
+                for key, value in (span.attributes or {}).items()
+                if key.startswith("lmnr.association.properties.metadata.")
+            },
+        }
+        for span in spans
+    ]
+
+
+def test_operation_metadata_reaches_the_exported_llm_span() -> None:
+    # Subprocess: Laminar.initialize() flips process-global tracing on for good,
+    # which would change every later test in this worker.
+    result = subprocess.run(
+        [sys.executable, __file__],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-4000:]
+    spans = json.loads(result.stdout.splitlines()[-1])
+
+    llm_spans = [span for span in spans if span["name"] == "litellm.completion"]
+    by_parent = {span["parent"]: span for span in llm_spans}
+    assert set(by_parent) == {
+        "agent.step",
+        "conversation.generate_title",
+        "conversation.ask_agent",
+    }
+
+    title_llm = by_parent["conversation.generate_title"]
+    ask_llm = by_parent["conversation.ask_agent"]
+    main_loop_llm = by_parent["agent.step"]
+
+    assert title_llm["metadata"][OPERATION_METADATA_KEY] == "title_generation"
+    assert ask_llm["metadata"][OPERATION_METADATA_KEY] == "ask_agent"
+
+    # Subtree-scoped: the main agent loop is untouched, and the conversation's
+    # own trace metadata still reaches every span.
+    assert OPERATION_METADATA_KEY not in main_loop_llm["metadata"]
+    for span in llm_spans:
+        assert span["metadata"]["repo"] == "OpenHands/software-agent-sdk"
+
+
+if __name__ == "__main__":
+    print(json.dumps(_probe_exported_spans()))

--- a/tests/sdk/conversation/test_utility_llm_span_metadata.py
+++ b/tests/sdk/conversation/test_utility_llm_span_metadata.py
@@ -14,6 +14,9 @@ from openhands.sdk.conversation.impl.remote_conversation import RemoteConversati
 from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY
 
 
+METADATA_ATTRIBUTE_PREFIX = "lmnr.association.properties.metadata."
+
+
 def _record_observe_kwargs(unbound_method: Any) -> dict[str, Any]:
     """Trigger the lazy ``observe`` build on a method and return the observe kwargs."""
     recorded: dict[str, Any] = {}
@@ -53,7 +56,6 @@ def _record_observe_kwargs(unbound_method: Any) -> dict[str, Any]:
             "title_generation",
         ),
         (LocalConversation.ask_agent, "conversation.ask_agent", "ask_agent"),
-        (RemoteConversation.ask_agent, "conversation.ask_agent", "ask_agent"),
     ],
 )
 def test_utility_methods_declare_operation_metadata(
@@ -128,14 +130,21 @@ def _probe_exported_spans() -> list[dict[str, Any]]:
         {
             "name": span.name,
             "parent": names_by_id.get(span.parent.span_id) if span.parent else None,
-            "metadata": {
-                key.removeprefix("lmnr.association.properties.metadata."): value
+            "attributes": {
+                key: value
                 for key, value in (span.attributes or {}).items()
-                if key.startswith("lmnr.association.properties.metadata.")
+                if key.startswith(METADATA_ATTRIBUTE_PREFIX)
             },
         }
         for span in spans
     ]
+
+
+def _metadata(span: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key.removeprefix(METADATA_ATTRIBUTE_PREFIX): value
+        for key, value in span["attributes"].items()
+    }
 
 
 def test_operation_metadata_reaches_the_exported_llm_span() -> None:
@@ -162,14 +171,26 @@ def test_operation_metadata_reaches_the_exported_llm_span() -> None:
     ask_llm = by_parent["conversation.ask_agent"]
     main_loop_llm = by_parent["agent.step"]
 
-    assert title_llm["metadata"][OPERATION_METADATA_KEY] == "title_generation"
-    assert ask_llm["metadata"][OPERATION_METADATA_KEY] == "ask_agent"
+    # Spelled out, not derived from OPERATION_METADATA_KEY: this exact attribute
+    # name is the wire contract downstream consumers hard-code.
+    assert (
+        title_llm["attributes"][
+            "lmnr.association.properties.metadata.openhands.operation"
+        ]
+        == "title_generation"
+    )
+    assert (
+        ask_llm["attributes"][
+            "lmnr.association.properties.metadata.openhands.operation"
+        ]
+        == "ask_agent"
+    )
 
     # Subtree-scoped: the main agent loop is untouched, and the conversation's
     # own trace metadata still reaches every span.
-    assert OPERATION_METADATA_KEY not in main_loop_llm["metadata"]
+    assert OPERATION_METADATA_KEY not in _metadata(main_loop_llm)
     for span in llm_spans:
-        assert span["metadata"]["repo"] == "OpenHands/software-agent-sdk"
+        assert _metadata(span)["repo"] == "OpenHands/software-agent-sdk"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Add metadata to ask_agent and title generation so they are distinguishable from regular agent outputs in Laminar.

---

AGENT:

## Why

`generate_title` and `ask_agent` run LLM completions alongside a conversation, and
their LLM spans are indistinguishable from real agent turns. A consumer that fetches
"all LLM spans for this session" (dataset-utils rebuilding a training trajectory from
Laminar) splices their output in as a genuine assistant turn.

Confirmed in production data: a trace whose "assistant" step content is the whole
string `"💄 Generate Title with Emoji\x00"` — `generate_title`'s degenerate output,
spliced into the middle of a real conversation and flagged downstream as text
corruption.

Nothing marked these calls as side utilities, so there was nothing to filter on:

- Title generation defaults to `agent.llm` — the *same* LLM and `usage_id` as the
  main loop — so not even the usage id distinguishes it.
- `LocalConversation.ask_agent` had **no** `@observe` at all on `main`, so its LLM
  span had no distinguishing ancestor span either.
- **The path a deployed agent-server actually takes was worse than unmarked.**
  Titles do not come from `LocalConversation.generate_title` in production — they
  come from `AutoTitleSubscriber` in `conversation_service.py`, which calls the
  module-level `generate_title_from_message` helper directly from a
  `run_in_executor` worker thread. That thread inherits no OTel context, so the
  `litellm.completion` span was a **root span in its own trace** — while still
  carrying the conversation's `session_id`. A session-keyed consumer therefore
  picked it up with no ancestor to filter it out. This is the exact shape that
  produced the corruption above.

## Summary

- Introduce `OPERATION_METADATA_KEY = "openhands.operation"` in
  `openhands/sdk/observability/laminar.py`, exported from
  `openhands.sdk.observability`, so the marker downstream consumers filter on has a
  single source of truth.
- **agent-server auto-title path** (`conversation_service.py`): route
  `AutoTitleSubscriber`'s executor call through a new `_generate_title_traced`
  helper carrying `@observe(name="conversation.generate_title", metadata={...})`.
  The conversation is passed as the helper's **first positional argument** — that
  is where `observe`'s `_maybe_use_root_span` looks for `_observability_root_span`,
  and re-attaching it there is what turns the orphan into a real child of the
  conversation trace across both the `asyncio.create_task` and the
  `run_in_executor` hop.
- `LocalConversation.generate_title` / `RemoteConversation.generate_title`: add
  `metadata={OPERATION_METADATA_KEY: "title_generation"}` to the existing
  `@observe`.
- `LocalConversation.ask_agent`: add
  `@observe(name="conversation.ask_agent", metadata={...: "ask_agent"})` — it
  previously had no span at all. This one *is* on the deployed path:
  `POST /{id}/ask_agent` → `ConversationService.ask_agent` →
  `EventService.ask_agent` → `run_in_executor(..., self._conversation.ask_agent, ...)`.
- `RemoteConversation.ask_agent`: **not** decorated (see Notes for why).
- Two regression tests, both driving a **real** Laminar tracer through an
  `InMemorySpanExporter` in a subprocess:
  `tests/sdk/conversation/test_utility_llm_span_metadata.py` (SDK conversation
  methods) and `tests/agent_server/test_auto_title_span_metadata.py` (the
  agent-server auto-title path, asserting both the marker and same-trace parenting).

LLM spans are not created by `@observe` — they come from lmnr's LiteLLM
auto-instrumentation as children of the enclosing `@observe` span. `metadata=` is
the only lmnr channel that reaches them: `_setup_span` stamps
`lmnr.association.properties.metadata.<key>`, `set_association_props_in_context`
lifts it into the OTel context, and `LaminarSpanProcessor.on_start` re-stamps it
onto every descendant. `tags=` does not propagate (it keeps the
`lmnr.association.properties.` prefix, which `set_association_props_in_context`
filters out), and plain span attributes never propagate in OTel.

## Issue Number

Partially addresses #4358 (Bug 2 of 2). Bug 1 — the TOOL-span parent loss under
`ParallelToolExecutor` — is PR #4360, so this one does not close the issue.

## How to Test

Everything below was run on this branch at `aacc6b136`.

### 1. The production auto-title path now joins the conversation trace

The new agent-server probe is directly runnable. It initializes a real `Laminar`
tracer, swaps `LaminarSpanProcessor.instance` for a
`SimpleSpanProcessor(InMemorySpanExporter())`, enables the real
`Instruments.LITELLM` auto-instrumentation, builds a real `Conversation` plus a
`StoredConversation`, and fires `AutoTitleSubscriber` with a user `MessageEvent`
— i.e. the full `create_task` → `run_in_executor` → `litellm.completion` chain,
with `litellm`'s own `mock_response` standing in for network I/O:

```
uv run --no-sync python tests/agent_server/test_auto_title_span_metadata.py
```

**Before** (sources at the pre-PR base `8c2297b19`) — the orphan:

```
conversation_trace_id: 88068842322890103784699585827543645958

litellm.completion   parent=None   trace_id=149314837929701029874291855801380402573
    association properties: {}
    lmnr.span.path: ['litellm.completion']
```

**After** — a real child of the conversation root, same trace, marked:

```
conversation_trace_id: 241786796964671280679697988124795999424

litellm.completion   parent=conversation.generate_title
                     trace_id=241786796964671280679697988124795999424
    lmnr.span.path: ['conversation', 'conversation.generate_title', 'litellm.completion']
    lmnr.association.properties.session_id:                          f135219d-7249-...
    lmnr.association.properties.metadata.repo:                       OpenHands/software-agent-sdk
    lmnr.association.properties.metadata.openhands.operation:        title_generation

conversation.generate_title   parent=None (the still-open conversation root)
    lmnr.span.input:  {"message":"fix the auth bug","max_length":50}
    lmnr.span.output: "Fix Auth Bug"
```

Note `lmnr.span.input` — `ignore_inputs=["conversation", "llm"]` keeps the
conversation object and the LLM out of the recorded span input.

### 2. End-to-end: the marker reaches the real exported LLM span (SDK methods)

```
uv run --no-sync python tests/sdk/conversation/test_utility_llm_span_metadata.py
```

Exported spans (name / parent / propagated metadata):

```
conversation.send_message     parent=None                          metadata={'repo': 'OpenHands/software-agent-sdk'}
litellm.completion            parent=agent.step                    metadata={'repo': 'OpenHands/software-agent-sdk'}
agent.step                    parent=conversation.run              metadata={'repo': 'OpenHands/software-agent-sdk'}
conversation.run              parent=None                          metadata={'repo': 'OpenHands/software-agent-sdk'}
litellm.completion            parent=conversation.generate_title   metadata={'repo': 'OpenHands/software-agent-sdk', 'openhands.operation': 'title_generation'}
conversation.generate_title   parent=None                          metadata={'repo': 'OpenHands/software-agent-sdk', 'openhands.operation': 'title_generation'}
litellm.completion            parent=conversation.ask_agent        metadata={'repo': 'OpenHands/software-agent-sdk', 'openhands.operation': 'ask_agent'}
conversation.ask_agent        parent=None                          metadata={'repo': 'OpenHands/software-agent-sdk', 'openhands.operation': 'ask_agent'}
```

Three things this shows:

1. The marker lands on the auto-instrumented `litellm.completion` **LLM** span, not
   just on the `@observe` span — that is the property a session-level consumer
   needs.
2. It is **subtree-scoped**: the main-loop `litellm.completion` under `agent.step`
   does not carry it.
3. Conversation-level trace metadata (`repo`, supplied via
   `observability_metadata`) still reaches every span, so nothing regressed there.

`parent=None` on the four top-level spans is the conversation root span, which is
still open (never ended) and therefore not in the exporter — normal, not a
regression.

### 3. Regression tests

```
uv run --no-sync pytest tests/sdk/conversation/test_utility_llm_span_metadata.py \
  tests/agent_server/test_auto_title_span_metadata.py -q
# 5 passed in 9.41s
```

Confirmed both tests actually catch the bug — with the three changed source files
reverted to the pre-PR base (`git checkout 8c2297b19 -- <3 source files>`) and only
the tests kept:

```
# 5 failed in 9.44s
#  2x AssertionError: assert None == {'openhands.operation': 'title_generation'}
#        (generate_title local + remote — @observe exists on main, metadata is None)
#  1x KeyError: 'name'
#        (LocalConversation.ask_agent — no decorator at all on main)
#  1x AssertionError: assert {'agent.step', None, 'conversation.generate_title'}
#        == {'agent.step', 'conversation.ask_agent', 'conversation.generate_title'}
#        (ask_agent's LLM span had no distinguishing parent at all)
#  1x AssertionError: assert None == 'conversation.generate_title'
#        (the auto-title LLM span was an orphan, not a child of the conversation)
```

### 4. Existing suites, lint, types

```
uv run --no-sync pytest tests/sdk/conversation/ tests/sdk/observability/ -q
# 806 passed, 3 warnings in 141.11s

uv run --no-sync pytest tests/agent_server/ -q
# 1864 passed, 13 deselected, 50 warnings in 192.96s

uv run --no-sync pytest tests/sdk/agent/test_acp_agent.py \
  tests/sdk/conversation/test_ask_agent.py tests/sdk/conversation/test_generate_title.py -q
# 452 passed in 10.41s

uv run --no-sync ruff check <changed files>          # All checks passed!
uv run --no-sync ruff format --check <changed files> # 7 files already formatted
uv run --no-sync pyright <changed files>             # 0 errors, 0 warnings, 0 informations
```

## Video/Screenshots

N/A — observability-only change; the span dumps in "How to Test" are the observable
output.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

### Why the auto-title fix is shaped this way

Two options were on the table for covering `AutoTitleSubscriber`:

**(a) Route it through `LocalConversation.generate_title`** so it inherits the
existing decorator. Rejected: it changes behaviour. `AutoTitleSubscriber`
deliberately extracts the message text *before* spawning its background task, to
avoid a race where the event is not yet in the events list; `generate_title` goes
back to `self._state.active_branch()` and re-extracts, reopening that race. It also
raises `ValueError` when no user message is found, which would degrade the current
truncation fallback into "no title at all" (the `except Exception: logger.warning`
swallows it).

**(b) Decorate the auto-title call itself** — chosen. The one trap is that a naive
decorator does *not* fix the orphan: `_maybe_use_root_span` / `_root_span_from_args`
only re-attach the root span when **`args[0]`** carries `_observability_root_span`,
and `_generate_and_save` is a zero-arg closure. So the helper takes the
conversation as its first positional argument. That parameter is unused in the body
(`# noqa: ARG001`) and carries a comment saying why it must stay — deleting it
would silently reintroduce the orphan with green CI. The "before/after" dump in
"How to Test" is the proof the reparenting works across both the `create_task` and
`run_in_executor` hops.

Behaviour is otherwise untouched: still non-blocking/background, still swallows
exceptions with `logger.warning`, still guards on "title already set", still
`title_llm_profile` → `agent.llm` → truncation, and the LLM is still resolved
*before* the task is spawned.

### `RemoteConversation.ask_agent` is deliberately **not** decorated

An earlier revision of this PR decorated it for symmetry. Removed, because the
decoration buys nothing and costs something:

- It is pure HTTP delegation — the LLM runs server-side. There is no local LLM span
  for the marker to reach.
- No W3C trace context crosses the boundary: the SDK never injects a `traceparent`
  (it does not import `opentelemetry` at all), lmnr's `Instruments` enum has no
  httpx/requests instrumentor, and agent-server installs no OTel extract middleware.
  So the server-side span is not in the client's trace either.
- The server side is already covered by `LocalConversation.ask_agent`, which *is*
  on the deployed path via `POST /{id}/ask_agent`.
- Its only net effect was writing `openhands.operation` into the **client** trace's
  metadata — which, given the trace-level rollup below, makes a client trace
  advertise a marker for which it holds no marked LLM span, and can
  non-deterministically clobber the trace-level value when a client-side
  `generate_title` happens in the same trace.

`RemoteConversation.generate_title` is genuinely different and keeps its marker: it
runs `generate_conversation_title` **client-side**, so there is a real local LLM
span to mark.

### Metadata is trace-level in Laminar's data model — known trade-off

At the OTel level the marker is strictly subtree-scoped, proven by the tests above,
and that span-level view is what the downstream consumer actually reads. But
Laminar's ingestion also rolls per-span metadata up into the **trace** record: its
backend aggregates spans into a trace (`TraceAggregation::from_spans`), merging the
`lmnr.association.properties.metadata.*` of *every* span in the trace and upserting
with `metadata = COALESCE(traces.metadata || EXCLUDED.metadata, ...)`. Laminar's own
docs say the same thing from the user side:

> "Trace metadata applies to the entire trace." … "Metadata set during the trace is
> merged as spans arrive." … "Set each metadata key in one place per trace (ideally
> the root span) and avoid duplicate keys in nested `observe(...)` calls." … "the
> last span processed wins (order is not guaranteed)"
> — https://laminar.sh/docs/tracing/structure/metadata

Consequences, stated plainly:

- Every conversation trace that contains a utility call now advertises
  `openhands.operation` at **trace** level, in the Laminar UI and API.
- If one trace contains both a title generation and an `ask_agent`, the trace-level
  value is last-writer-wins and therefore non-deterministic.
- The OTel **span**-level scoping is correct and unaffected. Removing
  `RemoteConversation.ask_agent`'s decoration (above) removes one of the two ways
  this could happen client-side.

(The backend specifics — `TraceAggregation::from_spans`, the `COALESCE` upsert —
come from review of Laminar's server source, not from anything I ran here. The
docs quote and the span-level behaviour are both verified.)

I still went with metadata, because:

- The bug is span-level. A consumer reading LLM span attributes gets a correct,
  stable, subtree-scoped answer, which is the only thing needed to stop splicing
  utility output into trajectories.
- There is no alternative channel. lmnr's context propagation extracts exactly four
  things (`user_id`, `session_id`, `trace_type`, `metadata`); metadata is the only
  non-reserved one, so no span-subtree-scoped attribute channel exists in lmnr.
- It cannot break existing trace-level filters — the key is new, nothing filters on
  it yet.

If a reviewer would rather keep trace-level metadata pristine, the conflict-free
variant is one key per operation (`openhands.utility.title_generation = true`,
`openhands.utility.ask_agent = true`): each key then has exactly one possible value,
so the merge is deterministic. It costs consumers a prefix match instead of an
equality check. Happy to switch.

### Marker key: why `openhands.operation` and not bare `operation`

`observability_metadata` is a fully caller-controlled dict of arbitrary keys
(`repo`, `repo_name`, …) landing in the *same*
`lmnr.association.properties.metadata.*` namespace, and
`_validate_observability_metadata` accepts **any** non-empty string key — including
`"openhands.operation"` itself. So namespacing does not make collision *impossible*;
it makes it implausible. `operation` is a generic enough word that a caller could
already be using it; `openhands.operation` is unambiguously SDK-owned. The dotted
key round-trips cleanly through lmnr (`on_start` strips only the fixed
`lmnr.association.properties.metadata.` prefix), as the span dumps show.

Both tests assert the raw exported attribute name
`lmnr.association.properties.metadata.openhands.operation` as a **literal**, not via
`OPERATION_METADATA_KEY`. Renaming the constant's value would otherwise leave the
suite green while silently breaking every downstream filter.

### `ask_agent` behavior review

- The agent-specific early return (`self.agent.ask_agent`, used by `ACPAgent`'s
  `fork_session`) is untouched: `@observe` wraps the call, the early return is
  inside the body, so return value and control flow are identical.
  `tests/sdk/agent/test_acp_agent.py` is green.
- Adding a span to `LocalConversation.ask_agent` is a real **trace-shape** change,
  and a beneficial one beyond the marker: `EventService.ask_agent` dispatches via
  `loop.run_in_executor(None, self._conversation.ask_agent, question)`, i.e. a
  pooled worker thread where `contextvars` propagation is unreliable. With the
  decorator, `_maybe_use_root_span` fires — `args[0]` is the conversation — and
  re-attaches the conversation root span, exactly as the auto-title fix does.
  Server-side `ask_agent` LLM spans should now be correctly parented rather than
  orphaned. Verified in-process by the span dump above; not verified against a live
  agent-server.
- Span input/output capture: `@observe(name="conversation.send_message")` already
  records the user's full message text and `generate_title` already records the
  generated title, so recording `ask_agent`'s question and answer is consistent
  with what the SDK already emits. Note this is *not* because the codebase never
  redacts — `hooks/executor.py:204` uses `ignore_inputs=["self", "hook", "event"]`
  **and** `ignore_output=True` on perfectly serializable pydantic models, so
  suppression for reasons other than serializability does have precedent. The
  argument here is consistency with the sibling conversation methods, not a house
  rule. Easy to add `ignore_input`/`ignore_output` if the team disagrees.

### Test isolation

Both end-to-end probes run in a **subprocess**. `Laminar.initialize()` flips
process-global state that cannot be undone — global `TracerProvider`, permanent
`should_enable_observability() == True`, global litellm instrumentation, and a
`BatchLogRecordProcessor` background thread — which would silently change every
later test in the same pytest worker. The three in-process cases use the existing
`patch("lmnr.observe", ...)` pattern from `tests/sdk/observability/test_laminar.py`
and exploit the lazy build in `observe`'s wrapper; the recorder returns the function
unchanged so the wrapper cache it leaves behind is behaviourally identical to no
decorator.

### Deliberately out of scope (follow-ups)

A consumer trusting `openhands.operation` alone is **not yet fully protected** —
these LLM calls still emit unmarked spans inside a conversation trace:

- **The condenser** (`context/condenser/llm_summarizing_condenser.py:293` and
  `:338`). Same class of defect: a trajectory rebuilder will splice condensation
  summaries in as assistant turns. A two-line follow-up using the same
  `OPERATION_METADATA_KEY`.
- **Agent hooks** (`hooks/executor.py:204`). `_execute_agent_hook` spawns a nested
  `LocalConversation`, so its LLM spans are literally named `agent.step` inside the
  parent trace — indistinguishable by name from the real loop, and the worst case
  for a name-based filter.
- **The `\x00` NUL byte in title output.** Real corruption seen in production
  (`"…Emoji\x00"`), but it is a sanitization concern at the title/consumer boundary,
  not a span-tagging one.
- **A dedicated `usage_id`/LLM profile for title generation.** Would make the
  utility call distinguishable by usage id too, but it changes cost attribution and
  other work is in flight there.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7785537-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7785537-python \
  ghcr.io/openhands/agent-server:7785537-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7785537-golang-amd64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-golang-amd64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-golang-amd64
ghcr.io/openhands/agent-server:7785537-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7785537-golang-arm64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-golang-arm64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-golang-arm64
ghcr.io/openhands/agent-server:7785537-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7785537-java-amd64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-java-amd64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-java-amd64
ghcr.io/openhands/agent-server:7785537-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7785537-java-arm64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-java-arm64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-java-arm64
ghcr.io/openhands/agent-server:7785537-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7785537-python-amd64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-python-amd64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-python-amd64
ghcr.io/openhands/agent-server:7785537-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7785537-python-arm64
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-python-arm64
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-python-arm64
ghcr.io/openhands/agent-server:7785537-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7785537-golang
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-golang
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-golang
ghcr.io/openhands/agent-server:7785537-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7785537-java
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-java
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-java
ghcr.io/openhands/agent-server:7785537-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7785537-python
ghcr.io/openhands/agent-server:77855373aae2da27487f9719ab3d1bc17bd4def5-python
ghcr.io/openhands/agent-server:fix-utility-llm-span-tagging-python
ghcr.io/openhands/agent-server:7785537-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7785537-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7785537-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
