### PR TITLE
feat(agent-server): Canvas Extensions installation persistence [3/4]

### DIFF
--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
@@ -1,6 +1,18 @@
 """Canvas Extensions: installable UI bundles that contribute pages to Canvas."""
 
+from openhands.agent_server.canvas_extensions.installed import (
+    InstalledCanvasExtensionInfo,
+    disable_canvas_extension,
+    enable_canvas_extension,
+    get_installed_canvas_extension,
+    get_installed_canvas_extensions_dir,
+    install_canvas_extension,
+    list_installed_canvas_extensions,
+    load_installed_canvas_extensions,
+    uninstall_canvas_extension,
+)
 from openhands.agent_server.canvas_extensions.manifest import (
+    MANIFEST_FILENAME,
     CanvasExtensionContributes,
     CanvasExtensionManifest,
     CanvasExtensionPage,
@@ -12,5 +24,15 @@ __all__ = [
     "CanvasExtensionManifest",
     "CanvasExtensionContributes",
     "CanvasExtensionPage",
+    "MANIFEST_FILENAME",
     "resolve_entrypoint",
+    "InstalledCanvasExtensionInfo",
+    "install_canvas_extension",
+    "uninstall_canvas_extension",
+    "enable_canvas_extension",
+    "disable_canvas_extension",
+    "list_installed_canvas_extensions",
+    "load_installed_canvas_extensions",
+    "get_installed_canvas_extension",
+    "get_installed_canvas_extensions_dir",
 ]

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
@@ -169,8 +169,25 @@ def list_installed_canvas_extensions(
 def load_installed_canvas_extensions(
     installed_dir: Path | None = None,
 ) -> list[CanvasExtensionManifest]:
-    """Load all enabled canvas extensions' manifests."""
-    return _manager(_resolve_installed_dir(installed_dir)).load_installed()
+    """Load all enabled canvas extensions' manifests.
+
+    Runs through ``list_installed_canvas_extensions`` first so discovery
+    is force-disabled before anything is loaded -- see the module
+    docstring. Mirrors ``InstallationManager.load_installed()``'s own
+    enabled-filter/load logic on top of the corrected info list.
+    """
+    installed_dir = _resolve_installed_dir(installed_dir)
+    manager = _manager(installed_dir)
+    manifests: list[CanvasExtensionManifest] = []
+    for info in list_installed_canvas_extensions(installed_dir):
+        if not info.enabled:
+            continue
+        extension_path = installed_dir / info.name
+        if extension_path.exists():
+            manifests.append(
+                manager.installation_interface.load_from_dir(extension_path)
+            )
+    return manifests
 
 
 def get_installed_canvas_extension(

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
@@ -1,0 +1,180 @@
+"""Installed Canvas Extensions: the disabled-by-default guarantee.
+
+Built on ``openhands.sdk.extensions.installation``, the shared install-
+tracking framework Plugins/Skills also use. Not reused unmodified though:
+``InstallationInfo.enabled`` defaults to ``True``, and neither
+``InstallationManager.install()`` nor its self-healing directory discovery
+override that for a genuinely new entry (only a force-reinstall of an
+already-tracked name preserves its prior state). This module corrects that,
+as an explicit post-write step, so any newly created entry — from an
+install or from discovery — lands disabled until explicitly enabled.
+"""
+
+from pathlib import Path
+
+from openhands.agent_server.canvas_extensions.manifest import (
+    MANIFEST_FILENAME,
+    CanvasExtensionManifest,
+    resolve_entrypoint,
+)
+from openhands.sdk.extensions.installation import (
+    InstallationInfo,
+    InstallationInterface,
+    InstallationManager,
+    InstallationMetadata,
+)
+
+
+# Public type alias, matching the InstalledPluginInfo convention.
+InstalledCanvasExtensionInfo = InstallationInfo
+
+
+def get_installed_canvas_extensions_dir() -> Path:
+    """Get the default directory for installed canvas extensions."""
+    return Path.home() / ".openhands" / "canvas-extensions" / "installed"
+
+
+class CanvasExtensionInstallationInterface(
+    InstallationInterface[CanvasExtensionManifest]
+):
+    @staticmethod
+    def load_from_dir(extension_dir: Path) -> CanvasExtensionManifest:
+        manifest_path = extension_dir / MANIFEST_FILENAME
+        manifest = CanvasExtensionManifest.model_validate_json(
+            manifest_path.read_text()
+        )
+        # Runs on every load (install + discovery): a parseable manifest
+        # isn't enough to trust the directory, containment must hold too.
+        resolve_entrypoint(manifest, extension_dir)
+        return manifest
+
+
+def _resolve_installed_dir(installed_dir: Path | None) -> Path:
+    return (
+        installed_dir
+        if installed_dir is not None
+        else get_installed_canvas_extensions_dir()
+    )
+
+
+def _manager(installed_dir: Path) -> InstallationManager[CanvasExtensionManifest]:
+    return InstallationManager(
+        installation_dir=installed_dir,
+        installation_interface=CanvasExtensionInstallationInterface(),
+    )
+
+
+def _tracked_names(installed_dir: Path) -> set[str]:
+    """Names backed by a real, valid tracked entry -- not just a metadata key.
+
+    A stale record with no matching directory (e.g. seeded to smuggle
+    ``enabled: true`` ahead of an install it doesn't correspond to yet)
+    must not count as "already installed", or a real install of that name
+    would inherit it as if it were a legitimate force-reinstall.
+    """
+    if not installed_dir.exists():
+        return set()
+    metadata = InstallationMetadata.load_from_dir(installed_dir)
+    return {info.name for info in metadata.validate_tracked(installed_dir)}
+
+
+def _force_disable_new(
+    manager: InstallationManager[CanvasExtensionManifest],
+    info: InstallationInfo,
+    pre_existing: set[str],
+) -> InstallationInfo:
+    """Force a newly created tracked entry to ``enabled=False``.
+
+    ``pre_existing`` (names tracked *before* the write that produced
+    ``info``) distinguishes a genuinely new entry from a force-reinstall of
+    an already-tracked one, whose prior enabled state is already preserved
+    correctly -- see the module docstring.
+    """
+    if info.name in pre_existing or not info.enabled:
+        return info
+    manager.disable(info.name)
+    info.enabled = False
+    return info
+
+
+def install_canvas_extension(
+    source: str,
+    ref: str | None = None,
+    repo_path: str | None = None,
+    installed_dir: Path | None = None,
+    force: bool = False,
+) -> InstalledCanvasExtensionInfo:
+    """Install a canvas extension from a source.
+
+    A newly created tracked entry always lands disabled — enabling is a
+    separate, explicit step, regardless of anything a caller passes in.
+    See the module docstring for why this doesn't just delegate to
+    ``InstallationManager.install()`` unmodified.
+
+    Args:
+        source: Extension source — ``"github:owner/repo"``, git URL, or
+            local path.
+        ref: Optional branch, tag, or commit to install.
+        repo_path: Subdirectory path within the repository (for monorepos).
+        installed_dir: Directory for installed canvas extensions. Defaults
+            to ``~/.openhands/canvas-extensions/installed/``.
+        force: If True, overwrite an existing installation.
+
+    Returns:
+        InstalledCanvasExtensionInfo with details about the installation.
+    """
+    installed_dir = _resolve_installed_dir(installed_dir)
+    manager = _manager(installed_dir)
+    pre_existing = _tracked_names(installed_dir)
+    info = manager.install(source, ref=ref, repo_path=repo_path, force=force)
+    return _force_disable_new(manager, info, pre_existing)
+
+
+def uninstall_canvas_extension(name: str, installed_dir: Path | None = None) -> bool:
+    """Uninstall a canvas extension by name.
+
+    Returns:
+        True if the extension was uninstalled, False if it wasn't installed.
+    """
+    return _manager(_resolve_installed_dir(installed_dir)).uninstall(name)
+
+
+def enable_canvas_extension(name: str, installed_dir: Path | None = None) -> bool:
+    """Enable an installed canvas extension by name."""
+    return _manager(_resolve_installed_dir(installed_dir)).enable(name)
+
+
+def disable_canvas_extension(name: str, installed_dir: Path | None = None) -> bool:
+    """Disable an installed canvas extension by name."""
+    return _manager(_resolve_installed_dir(installed_dir)).disable(name)
+
+
+def list_installed_canvas_extensions(
+    installed_dir: Path | None = None,
+) -> list[InstalledCanvasExtensionInfo]:
+    """List all installed canvas extensions.
+
+    Self-healing like ``InstallationManager.list_installed()``. A directory
+    discovered this way (dropped in directly, bypassing
+    ``install_canvas_extension``) also lands disabled — see the module
+    docstring.
+    """
+    installed_dir = _resolve_installed_dir(installed_dir)
+    manager = _manager(installed_dir)
+    pre_existing = _tracked_names(installed_dir)
+    infos = manager.list_installed()
+    return [_force_disable_new(manager, info, pre_existing) for info in infos]
+
+
+def load_installed_canvas_extensions(
+    installed_dir: Path | None = None,
+) -> list[CanvasExtensionManifest]:
+    """Load all enabled canvas extensions' manifests."""
+    return _manager(_resolve_installed_dir(installed_dir)).load_installed()
+
+
+def get_installed_canvas_extension(
+    name: str, installed_dir: Path | None = None
+) -> InstalledCanvasExtensionInfo | None:
+    """Get information about a specific installed canvas extension."""
+    return _manager(_resolve_installed_dir(installed_dir)).get(name)

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/manifest.py
@@ -16,11 +16,15 @@ two security-critical checks around it:
 
 import re
 from pathlib import Path
+from typing import Final
 
 from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.extensions.installation.utils import validate_extension_name
 
+
+# Filename a canvas extension's manifest is loaded from, at its package root.
+MANIFEST_FILENAME: Final[str] = "canvas-extension.json"
 
 # Absolute, kebab-case, multi-segment UI route, e.g. "/dashboard/settings".
 _PAGE_PATH_PATTERN: re.Pattern[str] = re.compile(

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
@@ -158,6 +158,25 @@ def test_manually_placed_directory_discovered_disabled(
     assert info.enabled is False
 
 
+def test_manually_placed_directory_discovered_disabled_excludes_from_load(
+    installed_dir: Path,
+):
+    """load_installed_canvas_extensions() must apply the same
+    disabled-by-default guarantee as list_installed_canvas_extensions() --
+    discovery here must not leave the extension loadable.
+    """
+    installed_dir.mkdir(parents=True)
+    manual = installed_dir / "manual-ext"
+    _write_extension(manual, name="manual-ext")
+    assert not (installed_dir / InstallationMetadata.metadata_filename).exists()
+
+    loaded = load_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert loaded == []
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert on_disk.extensions["manual-ext"].enabled is False
+
+
 def test_previously_enabled_tracked_extension_not_reset_by_listing(
     extension_dir: Path, installed_dir: Path
 ):

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
@@ -1,0 +1,413 @@
+"""Tests for canvas extension installation persistence.
+
+Covers the disabled-by-default regression scenarios (fresh install,
+smuggled ``enabled: true`` in stale metadata, manually-placed directory
+discovery), plus force-reinstall state preservation and entrypoint
+containment enforced at load time.
+"""
+
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from openhands.agent_server.canvas_extensions.installed import (
+    disable_canvas_extension,
+    enable_canvas_extension,
+    get_installed_canvas_extension,
+    get_installed_canvas_extensions_dir,
+    install_canvas_extension,
+    list_installed_canvas_extensions,
+    load_installed_canvas_extensions,
+    uninstall_canvas_extension,
+)
+from openhands.agent_server.canvas_extensions.manifest import MANIFEST_FILENAME
+from openhands.sdk.extensions.installation import InstallationMetadata
+
+
+def _write_extension(
+    directory: Path,
+    name: str = "my-extension",
+    version: str = "1.0.0",
+    display_name: str = "My Extension",
+    description: str = "",
+    entrypoint: str = "dist/index.js",
+) -> Path:
+    """Write a valid, loadable canvas extension package to *directory*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "name": name,
+        "display_name": display_name,
+        "version": version,
+        "description": description,
+        "entrypoint": entrypoint,
+    }
+    (directory / MANIFEST_FILENAME).write_text(json.dumps(manifest))
+    entry_file = directory / entrypoint
+    entry_file.parent.mkdir(parents=True, exist_ok=True)
+    entry_file.write_text("console.log('ok')")
+    return directory
+
+
+@pytest.fixture
+def extension_dir(tmp_path: Path) -> Path:
+    return _write_extension(tmp_path / "source" / "my-extension")
+
+
+@pytest.fixture
+def installed_dir(tmp_path: Path) -> Path:
+    return tmp_path / "installed"
+
+
+def test_default_installed_dir_layout():
+    parts = get_installed_canvas_extensions_dir().parts
+    assert parts[-3:] == (".openhands", "canvas-extensions", "installed")
+
+
+def test_fresh_install_lands_disabled(extension_dir: Path, installed_dir: Path):
+    info = install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    assert info.enabled is False
+
+    # Not just the in-memory return value -- persisted to disk too.
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert on_disk.extensions["my-extension"].enabled is False
+
+
+def test_fresh_install_disabled_excludes_from_load(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    loaded = load_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert loaded == []
+
+
+def test_explicit_enable_after_install_makes_it_load(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    assert enable_canvas_extension("my-extension", installed_dir=installed_dir) is True
+
+    loaded = load_installed_canvas_extensions(installed_dir=installed_dir)
+    assert [m.name for m in loaded] == ["my-extension"]
+
+
+def test_smuggled_enabled_true_in_stale_metadata_is_ignored(
+    extension_dir: Path, installed_dir: Path
+):
+    """Otherwise a real install of that name would inherit it as if it
+    were a legitimate force-reinstall.
+    """
+    installed_dir.mkdir(parents=True)
+    (installed_dir / InstallationMetadata.metadata_filename).write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "my-extension": {
+                        "name": "my-extension",
+                        "version": "0.0.0",
+                        "description": "",
+                        "enabled": True,
+                        "source": "local",
+                        "install_path": str(installed_dir / "my-extension"),
+                    }
+                }
+            }
+        )
+    )
+    assert not (installed_dir / "my-extension").exists()
+
+    info = install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    assert info.enabled is False
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert on_disk.extensions["my-extension"].enabled is False
+
+
+def test_install_ignores_unexpected_kwargs():
+    """No ``enabled`` parameter exists to pass one through, smuggled or not."""
+    params = inspect.signature(install_canvas_extension).parameters
+    assert "enabled" not in params
+
+
+def test_manually_placed_directory_discovered_disabled(
+    extension_dir: Path, installed_dir: Path
+):
+    installed_dir.mkdir(parents=True)
+    manual = installed_dir / "manual-ext"
+    _write_extension(manual, name="manual-ext")
+    # No .installed.json entry at all -- fully bypasses the install API.
+    assert not (installed_dir / InstallationMetadata.metadata_filename).exists()
+
+    discovered = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert len(discovered) == 1
+    assert discovered[0].name == "manual-ext"
+    assert discovered[0].enabled is False
+
+    # And it stays disabled on a subsequent get(), reading persisted state.
+    info = get_installed_canvas_extension("manual-ext", installed_dir=installed_dir)
+    assert info is not None
+    assert info.enabled is False
+
+
+def test_previously_enabled_tracked_extension_not_reset_by_listing(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+    infos = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert len(infos) == 1
+    assert infos[0].enabled is True
+
+
+def test_list_handles_mixed_states_across_multiple_extensions(
+    tmp_path: Path, installed_dir: Path
+):
+    """The per-entry force-disable correction must not cross-contaminate
+    sibling entries within the same listing call.
+    """
+    enabled_src = _write_extension(tmp_path / "source" / "enabled", name="enabled-ext")
+    disabled_src = _write_extension(
+        tmp_path / "source" / "disabled", name="disabled-ext"
+    )
+    install_canvas_extension(str(enabled_src), installed_dir=installed_dir)
+    enable_canvas_extension("enabled-ext", installed_dir=installed_dir)
+    install_canvas_extension(str(disabled_src), installed_dir=installed_dir)
+    _write_extension(installed_dir / "manual-ext", name="manual-ext")
+
+    states = {
+        info.name: info.enabled
+        for info in list_installed_canvas_extensions(installed_dir=installed_dir)
+    }
+
+    assert states == {
+        "enabled-ext": True,
+        "disabled-ext": False,
+        "manual-ext": False,
+    }
+
+
+def test_list_tolerates_invalid_name_in_stale_metadata(installed_dir: Path):
+    installed_dir.mkdir(parents=True)
+    (installed_dir / InstallationMetadata.metadata_filename).write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "Bad_Name": {
+                        "name": "Bad_Name",
+                        "version": "0.0.0",
+                        "description": "",
+                        "enabled": True,
+                        "source": "local",
+                        "install_path": str(installed_dir / "Bad_Name"),
+                    }
+                }
+            }
+        )
+    )
+
+    infos = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert infos == []
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert "Bad_Name" not in on_disk.extensions
+
+
+def test_list_empty_installed_dir_returns_empty(installed_dir: Path):
+    assert list_installed_canvas_extensions(installed_dir=installed_dir) == []
+
+
+def test_list_nonexistent_installed_dir_returns_empty(tmp_path: Path):
+    missing = tmp_path / "does-not-exist"
+    assert list_installed_canvas_extensions(installed_dir=missing) == []
+
+
+def test_force_reinstall_preserves_enabled_state(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+    info = install_canvas_extension(
+        str(extension_dir), installed_dir=installed_dir, force=True
+    )
+
+    assert info.enabled is True
+
+
+def test_force_reinstall_preserves_disabled_state(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    info = install_canvas_extension(
+        str(extension_dir), installed_dir=installed_dir, force=True
+    )
+
+    assert info.enabled is False
+
+
+def test_install_without_force_raises_when_already_installed(
+    extension_dir: Path, installed_dir: Path
+):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+    with pytest.raises(FileExistsError):
+        install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    # The existing install is untouched by the rejected attempt.
+    info = get_installed_canvas_extension("my-extension", installed_dir=installed_dir)
+    assert info is not None
+    assert info.enabled is True
+
+
+def test_install_rejects_manifest_with_escaping_entrypoint(
+    tmp_path: Path, installed_dir: Path
+):
+    outside = tmp_path / "outside.js"
+    outside.write_text("payload")
+
+    malicious = tmp_path / "source" / "evil-extension"
+    malicious.mkdir(parents=True)
+    (malicious / MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "evil-extension",
+                "display_name": "Evil",
+                "version": "1.0.0",
+                "entrypoint": "escape.js",
+            }
+        )
+    )
+    (malicious / "escape.js").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="resolves outside"):
+        install_canvas_extension(str(malicious), installed_dir=installed_dir)
+
+    # Rejected before anything was tracked or copied.
+    assert not (installed_dir / "evil-extension").exists()
+    assert list_installed_canvas_extensions(installed_dir=installed_dir) == []
+
+
+def test_discovery_skips_directory_with_escaping_entrypoint(
+    tmp_path: Path, installed_dir: Path
+):
+    installed_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.js"
+    outside.write_text("payload")
+
+    manual = installed_dir / "evil-extension"
+    manual.mkdir(parents=True)
+    (manual / MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "evil-extension",
+                "display_name": "Evil",
+                "version": "1.0.0",
+                "entrypoint": "escape.js",
+            }
+        )
+    )
+    (manual / "escape.js").symlink_to(outside)
+
+    discovered = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert discovered == []
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert "evil-extension" not in on_disk.extensions
+
+
+@pytest.mark.parametrize(
+    "drop_field,name_override",
+    [
+        pytest.param("entrypoint", None, id="missing-required-field"),
+        pytest.param(None, "Bad_Name", id="invalid-name"),
+    ],
+)
+def test_install_rejects_invalid_manifest(
+    tmp_path: Path,
+    installed_dir: Path,
+    drop_field: str | None,
+    name_override: str | None,
+):
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "name": name_override or "bad-extension",
+        "display_name": "Bad",
+        "version": "1.0.0",
+        "entrypoint": "dist/index.js",
+    }
+    if drop_field:
+        del payload[drop_field]
+    bad = tmp_path / "source" / "bad-extension"
+    bad.mkdir(parents=True)
+    (bad / MANIFEST_FILENAME).write_text(json.dumps(payload))
+
+    with pytest.raises(ValidationError):
+        install_canvas_extension(str(bad), installed_dir=installed_dir)
+
+    assert list_installed_canvas_extensions(installed_dir=installed_dir) == []
+
+
+def test_discovery_skips_directory_without_manifest_file(installed_dir: Path):
+    installed_dir.mkdir(parents=True)
+    (installed_dir / "no-manifest").mkdir()
+    (installed_dir / "no-manifest" / "random.txt").write_text("not a manifest")
+
+    discovered = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert discovered == []
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert "no-manifest" not in on_disk.extensions
+
+
+def test_discovery_skips_directory_with_mismatched_manifest_name(installed_dir: Path):
+    installed_dir.mkdir(parents=True)
+    _write_extension(installed_dir / "dir-name", name="manifest-name")
+
+    discovered = list_installed_canvas_extensions(installed_dir=installed_dir)
+
+    assert discovered == []
+    on_disk = InstallationMetadata.load_from_dir(installed_dir)
+    assert "dir-name" not in on_disk.extensions
+    assert "manifest-name" not in on_disk.extensions
+
+
+def test_uninstall_removes_tracked_extension(extension_dir: Path, installed_dir: Path):
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    assert (
+        uninstall_canvas_extension("my-extension", installed_dir=installed_dir) is True
+    )
+    assert not (installed_dir / "my-extension").exists()
+    assert (
+        get_installed_canvas_extension("my-extension", installed_dir=installed_dir)
+        is None
+    )
+
+
+def test_uninstall_untracked_extension_returns_false(installed_dir: Path):
+    assert (
+        uninstall_canvas_extension("nonexistent", installed_dir=installed_dir) is False
+    )
+
+
+def test_disable_nonexistent_extension_returns_false(installed_dir: Path):
+    assert disable_canvas_extension("nonexistent", installed_dir=installed_dir) is False
+
+
+def test_enable_nonexistent_extension_returns_false(installed_dir: Path):
+    assert enable_canvas_extension("nonexistent", installed_dir=installed_dir) is False


### PR DESCRIPTION
HUMAN:

Adding installation persistence for canvas-extension.

---

AGENT:

## Why

Part of the Canvas Extensions backend build-out (#4348). Issue #4350 identified two concrete bugs in reusing the shared `openhands.sdk.extensions.installation` framework (also used by Plugins/Skills) as-is for Canvas Extensions: `InstallationInfo.enabled` defaults to `True`, and neither `InstallationManager.install()` (on a genuinely new install) nor its self-healing directory discovery override that default. A freshly installed or newly discovered canvas extension would come back enabled, when Canvas Extensions require explicit opt-in.

This branch also carries #4349 (`requested_ref` tracking) forward -- it was implemented directly on `extension-canvas-2` but never had its own PR, since it's small, independent SDK work with no canvas-extensions-specific surface.

**Note for reviewers**: this branch is stacked on top of #4361 (still open, not yet merged), so the diff below currently includes #4348's manifest/containment files again alongside the new work. Those shrink out of this diff automatically once #4361 merges into `main`.

## Summary
- Add `openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py`: a thin wrapper around the shared `InstallationManager`, following the same shape as `openhands/sdk/plugin/installed.py`, with on-disk layout at `~/.openhands/canvas-extensions/installed/<name>/`.
- Force `enabled=False` on every write path that creates a *new* tracked entry (fresh install, self-healing discovery) via an explicit post-write correction, while correctly preserving the prior enabled state on a legitimate force-reinstall of an already-tracked extension. Hardened against a stale/tampered `.installed.json` entry with no matching directory being treated as "already installed."
- Wire up `resolve_entrypoint()` containment checking (built in #4348 but never called) at manifest load time, so both install and discovery enforce it.
- Add `MANIFEST_FILENAME` (`Final[str]`) constant to `manifest.py`.
- `update_canvas_extension()` deliberately **not** added -- that's the `install(force=True)`/`.update()` anti-pattern issue #4351 (staged install + atomic swap) exists to replace, not something to introduce here.

## Issue Number
#4350

## How to Test

```
uv run pytest tests/agent_server/canvas_extensions -v
```
77 tests pass (25 for the new persistence module, plus the existing manifest/containment suites). Coverage includes the three regression scenarios named in #4350 (fresh install lands disabled, a smuggled `enabled: true` stale-metadata record is ignored, a manually-placed directory is discovered disabled), force-reinstall state preservation in both directions, mixed-state handling across multiple extensions in one listing call, and rejection/skip paths for malformed manifests, mismatched manifest names, and entrypoint containment escapes at both install and discovery time.

Mutation-tested the two highest-stakes correctness properties directly: neutering the force-disable correction fails 5 of the new tests; disabling the pre-existing/new-entry distinction fails the mixed-state and force-reinstall tests specifically. Confirms the tests exercise real logic, not just happy-path assertions.

`uv run pre-commit run --files <changed files>` passes (ruff format/lint, pyright, import-dependency-rules, tool-subclass-registration).

## Video/Screenshots

N/A -- backend persistence module only, no UI or HTTP route in this PR (REST API surface is #4352, blocked on this one).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Scoped to #4350 (+ carrying forward the already-implemented #4349). Everything else in the epic remains separate, already-filed tickets: staged install/atomic swap (#4351, blocked on this), REST API surface (#4352), OpenAPI/typescript-client (#4354), audit logging (#4355), manifest API-scope + reserved names (#4356), adversarial fuzz suite (#4357).