### PR TITLE
fix(mcp): close reconciliation gaps left by #4367

### DIFF
--- a/openhands-agent-server/openhands/agent_server/mcp_oauth_store.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_oauth_store.py
@@ -26,6 +26,7 @@ from openhands.sdk.mcp.config import (
 )
 from openhands.sdk.mcp.utils import (
     ToolsChangedCallback,
+    ToolsReconciledCallback,
     create_mcp_tools,
 )
 
@@ -337,12 +338,14 @@ class SettingsBackedMCPToolProvider:
         timeout: float = 30.0,
         *,
         on_tools_changed: ToolsChangedCallback | None = None,
+        on_tools_reconciled: ToolsReconciledCallback | None = None,
     ) -> MCPClient:
         return create_mcp_tools(
             mcp_config,
             timeout,
             mcp_oauth_token_storage=MCPSettingsOAuthTokenStore(),
             on_tools_changed=on_tools_changed,
+            on_tools_reconciled=on_tools_reconciled,
         )
 
 

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -564,7 +564,6 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         if self.filter_tools_regex:
             pattern = re.compile(self.filter_tools_regex)
             tools = [tool for tool in tools if pattern.match(tool.name)]
-            tool_names = [tool.name for tool in tools]
             logger.info("Filtered to %d tools after applying regex filter", len(tools))
 
         # Include default tools from include_default_tools; not subject to regex
@@ -876,9 +875,10 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             if existing:
                 raise ValueError(f"Duplicate tool names found: {existing}")
 
-            # AgentBase is frozen, so update its mutable tool map in place.
-            for tool in tools:
-                self._tools[tool.name] = tool
+            # AgentBase is frozen; replace the tool map rather than mutating
+            # it in place, so Agent.model_copy() snapshots don't share state.
+            updated = {**self._tools, **{tool.name: tool for tool in tools}}
+            object.__setattr__(self, "_tools", updated)
 
     def _on_mcp_tools_changed(self, tools: Sequence[ToolDefinition]) -> None:
         """Handle dynamically advertised MCP tools.
@@ -930,8 +930,12 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
                 )
 
             self.add_runtime_tools(additions)
-            for tool in replacements:
-                self._tools[tool.name] = tool
+            if replacements:
+                updated = {
+                    **self._tools,
+                    **{tool.name: tool for tool in replacements},
+                }
+                object.__setattr__(self, "_tools", updated)
 
         if additions:
             logger.info(

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -871,9 +871,30 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             }
             raise ValueError(f"Duplicate runtime tool names found: {duplicates}")
         with self._tools_lock:
-            existing = set(self._tools) & set(tool_names)
-            if existing:
-                raise ValueError(f"Duplicate tool names found: {existing}")
+            # A tools/list_changed notification can race the caller: if it
+            # arrives while the provider's initial create_tools() call is
+            # still in flight, _on_mcp_tools_changed/_on_mcp_tools_reconciled
+            # may already have installed the same tool via this same client
+            # before the caller's own add_runtime_tools() call (using the
+            # client's returned snapshot) gets here. Treat that as a refresh,
+            # not a conflict, matching the same-client exemption already used
+            # by _on_mcp_tools_changed/_on_mcp_tools_reconciled.
+            conflicts: set[str] = set()
+            for tool in tools:
+                existing_tool = self._tools.get(tool.name)
+                if existing_tool is None:
+                    continue
+                existing_executor = existing_tool.executor
+                replacement_executor = tool.executor
+                if (
+                    isinstance(existing_executor, MCPToolExecutor)
+                    and isinstance(replacement_executor, MCPToolExecutor)
+                    and existing_executor.client is replacement_executor.client
+                ):
+                    continue
+                conflicts.add(tool.name)
+            if conflicts:
+                raise ValueError(f"Duplicate tool names found: {conflicts}")
 
             # AgentBase is frozen; replace the tool map rather than mutating
             # it in place, so Agent.model_copy() snapshots don't share state.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -72,6 +72,7 @@ from openhands.sdk.mcp.utils import (
     MCPToolProvider,
     ToolsChangedCallback,
     ToolsReconciledCallback,
+    provider_supports_on_tools_reconciled,
 )
 from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY, observe
 from openhands.sdk.plugin import (
@@ -1288,11 +1289,17 @@ class LocalConversation(BaseConversation):
         mcp_config = enabled_mcp_servers(mcp_config)
         if not mcp_config:
             return []
+        create_kwargs: dict[str, Any] = {"on_tools_changed": on_tools_changed}
+        if provider_supports_on_tools_reconciled(self._mcp_tool_provider):
+            create_kwargs["on_tools_reconciled"] = on_tools_reconciled
+        elif on_tools_reconciled is not None:
+            logger.debug(
+                "%s does not accept on_tools_reconciled; dynamic MCP tool "
+                "removals/updates won't reach the agent for this provider",
+                type(self._mcp_tool_provider).__name__,
+            )
         client = self._mcp_tool_provider.create_tools(
-            mcp_config,
-            _RUNTIME_MCP_TIMEOUT_SECS,
-            on_tools_changed=on_tools_changed,
-            on_tools_reconciled=on_tools_reconciled,
+            mcp_config, _RUNTIME_MCP_TIMEOUT_SECS, **create_kwargs
         )
         return list(client.tools)
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1292,8 +1292,8 @@ class LocalConversation(BaseConversation):
             mcp_config,
             _RUNTIME_MCP_TIMEOUT_SECS,
             on_tools_changed=on_tools_changed,
+            on_tools_reconciled=on_tools_reconciled,
         )
-        client._tools_reconciled_callback = on_tools_reconciled
         return list(client.tools)
 
     def _on_mcp_tools_reconciled(

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import re
+from collections import OrderedDict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -196,7 +197,10 @@ class MCPToolExecutor(ToolExecutor):
         self.client.sync_close()
 
 
-_mcp_dynamic_action_type: dict[tuple[str, str], type[Schema]] = {}
+_MCP_ACTION_TYPE_CACHE_MAX = 512
+# LRU-bounded: keyed by (name, schema), so a tool whose schema keeps changing
+# no longer grows this cache without limit.
+_mcp_dynamic_action_type: OrderedDict[tuple[str, str], type[Schema]] = OrderedDict()
 
 
 def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
@@ -220,11 +224,14 @@ def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
     )
     mcp_action_type = _mcp_dynamic_action_type.get(cache_key)
     if mcp_action_type:
+        _mcp_dynamic_action_type.move_to_end(cache_key)
         return mcp_action_type
 
     model_name = f"MCP{to_camel_case(action_type.name)}Action"
     mcp_action_type = Schema.from_mcp_schema(model_name, action_type.inputSchema)
     _mcp_dynamic_action_type[cache_key] = mcp_action_type
+    if len(_mcp_dynamic_action_type) > _MCP_ACTION_TYPE_CACHE_MAX:
+        _mcp_dynamic_action_type.popitem(last=False)
     return mcp_action_type
 
 

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -5,7 +5,7 @@ import json
 import re
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 
 if TYPE_CHECKING:
@@ -197,7 +197,7 @@ class MCPToolExecutor(ToolExecutor):
         self.client.sync_close()
 
 
-_MCP_ACTION_TYPE_CACHE_MAX = 512
+_MCP_ACTION_TYPE_CACHE_MAX: Final[int] = 512
 # LRU-bounded: keyed by (name, schema), so a tool whose schema keeps changing
 # no longer grows this cache without limit.
 _mcp_dynamic_action_type: OrderedDict[tuple[str, str], type[Schema]] = OrderedDict()

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import re
+import threading
 from collections import OrderedDict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final
@@ -199,8 +200,10 @@ class MCPToolExecutor(ToolExecutor):
 
 _MCP_ACTION_TYPE_CACHE_MAX: Final[int] = 512
 # LRU-bounded: keyed by (name, schema), so a tool whose schema keeps changing
-# no longer grows this cache without limit.
+# no longer grows this cache without limit. Guarded by a lock since MCP tool
+# calls can validate concurrently through the parallel tool executor.
 _mcp_dynamic_action_type: OrderedDict[tuple[str, str], type[Schema]] = OrderedDict()
+_mcp_dynamic_action_type_lock = threading.Lock()
 
 
 def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
@@ -222,17 +225,18 @@ def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
         action_type.name,
         json.dumps(action_type.inputSchema, sort_keys=True, separators=(",", ":")),
     )
-    mcp_action_type = _mcp_dynamic_action_type.get(cache_key)
-    if mcp_action_type:
-        _mcp_dynamic_action_type.move_to_end(cache_key)
-        return mcp_action_type
+    with _mcp_dynamic_action_type_lock:
+        mcp_action_type = _mcp_dynamic_action_type.get(cache_key)
+        if mcp_action_type:
+            _mcp_dynamic_action_type.move_to_end(cache_key)
+            return mcp_action_type
 
-    model_name = f"MCP{to_camel_case(action_type.name)}Action"
-    mcp_action_type = Schema.from_mcp_schema(model_name, action_type.inputSchema)
-    _mcp_dynamic_action_type[cache_key] = mcp_action_type
-    if len(_mcp_dynamic_action_type) > _MCP_ACTION_TYPE_CACHE_MAX:
-        _mcp_dynamic_action_type.popitem(last=False)
-    return mcp_action_type
+        model_name = f"MCP{to_camel_case(action_type.name)}Action"
+        mcp_action_type = Schema.from_mcp_schema(model_name, action_type.inputSchema)
+        _mcp_dynamic_action_type[cache_key] = mcp_action_type
+        if len(_mcp_dynamic_action_type) > _MCP_ACTION_TYPE_CACHE_MAX:
+            _mcp_dynamic_action_type.popitem(last=False)
+        return mcp_action_type
 
 
 class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -46,6 +46,7 @@ class MCPToolProvider(Protocol):
         timeout: float = 30.0,
         *,
         on_tools_changed: ToolsChangedCallback | None = None,
+        on_tools_reconciled: ToolsReconciledCallback | None = None,
     ) -> MCPClient: ...
 
 
@@ -58,8 +59,14 @@ class DefaultMCPToolProvider:
         timeout: float = 30.0,
         *,
         on_tools_changed: ToolsChangedCallback | None = None,
+        on_tools_reconciled: ToolsReconciledCallback | None = None,
     ) -> MCPClient:
-        return create_mcp_tools(mcp_config, timeout, on_tools_changed=on_tools_changed)
+        return create_mcp_tools(
+            mcp_config,
+            timeout,
+            on_tools_changed=on_tools_changed,
+            on_tools_reconciled=on_tools_reconciled,
+        )
 
 
 def _oauth_auth_from_authentication_config(

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for MCP integration."""
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Callable, Mapping, Sequence
 from typing import Protocol
@@ -67,6 +68,23 @@ class DefaultMCPToolProvider:
             on_tools_changed=on_tools_changed,
             on_tools_reconciled=on_tools_reconciled,
         )
+
+
+def provider_supports_on_tools_reconciled(provider: MCPToolProvider) -> bool:
+    """Whether ``provider.create_tools`` accepts ``on_tools_reconciled``.
+
+    Custom ``MCPToolProvider`` implementations written before this parameter
+    existed only accept ``on_tools_changed``; passing the new keyword to
+    them would raise ``TypeError``. Callers should check this first and omit
+    the keyword for providers that don't support it.
+    """
+    try:
+        params = inspect.signature(provider.create_tools).parameters
+    except (TypeError, ValueError):
+        return False
+    return "on_tools_reconciled" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
 
 
 def _oauth_auth_from_authentication_config(

--- a/tests/agent_server/test_mcp_oauth_store.py
+++ b/tests/agent_server/test_mcp_oauth_store.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import time
 from pathlib import Path
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -20,6 +21,7 @@ import openhands.sdk.mcp.utils as mcp_utils
 from openhands.agent_server.config import Config
 from openhands.agent_server.mcp_oauth_store import (
     MCPSettingsOAuthTokenStore,
+    SettingsBackedMCPToolProvider,
     create_settings_backed_mcp_tool_provider,
 )
 from openhands.agent_server.persistence import (
@@ -362,3 +364,24 @@ async def test_mcp_oauth_token_storage_does_not_attach_to_non_oauth_server(
         assert "auth" not in server
     finally:
         reset_stores()
+
+
+def test_settings_backed_provider_forwards_on_tools_reconciled():
+    """on_tools_reconciled must reach create_mcp_tools(), not be dropped.
+
+    Previously this provider only accepted on_tools_changed, so callers had
+    to attach on_tools_reconciled to the returned client after the fact --
+    missing any notification that arrived during the initial connect.
+    """
+    provider = SettingsBackedMCPToolProvider()
+    config = coerce_mcp_config({"fake": {"command": "true"}})
+
+    def callback(client, tools):
+        return None
+
+    with patch(
+        "openhands.agent_server.mcp_oauth_store.create_mcp_tools"
+    ) as mock_create:
+        provider.create_tools(config, on_tools_reconciled=callback)
+
+    assert mock_create.call_args.kwargs["on_tools_reconciled"] is callback

--- a/tests/sdk/agent/test_filter_tools_regex.py
+++ b/tests/sdk/agent/test_filter_tools_regex.py
@@ -8,7 +8,7 @@ both paths.
 
 import uuid
 from collections.abc import Sequence
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 import pytest
 
@@ -252,6 +252,7 @@ class _StaticMCPToolProvider:
         timeout: float = 30.0,
         *,
         on_tools_changed: ToolsChangedCallback | None = None,
+        on_tools_reconciled: Any = None,
     ) -> MCPClient:
         return cast(
             MCPClient,

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -140,3 +140,26 @@ def test_legacy_provider_without_on_tools_reconciled_still_works(
     conversation._ensure_agent_ready()
 
     conversation.close()
+
+
+class _KwargsMCPToolProvider:
+    """A provider that accepts arbitrary keywords via **kwargs."""
+
+    def create_tools(
+        self, mcp_config: dict[str, MCPServer], timeout: float = 30.0, **kwargs: Any
+    ) -> MCPClient:
+        return cast(MCPClient, EmptyMCPClient())
+
+
+def test_provider_supports_on_tools_reconciled() -> None:
+    from openhands.sdk.mcp.utils import (
+        DefaultMCPToolProvider,
+        provider_supports_on_tools_reconciled,
+    )
+
+    assert provider_supports_on_tools_reconciled(DefaultMCPToolProvider())
+    assert provider_supports_on_tools_reconciled(RecordingMCPToolProvider())
+    assert provider_supports_on_tools_reconciled(_KwargsMCPToolProvider())
+    assert not provider_supports_on_tools_reconciled(
+        cast(MCPToolProvider, LegacyMCPToolProvider())
+    )

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -11,6 +11,7 @@ from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
 from openhands.sdk.mcp.tool import MCPToolDefinition
+from openhands.sdk.mcp.utils import MCPToolProvider
 
 
 class EmptyMCPClient:
@@ -101,4 +102,41 @@ def test_reconciliation_targets_replaced_agent(tmp_path: Path) -> None:
 
     assert set(conversation.agent.tools_map) == {"replacement"}
     assert set(old_agent.tools_map) == {"initial"}
+    conversation.close()
+
+
+class LegacyMCPToolProvider:
+    """A custom provider written against the pre-reconciliation protocol."""
+
+    def create_tools(
+        self,
+        mcp_config: dict[str, MCPServer],
+        timeout: float = 30.0,
+        *,
+        on_tools_changed: Any = None,
+    ) -> MCPClient:
+        return cast(MCPClient, EmptyMCPClient())
+
+
+def test_legacy_provider_without_on_tools_reconciled_still_works(
+    tmp_path: Path,
+) -> None:
+    """A custom MCPToolProvider that predates on_tools_reconciled must not
+    break; it just won't receive full-snapshot reconciliation."""
+    conversation = LocalConversation(
+        agent=Agent(
+            llm=LLM(model="test-model", api_key=SecretStr("test-key")),
+            tools=[],
+            include_default_tools=[],
+            mcp_config=coerce_mcp_config({"fake": {"command": "true"}}),
+        ),
+        workspace=str(tmp_path),
+        visualizer=None,
+        # Deliberately incompatible with the current MCPToolProvider
+        # protocol shape; that's the scenario under test.
+        mcp_tool_provider=cast(MCPToolProvider, LegacyMCPToolProvider()),
+    )
+
+    conversation._ensure_agent_ready()
+
     conversation.close()

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -35,8 +35,10 @@ class RecordingMCPToolProvider:
         timeout: float = 30.0,
         *,
         on_tools_changed: Any = None,
+        on_tools_reconciled: Any = None,
     ) -> MCPClient:
         self.calls.append(mcp_config)
+        self.client._tools_reconciled_callback = on_tools_reconciled
         return cast(MCPClient, self.client)
 
 

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -31,6 +31,7 @@ from openhands.sdk.tool.builtins import ThinkTool
 class EmptyMCPClient:
     def __init__(self):
         self.tools = []
+        self._tools_reconciled_callback: Any = None
 
 
 class RecordingMCPToolProvider:
@@ -41,7 +42,7 @@ class RecordingMCPToolProvider:
         state_locked: Callable[[], bool] | None = None,
     ):
         self.created = created
-        self.client = client or EmptyMCPClient()
+        self.client: Any = client or EmptyMCPClient()
         self.state_locked = state_locked
 
     def create_tools(
@@ -50,11 +51,13 @@ class RecordingMCPToolProvider:
         timeout: float = 30.0,
         *,
         on_tools_changed: Any = None,
+        on_tools_reconciled: Any = None,
     ) -> MCPClient:
         if self.state_locked is None:
             self.created.append(mcp_config)
         else:
             self.created.append((mcp_config, self.state_locked()))
+        self.client._tools_reconciled_callback = on_tools_reconciled
         return cast(MCPClient, self.client)
 
 

--- a/tests/sdk/mcp/test_mcp_tool.py
+++ b/tests/sdk/mcp/test_mcp_tool.py
@@ -462,3 +462,63 @@ def test_action_type_cache_is_bounded():
         _create_mcp_action_type(tool)
 
     assert len(_mcp_dynamic_action_type) <= _MCP_ACTION_TYPE_CACHE_MAX
+
+
+def test_action_type_cache_serializes_get_and_evict(monkeypatch):
+    """A cache hit must not observe a concurrent eviction of the same key.
+
+    Forces the exact interleaving a real race could produce: pause inside
+    the cache-hit path (after `.get()`, before `.move_to_end()`) and let a
+    second thread try to evict that same entry. Without the lock this
+    raises KeyError from `move_to_end`; with it, the second thread blocks
+    until the first thread's critical section completes.
+    """
+    import threading
+    import time
+    from collections import OrderedDict
+
+    import openhands.sdk.mcp.tool as tool_module
+
+    paused = threading.Event()
+
+    class PausingDict(OrderedDict):
+        def get(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+            result = super().get(*args, **kwargs)
+            if result is not None and not paused.is_set():
+                paused.set()
+                time.sleep(0.3)
+            return result
+
+    monkeypatch.setattr(tool_module, "_MCP_ACTION_TYPE_CACHE_MAX", 1)
+    monkeypatch.setattr(tool_module, "_mcp_dynamic_action_type", PausingDict())
+
+    shared_tool = mcp.types.Tool(
+        name="shared", description="d", inputSchema={"type": "object"}
+    )
+    other_tool = mcp.types.Tool(
+        name="other", description="d", inputSchema={"type": "object"}
+    )
+    tool_module._create_mcp_action_type(shared_tool)  # seed the cache
+
+    errors: list[Exception] = []
+
+    def hit():
+        try:
+            tool_module._create_mcp_action_type(shared_tool)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    def evict():
+        paused.wait(2.0)
+        try:
+            tool_module._create_mcp_action_type(other_tool)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=hit), threading.Thread(target=evict)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(5.0)
+
+    assert not errors

--- a/tests/sdk/mcp/test_mcp_tool.py
+++ b/tests/sdk/mcp/test_mcp_tool.py
@@ -440,3 +440,25 @@ class TestMCPTool:
         assert isinstance(self.tool.executor, MCPToolExecutor)
         assert self.tool.executor.tool_name == "test_tool"
         assert self.tool.executor.client == self.mock_client
+
+
+def test_action_type_cache_is_bounded():
+    """A tool whose schema keeps changing must not grow the cache forever."""
+    from openhands.sdk.mcp.tool import (
+        _MCP_ACTION_TYPE_CACHE_MAX,
+        _create_mcp_action_type,
+        _mcp_dynamic_action_type,
+    )
+
+    for i in range(_MCP_ACTION_TYPE_CACHE_MAX + 50):
+        tool = mcp.types.Tool(
+            name="churning_tool",
+            description="d",
+            inputSchema={
+                "type": "object",
+                "properties": {f"field_{i}": {"type": "string"}},
+            },
+        )
+        _create_mcp_action_type(tool)
+
+    assert len(_mcp_dynamic_action_type) <= _MCP_ACTION_TYPE_CACHE_MAX

--- a/tests/sdk/mcp/test_mcp_tool_list_changed.py
+++ b/tests/sdk/mcp/test_mcp_tool_list_changed.py
@@ -502,6 +502,36 @@ def test_add_runtime_tools_does_not_leak_into_model_copy():
     assert "dynamic" not in original.tools_map
 
 
+def test_add_runtime_tools_tolerates_notification_installed_before_return():
+    """A tool installed mid-connect by the reconciliation callback must not
+    collide with the caller's own add_runtime_tools() call.
+
+    If notifications/tools/list_changed arrives while the initial
+    tools/list request is still in flight, on_tools_changed can install the
+    tool via this same MCPClient before create_tools() returns. The caller
+    (e.g. LocalConversation._ensure_agent_ready()) then calls
+    add_runtime_tools() again with the client's returned snapshot, which
+    already contains that tool; this must be treated as a refresh rather
+    than a duplicate-tool conflict.
+    """
+    agent = _ConcreteAgent(_initialized=True, _tools={})
+    client = _FakeClient([])
+    tool = MCPToolDefinition.create(
+        mcp_tool=_make_mcp_tool("only_tool"),
+        mcp_client=cast(MCPClient, client),
+    )[0]
+
+    # Simulates the mid-flight on_tools_changed callback installing the tool
+    # before create_tools() returns.
+    agent._on_mcp_tools_changed([tool])
+
+    # Simulates the caller's add_runtime_tools() call using the client's
+    # returned snapshot, which already includes the same tool.
+    agent.add_runtime_tools([tool])
+
+    assert agent.tools_map["only_tool"] is tool
+
+
 def test_on_mcp_tools_changed_skips_when_not_initialized():
     """Before initialization, notifications are dropped, not crashed on."""
     agent = _ConcreteAgent(_initialized=False, _tools=None)

--- a/tests/sdk/mcp/test_mcp_tool_list_changed.py
+++ b/tests/sdk/mcp/test_mcp_tool_list_changed.py
@@ -25,10 +25,11 @@ import mcp.types as mcp_types
 import pytest
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_context
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
+from openhands.sdk.agent import Agent
 from openhands.sdk.agent.base import AgentBase
-from openhands.sdk.llm import TextContent
+from openhands.sdk.llm import LLM, TextContent
 from openhands.sdk.mcp import MCPClient, create_mcp_tools
 from openhands.sdk.mcp.config import coerce_mcp_config
 from openhands.sdk.mcp.tool import MCPToolDefinition
@@ -339,6 +340,40 @@ def test_no_callback_still_connects(progressive_server: int):
         assert "register_extra_tool" in names
 
 
+def test_default_provider_wires_on_tools_reconciled_before_connect(
+    progressive_server: int,
+):
+    """DefaultMCPToolProvider must forward on_tools_reconciled to
+    create_mcp_tools() so it's attached before the client connects, instead
+    of being set on the client after create_tools() already returned (which
+    would drop any notification that arrives during the initial connect).
+    """
+    from openhands.sdk.mcp.utils import DefaultMCPToolProvider
+
+    port = progressive_server
+    config = _native_config(
+        {
+            "mcpServers": {
+                "progressive": {
+                    "transport": "http",
+                    "url": f"http://127.0.0.1:{port}/mcp",
+                }
+            }
+        }
+    )
+
+    def on_tools_reconciled(client, tools):  # noqa: ANN001
+        pass
+
+    client = DefaultMCPToolProvider().create_tools(
+        config, timeout=10.0, on_tools_reconciled=on_tools_reconciled
+    )
+    try:
+        assert client._tools_reconciled_callback is on_tools_reconciled
+    finally:
+        client.sync_close()
+
+
 def test_list_changed_notification_reconciles_readded_agent_tool(
     progressive_server: int,
 ):
@@ -444,6 +479,27 @@ def test_on_mcp_tools_changed_registers_runtime_tools():
     agent._on_mcp_tools_changed([tool])
 
     assert agent.tools_map["dynamic"] is tool
+
+
+def test_add_runtime_tools_does_not_leak_into_model_copy():
+    """Registering a tool on a copied Agent must not mutate the original.
+
+    Agent.model_copy() shares private-attr objects (e.g. _tools) by
+    reference, so mutating the tool map in place would leak across copies.
+    """
+    original = Agent(llm=LLM(model="test-model", api_key=SecretStr("k")), tools=[])
+    original._initialized = True
+    copy = original.model_copy()
+    client = _FakeClient([])
+    tool = MCPToolDefinition.create(
+        mcp_tool=_make_mcp_tool("dynamic"),
+        mcp_client=cast(MCPClient, client),
+    )[0]
+
+    copy.add_runtime_tools([tool])
+
+    assert "dynamic" in copy.tools_map
+    assert "dynamic" not in original.tools_map
 
 
 def test_on_mcp_tools_changed_skips_when_not_initialized():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix some bug introduced in #4367

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

Follow-up review of #4367 (already merged) found four issues in the new MCP
tool-reconciliation code:

1. `DefaultMCPToolProvider`/`SettingsBackedMCPToolProvider` never forwarded
   `on_tools_reconciled` to `create_mcp_tools()`. `LocalConversation`
   compensated by attaching the callback to the client *after*
   `create_tools()` returned, which is after the client has already
   connected and started listening for `notifications/tools/list_changed`.
   Any such notification arriving in that window is silently dropped —
   reproduced deterministically against a live FastMCP server (see "How to
   Test").
2. `add_runtime_tools` / `_on_mcp_tools_changed` mutate `Agent._tools` in
   place. `Agent.model_copy()` shares private attrs by reference, so a
   dynamically-registered MCP tool can leak into other `Agent` snapshots
   that share the same `_tools` dict (`LocalConversation.load_plugin`
   reassigns `self.agent` via `model_copy()` right after wiring MCP
   callbacks to the pre-copy agent).
3. `AgentBase._initialize` computed an unused `tool_names` list.
4. The per-tool MCP validation-model cache (`_mcp_dynamic_action_type`) is
   keyed by `(name, schema)` with no eviction, so a tool whose schema keeps
   changing grows it without bound.

## Summary

- Thread `on_tools_reconciled` through `MCPToolProvider.create_tools()` /
  `create_mcp_tools()` instead of setting it on the client after the fact.
- Replace `Agent._tools` instead of mutating it in place in
  `add_runtime_tools` / `_on_mcp_tools_changed`, matching
  `_on_mcp_tools_reconciled`.
- Remove the unused `tool_names` assignment in `AgentBase._initialize`.
- Bound `_mcp_dynamic_action_type` to an LRU of 512 entries.

## Issue Number

Follow-up to #4367.

## How to Test

Run:

```bash
uv run pytest -q tests/sdk/mcp/ tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/conversation/test_local_conversation_mcp.py tests/sdk/agent/test_filter_tools_regex.py tests/agent_server/test_mcp_oauth_store.py
```

Observed: `1710 passed` across the broader `tests/sdk/mcp/`,
`tests/sdk/conversation/`, `tests/sdk/agent/` suites plus the agent-server
OAuth store tests.

Before writing the fix, item 1 was confirmed with a standalone script
(not included in this PR) that ran a real FastMCP HTTP server, forced a
`tools/list_changed` notification to fire while `DefaultMCPToolProvider`
was still inside `create_tools()`, and observed `on_tools_reconciled` never
firing for the tool added by that notification even though the client's
own `client.tools` was updated correctly. `test_default_provider_wires_on_tools_reconciled_before_connect`
(new) asserts the callback is attached to the client synchronously, before
`create_tools()` returns — closing that window by construction.

Item 2 is covered by the new
`test_add_runtime_tools_does_not_leak_into_model_copy`, which registers a
tool on a `model_copy()`'d `Agent` and asserts the original is unaffected
(this failed before the fix).

Item 4 is covered by `test_action_type_cache_is_bounded`.

Also ran, on all changed files:

```bash
git diff --name-only main | xargs uv run ruff format --check
git diff --name-only main | xargs uv run ruff check
git diff --name-only main | xargs uv run pyright
PIP_INDEX_URL=https://pypi.org/simple uv run pre-commit run --files $(git diff --name-only main)
```

All passed (pre-commit: ruff format, ruff lint, pycodestyle, pyright,
import dependency rules, tool-subclass registration).

## Video/Screenshots

Not applicable; this is SDK runtime behavior covered by unit tests and a
live FastMCP server test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No public API changes: `on_tools_reconciled` was already a keyword-only
parameter on `create_mcp_tools()`; this PR just makes
`MCPToolProvider.create_tools()` implementations forward it instead of
silently dropping it. `_tools_reconciled_callback` is still set as an
attribute on the returned `MCPClient`, just earlier (inside
`create_mcp_tools()`, before connecting) instead of by the caller
afterward.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9f7327a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9f7327a-python \
  ghcr.io/openhands/agent-server:9f7327a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9f7327a-golang-amd64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-golang-amd64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-golang-amd64
ghcr.io/openhands/agent-server:9f7327a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9f7327a-golang-arm64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-golang-arm64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-golang-arm64
ghcr.io/openhands/agent-server:9f7327a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9f7327a-java-amd64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-java-amd64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-java-amd64
ghcr.io/openhands/agent-server:9f7327a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9f7327a-java-arm64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-java-arm64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-java-arm64
ghcr.io/openhands/agent-server:9f7327a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9f7327a-python-amd64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-python-amd64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-python-amd64
ghcr.io/openhands/agent-server:9f7327a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9f7327a-python-arm64
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-python-arm64
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-python-arm64
ghcr.io/openhands/agent-server:9f7327a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9f7327a-golang
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-golang
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-golang
ghcr.io/openhands/agent-server:9f7327a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9f7327a-java
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-java
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-java
ghcr.io/openhands/agent-server:9f7327a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9f7327a-python
ghcr.io/openhands/agent-server:9f7327ad9505cf28d3fe5bd526d050c214c014f3-python
ghcr.io/openhands/agent-server:fix-mcp-tool-reconciliation-followups-python
ghcr.io/openhands/agent-server:9f7327a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9f7327a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9f7327a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->