### PR TITLE
feat(agent-server): Canvas Extensions staged refresh (check/apply) [4/4]

### DIFF
--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/__init__.py
@@ -1,7 +1,10 @@
 """Canvas Extensions: installable UI bundles that contribute pages to Canvas."""
 
 from openhands.agent_server.canvas_extensions.installed import (
+    CanvasExtensionUpdateCheck,
     InstalledCanvasExtensionInfo,
+    apply_canvas_extension_update,
+    check_canvas_extension_update,
     disable_canvas_extension,
     enable_canvas_extension,
     get_installed_canvas_extension,
@@ -35,4 +38,7 @@ __all__ = [
     "load_installed_canvas_extensions",
     "get_installed_canvas_extension",
     "get_installed_canvas_extensions_dir",
+    "CanvasExtensionUpdateCheck",
+    "check_canvas_extension_update",
+    "apply_canvas_extension_update",
 ]

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions/installed.py
@@ -1,31 +1,43 @@
-"""Installed Canvas Extensions: the disabled-by-default guarantee.
+"""Installed Canvas Extensions.
 
-Built on ``openhands.sdk.extensions.installation``, the shared install-
-tracking framework Plugins/Skills also use. Not reused unmodified though:
-``InstallationInfo.enabled`` defaults to ``True``, and neither
-``InstallationManager.install()`` nor its self-healing directory discovery
-override that for a genuinely new entry (only a force-reinstall of an
-already-tracked name preserves its prior state). This module corrects that,
-as an explicit post-write step, so any newly created entry — from an
-install or from discovery — lands disabled until explicitly enabled.
+Built on ``openhands.sdk.extensions.installation``, shared with Plugins/
+Skills, with two behaviors specific to this module:
+
+Disabled by default -- ``InstallationInfo.enabled`` defaults to ``True``
+and neither ``InstallationManager.install()`` nor its directory discovery
+override that for a new entry, so every write path that can create one
+forces ``enabled=False`` as an explicit post-write step.
+
+Staged refresh -- ``check``/``apply`` replace ``update()``/
+``install(force=True)``, which rmtree+copytree straight onto the live
+install path with no staging directory. ``check`` fetches and validates
+into ``.staging/`` without touching the active install; ``apply`` swaps it
+in via two atomic renames (POSIX can't atomically replace a non-empty
+directory in one rename), rolling back if the second fails.
 """
 
+import os
+import shutil
 from pathlib import Path
+
+from pydantic import BaseModel, Field, ValidationError
 
 from openhands.agent_server.canvas_extensions.manifest import (
     MANIFEST_FILENAME,
     CanvasExtensionManifest,
     resolve_entrypoint,
 )
+from openhands.sdk.extensions.fetch import fetch_with_resolution
 from openhands.sdk.extensions.installation import (
     InstallationInfo,
     InstallationInterface,
     InstallationManager,
     InstallationMetadata,
 )
+from openhands.sdk.extensions.installation.manager import DEFAULT_CACHE_DIR
 
 
-# Public type alias, matching the InstalledPluginInfo convention.
+# Matches the InstalledPluginInfo naming convention.
 InstalledCanvasExtensionInfo = InstallationInfo
 
 
@@ -43,8 +55,7 @@ class CanvasExtensionInstallationInterface(
         manifest = CanvasExtensionManifest.model_validate_json(
             manifest_path.read_text()
         )
-        # Runs on every load (install + discovery): a parseable manifest
-        # isn't enough to trust the directory, containment must hold too.
+        # Containment must hold too -- a parseable manifest alone isn't enough.
         resolve_entrypoint(manifest, extension_dir)
         return manifest
 
@@ -65,12 +76,11 @@ def _manager(installed_dir: Path) -> InstallationManager[CanvasExtensionManifest
 
 
 def _tracked_names(installed_dir: Path) -> set[str]:
-    """Names backed by a real, valid tracked entry -- not just a metadata key.
+    """Names with a real, valid tracked entry, not just a metadata key.
 
-    A stale record with no matching directory (e.g. seeded to smuggle
-    ``enabled: true`` ahead of an install it doesn't correspond to yet)
-    must not count as "already installed", or a real install of that name
-    would inherit it as if it were a legitimate force-reinstall.
+    A stale record with no matching directory must not count as "already
+    installed" -- otherwise a real install of that name would wrongly
+    inherit its state as if this were a force-reinstall.
     """
     if not installed_dir.exists():
         return set()
@@ -85,10 +95,8 @@ def _force_disable_new(
 ) -> InstallationInfo:
     """Force a newly created tracked entry to ``enabled=False``.
 
-    ``pre_existing`` (names tracked *before* the write that produced
-    ``info``) distinguishes a genuinely new entry from a force-reinstall of
-    an already-tracked one, whose prior enabled state is already preserved
-    correctly -- see the module docstring.
+    ``pre_existing`` distinguishes a genuinely new entry from a
+    force-reinstall, whose prior enabled state is already preserved.
     """
     if info.name in pre_existing or not info.enabled:
         return info
@@ -106,22 +114,18 @@ def install_canvas_extension(
 ) -> InstalledCanvasExtensionInfo:
     """Install a canvas extension from a source.
 
-    A newly created tracked entry always lands disabled — enabling is a
-    separate, explicit step, regardless of anything a caller passes in.
-    See the module docstring for why this doesn't just delegate to
-    ``InstallationManager.install()`` unmodified.
+    A newly created entry always lands disabled, regardless of what the
+    caller passes in.
 
     Args:
-        source: Extension source — ``"github:owner/repo"``, git URL, or
-            local path.
+        source: ``"github:owner/repo"``, a git URL, or a local path.
         ref: Optional branch, tag, or commit to install.
-        repo_path: Subdirectory path within the repository (for monorepos).
-        installed_dir: Directory for installed canvas extensions. Defaults
-            to ``~/.openhands/canvas-extensions/installed/``.
+        repo_path: Subdirectory within the repository (for monorepos).
+        installed_dir: Defaults to ``~/.openhands/canvas-extensions/installed/``.
         force: If True, overwrite an existing installation.
 
     Returns:
-        InstalledCanvasExtensionInfo with details about the installation.
+        InstalledCanvasExtensionInfo for the installed extension.
     """
     installed_dir = _resolve_installed_dir(installed_dir)
     manager = _manager(installed_dir)
@@ -133,10 +137,17 @@ def install_canvas_extension(
 def uninstall_canvas_extension(name: str, installed_dir: Path | None = None) -> bool:
     """Uninstall a canvas extension by name.
 
+    Also drops any staged, not-yet-applied update for *name*, so refreshing
+    a since-uninstalled name never leaves an orphaned staging slot behind.
+
     Returns:
-        True if the extension was uninstalled, False if it wasn't installed.
+        True if uninstalled, False if it wasn't installed.
     """
-    return _manager(_resolve_installed_dir(installed_dir)).uninstall(name)
+    installed_dir = _resolve_installed_dir(installed_dir)
+    uninstalled = _manager(installed_dir).uninstall(name)
+    if uninstalled:
+        shutil.rmtree(_staging_root(installed_dir) / name, ignore_errors=True)
+    return uninstalled
 
 
 def enable_canvas_extension(name: str, installed_dir: Path | None = None) -> bool:
@@ -154,10 +165,8 @@ def list_installed_canvas_extensions(
 ) -> list[InstalledCanvasExtensionInfo]:
     """List all installed canvas extensions.
 
-    Self-healing like ``InstallationManager.list_installed()``. A directory
-    discovered this way (dropped in directly, bypassing
-    ``install_canvas_extension``) also lands disabled — see the module
-    docstring.
+    Self-healing like ``InstallationManager.list_installed()``; directories
+    discovered this way also land disabled.
     """
     installed_dir = _resolve_installed_dir(installed_dir)
     manager = _manager(installed_dir)
@@ -195,3 +204,200 @@ def get_installed_canvas_extension(
 ) -> InstalledCanvasExtensionInfo | None:
     """Get information about a specific installed canvas extension."""
     return _manager(_resolve_installed_dir(installed_dir)).get(name)
+
+
+class CanvasExtensionUpdateCheck(BaseModel):
+    """Result of ``check_canvas_extension_update``.
+
+    The active install is untouched; only ``.staging/`` is written. Pass
+    ``resolved_ref`` back to ``apply_canvas_extension_update`` to confirm
+    and swap this exact staged content into place.
+    """
+
+    requested_ref: str | None = Field(
+        description="Ref the staged fetch was resolved against"
+    )
+    resolved_ref: str | None = Field(
+        description="Commit SHA the staged content was resolved to"
+    )
+    validated: bool = Field(
+        description="Whether staged content passed validation; only True may be applied"
+    )
+
+
+def _staging_root(installed_dir: Path) -> Path:
+    return installed_dir / ".staging"
+
+
+def _staged_path(installed_dir: Path, name: str, resolved_ref: str | None) -> Path:
+    """Path to the staging slot for (*name*, *resolved_ref*).
+
+    *resolved_ref* is untrusted (``apply_canvas_extension_update`` takes it
+    as a caller-supplied argument), so it's rejected if it could escape the
+    staging directory -- same check as ``entrypoint`` in manifest.py.
+    """
+    if resolved_ref is not None and (
+        not resolved_ref
+        or resolved_ref.startswith("/")
+        or ".." in Path(resolved_ref).parts
+    ):
+        raise ValueError(f"Invalid resolved_ref: {resolved_ref!r}")
+    return _staging_root(installed_dir) / name / (resolved_ref or "local")
+
+
+def _stage_fetched_content(
+    installed_dir: Path, name: str, resolved_ref: str | None, fetched_path: Path
+) -> Path:
+    """Copy fetched content into a clean staging slot for *name*.
+
+    Clears any previously staged candidate first -- at most one is kept
+    per extension at a time.
+    """
+    slot_root = _staging_root(installed_dir) / name
+    shutil.rmtree(slot_root, ignore_errors=True)
+    staged_path = _staged_path(installed_dir, name, resolved_ref)
+    # symlinks=True: dereferencing here would copy a malicious symlink's
+    # target in as a plain file, defeating containment validation below.
+    shutil.copytree(fetched_path, staged_path, symlinks=True)
+    return staged_path
+
+
+def _load_validated_manifest(
+    staged_path: Path, expected_name: str
+) -> CanvasExtensionManifest:
+    """Load and validate a staged extension's manifest.
+
+    Raises if the manifest is malformed, its entrypoint escapes the package
+    root, or its name no longer matches *expected_name*.
+    """
+    manifest = CanvasExtensionInstallationInterface.load_from_dir(staged_path)
+    if manifest.name != expected_name:
+        raise ValueError(
+            f"Staged content for {expected_name!r} declares a different "
+            f"name {manifest.name!r}; refusing to treat it as an update"
+        )
+    return manifest
+
+
+def check_canvas_extension_update(
+    name: str, installed_dir: Path | None = None
+) -> CanvasExtensionUpdateCheck | None:
+    """Check for an update to *name*, staging and validating it.
+
+    Re-fetches the tracked source at its original ref (never "latest")
+    into ``.staging/``; the active install is untouched. See
+    ``apply_canvas_extension_update`` for the step that swaps it into
+    place.
+
+    Args:
+        name: Name of the installed extension to check.
+        installed_dir: Defaults to ``~/.openhands/canvas-extensions/installed/``.
+
+    Returns:
+        None if not installed, else a result -- only apply when ``validated``.
+
+    Raises:
+        ValueError: If *name* is not valid kebab-case.
+        ExtensionFetchError: If fetching the tracked source fails.
+    """
+    installed_dir = _resolve_installed_dir(installed_dir)
+    manager = _manager(installed_dir)
+    current_info = manager.get(name)
+    if current_info is None:
+        return None
+
+    fetched_path, resolved_ref = fetch_with_resolution(
+        source=current_info.source,
+        cache_dir=DEFAULT_CACHE_DIR,
+        ref=current_info.requested_ref,
+        repo_path=current_info.repo_path,
+        update=True,
+    )
+
+    staged_path = _stage_fetched_content(
+        installed_dir, name, resolved_ref, fetched_path
+    )
+    try:
+        _load_validated_manifest(staged_path, name)
+        validated = True
+    except (ValidationError, ValueError, OSError):
+        validated = False
+        shutil.rmtree(staged_path.parent, ignore_errors=True)
+
+    return CanvasExtensionUpdateCheck(
+        requested_ref=current_info.requested_ref,
+        resolved_ref=resolved_ref,
+        validated=validated,
+    )
+
+
+def apply_canvas_extension_update(
+    name: str,
+    resolved_ref: str | None,
+    enabled: bool,
+    installed_dir: Path | None = None,
+) -> InstalledCanvasExtensionInfo | None:
+    """Apply a previously checked and validated update.
+
+    *resolved_ref* must match a staged candidate already validated by
+    ``check_canvas_extension_update``, reconfirming what's being applied.
+    Atomically swaps staged content into the active install path;
+    *enabled* is always applied explicitly, never inherited.
+
+    Args:
+        name: Name of the installed extension to update.
+        resolved_ref: The ``resolved_ref`` from a prior, validated check.
+        enabled: Enabled state to apply to the new bundle.
+        installed_dir: Defaults to ``~/.openhands/canvas-extensions/installed/``.
+
+    Returns:
+        None if not installed, else the InstallationInfo for the new bundle.
+
+    Raises:
+        ValueError: If *name* is invalid, *resolved_ref* could escape the
+            staging directory, or no validated staged candidate matches it
+            -- call check first.
+    """
+    installed_dir = _resolve_installed_dir(installed_dir)
+    manager = _manager(installed_dir)
+    current_info = manager.get(name)
+    if current_info is None:
+        return None
+
+    staged_path = _staged_path(installed_dir, name, resolved_ref)
+    if not staged_path.is_dir():
+        raise ValueError(
+            f"No validated staged update found for {name!r} at ref "
+            f"{resolved_ref!r}. Call check_canvas_extension_update() first."
+        )
+    manifest = _load_validated_manifest(staged_path, name)
+
+    install_path = installed_dir / name
+    backup_path = _staging_root(installed_dir) / f"{name}.previous"
+    shutil.rmtree(backup_path, ignore_errors=True)
+
+    # POSIX rename() can't atomically replace a non-empty directory, so the
+    # active bundle moves aside first; roll back if the second rename fails.
+    os.replace(install_path, backup_path)
+    try:
+        os.replace(staged_path, install_path)
+    except OSError:
+        os.replace(backup_path, install_path)
+        raise
+    shutil.rmtree(backup_path, ignore_errors=True)
+    shutil.rmtree(_staging_root(installed_dir) / name, ignore_errors=True)
+
+    info = InstallationInfo.from_extension(
+        manifest,
+        source=current_info.source,
+        install_path=install_path,
+        requested_ref=current_info.requested_ref,
+        resolved_ref=resolved_ref,
+        repo_path=current_info.repo_path,
+    )
+    info.enabled = enabled
+
+    with manager.metadata_session as session:
+        session.extensions[name] = info
+
+    return info

--- a/tests/agent_server/canvas_extensions/conftest.py
+++ b/tests/agent_server/canvas_extensions/conftest.py
@@ -1,0 +1,44 @@
+"""Shared fixtures for canvas extension tests."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openhands.agent_server.canvas_extensions.manifest import MANIFEST_FILENAME
+
+
+def write_extension(
+    directory: Path,
+    name: str = "my-extension",
+    version: str = "1.0.0",
+    display_name: str = "My Extension",
+    description: str = "",
+    entrypoint: str = "dist/index.js",
+) -> Path:
+    """Write a valid, loadable canvas extension package to *directory*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "name": name,
+        "display_name": display_name,
+        "version": version,
+        "description": description,
+        "entrypoint": entrypoint,
+    }
+    (directory / MANIFEST_FILENAME).write_text(json.dumps(manifest))
+    entry_file = directory / entrypoint
+    entry_file.parent.mkdir(parents=True, exist_ok=True)
+    entry_file.write_text("console.log('ok')")
+    return directory
+
+
+@pytest.fixture
+def extension_dir(tmp_path: Path) -> Path:
+    return write_extension(tmp_path / "source" / "my-extension")
+
+
+@pytest.fixture
+def installed_dir(tmp_path: Path) -> Path:
+    return tmp_path / "installed"

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_installed.py
@@ -27,40 +27,7 @@ from openhands.agent_server.canvas_extensions.installed import (
 from openhands.agent_server.canvas_extensions.manifest import MANIFEST_FILENAME
 from openhands.sdk.extensions.installation import InstallationMetadata
 
-
-def _write_extension(
-    directory: Path,
-    name: str = "my-extension",
-    version: str = "1.0.0",
-    display_name: str = "My Extension",
-    description: str = "",
-    entrypoint: str = "dist/index.js",
-) -> Path:
-    """Write a valid, loadable canvas extension package to *directory*."""
-    directory.mkdir(parents=True, exist_ok=True)
-    manifest: dict[str, Any] = {
-        "schema_version": 1,
-        "name": name,
-        "display_name": display_name,
-        "version": version,
-        "description": description,
-        "entrypoint": entrypoint,
-    }
-    (directory / MANIFEST_FILENAME).write_text(json.dumps(manifest))
-    entry_file = directory / entrypoint
-    entry_file.parent.mkdir(parents=True, exist_ok=True)
-    entry_file.write_text("console.log('ok')")
-    return directory
-
-
-@pytest.fixture
-def extension_dir(tmp_path: Path) -> Path:
-    return _write_extension(tmp_path / "source" / "my-extension")
-
-
-@pytest.fixture
-def installed_dir(tmp_path: Path) -> Path:
-    return tmp_path / "installed"
+from .conftest import write_extension as _write_extension
 
 
 def test_default_installed_dir_layout():

--- a/tests/agent_server/canvas_extensions/test_canvas_extensions_refresh.py
+++ b/tests/agent_server/canvas_extensions/test_canvas_extensions_refresh.py
@@ -1,0 +1,706 @@
+"""Tests for the staged two-step refresh flow: check() / apply()."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from openhands.agent_server.canvas_extensions.installed import (
+    _staged_path,
+    apply_canvas_extension_update,
+    check_canvas_extension_update,
+    enable_canvas_extension,
+    get_installed_canvas_extension,
+    install_canvas_extension,
+    uninstall_canvas_extension,
+)
+from openhands.agent_server.canvas_extensions.manifest import MANIFEST_FILENAME
+from openhands.sdk.extensions.fetch import ExtensionFetchError
+
+from .conftest import write_extension as _write_extension
+
+
+@pytest.fixture
+def installed(extension_dir: Path, installed_dir: Path) -> Path:
+    """A tracked, enabled install of "my-extension" -- the common baseline."""
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+    return installed_dir
+
+
+def _active_version(installed_dir: Path, name: str = "my-extension") -> str:
+    manifest = json.loads((installed_dir / name / MANIFEST_FILENAME).read_text())
+    return manifest["version"]
+
+
+# ============================================================================
+# check_canvas_extension_update
+# ============================================================================
+
+
+def test_check_returns_none_when_not_installed(installed_dir: Path):
+    result = check_canvas_extension_update("nonexistent", installed_dir=installed_dir)
+    assert result is None
+
+
+def test_check_invalid_name_raises(installed_dir: Path):
+    with pytest.raises(ValueError, match="Invalid extension name"):
+        check_canvas_extension_update("Bad_Name", installed_dir=installed_dir)
+
+
+def test_check_reports_validated_and_new_resolved_ref(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+
+    result = check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert result is not None
+    assert result.validated is True
+    # Local sources never resolve to a commit SHA.
+    assert result.resolved_ref is None
+    assert result.requested_ref is None
+
+
+def test_check_does_not_touch_active_install(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_check_does_not_mutate_metadata_or_enabled_state(
+    extension_dir: Path, installed: Path
+):
+    before = get_installed_canvas_extension("my-extension", installed_dir=installed)
+    assert before is not None
+
+    _write_extension(extension_dir, version="2.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    after = get_installed_canvas_extension("my-extension", installed_dir=installed)
+    assert after is not None
+    assert after.enabled == before.enabled
+    assert after.version == before.version
+    assert after.installed_at == before.installed_at
+
+
+def test_check_stages_new_content(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    staged = installed / ".staging" / "my-extension" / "local"
+    assert staged.is_dir()
+    staged_manifest = json.loads((staged / MANIFEST_FILENAME).read_text())
+    assert staged_manifest["version"] == "2.0.0"
+
+
+def test_check_uses_originally_requested_ref_not_latest(
+    extension_dir: Path, installed_dir: Path
+):
+    """A pinned ref must survive a check, unlike update() which forces ref=None."""
+    # Patch both: install() fetches via the SDK manager, check() via this module.
+    with (
+        patch(
+            "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
+            return_value=(extension_dir, "sha-v1"),
+        ),
+        patch(
+            "openhands.agent_server.canvas_extensions.installed.fetch_with_resolution",
+            return_value=(extension_dir, "sha-v1-updated"),
+        ) as mock_check_fetch,
+    ):
+        install_canvas_extension(
+            "github:org/repo", ref="v1.0.0", installed_dir=installed_dir
+        )
+        enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+        result = check_canvas_extension_update(
+            "my-extension", installed_dir=installed_dir
+        )
+
+    assert mock_check_fetch.call_args.kwargs["ref"] == "v1.0.0"
+    assert result is not None
+    assert result.requested_ref == "v1.0.0"
+    assert result.resolved_ref == "sha-v1-updated"
+
+
+def test_check_invalid_manifest_marks_unvalidated_and_cleans_staging(
+    extension_dir: Path, installed: Path
+):
+    (extension_dir / MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "my-extension",
+                "display_name": "My Extension",
+                "version": "2.0.0",
+                # entrypoint dropped -- required field.
+            }
+        )
+    )
+
+    result = check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert result is not None
+    assert result.validated is False
+    assert not (installed / ".staging" / "my-extension").exists()
+    # Active install is unaffected.
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_check_escaping_entrypoint_marks_unvalidated_and_cleans_staging(
+    tmp_path: Path, extension_dir: Path, installed: Path
+):
+    outside = tmp_path / "outside.js"
+    outside.write_text("payload")
+    (extension_dir / "escape.js").symlink_to(outside)
+    manifest = json.loads((extension_dir / MANIFEST_FILENAME).read_text())
+    manifest["entrypoint"] = "escape.js"
+    manifest["version"] = "2.0.0"
+    (extension_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest))
+
+    result = check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert result is not None
+    assert result.validated is False
+    assert not (installed / ".staging" / "my-extension").exists()
+
+
+def test_check_manifest_name_mismatch_marks_unvalidated(
+    extension_dir: Path, installed: Path
+):
+    """A manifest name change isn't a valid update for the tracked extension."""
+    _write_extension(extension_dir, name="renamed-extension", version="2.0.0")
+
+    result = check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert result is not None
+    assert result.validated is False
+    assert not (installed / ".staging" / "my-extension").exists()
+
+
+def test_check_clears_previous_unapplied_staged_candidate(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    _write_extension(extension_dir, version="3.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    slot = installed / ".staging" / "my-extension"
+    candidates = list(slot.iterdir())
+    assert len(candidates) == 1
+    staged_manifest = json.loads((candidates[0] / MANIFEST_FILENAME).read_text())
+    assert staged_manifest["version"] == "3.0.0"
+
+
+def test_check_is_repeatable_when_nothing_changed(extension_dir: Path, installed: Path):
+    first = check_canvas_extension_update("my-extension", installed_dir=installed)
+    second = check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert first is not None
+    assert second is not None
+    assert first.validated is True
+    assert second.validated is True
+
+
+def test_check_propagates_fetch_error(extension_dir: Path, installed: Path):
+    """A fetch failure (network/auth) is an infra problem, not "this
+    content is invalid" -- it must raise, not come back as validated=False.
+    """
+    with patch(
+        "openhands.agent_server.canvas_extensions.installed.fetch_with_resolution",
+        side_effect=ExtensionFetchError("network down"),
+    ):
+        with pytest.raises(ExtensionFetchError):
+            check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    assert _active_version(installed) == "1.0.0"
+    assert not (installed / ".staging" / "my-extension").exists()
+
+
+def test_check_does_not_affect_other_extensions_staging(
+    tmp_path: Path, installed_dir: Path
+):
+    other_src = _write_extension(tmp_path / "source" / "other", name="other-ext")
+    my_src = _write_extension(tmp_path / "source" / "my-extension")
+    install_canvas_extension(str(my_src), installed_dir=installed_dir)
+    install_canvas_extension(str(other_src), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+    enable_canvas_extension("other-ext", installed_dir=installed_dir)
+
+    check_canvas_extension_update("other-ext", installed_dir=installed_dir)
+
+    assert (installed_dir / ".staging" / "other-ext").exists()
+    assert not (installed_dir / ".staging" / "my-extension").exists()
+
+
+# ============================================================================
+# apply_canvas_extension_update
+# ============================================================================
+
+
+def test_apply_returns_none_when_not_installed(installed_dir: Path):
+    result = apply_canvas_extension_update(
+        "nonexistent", resolved_ref=None, enabled=True, installed_dir=installed_dir
+    )
+    assert result is None
+
+
+def test_apply_invalid_name_raises(installed_dir: Path):
+    with pytest.raises(ValueError, match="Invalid extension name"):
+        apply_canvas_extension_update(
+            "Bad_Name", resolved_ref=None, enabled=True, installed_dir=installed_dir
+        )
+
+
+def test_apply_without_prior_check_raises(installed: Path):
+    with pytest.raises(ValueError, match="No validated staged update"):
+        apply_canvas_extension_update(
+            "my-extension", resolved_ref=None, enabled=True, installed_dir=installed
+        )
+
+    # Nothing about the active install changed.
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_apply_with_mismatched_resolved_ref_raises(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    with pytest.raises(ValueError, match="No validated staged update"):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref="some-other-sha",
+            enabled=True,
+            installed_dir=installed,
+        )
+
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_apply_rejects_resolved_ref_with_parent_traversal(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+
+    with pytest.raises(ValueError, match="Invalid resolved_ref"):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref="../../../etc",
+            enabled=True,
+            installed_dir=installed,
+        )
+
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_apply_rejects_absolute_resolved_ref(
+    extension_dir: Path, installed: Path, tmp_path: Path
+):
+    """A resolved_ref shaped like an absolute path must not let Path's
+    "/" operator discard the staging root and point anywhere on disk."""
+    outside = _write_extension(
+        tmp_path / "evil", name="my-extension", version="666.0.0"
+    )
+
+    with pytest.raises(ValueError, match="Invalid resolved_ref"):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=str(outside),
+            enabled=True,
+            installed_dir=installed,
+        )
+
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_staged_path_rejects_traversal_and_absolute_refs(installed_dir: Path):
+    with pytest.raises(ValueError, match="Invalid resolved_ref"):
+        _staged_path(installed_dir, "my-extension", "../escape")
+    with pytest.raises(ValueError, match="Invalid resolved_ref"):
+        _staged_path(installed_dir, "my-extension", "/etc/passwd")
+
+
+def test_staged_path_rejects_empty_string_ref(installed_dir: Path):
+    """ "" must not silently alias the None/"local" slot -- a caller that
+    serializes None as "" would otherwise get a false-positive match."""
+    with pytest.raises(ValueError, match="Invalid resolved_ref"):
+        _staged_path(installed_dir, "my-extension", "")
+
+
+def test_staged_path_allows_ref_with_internal_slash(installed_dir: Path):
+    """A branch name like "feature/foo" is a legitimate resolved_ref
+    fallback value and must not be rejected, only ".." and a leading "/"."""
+    path = _staged_path(installed_dir, "my-extension", "feature/foo")
+    assert path == installed_dir / ".staging" / "my-extension" / "feature" / "foo"
+
+
+def test_apply_rejects_unvalidated_check_result(extension_dir: Path, installed: Path):
+    (extension_dir / MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "my-extension",
+                "display_name": "My Extension",
+                "version": "2.0.0",
+            }
+        )
+    )
+    result = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert result is not None
+    assert result.validated is False
+
+    with pytest.raises(ValueError, match="No validated staged update"):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=result.resolved_ref,
+            enabled=True,
+            installed_dir=installed,
+        )
+
+
+def test_apply_swaps_active_content(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    result = apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed,
+    )
+
+    assert result is not None
+    assert result.version == "2.0.0"
+    assert _active_version(installed) == "2.0.0"
+
+
+def test_apply_sets_enabled_explicitly_not_inherited(
+    extension_dir: Path, installed: Path
+):
+    """enabled=False must not be overridden by the prior True state."""
+    before = get_installed_canvas_extension("my-extension", installed_dir=installed)
+    assert before is not None
+    assert before.enabled is True
+
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    result = apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=False,
+        installed_dir=installed,
+    )
+
+    assert result is not None
+    assert result.enabled is False
+    on_disk = get_installed_canvas_extension("my-extension", installed_dir=installed)
+    assert on_disk is not None
+    assert on_disk.enabled is False
+
+
+def test_apply_can_enable_a_previously_disabled_extension(
+    extension_dir: Path, installed_dir: Path
+):
+    # Fresh install lands disabled.
+    install_canvas_extension(str(extension_dir), installed_dir=installed_dir)
+
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed_dir)
+    assert check is not None
+
+    result = apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed_dir,
+    )
+
+    assert result is not None
+    assert result.enabled is True
+
+
+def test_apply_preserves_source_and_repo_path(extension_dir: Path, installed_dir: Path):
+    with (
+        patch(
+            "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
+            return_value=(extension_dir, "sha-1"),
+        ),
+        patch(
+            "openhands.agent_server.canvas_extensions.installed.fetch_with_resolution",
+            return_value=(extension_dir, "sha-1"),
+        ) as mock_check_fetch,
+    ):
+        install_canvas_extension(
+            "github:org/repo",
+            repo_path="packages/my-extension",
+            installed_dir=installed_dir,
+        )
+        enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+        check = check_canvas_extension_update(
+            "my-extension", installed_dir=installed_dir
+        )
+        assert check is not None
+        applied = apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=check.resolved_ref,
+            enabled=True,
+            installed_dir=installed_dir,
+        )
+
+    assert applied is not None
+    assert applied.source == "github:org/repo"
+    assert applied.repo_path == "packages/my-extension"
+    assert mock_check_fetch.call_args.kwargs["repo_path"] == "packages/my-extension"
+
+
+def test_apply_persists_new_resolved_ref(extension_dir: Path, installed_dir: Path):
+    with (
+        patch(
+            "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
+            return_value=(extension_dir, "sha-1"),
+        ),
+        patch(
+            "openhands.agent_server.canvas_extensions.installed.fetch_with_resolution",
+            return_value=(extension_dir, "sha-2"),
+        ),
+    ):
+        install_canvas_extension(
+            "github:org/repo", ref="main", installed_dir=installed_dir
+        )
+        enable_canvas_extension("my-extension", installed_dir=installed_dir)
+
+        check = check_canvas_extension_update(
+            "my-extension", installed_dir=installed_dir
+        )
+        assert check is not None
+
+        applied = apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=check.resolved_ref,
+            enabled=True,
+            installed_dir=installed_dir,
+        )
+
+    assert applied is not None
+    assert applied.resolved_ref == "sha-2"
+    assert applied.requested_ref == "main"
+    assert applied.source == "github:org/repo"
+
+    on_disk = get_installed_canvas_extension(
+        "my-extension", installed_dir=installed_dir
+    )
+    assert on_disk is not None
+    assert on_disk.resolved_ref == "sha-2"
+    assert on_disk.requested_ref == "main"
+
+
+def test_apply_cleans_up_staging_after_success(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed,
+    )
+
+    assert not (installed / ".staging" / "my-extension").exists()
+    assert not (installed / ".staging" / "my-extension.previous").exists()
+
+
+def test_double_apply_without_recheck_raises(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed,
+    )
+
+    with pytest.raises(ValueError, match="No validated staged update"):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=check.resolved_ref,
+            enabled=True,
+            installed_dir=installed,
+        )
+
+
+def test_apply_does_not_affect_other_installed_extensions(
+    tmp_path: Path, installed_dir: Path
+):
+    other_src = _write_extension(tmp_path / "source" / "other", name="other-ext")
+    my_src = _write_extension(tmp_path / "source" / "my-extension")
+    install_canvas_extension(str(my_src), installed_dir=installed_dir)
+    install_canvas_extension(str(other_src), installed_dir=installed_dir)
+    enable_canvas_extension("my-extension", installed_dir=installed_dir)
+    enable_canvas_extension("other-ext", installed_dir=installed_dir)
+
+    _write_extension(my_src, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed_dir)
+    assert check is not None
+    apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed_dir,
+    )
+
+    other_info = get_installed_canvas_extension(
+        "other-ext", installed_dir=installed_dir
+    )
+    assert other_info is not None
+    assert other_info.version == "1.0.0"
+    assert (installed_dir / "other-ext").exists()
+
+
+def test_apply_rolls_back_active_install_on_failed_swap(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    real_replace = os.replace
+    call_count = {"n": 0}
+
+    def flaky_replace(src, dst):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise OSError("simulated mid-swap failure")
+        return real_replace(src, dst)
+
+    with patch("os.replace", side_effect=flaky_replace):
+        with pytest.raises(OSError, match="simulated mid-swap failure"):
+            apply_canvas_extension_update(
+                "my-extension",
+                resolved_ref=check.resolved_ref,
+                enabled=True,
+                installed_dir=installed,
+            )
+
+    # Rolled back: the active install still serves the old content.
+    assert _active_version(installed) == "1.0.0"
+    assert (installed / "my-extension").is_dir()
+
+    # Metadata untouched by the failed apply.
+    info = get_installed_canvas_extension("my-extension", installed_dir=installed)
+    assert info is not None
+    assert info.version == "1.0.0"
+    assert info.enabled is True
+
+    # The validated staged candidate survives the failure -- retryable.
+    staged = installed / ".staging" / "my-extension" / "local"
+    assert staged.is_dir()
+
+
+def test_apply_retry_succeeds_after_rolled_back_failure(
+    extension_dir: Path, installed: Path
+):
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    real_replace = os.replace
+    call_count = {"n": 0}
+
+    def flaky_replace(src, dst):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise OSError("simulated mid-swap failure")
+        return real_replace(src, dst)
+
+    with patch("os.replace", side_effect=flaky_replace):
+        with pytest.raises(OSError):
+            apply_canvas_extension_update(
+                "my-extension",
+                resolved_ref=check.resolved_ref,
+                enabled=True,
+                installed_dir=installed,
+            )
+
+    result = apply_canvas_extension_update(
+        "my-extension",
+        resolved_ref=check.resolved_ref,
+        enabled=True,
+        installed_dir=installed,
+    )
+
+    assert result is not None
+    assert result.version == "2.0.0"
+    assert _active_version(installed) == "2.0.0"
+
+
+def test_apply_leaves_no_backup_when_first_rename_fails(
+    extension_dir: Path, installed: Path
+):
+    """If the first rename fails, nothing moved -- no rollback needed."""
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    with patch("os.replace", side_effect=OSError("cannot move active install")):
+        with pytest.raises(OSError, match="cannot move active install"):
+            apply_canvas_extension_update(
+                "my-extension",
+                resolved_ref=check.resolved_ref,
+                enabled=True,
+                installed_dir=installed,
+            )
+
+    assert _active_version(installed) == "1.0.0"
+    staged = installed / ".staging" / "my-extension" / "local"
+    assert staged.is_dir()
+
+
+def test_apply_rejects_manifest_that_became_invalid_since_check(
+    extension_dir: Path, installed: Path
+):
+    """apply() re-validates staged content right before swapping."""
+    _write_extension(extension_dir, version="2.0.0")
+    check = check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert check is not None
+
+    staged = installed / ".staging" / "my-extension" / "local"
+    (staged / MANIFEST_FILENAME).write_text("{not valid json")
+
+    with pytest.raises(ValidationError):
+        apply_canvas_extension_update(
+            "my-extension",
+            resolved_ref=check.resolved_ref,
+            enabled=True,
+            installed_dir=installed,
+        )
+
+    assert _active_version(installed) == "1.0.0"
+
+
+def test_uninstall_drops_orphaned_staged_update(extension_dir: Path, installed: Path):
+    _write_extension(extension_dir, version="2.0.0")
+    check_canvas_extension_update("my-extension", installed_dir=installed)
+    assert (installed / ".staging" / "my-extension").exists()
+
+    uninstall_canvas_extension("my-extension", installed_dir=installed)
+
+    assert not (installed / ".staging" / "my-extension").exists()


### PR DESCRIPTION
HUMAN:

Adding staged install + atomic swap + two-step refresh (check/apply) for canvas extensions.

---

AGENT:

## Why

Part of the Canvas Extensions backend build-out (#4348). Issue #4351 identified two concrete bugs in reusing `InstallationManager.update()`/`install(force=True)` for refresh: both resolve `ref=None` ("latest available") even when the extension was pinned to a specific ref, and both `shutil.rmtree` the live install path immediately followed by `shutil.copytree` directly onto it -- no staging directory, and a real window where the path is empty/partial if anything fails mid-swap.

**Note for reviewers**: this branch is stacked on top of #4364 (still open, not yet merged), so the diff below currently includes #4364/#4361's files again alongside the new work. Those shrink out of this diff automatically once #4364 merges into `extension-canvas-2`.

## Summary
- Add `check_canvas_extension_update()`: re-fetches the tracked source at its *originally requested* ref (never silently reset to "latest") into a `.staging/` sibling directory and validates it there (manifest + entrypoint containment + a name-consistency check against the tracked extension). The active install is never touched; returns `{requested_ref, resolved_ref, validated}`.
- Add `apply_canvas_extension_update()`: a separate, explicit call that reconfirms the exact validated `resolved_ref` from a prior check, then atomically swaps staged → active via two `os.replace` renames (POSIX `rename()` can't atomically replace a non-empty directory in one step, so the active bundle moves aside first) with rollback if the second rename fails. The new bundle's `enabled` state is always taken from the caller, never inherited.
- **Security fix found during review**: `resolved_ref` was being used unsanitized to build the staging filesystem path, so a caller passing `../../../evil` or an absolute path could make `apply()` swap in content from anywhere on disk as the extension's new active bundle. Now rejects absolute paths, `..` segments, and empty strings (mirrors the existing `entrypoint` containment check in `manifest.py`).
- `uninstall_canvas_extension()` now also drops any staged-but-unapplied update for that name, so it can't outlive the extension it belongs to.
- Extracted the `write_extension()` helper and `extension_dir`/`installed_dir` fixtures (previously copy-pasted verbatim across two test files) into a shared `tests/agent_server/canvas_extensions/conftest.py`.

## Issue Number
#4351

## How to Test

```
uv run pytest tests/agent_server/canvas_extensions -v
```
114 tests pass (37 new, in `test_canvas_extensions_refresh.py`). Coverage includes: happy-path check/apply and the active install staying untouched by `check()`; the originally requested ref surviving a check instead of being reset to "latest" (the exact bug being replaced, verified by asserting the mocked fetch call's `ref` kwarg); invalid manifest, entrypoint-escape, and manifest-name-mismatch staged content all marking `validated=False` and cleaning up `.staging/` without touching the active install; `apply()` without a prior check, with a mismatched `resolved_ref`, or re-applying an already-consumed one all raising; explicit enable/disable reconfirmation on `apply()` never being inherited from the prior state; atomic-swap rollback plus a successful retry after a simulated mid-swap failure (`os.replace` patched to fail on its second call); `apply()`'s defense-in-depth re-validation immediately before swapping; cross-extension staging isolation; and the path-traversal/absolute-path/empty-string `resolved_ref` rejections for the security fix.

Manually reproduced the path-traversal bug against the pre-fix code with a standalone script: two extensions installed, `apply_canvas_extension_update("victim", resolved_ref="../../../evil", ...)` and an absolute-path variant both swapped attacker-controlled content into the active install before the fix (confirmed by reading back the resulting `canvas-extension.json` version); after the fix both raise `ValueError` and the legitimate apply path still succeeds.

`uv run pre-commit run --files <changed files>` passes (ruff format/lint, pycodestyle, pyright, import-dependency-rules, tool-subclass-registration).

## Video/Screenshots

N/A -- backend refresh module only, no UI or HTTP route in this PR (REST API surface is #4352, blocked on this one).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Scoped to #4351. Everything else in the epic remains separate, already-filed tickets: REST API surface (#4352), OpenAPI/typescript-client (#4354), audit logging (#4355), manifest API-scope + reserved names (#4356), adversarial fuzz suite (#4357).
