### PR TITLE
docs: encourage .pr/ HTML design doc + htmlpreview link for non-trivial PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,19 @@ Provide a video or screenshots of testing your PR. e.g. you added a new feature 
 
 -->
 
+## Design Doc
+
+<!--
+Optional, encouraged for non-trivial PRs. Add a self-contained HTML design doc under the
+temporary `.pr/` directory (e.g. `.pr/design.html`) covering the code/API design and a
+before/after of your change, then link it here via htmlpreview so reviewers see it at a glance:
+
+  https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
+
+The `.pr/` directory is temporary — it is removed automatically when the PR is approved.
+See CONTRIBUTING.md ("Design doc for non-trivial PRs") for details.
+-->
+
 ## Type
 
 - [ ] Bug fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,8 +57,9 @@ before/after of your change, then link it here via htmlpreview so reviewers see 
 
   https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
 
-The `.pr/` directory is temporary — it is removed automatically when the PR is approved.
-See CONTRIBUTING.md ("Design doc for non-trivial PRs") for details.
+The `.pr/` directory is temporary — it is removed automatically (on approval for
+same-repository PRs, right after merge for fork PRs). See CONTRIBUTING.md ("Design doc for
+non-trivial PRs") for details.
 -->
 
 ## Type

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ The convention:
    ```
 
 Skip this for trivial PRs (a typo, a one-line guard, a dependency bump, a small bug fix) — there, a design doc is
-just noise. htmlpreview only works for public repos and self-contained pages.
+just noise.
 
 The `pr-design-doc` skill in the [OpenHands extensions](https://github.com/OpenHands/extensions)
 repo can generate the page for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ This file is mostly about principles. For the mechanics, please see:
 For a non-trivial PR — a new or changed public API (Python or the agent-server REST/WebSocket
 surface), a new subsystem, a behavior change in the agent loop, or a migration — a reviewer
 often has to reconstruct the design from the diff alone. That is slow, and it is where the
-compatibility risks we care about hide. You are encouraged (not required) to add a short design
+compatibility risks we care about hide. You are encouraged (though not required) to add a short design
 doc so reviewers grasp the proposal at a glance.
 
 The convention:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,36 @@ This file is mostly about principles. For the mechanics, please see:
 - `examples/01_standalone_sdk/41_task_tool_set.py` for delegating work to registered subagents with resume support
 - `examples/01_standalone_sdk/42_file_based_subagents.py` for programmatic `AgentDefinition` registration
 
+## Design doc for non-trivial PRs
+
+For a non-trivial PR — a new or changed public API (Python or the agent-server REST/WebSocket
+surface), a new subsystem, a behavior change in the agent loop, or a migration — a reviewer
+often has to reconstruct the design from the diff alone. That is slow, and it is where the
+compatibility risks we care about hide. You are encouraged (not required) to add a short design
+doc so reviewers grasp the proposal at a glance.
+
+The convention:
+
+1. Write a **self-contained HTML** page (inline CSS/SVG, opens by double-click) that covers the
+   code/API design and a **before/after** of your change, grounded to the actual code. Show the
+   interface before and after when you touch one — signatures, schemas, or event shapes — and
+   state the compatibility impact (additive, breaking, or behind a flag).
+2. Commit it under the temporary **`.pr/`** directory, e.g. `.pr/design.html`. This directory is
+   for PR-only artifacts and is **removed automatically when the PR is approved**
+   (`.github/workflows/pr-artifacts.yml`), so it never lands in `main`.
+3. Link it near the top of the PR description via htmlpreview, pointing at the fork and branch the
+   PR is opened from so it renders before the PR is merged:
+
+   ```
+   https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
+   ```
+
+Skip this for trivial PRs (a typo, a one-line guard, a dependency bump) — there, a design doc is
+just noise. htmlpreview only works for public repos and self-contained pages.
+
+The `pr-design-doc` skill in the [OpenHands extensions](https://github.com/OpenHands/extensions)
+repo can generate the page for you.
+
 ## Questions / discussion
 
 Join us on Slack: https://openhands.dev/joinslack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,9 @@ The convention:
    interface before and after when you touch one — signatures, schemas, or event shapes — and
    state the compatibility impact (additive, breaking, or behind a flag).
 2. Commit it under the temporary **`.pr/`** directory, e.g. `.pr/design.html`. This directory is
-   for PR-only artifacts and is **removed automatically when the PR is approved**
-   (`.github/workflows/pr-artifacts.yml`), so it never lands in `main`.
+   for PR-only artifacts and is **removed automatically** by `.github/workflows/pr-artifacts.yml`:
+   same-repository PRs are cleaned up when the PR is approved, and fork PRs are cleaned up
+   automatically from the base branch right after merge — either way it does not persist in `main`.
 3. Link it near the top of the PR description via htmlpreview, pointing at the fork and branch the
    PR is opened from so it renders before the PR is merged:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ The convention:
    https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
    ```
 
-Skip this for trivial PRs (a typo, a one-line guard, a dependency bump) — there, a design doc is
+Skip this for trivial PRs (a typo, a one-line guard, a dependency bump, a small bug fix) — there, a design doc is
 just noise. htmlpreview only works for public repos and self-contained pages.
 
 The `pr-design-doc` skill in the [OpenHands extensions](https://github.com/OpenHands/extensions)


### PR DESCRIPTION
HUMAN:

Docs-only change, the SDK counterpart to OpenHands/OpenHands#16316. Reviewed the rendered template and CONTRIBUTING section locally; htmlpreview link shape verified against the .pr/ convention already wired in this repo.

AGENT:

## Why

Reviewers of a non-trivial SDK PR often reconstruct the design from the diff alone — slow, and it is exactly where the compatibility risks this repo cares about hide (Python API + agent-server REST/WebSocket surface). This adds a soft, optional guideline: commit a self-contained HTML design doc under the temporary `.pr/` directory and link it via htmlpreview so reviewers see the code/API design and before/after at a glance. The `.pr/` directory is already auto-removed on approval (`.github/workflows/pr-artifacts.yml`).

This is the counterpart to the OpenHands/OpenHands guideline PR, same process, so both repos read consistently.

## Summary

- **PR template**: add an optional `## Design Doc` section with the htmlpreview link shape.
- **CONTRIBUTING.md**: add a "Design doc for non-trivial PRs" section, emphasizing the interface before/after and the compatibility impact (additive / breaking / behind a flag) this repo reviews for.

## Issue Number

N/A (docs; companion to OpenHands/OpenHands#16316)

## How to Test

Docs only — nothing to run. Read `.github/PULL_REQUEST_TEMPLATE.md` (new `## Design Doc` block) and `CONTRIBUTING.md` ("Design doc for non-trivial PRs"). The htmlpreview link shape is:

```
https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
```

Companion PRs: OpenHands/OpenHands#16316 (same guideline) and OpenHands/extensions#451 (the `pr-design-doc` skill that generates the page).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Soft-encouraged, not enforced. htmlpreview works only for public repos and self-contained pages.

Co-authored-by: smolpaws <engel@enyst.org>
