### PR TITLE
feat(agent-server): Canvas Extensions manifest and containment [1/4]

### DIFF
--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
@@ -1,0 +1,16 @@
+"""Canvas Extensions: installable UI bundles that contribute pages to Canvas."""
+
+from openhands.agent_server.canvas_extensions.manifest import (
+    CanvasExtensionContributes,
+    CanvasExtensionManifest,
+    CanvasExtensionPage,
+    resolve_entrypoint,
+)
+
+
+__all__ = [
+    "CanvasExtensionManifest",
+    "CanvasExtensionContributes",
+    "CanvasExtensionPage",
+    "resolve_entrypoint",
+]

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
@@ -1,0 +1,164 @@
+"""Canvas Extensions manifest: schema, validation, and entrypoint containment.
+
+A Canvas extension is an installable UI bundle that contributes pages to the
+OpenHands Canvas frontend. Extensions are installed and served entirely by
+the agent-server (via ``openhands.sdk.extensions.installation``, the same
+type-agnostic install-tracking framework Plugins/Skills use); nothing here
+is consumed by ``Agent``/``Conversation``.
+
+This module defines the manifest schema (``canvas-extension.json``) and the
+two security-critical checks around it:
+
+* Name / contribution-id / page-path validation (syntactic, on the model).
+* Entrypoint containment (filesystem-level, once a package root is known) —
+  rejects both textual path traversal and symlink escapes.
+"""
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, Field, field_validator
+
+from openhands.sdk.extensions.installation.utils import validate_extension_name
+
+
+# Absolute, kebab-case, multi-segment UI route, e.g. "/dashboard/settings".
+_PAGE_PATH_PATTERN: re.Pattern[str] = re.compile(
+    r"^/[a-z0-9]+(?:-[a-z0-9]+)*(?:/[a-z0-9]+(?:-[a-z0-9]+)*)*$"
+)
+
+
+class CanvasExtensionPage(BaseModel):
+    """A single page contributed to the Canvas UI by an extension."""
+
+    id: str = Field(description="Unique contribution id within the extension")
+    title: str = Field(description="Page title shown in Canvas navigation")
+    path: str = Field(description="Route the page is mounted at, e.g. '/dashboard'")
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, v: str) -> str:
+        # Same kebab-case rule as extension names, with a message scoped
+        # to page contributions rather than validate_extension_name's own.
+        try:
+            validate_extension_name(v)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid contribution id. Expected kebab-case, got {v!r}."
+            ) from e
+        return v
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, v: str) -> str:
+        if not _PAGE_PATH_PATTERN.fullmatch(v):
+            raise ValueError(
+                "Invalid page path. Expected an absolute kebab-case route "
+                f"(e.g. '/dashboard'), got {v!r}."
+            )
+        return v
+
+
+class CanvasExtensionContributes(BaseModel):
+    """Contributions an extension makes to the Canvas UI."""
+
+    pages: list[CanvasExtensionPage] = Field(
+        default_factory=list, description="Pages contributed to Canvas navigation"
+    )
+
+    @field_validator("pages")
+    @classmethod
+    def _validate_unique_pages(
+        cls, v: list[CanvasExtensionPage]
+    ) -> list[CanvasExtensionPage]:
+        seen_ids: set[str] = set()
+        seen_paths: set[str] = set()
+        for page in v:
+            if page.id in seen_ids:
+                raise ValueError(f"Duplicate page contribution id: {page.id!r}")
+            if page.path in seen_paths:
+                raise ValueError(f"Duplicate page path: {page.path!r}")
+            seen_ids.add(page.id)
+            seen_paths.add(page.path)
+        return v
+
+
+class CanvasExtensionManifest(BaseModel):
+    """Canvas extension manifest (``canvas-extension.json``)."""
+
+    schema_version: int = Field(description="Manifest schema version")
+    name: str = Field(description="Extension name (kebab-case)")
+    display_name: str = Field(description="Human-readable extension name")
+    version: str = Field(description="Extension version")
+    description: str = Field(default="", description="Extension description")
+    entrypoint: str = Field(
+        description=(
+            "Path, relative to the extension package root, to the bundle entry file"
+        )
+    )
+    contributes: CanvasExtensionContributes = Field(
+        default_factory=CanvasExtensionContributes,
+        description="Contributions this extension makes to the Canvas UI",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        validate_extension_name(v)
+        return v
+
+    @field_validator("entrypoint")
+    @classmethod
+    def _validate_entrypoint(cls, v: str) -> str:
+        """Reject textual traversal/absolute paths.
+
+        Syntactic only — see :func:`resolve_entrypoint` for the real,
+        symlink-aware containment check against the installed package root.
+        """
+        if not v:
+            raise ValueError("entrypoint must not be empty")
+        if v.startswith("/"):
+            raise ValueError("entrypoint must be relative, not absolute")
+        if ".." in Path(v).parts:
+            raise ValueError(
+                "entrypoint cannot contain '..' (parent directory traversal)"
+            )
+        return v
+
+
+def resolve_entrypoint(manifest: CanvasExtensionManifest, package_root: Path) -> Path:
+    """Resolve ``manifest.entrypoint`` against ``package_root``, safely.
+
+    Field-level validation on ``entrypoint`` only rejects textual traversal
+    (``..``) and absolute paths. It cannot catch a symlink inside the
+    package that resolves outside of it. This performs the real
+    filesystem-level containment check (resolving symlinks) and must be
+    called both when an extension is installed and again immediately
+    before its entrypoint is read or served over HTTP.
+
+    Args:
+        manifest: A validated manifest.
+        package_root: The extension's installed package root directory.
+
+    Returns:
+        The resolved, contained entrypoint path.
+
+    Raises:
+        ValueError: If the resolved entrypoint escapes ``package_root``, or
+            does not resolve to a regular file within it (covers ``.``,
+            a directory, a dangling symlink, and symlink cycles — none of
+            which ``is_relative_to`` alone rejects).
+    """
+    root = package_root.resolve()
+    candidate = (root / manifest.entrypoint).resolve()
+    if candidate != root and not candidate.is_relative_to(root):
+        raise ValueError(
+            f"entrypoint {manifest.entrypoint!r} resolves outside the "
+            "extension package root"
+        )
+    if not candidate.is_file():
+        raise ValueError(
+            f"entrypoint {manifest.entrypoint!r} does not resolve to a file "
+            "in the extension package"
+        )
+    return candidate

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
@@ -38,8 +38,6 @@ class CanvasExtensionPage(BaseModel):
     @field_validator("id")
     @classmethod
     def _validate_id(cls, v: str) -> str:
-        # Same kebab-case rule as extension names, with a message scoped
-        # to page contributions rather than validate_extension_name's own.
         try:
             validate_extension_name(v)
         except ValueError as e:
@@ -151,7 +149,7 @@ def resolve_entrypoint(manifest: CanvasExtensionManifest, package_root: Path) ->
     """
     root = package_root.resolve()
     candidate = (root / manifest.entrypoint).resolve()
-    if candidate != root and not candidate.is_relative_to(root):
+    if not candidate.is_relative_to(root):
         raise ValueError(
             f"entrypoint {manifest.entrypoint!r} resolves outside the "
             "extension package root"

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_entrypoint_containment.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_entrypoint_containment.py
@@ -1,0 +1,178 @@
+"""Adversarial tests for entrypoint containment (security-critical).
+
+Kept separate from generic manifest validation: these exercise the
+filesystem-level check in ``resolve_entrypoint`` (path traversal and
+symlink escapes), not the syntactic ``entrypoint`` field validator.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from openhands.agent_server.canvas_extensions.manifest import (
+    CanvasExtensionManifest,
+    resolve_entrypoint,
+)
+
+
+def _manifest_with_raw_entrypoint(entrypoint: str) -> CanvasExtensionManifest:
+    """Build a manifest bypassing field validation.
+
+    Lets these tests drive ``resolve_entrypoint`` directly with entrypoints
+    the syntactic validator would already reject at construction time.
+    """
+    manifest = CanvasExtensionManifest(
+        schema_version=1,
+        name="my-extension",
+        display_name="My Extension",
+        version="1.0.0",
+        entrypoint="index.js",
+    )
+    return manifest.model_copy(update={"entrypoint": entrypoint})
+
+
+@pytest.fixture
+def package_root(tmp_path: Path) -> Path:
+    root = tmp_path / "installed" / "my-extension"
+    root.mkdir(parents=True)
+    (root / "index.js").write_text("console.log('ok')")
+    return root
+
+
+def test_resolves_valid_entrypoint(package_root: Path):
+    manifest = _manifest_with_raw_entrypoint("index.js")
+    resolved = resolve_entrypoint(manifest, package_root)
+    assert resolved == (package_root / "index.js").resolve()
+
+
+def test_resolves_valid_nested_entrypoint(package_root: Path):
+    (package_root / "dist").mkdir()
+    (package_root / "dist" / "bundle.js").write_text("console.log('ok')")
+    manifest = _manifest_with_raw_entrypoint("dist/bundle.js")
+    resolved = resolve_entrypoint(manifest, package_root)
+    assert resolved == (package_root / "dist" / "bundle.js").resolve()
+
+
+def test_resolves_entrypoint_via_in_package_symlink(package_root: Path):
+    """A symlink that stays inside ``package_root`` is legitimate (e.g. build
+    tooling) and must still resolve — only escapes are rejected.
+    """
+    (package_root / "dist").mkdir()
+    real_bundle = package_root / "dist" / "bundle.js"
+    real_bundle.write_text("console.log('ok')")
+    (package_root / "index.js").unlink()
+    (package_root / "index.js").symlink_to(real_bundle)
+
+    manifest = _manifest_with_raw_entrypoint("index.js")
+    resolved = resolve_entrypoint(manifest, package_root)
+    assert resolved == real_bundle.resolve()
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    [
+        "../../../../etc/passwd",
+        "../sibling-package/index.js",
+        "dist/../../escape.js",
+        "a/b/c/../../../../../../etc/passwd",
+    ],
+)
+def test_rejects_textual_traversal_escape(package_root: Path, entrypoint: str):
+    manifest = _manifest_with_raw_entrypoint(entrypoint)
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_absolute_entrypoint_bypassing_field_validation(
+    package_root: Path, tmp_path: Path
+):
+    """``root / "/abs/path"`` silently discards ``root`` (a well-known
+    pathlib footgun: joining with an absolute path drops everything to its
+    left, same as ``os.path.join``). Confirms containment still catches
+    this rather than trusting the join, for an entrypoint value that
+    reaches ``resolve_entrypoint`` without going through field validation
+    (which normally rejects absolute paths first).
+    """
+    outside_secret = tmp_path / "outside-secret.js"
+    outside_secret.write_text("should never be served")
+    assert (package_root / str(outside_secret)) == outside_secret  # the footgun
+
+    manifest = _manifest_with_raw_entrypoint(str(outside_secret))
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_symlinked_file_escaping_root(package_root: Path, tmp_path: Path):
+    outside_secret = tmp_path / "outside-secret.js"
+    outside_secret.write_text("should never be served")
+
+    escape_link = package_root / "index.js"
+    escape_link.unlink()
+    escape_link.symlink_to(outside_secret)
+
+    manifest = _manifest_with_raw_entrypoint("index.js")
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_symlinked_directory_escaping_root(package_root: Path, tmp_path: Path):
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (outside_dir / "payload.js").write_text("should never be served")
+
+    (package_root / "linked").symlink_to(outside_dir, target_is_directory=True)
+
+    manifest = _manifest_with_raw_entrypoint("linked/payload.js")
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_symlinked_package_root_itself(package_root: Path, tmp_path: Path):
+    """A symlinked ``package_root`` should still confine resolution to its target."""
+    outside_secret = tmp_path / "outside-secret.js"
+    outside_secret.write_text("should never be served")
+
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    (real_root / "index.js").write_text("console.log('ok')")
+    (real_root / "escape").symlink_to(outside_secret)
+
+    aliased_root = tmp_path / "aliased-root"
+    aliased_root.symlink_to(real_root, target_is_directory=True)
+
+    manifest = _manifest_with_raw_entrypoint("escape")
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_entrypoint(manifest, aliased_root)
+
+
+def test_rejects_entrypoint_equal_to_package_root(package_root: Path):
+    """``.`` is contained (no escape) but is a directory, not an entrypoint."""
+    manifest = _manifest_with_raw_entrypoint(".")
+    with pytest.raises(ValueError, match="does not resolve to a file"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_entrypoint_pointing_at_a_directory(package_root: Path):
+    (package_root / "dist").mkdir()
+    manifest = _manifest_with_raw_entrypoint("dist")
+    with pytest.raises(ValueError, match="does not resolve to a file"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_missing_entrypoint(package_root: Path):
+    manifest = _manifest_with_raw_entrypoint("does-not-exist.js")
+    with pytest.raises(ValueError, match="does not resolve to a file"):
+        resolve_entrypoint(manifest, package_root)
+
+
+def test_rejects_symlink_cycle(package_root: Path):
+    """A self-referential symlink must resolve() cleanly, not hang or crash,
+    and must still be rejected since it never resolves to a real file.
+    """
+    loop = package_root / "index.js"
+    loop.unlink()
+    loop.symlink_to(loop)
+
+    manifest = _manifest_with_raw_entrypoint("index.js")
+    with pytest.raises(ValueError, match="does not resolve to a file"):
+        resolve_entrypoint(manifest, package_root)

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_manifest.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_manifest.py
@@ -1,0 +1,200 @@
+"""Tests for the CanvasExtensionManifest model and its field validation."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from openhands.agent_server.canvas_extensions.manifest import (
+    CanvasExtensionContributes,
+    CanvasExtensionManifest,
+    CanvasExtensionPage,
+)
+
+
+def _manifest(**overrides: Any) -> CanvasExtensionManifest:
+    defaults: dict[str, Any] = dict(
+        schema_version=1,
+        name="my-extension",
+        display_name="My Extension",
+        version="1.0.0",
+        entrypoint="dist/index.js",
+    )
+    defaults.update(overrides)
+    return CanvasExtensionManifest(**defaults)
+
+
+def test_minimal_manifest():
+    manifest = _manifest()
+    assert manifest.name == "my-extension"
+    assert manifest.description == ""
+    assert manifest.contributes.pages == []
+
+
+def test_manifest_with_page_contribution():
+    manifest = _manifest(
+        contributes=CanvasExtensionContributes(
+            pages=[
+                CanvasExtensionPage(
+                    id="dashboard", title="Dashboard", path="/dashboard"
+                )
+            ]
+        )
+    )
+    assert manifest.contributes.pages[0].id == "dashboard"
+    assert manifest.contributes.pages[0].title == "Dashboard"
+    assert manifest.contributes.pages[0].path == "/dashboard"
+
+
+def test_manifest_with_multiple_distinct_pages():
+    manifest = _manifest(
+        contributes=CanvasExtensionContributes(
+            pages=[
+                CanvasExtensionPage(
+                    id="dashboard", title="Dashboard", path="/dashboard"
+                ),
+                CanvasExtensionPage(
+                    id="settings", title="Settings", path="/dashboard/settings"
+                ),
+            ]
+        )
+    )
+    ids = [p.id for p in manifest.contributes.pages]
+    paths = [p.path for p in manifest.contributes.pages]
+    assert ids == ["dashboard", "settings"]
+    assert paths == ["/dashboard", "/dashboard/settings"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["CamelCase", "", "has_underscore", "../evil", "-leading-hyphen"],
+)
+def test_invalid_name_rejected(name: str):
+    with pytest.raises(ValidationError, match="Invalid extension name"):
+        _manifest(name=name)
+
+
+@pytest.mark.parametrize(
+    "page_id",
+    ["CamelCase", "", "has_underscore", "../evil", "with space"],
+)
+def test_invalid_contribution_id_rejected(page_id: str):
+    with pytest.raises(ValidationError, match="Invalid contribution id"):
+        CanvasExtensionPage(id=page_id, title="Title", path="/valid")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "dashboard",  # missing leading slash
+        "",  # empty
+        "/",  # root alone — no segment after the slash
+        "/../etc/passwd",  # traversal
+        "//double-slash",  # empty segment
+        "/trailing/",  # trailing slash / empty final segment
+        "/Bad-Case",  # uppercase not allowed
+        "/foo--bar",  # double hyphen: no segment between them
+        "/foo_bar",  # underscore not allowed
+    ],
+)
+def test_invalid_page_path_rejected(path: str):
+    with pytest.raises(ValidationError, match="Invalid page path"):
+        CanvasExtensionPage(id="valid-id", title="Title", path=path)
+
+
+def test_valid_multi_segment_page_path_accepted():
+    page = CanvasExtensionPage(
+        id="settings", title="Settings", path="/dashboard/settings"
+    )
+    assert page.path == "/dashboard/settings"
+
+
+def test_duplicate_page_contribution_ids_rejected():
+    with pytest.raises(ValidationError, match="Duplicate page contribution id"):
+        CanvasExtensionContributes(
+            pages=[
+                CanvasExtensionPage(id="dup", title="A", path="/a"),
+                CanvasExtensionPage(id="dup", title="B", path="/b"),
+            ]
+        )
+
+
+def test_duplicate_page_paths_rejected():
+    with pytest.raises(ValidationError, match="Duplicate page path"):
+        CanvasExtensionContributes(
+            pages=[
+                CanvasExtensionPage(id="a", title="A", path="/dup"),
+                CanvasExtensionPage(id="b", title="B", path="/dup"),
+            ]
+        )
+
+
+def test_duplicate_page_contribution_ids_rejected_through_full_manifest():
+    """The nested ``contributes.pages`` validator must still fire when built
+    from a raw dict (as ``canvas-extension.json`` loads), not just when
+    ``CanvasExtensionContributes`` is constructed directly in Python.
+    """
+    with pytest.raises(ValidationError, match="Duplicate page contribution id"):
+        _manifest(
+            contributes={
+                "pages": [
+                    {"id": "dup", "title": "A", "path": "/a"},
+                    {"id": "dup", "title": "B", "path": "/b"},
+                ]
+            }
+        )
+
+
+def test_manifest_round_trips_through_json_dict():
+    """``model_validate`` over a full, schema-shaped dict — the actual
+    ``canvas-extension.json`` ingestion path — round-trips unchanged.
+    """
+    payload = {
+        "schema_version": 1,
+        "name": "my-extension",
+        "display_name": "My Extension",
+        "version": "1.0.0",
+        "description": "Does things",
+        "entrypoint": "dist/index.js",
+        "contributes": {
+            "pages": [
+                {"id": "dashboard", "title": "Dashboard", "path": "/dashboard"},
+            ]
+        },
+    }
+    manifest = CanvasExtensionManifest.model_validate(payload)
+    assert manifest.model_dump() == payload
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    ["", "/absolute/index.js", "../escape/index.js", "nested/../../escape.js"],
+)
+def test_invalid_entrypoint_syntax_rejected(entrypoint: str):
+    with pytest.raises(ValidationError, match="entrypoint"):
+        _manifest(entrypoint=entrypoint)
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["schema_version", "name", "display_name", "version", "entrypoint"],
+)
+def test_missing_required_field_rejected(missing_field: str):
+    """Confirms these fields are genuinely required (no silent default),
+    catching e.g. an accidental ``= None`` or ``default=""`` creeping in.
+    """
+    payload: dict[str, Any] = dict(
+        schema_version=1,
+        name="my-extension",
+        display_name="My Extension",
+        version="1.0.0",
+        entrypoint="dist/index.js",
+    )
+    del payload[missing_field]
+    with pytest.raises(ValidationError, match=missing_field):
+        CanvasExtensionManifest(**payload)
+
+
+def test_schema_version_rejects_non_integer():
+    with pytest.raises(ValidationError, match="schema_version"):
+        _manifest(schema_version="not-a-number")


### PR DESCRIPTION
HUMAN:

First PR to add extension in the agent-server. Just adding the manifest of an extension.

---

AGENT:

## Why

Part of the Canvas Extensions backend build-out (#4348). It's the foundational ticket in the epic: #4349-#4357 all depend on it, either directly (#4350, #4351, #4352 all reference this manifest/installation shape) or need the containment primitive it introduces before any install/serve code can be written safely.

## Summary
- Add `CanvasExtensionManifest` (`schema_version`, `name`, `display_name`, `version`, `description`, `entrypoint`, `contributes.pages[]`) with name/contribution-id/page-path validation. The `name` validator reuses the SDK's existing `validate_extension_name()` instead of duplicating its kebab-case regex.
- Add `resolve_entrypoint()`: filesystem-level containment (`resolve()` + `is_relative_to()`, plus an is-a-file check) that rejects path traversal, symlink escapes, and non-file targets (`.`, a directory, a dangling symlink, a symlink cycle).
- Lives in `openhands-agent-server`, not `openhands-sdk`: Canvas Extensions are installed and served entirely by the agent-server, with nothing consumed by `Agent`/`Conversation`, so this consumes `openhands.sdk.extensions.installation` as a library the same way an external app would (that framework is explicitly designed for reuse this way).

## Issue Number
#4348

## How to Test

```
uv run pytest tests/agent_server/canvas_extensions -v
```
52 tests pass: field validation (including required-field and wrong-type checks), duplicate id/path detection (including through a realistic dict/JSON-shaped `model_validate` call, not just direct nested-model construction), and adversarial entrypoint containment (textual traversal, symlinked file/directory/package-root escapes, a symlink cycle, the pathlib absolute-path-join footgun where `root / "/etc/passwd"` silently discards `root`, and a legitimate in-package symlink that must still resolve so the hardening doesn't overreach).

`uv run pre-commit run --files <changed files>` also passes (ruff format/lint, pyright, import-dependency-rules, tool-subclass-registration).

End-to-end sanity check outside pytest — loads a realistic manifest JSON string, resolves a real entrypoint on disk, then confirms a symlink-escape attack and an invalid name are both rejected with a clear error rather than a stack trace:
```
Loaded manifest OK: weather-widget /weather
Resolved entrypoint OK: /tmp/.../installed/weather-widget/dist/index.js
Symlink escape correctly rejected: entrypoint 'dist/index.js' resolves outside the extension package root
Invalid name correctly rejected: ValidationError
```

## Video/Screenshots

N/A — backend manifest/validation module only, no UI or HTTP route in this PR (the REST API surface is #4352, blocked on this one).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Scoped strictly to #4348. Everything else in the epic is a separate, already-filed ticket that depends on this one: installation persistence (#4350), staged install/atomic swap (#4351), REST API surface (#4352), OpenAPI/typescript-client (#4354), audit logging (#4355), manifest API-scope + reserved names (#4356), adversarial fuzz suite (#4357). #4349 (`requested_ref` field) is independent SDK work, not touched here.