### PR TITLE
fix(observability): keep the conversation object out of TOOL span input

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -1325,6 +1325,9 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 observation: Observation = observe(
                     name=tool_name,
                     span_type="TOOL",
+                    # Only the action is input; the conversation would serialize
+                    # as a bare object repr carrying a memory address.
+                    ignore_inputs=["conversation"],
                     metadata={"tool_call_id": action_event.tool_call.id},
                 )(tool)(action_event.action, conversation)
             else:

--- a/tests/sdk/agent/test_tool_span_input.py
+++ b/tests/sdk/agent/test_tool_span_input.py
@@ -6,8 +6,9 @@ memory address, and dead weight through every downstream stage that scans it.
 """
 
 import json
-import os
-from typing import Any
+import threading
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Self
 from unittest.mock import patch
 
 import pytest
@@ -18,47 +19,93 @@ from litellm.types.utils import (
     Message as LiteLLMMessage,
     ModelResponse,
 )
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
 from openhands.sdk.llm import LLM, Message, TextContent
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.terminal import TerminalTool
+from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
+from openhands.sdk.tool.tool import ToolDefinition
 
 
-register_tool("TerminalTool", TerminalTool)
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+class _SpanInputAction(Action):
+    value: str = ""
+
+
+class _SpanInputObservation(Observation):
+    result: str = ""
+
+
+class _SpanInputExecutor(ToolExecutor[_SpanInputAction, _SpanInputObservation]):
+    def __call__(
+        self, action: _SpanInputAction, conversation=None
+    ) -> _SpanInputObservation:
+        return _SpanInputObservation(result=action.value)
+
+
+class _SpanInputTool(ToolDefinition[_SpanInputAction, _SpanInputObservation]):
+    name = "span_input_echo_tool"
+
+    @classmethod
+    def create(cls, conv_state: "ConversationState | None" = None) -> Sequence[Self]:
+        return [
+            cls(
+                description="Echoes its input",
+                action_type=_SpanInputAction,
+                observation_type=_SpanInputObservation,
+                executor=_SpanInputExecutor(),
+            )
+        ]
+
+
+register_tool("SpanInputEchoTool", _SpanInputTool)
 
 
 @pytest.fixture
 def exported():
-    os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
-    from lmnr import Instruments, Laminar
-    from lmnr.opentelemetry_lib.tracing import TracerWrapper
-    from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
-        InMemorySpanExporter,
-    )
+    """Real Laminar tracer writing to an in-memory exporter, torn down after.
 
-    if not Laminar.is_initialized():
-        Laminar.initialize(
-            project_api_key="test-key",
-            base_url="http://localhost",
-            http_port=1,
-            grpc_port=1,
-            disable_batch=True,
-            instruments={Instruments.LITELLM},
-        )
+    The exporter is installed *before* ``initialize`` so no OTLP endpoint is ever
+    created; an unreachable one leaves every later test in the process retrying
+    exports with backoff.
+    """
+    from lmnr import Laminar
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.threading import (
+        ThreadingInstrumentor,
+    )
+    from lmnr.opentelemetry_lib.tracing import TracerWrapper
+
+    if TracerWrapper.verify_initialized():
+        pytest.skip("lmnr already initialized by another test in this process")
+
     exporter = InMemorySpanExporter()
-    processor = TracerWrapper.instance._span_processor
-    assert isinstance(processor, LaminarSpanProcessor)
-    previous = processor.instance
-    processor.instance = SimpleSpanProcessor(exporter)
+    original_thread_init = threading.Thread.__init__
+    TracerWrapper(
+        exporter=exporter,
+        disable_batch=True,
+        instruments=set(),
+        set_global_tracer_provider=False,
+    )
+    Laminar.initialize(
+        project_api_key="test-key",
+        disable_batch=True,
+        instruments=set(),
+        set_global_tracer_provider=False,
+    )
     try:
-        yield lambda: exporter.get_finished_spans()
+        yield exporter.get_finished_spans
     finally:
-        processor.instance = previous
+        Laminar.shutdown()
+        ThreadingInstrumentor().uninstrument()
+        threading.Thread.__init__ = original_thread_init  # type: ignore[method-assign]
+        TracerWrapper._original_thread_init = None
+        if hasattr(TracerWrapper, "instance"):
+            del TracerWrapper.instance
 
 
 def _responses() -> Any:
@@ -75,8 +122,8 @@ def _responses() -> Any:
                         id="call_x",
                         type="function",
                         function=Function(
-                            name="execute_bash",
-                            arguments=json.dumps({"command": "echo hi"}),
+                            name="span_input_echo_tool",
+                            arguments=json.dumps({"value": "hi"}),
                         ),
                     )
                 ],
@@ -96,12 +143,11 @@ def _responses() -> Any:
     return fake
 
 
-def test_tool_span_input_is_the_action_only(exported, tmp_path):
+def test_tool_span_input_is_the_action_only(exported):
     llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
     conversation = Conversation(
-        agent=Agent(llm=llm, tools=[Tool(name="TerminalTool")]),
+        agent=Agent(llm=llm, tools=[Tool(name="SpanInputEchoTool")]),
         callbacks=[],
-        workspace=str(tmp_path),
     )
     with patch("openhands.sdk.llm.llm.litellm_completion", side_effect=_responses()):
         conversation.send_message(
@@ -117,4 +163,4 @@ def test_tool_span_input_is_the_action_only(exported, tmp_path):
     payload = json.loads((tool_spans[0].attributes or {})["lmnr.span.input"])
 
     assert "conversation" not in payload
-    assert payload["action"]["command"] == "echo hi"
+    assert payload["action"]["value"] == "hi"

--- a/tests/sdk/agent/test_tool_span_input.py
+++ b/tests/sdk/agent/test_tool_span_input.py
@@ -1,0 +1,120 @@
+"""The TOOL span's input is the action, not the conversation object.
+
+`tool(action, conversation)` would otherwise serialize the second argument as a
+bare ``<LocalConversation object at 0x…>`` repr — no analytical value, a leaked
+memory address, and dead weight through every downstream stage that scans it.
+"""
+
+import json
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import (
+    Choices,
+    Function,
+    Message as LiteLLMMessage,
+    ModelResponse,
+)
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.tools.terminal import TerminalTool
+
+
+register_tool("TerminalTool", TerminalTool)
+
+
+@pytest.fixture
+def exported():
+    os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+    from lmnr import Instruments, Laminar
+    from lmnr.opentelemetry_lib.tracing import TracerWrapper
+    from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    if not Laminar.is_initialized():
+        Laminar.initialize(
+            project_api_key="test-key",
+            base_url="http://localhost",
+            http_port=1,
+            grpc_port=1,
+            disable_batch=True,
+            instruments={Instruments.LITELLM},
+        )
+    exporter = InMemorySpanExporter()
+    processor = TracerWrapper.instance._span_processor
+    assert isinstance(processor, LaminarSpanProcessor)
+    previous = processor.instance
+    processor.instance = SimpleSpanProcessor(exporter)
+    try:
+        yield lambda: exporter.get_finished_spans()
+    finally:
+        processor.instance = previous
+
+
+def _responses() -> Any:
+    calls = {"n": 0}
+
+    def fake(**kwargs: Any):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            message = LiteLLMMessage(
+                role="assistant",
+                content="checking",
+                tool_calls=[
+                    ChatCompletionMessageToolCall(
+                        id="call_x",
+                        type="function",
+                        function=Function(
+                            name="execute_bash",
+                            arguments=json.dumps({"command": "echo hi"}),
+                        ),
+                    )
+                ],
+            )
+            finish = "tool_calls"
+        else:
+            message = LiteLLMMessage(role="assistant", content="done", tool_calls=None)
+            finish = "stop"
+        return ModelResponse(
+            id=f"r{calls['n']}",
+            created=0,
+            model="gpt-4o",
+            object="chat.completion",
+            choices=[Choices(index=0, message=message, finish_reason=finish)],
+        )
+
+    return fake
+
+
+def test_tool_span_input_is_the_action_only(exported, tmp_path):
+    llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
+    conversation = Conversation(
+        agent=Agent(llm=llm, tools=[Tool(name="TerminalTool")]),
+        callbacks=[],
+        workspace=str(tmp_path),
+    )
+    with patch("openhands.sdk.llm.llm.litellm_completion", side_effect=_responses()):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="hi")])
+        )
+        conversation.run()
+    conversation.close()
+
+    tool_spans = [
+        s for s in exported() if (s.attributes or {}).get("lmnr.span.type") == "TOOL"
+    ]
+    assert len(tool_spans) == 1
+    payload = json.loads((tool_spans[0].attributes or {})["lmnr.span.input"])
+
+    assert "conversation" not in payload
+    assert payload["action"]["command"] == "echo hi"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Agent._execute_action_event builds the TOOL span around tool(action, conversation).
lmnr serializes both positional arguments as span input, so every TOOL span in
every traced conversation carries a second key that is a bare Python object repr:

---

AGENT:

## Why

`Agent._execute_action_event` builds the TOOL span around `tool(action, conversation)`.
lmnr serializes **both** positional arguments as span input, so every TOOL span in
every traced conversation carries a second key that is a bare Python object repr:

```json
{"action": {"command": "echo hi", "kind": "TerminalAction", ...},
 "conversation": "<openhands.sdk.conversation.impl.local_conversation.LocalConversation object at 0x13950f8c0>"}
```

It has no analytical value, it leaks a heap address, and it is not free: it is
exported to the backend, then re-read, scanned, and stored by everything downstream.
In a sampled production corpus it is **6.8% of all TOOL-span input bytes** — 11,190
copies of the string across three shards — and the trajectory-export pipeline runs
four PII/secret detectors over every string leaf it fetches.

`agent.step` already excludes its non-serializable arguments this way
(`ignore_inputs=["state", "on_event"]`); the TOOL span was simply missed.

## Summary

- Add `ignore_inputs=["conversation"]` to the TOOL-span `observe(...)` call. The
  action — the part with analytical value — is untouched.
- New regression test asserting the exported TOOL span's input contains the action
  and no `conversation` key.

## Issue Number

None — found while auditing what the trajectory-export pipeline fetches and scans
(context: #4373).

## How to Test

```bash
uv run pytest tests/sdk/agent/test_tool_span_input.py -q                  # 1 passed
uv run pytest tests/sdk/agent/ tests/sdk/observability/ -q                # 852 passed
uv run ruff check <changed files>                                         # All checks passed!
uv run pyright <changed files>                                            # 0 errors, 0 warnings
```

The new test fails without the change (`1 failed`).

Measured on a real `Agent` + `Conversation` run with lmnr initialized, comparing the
exported TOOL span both ways:

```
ignore_inputs=NO  | len= 212 | has_conversation_repr=True
   {"action":{"command":"echo hi",...,"kind":"TerminalAction"},"conversation":"<...LocalConversation object at 0x13950f8c0>"}

ignore_inputs=YES | len= 102 | has_conversation_repr=False
   {"action":{"command":"echo hi",...,"kind":"TerminalAction"}}
```

52% smaller on that span, with the action fully preserved. The corpus-wide figure is
lower (6.8% of TOOL input) because real actions are larger than `echo hi`.

## Video/Screenshots

Not applicable — observability plumbing; the span-input dumps above are the observable
behaviour.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Nothing consumes the removed field.** It is a repr of a live Python object, so it
was never machine-readable to begin with — no id, no path, nothing joinable. Anyone
who wants conversation identity already has it: the span's `session_id` is the
conversation id.

**Touches the same call site as #4131**, which adds `action_event_id` to that
`observe(...)`. Whichever lands second takes a trivial conflict — both are added
kwargs on the same call.

**Not addressed here:** the same pipeline fetches TOOL-span `input` in full and then
never delivers it, which is a larger saving but belongs on the consumer side.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:44fc324-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-44fc324-python \
  ghcr.io/openhands/agent-server:44fc324-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:44fc324-golang-amd64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-golang-amd64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-golang-amd64
ghcr.io/openhands/agent-server:44fc324-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:44fc324-golang-arm64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-golang-arm64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-golang-arm64
ghcr.io/openhands/agent-server:44fc324-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:44fc324-java-amd64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-java-amd64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-java-amd64
ghcr.io/openhands/agent-server:44fc324-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:44fc324-java-arm64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-java-arm64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-java-arm64
ghcr.io/openhands/agent-server:44fc324-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:44fc324-python-amd64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-python-amd64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-python-amd64
ghcr.io/openhands/agent-server:44fc324-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:44fc324-python-arm64
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-python-arm64
ghcr.io/openhands/agent-server:tool-span-drop-conversation-python-arm64
ghcr.io/openhands/agent-server:44fc324-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:44fc324-golang
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-golang
ghcr.io/openhands/agent-server:tool-span-drop-conversation-golang
ghcr.io/openhands/agent-server:44fc324-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:44fc324-java
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-java
ghcr.io/openhands/agent-server:tool-span-drop-conversation-java
ghcr.io/openhands/agent-server:44fc324-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:44fc324-python
ghcr.io/openhands/agent-server:44fc324bb7329a50cd405d3579b595c8ed846860-python
ghcr.io/openhands/agent-server:tool-span-drop-conversation-python
ghcr.io/openhands/agent-server:44fc324-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `44fc324-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `44fc324-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->