### PR TITLE
refactor(observability): stop depending on lmnr to propagate trace context into tool workers

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -97,8 +97,8 @@ class ParallelToolExecutor:
             ]
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
-            # ThreadPoolExecutor does not propagate contextvars; a fresh copy
-            # per task because one Context cannot be entered by two threads.
+            # submit() itself propagates no contextvars; a fresh copy per task
+            # because one Context cannot be entered by two threads.
             futures = [
                 executor.submit(
                     contextvars.copy_context().run,
@@ -201,7 +201,7 @@ class ParallelToolExecutor:
         timeout.
         """
         loop = asyncio.get_running_loop()
-        # run_in_executor does not copy contextvars, unlike asyncio.to_thread.
+        # run_in_executor copies no contextvars, unlike asyncio.to_thread.
         ctx = contextvars.copy_context()
 
         def run_in_caller_context() -> list[Event]:

--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -19,6 +19,7 @@ while tools touching *different* resources can run concurrently.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
@@ -96,8 +97,11 @@ class ParallelToolExecutor:
             ]
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            # ThreadPoolExecutor does not propagate contextvars; a fresh copy
+            # per task because one Context cannot be entered by two threads.
             futures = [
                 executor.submit(
+                    contextvars.copy_context().run,
                     self._run_safe,
                     action,
                     tool_runner,
@@ -197,9 +201,13 @@ class ParallelToolExecutor:
         timeout.
         """
         loop = asyncio.get_running_loop()
-        fut = loop.run_in_executor(
-            executor, self._run_safe, action, tool_runner, tool, cancel_token
-        )
+        # run_in_executor does not copy contextvars, unlike asyncio.to_thread.
+        ctx = contextvars.copy_context()
+
+        def run_in_caller_context() -> list[Event]:
+            return ctx.run(self._run_safe, action, tool_runner, tool, cancel_token)
+
+        fut = loop.run_in_executor(executor, run_in_caller_context)
         try:
             return await fut
         except asyncio.CancelledError:

--- a/tests/sdk/agent/test_parallel_tool_span_context.py
+++ b/tests/sdk/agent/test_parallel_tool_span_context.py
@@ -1,15 +1,26 @@
 """Trace-context propagation into ``ParallelToolExecutor`` worker threads.
 
-``ThreadPoolExecutor.submit`` and ``loop.run_in_executor`` do not copy
-``contextvars``, so without an explicit copy every off-main-thread tool call
-starts a fresh, parentless OTel/Laminar context and its TOOL span is orphaned
-from the conversation trace.
+Neither ``ThreadPoolExecutor.submit`` nor ``loop.run_in_executor`` copies
+``contextvars`` by itself, so a dispatched tool call inherits nothing from the
+dispatching thread unless the executor copies it explicitly.
+
+Two configurations behave differently and are covered separately here:
+
+* **lmnr not initialized** — nothing crosses the thread boundary at all, so a
+  span opened in the worker starts its own trace.
+* **lmnr initialized** (the ``lmnr_initialized`` fixture) — lmnr's vendored
+  ``ThreadingInstrumentor`` patches ``ThreadPoolExecutor.submit`` to carry its
+  own *isolated* context across, which is what ``@observe`` parents against, so
+  TOOL spans already nest there without our copy. What lmnr does **not** carry
+  is the OpenTelemetry *global* context or ordinary ``ContextVar``s; those gaps
+  are what the copy closes, and the ``with_lmnr`` tests pin them.
 """
 
 import asyncio
 import contextvars
 import threading
 from collections.abc import Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Self
 from unittest.mock import MagicMock, patch
 
@@ -63,6 +74,45 @@ def tracing() -> Iterator[tuple[Tracer, InMemorySpanExporter]]:
         yield provider.get_tracer("test"), exporter
     finally:
         provider.shutdown()
+
+
+@pytest.fixture
+def lmnr_initialized() -> Iterator[None]:
+    """Bring up lmnr's real ``TracerWrapper``, as ``maybe_init_laminar()`` does.
+
+    Its side effects are process-wide monkeypatches, so tear them down again.
+    """
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.threading import (
+        ThreadingInstrumentor,
+    )
+    from lmnr.opentelemetry_lib.tracing import TracerWrapper
+
+    if TracerWrapper.verify_initialized():
+        yield
+        return
+
+    original_thread_init = threading.Thread.__init__
+    TracerWrapper(
+        exporter=InMemorySpanExporter(),
+        disable_batch=True,
+        instruments=set(),
+        set_global_tracer_provider=False,
+    )
+    try:
+        yield
+    finally:
+        ThreadingInstrumentor().uninstrument()
+        threading.Thread.__init__ = original_thread_init  # type: ignore[method-assign]
+        TracerWrapper._original_thread_init = None
+        del TracerWrapper.instance
+
+
+def _assert_lmnr_wraps_submit() -> None:
+    """Guard: these tests are vacuous if lmnr's submit patch is not live."""
+    assert hasattr(ThreadPoolExecutor.submit, "__wrapped__"), (
+        "lmnr's ThreadingInstrumentor did not patch ThreadPoolExecutor.submit; "
+        "the with_lmnr tests would silently degrade to the without_lmnr case"
+    )
 
 
 def _make_action(tool_call_id: str, tool_name: str = "my_tool") -> Any:
@@ -164,6 +214,7 @@ def test_aexecute_batch_overlapping_tasks_each_get_a_fresh_context(probe) -> Non
 
 
 # ── OTel spans created in the worker nest under the dispatcher ────
+# lmnr not initialized: nothing crosses the thread boundary without the copy.
 
 
 def _span_nesting_runner(
@@ -178,7 +229,9 @@ def _span_nesting_runner(
     return tool_runner
 
 
-def test_execute_batch_worker_spans_nest_under_dispatching_span(tracing) -> None:
+def test_execute_batch_worker_spans_nest_under_dispatcher_without_lmnr(
+    tracing,
+) -> None:
     tracer, exporter = tracing
     executor = ParallelToolExecutor(max_workers=2)
     recorded: list[SpanContext] = []
@@ -197,7 +250,9 @@ def test_execute_batch_worker_spans_nest_under_dispatching_span(tracing) -> None
         assert span.parent.span_id == parent_ctx.span_id
 
 
-def test_aexecute_batch_worker_spans_nest_under_dispatching_span(tracing) -> None:
+def test_aexecute_batch_worker_spans_nest_under_dispatcher_without_lmnr(
+    tracing,
+) -> None:
     tracer, exporter = tracing
     executor = ParallelToolExecutor(max_workers=2)
     recorded: list[SpanContext] = []
@@ -220,11 +275,81 @@ def test_aexecute_batch_worker_spans_nest_under_dispatching_span(tracing) -> Non
         assert span.parent.span_id == parent_ctx.span_id
 
 
-# ── Laminar's *isolated* context is what @observe parents against ──
+# ── What lmnr's own instrumentation leaves uncovered ──────────────
+# lmnr patches ThreadPoolExecutor.submit to carry its isolated context, so
+# @observe spans nest across the boundary with or without this executor's
+# copy. The OTel global context and plain ContextVars are not carried; these
+# pin that the copy closes those two gaps in lmnr's own configuration.
 
 
-def test_execute_batch_propagates_laminar_isolated_context() -> None:
-    """Laminar keeps its own ContextVar-backed context; it must copy too."""
+def test_execute_batch_worker_spans_nest_under_dispatcher_with_lmnr(
+    tracing, lmnr_initialized
+) -> None:
+    _assert_lmnr_wraps_submit()
+    tracer, exporter = tracing
+    executor = ParallelToolExecutor(max_workers=2)
+    recorded: list[SpanContext] = []
+    tool_runner = _span_nesting_runner(tracer, recorded, threading.Lock())
+
+    with tracer.start_as_current_span("agent.step") as parent:
+        parent_ctx = parent.get_span_context()
+        executor.execute_batch(
+            [_make_action("c0", "tool_0"), _make_action("c1", "tool_1")], tool_runner
+        )
+
+    assert {c.trace_id for c in recorded} == {parent_ctx.trace_id}
+    for tool_call_id in ("c0", "c1"):
+        span = _finished(exporter, f"tool-{tool_call_id}")
+        assert span.parent is not None
+        assert span.parent.span_id == parent_ctx.span_id
+
+
+def test_aexecute_batch_worker_spans_nest_under_dispatcher_with_lmnr(
+    tracing, lmnr_initialized
+) -> None:
+    _assert_lmnr_wraps_submit()
+    tracer, exporter = tracing
+    executor = ParallelToolExecutor(max_workers=2)
+    recorded: list[SpanContext] = []
+    tool_runner = _span_nesting_runner(tracer, recorded, threading.Lock())
+
+    async def main() -> SpanContext:
+        with tracer.start_as_current_span("agent.astep") as parent:
+            await executor.aexecute_batch(
+                [_make_action("c0", "tool_0"), _make_action("c1", "tool_1")],
+                tool_runner,
+            )
+            return parent.get_span_context()
+
+    parent_ctx = asyncio.run(main())
+
+    assert {c.trace_id for c in recorded} == {parent_ctx.trace_id}
+    for tool_call_id in ("c0", "c1"):
+        span = _finished(exporter, f"tool-{tool_call_id}")
+        assert span.parent is not None
+        assert span.parent.span_id == parent_ctx.span_id
+
+
+def test_execute_batch_propagates_contextvars_with_lmnr(
+    probe, lmnr_initialized
+) -> None:
+    _assert_lmnr_wraps_submit()
+    executor = ParallelToolExecutor(max_workers=2)
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def tool_runner(action: Any) -> list[Any]:
+        with lock:
+            seen.append(probe.get())
+        return [MagicMock()]
+
+    executor.execute_batch([_make_action("c0"), _make_action("c1")], tool_runner)
+
+    assert seen == ["set-by-dispatcher", "set-by-dispatcher"]
+
+
+def test_lmnr_isolated_context_survives_the_context_copy(lmnr_initialized) -> None:
+    """The copy must not clobber what lmnr already propagates for itself."""
     from lmnr.opentelemetry_lib.tracing.context import (
         attach_context,
         detach_context,
@@ -251,6 +376,9 @@ def test_execute_batch_propagates_laminar_isolated_context() -> None:
 
 
 # ── End-to-end through a real Agent with tool_concurrency_limit=2 ──
+# ``observe`` is replaced by a raw-OTel stand-in, so this exercises the
+# no-lmnr path end to end. With lmnr live the real ``observe`` parents against
+# lmnr's isolated context, which lmnr carries across the boundary itself.
 
 
 class _SpanCtxAction(Action):
@@ -318,7 +446,7 @@ def _response_with_two_tool_calls() -> ModelResponse:
     )
 
 
-def test_agent_step_tool_spans_nest_under_dispatching_span(tracing) -> None:
+def test_agent_step_tool_spans_nest_under_dispatcher_without_lmnr(tracing) -> None:
     tracer, exporter = tracing
     llm = LLM(
         usage_id="test-llm",

--- a/tests/sdk/agent/test_parallel_tool_span_context.py
+++ b/tests/sdk/agent/test_parallel_tool_span_context.py
@@ -1,0 +1,375 @@
+"""Trace-context propagation into ``ParallelToolExecutor`` worker threads.
+
+``ThreadPoolExecutor.submit`` and ``loop.run_in_executor`` do not copy
+``contextvars``, so without an explicit copy every off-main-thread tool call
+starts a fresh, parentless OTel/Laminar context and its TOOL span is orphaned
+from the conversation trace.
+"""
+
+import asyncio
+import contextvars
+import threading
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Self
+from unittest.mock import MagicMock, patch
+
+import pytest
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import (
+    Choices,
+    Function,
+    Message as LiteLLMMessage,
+    ModelResponse,
+)
+from opentelemetry.context import Context, create_key, get_value, set_value
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanContext, Tracer
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.agent.parallel_executor import ParallelToolExecutor
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
+from openhands.sdk.tool.tool import ToolDefinition
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+_PROBE: contextvars.ContextVar[str] = contextvars.ContextVar("probe", default="unset")
+
+_BARRIER_TIMEOUT = 10.0
+
+
+@pytest.fixture
+def probe() -> Iterator[contextvars.ContextVar[str]]:
+    token = _PROBE.set("set-by-dispatcher")
+    try:
+        yield _PROBE
+    finally:
+        _PROBE.reset(token)
+
+
+@pytest.fixture
+def tracing() -> Iterator[tuple[Tracer, InMemorySpanExporter]]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    try:
+        yield provider.get_tracer("test"), exporter
+    finally:
+        provider.shutdown()
+
+
+def _make_action(tool_call_id: str, tool_name: str = "my_tool") -> Any:
+    ae = MagicMock()
+    ae.tool_name = tool_name
+    ae.tool_call_id = tool_call_id
+    return ae
+
+
+def _finished(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
+    matches = [s for s in exporter.get_finished_spans() if s.name == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} span, got {matches}"
+    return matches[0]
+
+
+# ── contextvars reach the worker thread ───────────────────────────
+
+
+def test_execute_batch_propagates_contextvars(probe) -> None:
+    executor = ParallelToolExecutor(max_workers=2)
+    seen: list[str] = []
+    threads: set[str] = set()
+
+    def tool_runner(action: Any) -> list[Any]:
+        seen.append(probe.get())
+        threads.add(threading.current_thread().name)
+        return [MagicMock()]
+
+    executor.execute_batch([_make_action("c0"), _make_action("c1")], tool_runner)
+
+    assert threading.current_thread().name not in threads
+    assert seen == ["set-by-dispatcher", "set-by-dispatcher"]
+
+
+def test_aexecute_batch_propagates_contextvars(probe) -> None:
+    executor = ParallelToolExecutor(max_workers=2)
+    seen: list[str] = []
+    threads: set[str] = set()
+
+    def tool_runner(action: Any) -> list[Any]:
+        seen.append(probe.get())
+        threads.add(threading.current_thread().name)
+        return [MagicMock()]
+
+    asyncio.run(
+        executor.aexecute_batch([_make_action("c0"), _make_action("c1")], tool_runner)
+    )
+
+    assert threading.current_thread().name not in threads
+    assert seen == ["set-by-dispatcher", "set-by-dispatcher"]
+
+
+# ── each task needs its own Context object ────────────────────────
+# A single contextvars.Context cannot be entered by two threads at once
+# (``RuntimeError: cannot enter context: ... is already entered``), so these
+# force genuine overlap via a Barrier.
+
+
+def test_execute_batch_overlapping_tasks_each_get_a_fresh_context(probe) -> None:
+    executor = ParallelToolExecutor(max_workers=3)
+    barrier = threading.Barrier(3)
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def tool_runner(action: Any) -> list[Any]:
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        with lock:
+            seen.append(probe.get())
+        return ["ok"]
+
+    results = executor.execute_batch(
+        [_make_action(f"c{i}", f"tool_{i}") for i in range(3)], tool_runner
+    )
+
+    assert results == [["ok"], ["ok"], ["ok"]]
+    assert seen == ["set-by-dispatcher"] * 3
+
+
+def test_aexecute_batch_overlapping_tasks_each_get_a_fresh_context(probe) -> None:
+    executor = ParallelToolExecutor(max_workers=3)
+    barrier = threading.Barrier(3)
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def tool_runner(action: Any) -> list[Any]:
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        with lock:
+            seen.append(probe.get())
+        return ["ok"]
+
+    results = asyncio.run(
+        executor.aexecute_batch(
+            [_make_action(f"c{i}", f"tool_{i}") for i in range(3)], tool_runner
+        )
+    )
+
+    assert results == [["ok"], ["ok"], ["ok"]]
+    assert seen == ["set-by-dispatcher"] * 3
+
+
+# ── OTel spans created in the worker nest under the dispatcher ────
+
+
+def _span_nesting_runner(
+    tracer: Tracer, recorded: list[SpanContext], lock: threading.Lock
+) -> Any:
+    def tool_runner(action: Any) -> list[Any]:
+        with tracer.start_as_current_span(f"tool-{action.tool_call_id}") as span:
+            with lock:
+                recorded.append(span.get_span_context())
+        return [MagicMock()]
+
+    return tool_runner
+
+
+def test_execute_batch_worker_spans_nest_under_dispatching_span(tracing) -> None:
+    tracer, exporter = tracing
+    executor = ParallelToolExecutor(max_workers=2)
+    recorded: list[SpanContext] = []
+    tool_runner = _span_nesting_runner(tracer, recorded, threading.Lock())
+
+    with tracer.start_as_current_span("agent.step") as parent:
+        parent_ctx = parent.get_span_context()
+        executor.execute_batch(
+            [_make_action("c0", "tool_0"), _make_action("c1", "tool_1")], tool_runner
+        )
+
+    assert {c.trace_id for c in recorded} == {parent_ctx.trace_id}
+    for tool_call_id in ("c0", "c1"):
+        span = _finished(exporter, f"tool-{tool_call_id}")
+        assert span.parent is not None
+        assert span.parent.span_id == parent_ctx.span_id
+
+
+def test_aexecute_batch_worker_spans_nest_under_dispatching_span(tracing) -> None:
+    tracer, exporter = tracing
+    executor = ParallelToolExecutor(max_workers=2)
+    recorded: list[SpanContext] = []
+    tool_runner = _span_nesting_runner(tracer, recorded, threading.Lock())
+
+    async def main() -> SpanContext:
+        with tracer.start_as_current_span("agent.astep") as parent:
+            await executor.aexecute_batch(
+                [_make_action("c0", "tool_0"), _make_action("c1", "tool_1")],
+                tool_runner,
+            )
+            return parent.get_span_context()
+
+    parent_ctx = asyncio.run(main())
+
+    assert {c.trace_id for c in recorded} == {parent_ctx.trace_id}
+    for tool_call_id in ("c0", "c1"):
+        span = _finished(exporter, f"tool-{tool_call_id}")
+        assert span.parent is not None
+        assert span.parent.span_id == parent_ctx.span_id
+
+
+# ── Laminar's *isolated* context is what @observe parents against ──
+
+
+def test_execute_batch_propagates_laminar_isolated_context() -> None:
+    """Laminar keeps its own ContextVar-backed context; it must copy too."""
+    from lmnr.opentelemetry_lib.tracing.context import (
+        attach_context,
+        detach_context,
+        get_current_context,
+    )
+
+    key = create_key("openhands.test.isolated")
+    executor = ParallelToolExecutor(max_workers=2)
+    seen: list[Any] = []
+    lock = threading.Lock()
+
+    def tool_runner(action: Any) -> list[Any]:
+        with lock:
+            seen.append(get_value(key, get_current_context()))
+        return [MagicMock()]
+
+    token = attach_context(set_value(key, "isolated-parent", Context()))
+    try:
+        executor.execute_batch([_make_action("c0"), _make_action("c1")], tool_runner)
+    finally:
+        detach_context(token)
+
+    assert seen == ["isolated-parent", "isolated-parent"]
+
+
+# ── End-to-end through a real Agent with tool_concurrency_limit=2 ──
+
+
+class _SpanCtxAction(Action):
+    value: str = ""
+
+
+class _SpanCtxObservation(Observation):
+    result: str = ""
+
+
+class _SpanCtxExecutor(ToolExecutor[_SpanCtxAction, _SpanCtxObservation]):
+    def __call__(
+        self, action: _SpanCtxAction, conversation=None
+    ) -> _SpanCtxObservation:
+        return _SpanCtxObservation(result=action.value)
+
+
+class _SpanCtxToolA(ToolDefinition[_SpanCtxAction, _SpanCtxObservation]):
+    name = "echo_a"
+
+    @classmethod
+    def create(cls, conv_state: "ConversationState | None" = None) -> Sequence[Self]:
+        return [
+            cls(
+                description="Echoes its input",
+                action_type=_SpanCtxAction,
+                observation_type=_SpanCtxObservation,
+                executor=_SpanCtxExecutor(),
+            )
+        ]
+
+
+class _SpanCtxToolB(_SpanCtxToolA):
+    name = "echo_b"
+
+
+register_tool("SpanCtxEchoToolA", _SpanCtxToolA)
+register_tool("SpanCtxEchoToolB", _SpanCtxToolB)
+
+
+def _response_with_two_tool_calls() -> ModelResponse:
+    return ModelResponse(
+        id="mock-response-1",
+        choices=[
+            Choices(
+                index=0,
+                message=LiteLLMMessage(
+                    role="assistant",
+                    content="calling both tools",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id=f"call_{name}",
+                            type="function",
+                            function=Function(name=name, arguments='{"value": "hi"}'),
+                        )
+                        for name in ("echo_a", "echo_b")
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        created=0,
+        model="test-model",
+        object="chat.completion",
+    )
+
+
+def test_agent_step_tool_spans_nest_under_dispatching_span(tracing) -> None:
+    tracer, exporter = tracing
+    llm = LLM(
+        usage_id="test-llm",
+        model="test-model",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    agent = Agent(
+        llm=llm,
+        tools=[Tool(name="SpanCtxEchoToolA"), Tool(name="SpanCtxEchoToolB")],
+        tool_concurrency_limit=2,
+    )
+    conversation = Conversation(agent=agent, callbacks=[])
+    worker_threads: set[str] = set()
+
+    def fake_observe(**kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            def wrapper(*args: Any, **fkwargs: Any) -> Any:
+                worker_threads.add(threading.current_thread().name)
+                with tracer.start_as_current_span("tool.execute"):
+                    return fn(*args, **fkwargs)
+
+            return wrapper
+
+        return decorator
+
+    with (
+        patch(
+            "openhands.sdk.llm.llm.litellm_completion",
+            side_effect=lambda messages, **kw: _response_with_two_tool_calls(),
+        ),
+        patch(
+            "openhands.sdk.agent.agent.should_enable_observability", return_value=True
+        ),
+        patch("openhands.sdk.agent.agent.observe", side_effect=fake_observe),
+    ):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="please echo hi")])
+        )
+        with tracer.start_as_current_span("agent.step") as parent:
+            parent_ctx = parent.get_span_context()
+            agent.step(conversation, on_event=lambda e: None)
+
+    assert threading.current_thread().name not in worker_threads, (
+        "tool calls did not run off the dispatching thread; "
+        "the test is not exercising the parallel path"
+    )
+    tool_spans = [s for s in exporter.get_finished_spans() if s.name == "tool.execute"]
+    assert len(tool_spans) == 2
+    for span in tool_spans:
+        assert span.context is not None
+        assert span.context.trace_id == parent_ctx.trace_id
+        assert span.parent is not None
+        assert span.parent.span_id == parent_ctx.span_id


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Explicitly propagate trace context on parallel tool calls 

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

> **This changes nothing about the traces we emit today.** With lmnr initialized —
> the only configuration in which TOOL spans exist at all — the exported trace shape
> is byte-identical before and after. Merge this for the dependency it removes and
> the canary it adds, not for a defect it fixes. It fixes none.

## Why

When `tool_concurrency_limit > 1`, `ParallelToolExecutor` dispatches tool calls to a
raw `ThreadPoolExecutor` — `executor.submit` on the sync path, `loop.run_in_executor`
on the async one (which calls `submit` internally). Neither copies `contextvars`.

Tool spans nest correctly anyway, because **lmnr monkeypatches
`concurrent.futures.ThreadPoolExecutor.submit`** and propagates its isolated context —
the context `@observe` parents new spans against:

- `lmnr/opentelemetry_lib/opentelemetry/instrumentation/threading/__init__.py` (`__wrap_thread_pool_submit`)
- installed unconditionally in `TracerWrapper.__new__` (`lmnr/opentelemetry_lib/tracing/__init__.py:149`),
  before and independent of the `instruments=` / `block_instruments` filter

So correct span parentage on our hottest observability path is currently a property of
a third-party monkeypatch of a stdlib method. That dependency is undocumented, outside
our control, and pinned only as `lmnr>=0.7.56,<0.8.0` — free to move inside the range,
with a 0.8 bump foreseeable.

The problem is not the likelihood, it is the failure mode. If that patch ever changes,
tool spans orphan **silently**: no exception, no failing test, no alert. The corruption
surfaces months later in an exported training corpus. That is exactly the detection
latency that made the `dataset-utils#39` trace-quality investigation expensive.

This PR does two things about that:

1. **Makes propagation ours.** The context is copied explicitly, so parentage no longer
   depends on lmnr patching stdlib.
2. **Adds a canary.** `_assert_lmnr_wraps_submit()` fails loudly the moment lmnr stops
   wrapping `submit`, instead of degrading into a silently-passing test.

It also closes two gaps lmnr does not cover, since lmnr propagates only its *own*
isolated context — measured inside a worker thread with lmnr live:

```
dispatcher   lmnr_isolated=975cee…  otel_global=975cee…  plain_cv=set-by-dispatcher
before       lmnr_isolated=975cee…  otel_global=0000…    plain_cv=UNSET
after        lmnr_isolated=975cee…  otel_global=975cee…  plain_cv=set-by-dispatcher
```

Nothing in the SDK creates spans with a raw OTel tracer today, so that gap is latent —
but any standard OTel auto-instrumentation used inside a tool would hit it.

## Summary

- Copy the dispatching thread's `contextvars` into each `ParallelToolExecutor` worker,
  on both the sync (`executor.submit`) and async (`run_in_executor`) paths.
- A **fresh** `copy_context()` per submitted task: one `contextvars.Context` cannot be
  entered by two threads at once (`RuntimeError: cannot enter context ... is already
  entered`), which a shared-context implementation would hit precisely when the batch
  is parallel enough to matter.
- Tests split explicitly into `*_without_lmnr` (raw `TracerProvider` — the gap this
  change closes) and `*_with_lmnr` (real `TracerWrapper`, guarded by the canary), so
  neither configuration can be mistaken for the other.
- No change to `agent.py`. No change to `laminar.py`.

## Issue Number

Context: #4358. **This PR does not fix Bug 1 of that issue**, and deliberately carries
no closing keyword.

Bug 1's diagnosis — that parallel dispatch orphans TOOL spans — does not hold; lmnr's
threading instrumentation already prevents it in every reachable configuration. The
actual cause of the unmatched tool calls in the `dataset-utils#39` sample was
consumer-side: positional call/result pairing in the export tooling, since fixed there.
A correction is posted on #4358. #4359 covers Bug 2.

## How to Test

```bash
uv run pytest tests/sdk/agent/test_parallel_tool_span_context.py -q   # 11 passed
uv run pytest tests/sdk/agent/ tests/sdk/observability/ -q            # 851 passed
uv run ruff check <changed files>                                     # All checks passed!
uv run ruff format --check <changed files>                            # 2 files already formatted
uv run pyright <changed files>                                        # 0 errors, 0 warnings
```

Reverting only `parallel_executor.py` to this PR's base gives **10 failed, 1 passed**.
The single pass is `test_lmnr_isolated_context_survives_the_context_copy`, which is a
no-regression guard and is *supposed* to pass without the change — stated here rather
than presented as evidence for it.

Stability under contention (the parallel paths are timing-sensitive): 25 consecutive
runs of the new file and 5 full-suite runs under `pytest -n 4`, zero failures.

**Production-shape check.** A real `Agent` + `Conversation` at
`tool_concurrency_limit=2` with lmnr initialized, exported spans diffed before/after:
identical — 2 TOOL spans under `agent.step` either way, on both dispatch paths. This is
the evidence for the "changes nothing today" claim at the top.

## Video/Screenshots

Not applicable — observability plumbing, covered by the span-parentage assertions above.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**The one real behaviour delta.** An auto-instrumented span created in a worker thread
*outside* an `observe` span was previously parentless and is now parented under
`agent.step`. Almost certainly an improvement, but it is a change, and it is the only
one.

**A smaller alternative, if the code is not wanted.** Keep only the canary tests and
drop the `parallel_executor.py` change. That still converts a future silent lmnr
regression into a loud CI failure, at the cost of reacting to a broken build rather
than never being exposed. Merging the full change and merging only the canary are both
defensible; merging nothing leaves the silent failure mode in place.

**Rejected alternative.** #4358 suggested making `_root_span_from_args`
(`observability/laminar.py`) see the conversation so the existing reattachment fires
for TOOL spans. Verified empirically that this re-parents TOOL spans onto the
conversation *root* span, flattening them out from under `agent.step` — and it would do
so on the default sequential path too, changing trace shape for every user.

**Same gap, not addressed here.** `AgentBase.astep` (`agent/base.py:665`) does
`loop.run_in_executor(None, self.step, …)` with no context copy — it would orphan an
entire step rather than just TOOL spans. `Agent` and `ACPAgent` both override `astep`,
so the exposure is limited to third-party subclasses. Also four `run_in_executor` sites
in `llm/llm.py` (965, 1952, 2259, 2316).

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e3dc96f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e3dc96f-python \
  ghcr.io/openhands/agent-server:e3dc96f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e3dc96f-golang-amd64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-golang-amd64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-golang-amd64
ghcr.io/openhands/agent-server:e3dc96f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e3dc96f-golang-arm64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-golang-arm64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-golang-arm64
ghcr.io/openhands/agent-server:e3dc96f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e3dc96f-java-amd64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-java-amd64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-java-amd64
ghcr.io/openhands/agent-server:e3dc96f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e3dc96f-java-arm64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-java-arm64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-java-arm64
ghcr.io/openhands/agent-server:e3dc96f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e3dc96f-python-amd64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-python-amd64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-python-amd64
ghcr.io/openhands/agent-server:e3dc96f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e3dc96f-python-arm64
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-python-arm64
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-python-arm64
ghcr.io/openhands/agent-server:e3dc96f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e3dc96f-golang
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-golang
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-golang
ghcr.io/openhands/agent-server:e3dc96f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e3dc96f-java
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-java
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-java
ghcr.io/openhands/agent-server:e3dc96f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e3dc96f-python
ghcr.io/openhands/agent-server:e3dc96f4fe6dc746be0f19a5111aeebfefdde48f-python
ghcr.io/openhands/agent-server:fix-parallel-tool-span-context-python
ghcr.io/openhands/agent-server:e3dc96f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e3dc96f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e3dc96f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->