### PR TITLE
Set AI_AGENT for SDK subprocesses

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import threading
 from collections.abc import Mapping
+from typing import Final
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.redact import redact_text_secrets
@@ -16,7 +17,7 @@ logger = get_logger(__name__)
 # executed by the agent). These credentials allow access to user secrets via
 # the SaaS API and must remain isolated to the SDK's Python process.
 _SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})
-_AI_AGENT_ENV_VAR = "AI_AGENT"
+_AI_AGENT_ENV_VAR: Final[str] = "AI_AGENT"
 
 
 def sanitized_env(

--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -16,6 +16,7 @@ logger = get_logger(__name__)
 # executed by the agent). These credentials allow access to user secrets via
 # the SaaS API and must remain isolated to the SDK's Python process.
 _SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})
+_AI_AGENT_ENV_VAR = "AI_AGENT"
 
 
 def sanitized_env(
@@ -30,6 +31,9 @@ def sanitized_env(
     Sensitive environment variables (e.g., ``SESSION_API_KEY``) are stripped
     to prevent LLM-driven agents from accessing credentials via terminal
     commands.
+
+    ``AI_AGENT`` defaults to ``openhands`` so downstream tools can select
+    agent-friendly output without relying on product-specific heuristics.
     """
 
     base_env: dict[str, str]
@@ -41,6 +45,9 @@ def sanitized_env(
     # Strip sensitive env vars to prevent agent access via bash commands
     for key in _SENSITIVE_ENV_VARS:
         base_env.pop(key, None)
+
+    if not base_env.get(_AI_AGENT_ENV_VAR, "").strip():
+        base_env[_AI_AGENT_ENV_VAR] = "openhands"
 
     if "LD_LIBRARY_PATH_ORIG" in base_env:
         origin = base_env["LD_LIBRARY_PATH_ORIG"]

--- a/tests/sdk/utils/test_command.py
+++ b/tests/sdk/utils/test_command.py
@@ -19,6 +19,11 @@ def test_sanitized_env_preserves_explicit_ai_agent():
     assert result["AI_AGENT"] == "wrapper"
 
 
+def test_sanitized_env_replaces_blank_ai_agent():
+    result = sanitized_env({"AI_AGENT": "  "})
+    assert result["AI_AGENT"] == "openhands"
+
+
 def test_sanitized_env_defaults_to_os_environ(monkeypatch):
     """When env is None, returns a dict based on os.environ."""
     monkeypatch.setenv("TEST_SANITIZED_ENV_VAR", "test_value")

--- a/tests/sdk/utils/test_command.py
+++ b/tests/sdk/utils/test_command.py
@@ -10,8 +10,13 @@ def test_sanitized_env_returns_copy():
     """Returns a dict copy, not the original."""
     env = {"FOO": "bar"}
     result = sanitized_env(env)
-    assert result == {"FOO": "bar"}
+    assert result == {"FOO": "bar", "AI_AGENT": "openhands"}
     assert result is not env
+
+
+def test_sanitized_env_preserves_explicit_ai_agent():
+    result = sanitized_env({"AI_AGENT": "wrapper"})
+    assert result["AI_AGENT"] == "wrapper"
 
 
 def test_sanitized_env_defaults_to_os_environ(monkeypatch):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Reviewed manually, tested automatically using other agents. Very simple PR aligning with the most recent trands in the industry. I think it is useful.

---

AGENT:

## Why

The process launching a tool knows its agent identity exactly. Without a common marker, every downstream CLI must maintain product-specific environment and parent-process heuristics just to select agent-friendly behavior such as JSON output, no pager, quiet progress, or no prompts.

`AI_AGENT` is a universal marker that turns that growing N-by-M integration problem into one stable convention: agents write a slug and tools read one variable. It is advisory UX metadata only, not an authorization, sandbox, policy, or trust signal. An existing non-empty value is preserved so orchestrators and nested wrappers retain an intentional outer identity.

## Summary

- Default `AI_AGENT` to `openhands` in the SDK's centralized sanitized subprocess environment.
- Preserve explicit non-empty values and replace blank values.
- Cover default, blank, and override behavior in the command utility tests.

## Issue Number

No existing issue found for this focused interoperability change.

## How to Test

Executed repository-required hooks for both changed files:

`UV_CACHE_DIR=/tmp/uv-cache-openhands uv run pre-commit run --files openhands-sdk/openhands/sdk/utils/command.py tests/sdk/utils/test_command.py`

All applicable hooks passed: Ruff format, Ruff lint, pycodestyle, pyright, import dependency rules, and Tool subclass registration.

Executed focused tests:

`UV_CACHE_DIR=/tmp/uv-cache-openhands uv run pytest tests/sdk/utils/test_command.py -q`

Result: 12 passed.

Executed an end-to-end child-process reproduction using `sanitized_env({})`; the child printed `openhands`, and the command asserted that exact value.

Reviewer reproduction:

1. Call `sanitized_env({})` and pass the result to a child process.
2. Read `AI_AGENT` in the child and confirm it is `openhands`.
3. Repeat with `sanitized_env({"AI_AGENT": "wrapper"})` and confirm `wrapper` is preserved.

## Video/Screenshots

Not applicable; this is a subprocess environment change with no visual surface.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The marker is intentionally injected after sensitive environment variables are removed and before the resulting environment reaches terminal and other SDK subprocess call sites.
