### PR TITLE
feat(acp): surface session effort state and support model/effort switching via config options

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -449,6 +449,20 @@ def _compose_conversation_info(
         or agent_state.get("acp_available_models")
         or []
     )
+    # current_effort / available_efforts: same live → persisted precedence as
+    # the model fields above, but with no third ``acp_model``-derived
+    # fallback for cold reads. Splitting the effort component off a composite
+    # ``acp_model`` (e.g. ``"sonnet/high"``) is provider-specific logic
+    # (``_model_config_option_effort``) that lives in ``acp_agent`` and isn't
+    # reproduced here, so a cold read with no live PrivateAttr and no
+    # persisted hint honestly reports ``None`` rather than guessing — there
+    # is no ``agent_initialized`` gate to apply on this field.
+    current_effort = getattr(agent, "current_effort", None) or agent_state.get(
+        "acp_current_effort"
+    )
+    available_efforts = getattr(agent, "available_efforts", None) or agent_state.get(
+        "acp_available_efforts"
+    )
     # Static provider capability. Unlike the two fields above it has no
     # meaningful live-vs-persisted distinction — it's derived from the stable
     # provider identity and written once at session init — so we read the
@@ -469,6 +483,8 @@ def _compose_conversation_info(
         sub_conversation_ids=sub_conversation_ids or [],
         current_model_id=current_model_id,
         available_models=available_models,
+        current_effort=current_effort,
+        available_efforts=available_efforts,
         supports_runtime_model_switch=supports_runtime_model_switch,
         client_tools=stored.client_tools,
         launched_agent_profile=stored.launched_agent_profile,

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -180,7 +180,7 @@ RUN set -ux; \
          && "$ACP_NODE_DIR/bin/node" --version; then \
         PATH="$ACP_NODE_DIR/bin:$PATH"; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
-            @agentclientprotocol/claude-agent-acp@0.44.0 \
+            @agentclientprotocol/claude-agent-acp@0.64.2 \
             @agentclientprotocol/codex-acp@1.1.2 \
             @google/gemini-cli@0.46.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -292,6 +292,36 @@ class _ConversationInfoBase(BaseModel):
             '``"Opus 4.7 with 1M context · ..."``).'
         ),
     )
+    current_effort: str | None = Field(
+        default=None,
+        description=(
+            "Effort/reasoning-effort level the agent is actually using for "
+            "this session. For ACP agents, this is lifted off "
+            "``ACPAgent.current_effort`` (populated from the ``effort`` "
+            "(claude-agent-acp) or ``reasoning_effort`` (codex-acp) "
+            "``configOptions`` select on the ACP session response, or from "
+            "the effort component of a forced ``acp_model`` override such as "
+            '``"sonnet/high"``). ``None`` for older ACP servers or providers '
+            "that don't surface effort selection, or while the agent is "
+            "still initializing. Native OpenHands agents leave this "
+            "``None``."
+        ),
+    )
+    available_efforts: list[str] | None = Field(
+        default=None,
+        description=(
+            "Effort/reasoning-effort levels the ACP server offers for this "
+            "session, lifted off ``ACPAgent.available_efforts`` (the "
+            "``effort``/``reasoning_effort`` ``configOptions`` select's "
+            "``options`` on the ACP session response). Surfaced verbatim so "
+            "clients can render an effort picker and resolve "
+            "``current_effort`` against it. ``None`` when no effort-capable "
+            "select was reported (older ACP servers, providers without "
+            "effort selection, and native OpenHands agents) — distinct from "
+            "``[]``, which means the select was present but offered no "
+            "usable levels."
+        ),
+    )
     supports_runtime_model_switch: bool = Field(
         default=False,
         description=(

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -29,6 +29,7 @@ import weakref
 from collections.abc import Awaitable, Callable, Collection, Generator, Iterable
 from concurrent.futures import Future
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
 from acp.client.connection import ClientSideConnection
@@ -38,6 +39,7 @@ from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
     AllowedOutcome,
+    ConfigOptionUpdate,
     EnvVariable,
     HttpHeader,
     HttpMcpServer,
@@ -501,6 +503,40 @@ async def _apply_acp_model(
         await conn.set_session_model(model_id=model, session_id=session_id)
 
 
+def _flatten_select_options(options: Iterable[Any]) -> list[Any]:
+    """Flatten a ``configOptions`` select's ``options`` into leaf options.
+
+    The pinned ``agent-client-protocol`` lib (0.10.1) types
+    ``SessionConfigSelect.options`` (the base of both ``SessionConfigOptionSelect``
+    — the ``model``/``effort``/``reasoning_effort`` selects — and
+    ``SetSessionConfigOptionSelectRequest``) as
+    ``List[SessionConfigSelectOption] | List[SessionConfigSelectGroup]``: an
+    agent may present its selectable values either as a flat list, or grouped
+    under a labelled heading (``SessionConfigSelectGroup``, carrying its
+    ``group``/``name`` plus a nested ``options: List[SessionConfigSelectOption]``).
+    Reading every entry as a flat option — the prior behavior — silently drops
+    group entries: a group has no ``value``/``model_id`` of its own, so
+    :meth:`ACPModelInfo.from_protocol` yields an empty id that
+    :func:`_usable_models` then filters out, leaving an agent using grouped
+    selects with an apparently empty model/effort list.
+
+    A flat ``SessionConfigSelectOption`` has no nested ``options`` of its own
+    (``getattr`` returns ``None``), so it is appended as-is; a
+    ``SessionConfigSelectGroup`` is replaced by its nested leaf options.
+    Order is preserved — groups are flattened in place, each group's members
+    in the order the server sent them — and an empty group (or an all-empty
+    list of groups) simply contributes nothing.
+    """
+    flattened: list[Any] = []
+    for entry in options:
+        nested = getattr(entry, "options", None)
+        if nested is not None:
+            flattened.extend(nested)
+        else:
+            flattened.append(entry)
+    return flattened
+
+
 def _usable_models(infos: Iterable[ACPModelInfo]) -> list[ACPModelInfo]:
     """Drop entries without a usable ``model_id`` — an empty/missing id is an
     invalid picker option and an unusable model-switch target."""
@@ -543,13 +579,16 @@ def _extract_session_models(
     # Prefer configOptions when an adapter advertises both it and the legacy
     # ``models`` extension. The ``model`` select carries the same state, with
     # each option's ``value`` as the model id (== the ``set_config_option`` target).
+    # ``options`` may be flat or grouped under labelled headings — see
+    # :func:`_flatten_select_options`.
     opt = _model_config_option(response)
     if opt is not None:
         current = getattr(opt, "current_value", None)
         current = current if isinstance(current, str) and current else None
         options = getattr(opt, "options", None) or []
         usable = _usable_models(
-            ACPModelInfo.from_protocol(o, id_attr="value") for o in options
+            ACPModelInfo.from_protocol(o, id_attr="value")
+            for o in _flatten_select_options(options)
         )
         return current, usable, True
     models = getattr(response, "models", None)
@@ -585,10 +624,11 @@ def _extract_session_efforts(response: Any) -> tuple[str | None, list[str] | Non
 
     Returns ``(current_effort, available_efforts)``, best-effort. Reads the
     ``effort`` (claude-agent-acp) or ``reasoning_effort`` (codex-acp)
-    ``configOptions`` select — only plain (ungrouped) select options are
-    handled, mirroring :func:`_model_config_option`. There is no legacy
-    ``models``-capability equivalent for effort, so unlike
-    :func:`_extract_session_models` this has a single mechanism to check.
+    ``configOptions`` select, mirroring :func:`_model_config_option`; both
+    flat and grouped ``options`` are handled (see
+    :func:`_flatten_select_options`). There is no legacy ``models``-capability
+    equivalent for effort, so unlike :func:`_extract_session_models` this has
+    a single mechanism to check.
 
     ``available_efforts`` distinguishes **absent** from **empty**, same as
     ``_extract_session_models``'s ``available_models``:
@@ -614,7 +654,7 @@ def _extract_session_efforts(response: Any) -> tuple[str | None, list[str] | Non
     options = getattr(opt, "options", None) or []
     available = [
         value
-        for o in options
+        for o in _flatten_select_options(options)
         if isinstance((value := getattr(o, "value", None)), str) and value
     ]
     return current, available
@@ -644,6 +684,72 @@ def _model_config_option_effort(
         if config_id in _EFFORT_CONFIG_OPTION_IDS:
             return value
     return None
+
+
+def _reconcile_current_model_id(
+    tracked_model_id: str | None,
+    reported_model_id: str | None,
+    reported_effort: str | None,
+    *,
+    agent_name: str | None,
+    model_override_applied: bool,
+) -> str | None:
+    """Reconcile a tracked (possibly composite) ``_current_model_id`` against a
+    fresh server report of ``(model, effort)`` — e.g. from a live
+    ``config_option_update`` notification.
+
+    codex-acp and claude-agent-acp split a composite Canvas model id (e.g.
+    ``"sonnet/high"``) into two independent ``configOptions`` values (see
+    :func:`_model_config_options`): a ``model`` select carrying the *base* id
+    alone, plus a separate effort select. A server report of that state is
+    therefore always two bare values, never the composite string
+    ``_current_model_id`` tracks locally. Adopting ``reported_model_id``
+    verbatim would silently regress ``"sonnet/high"`` down to ``"sonnet"``
+    on every resend even though nothing actually changed server-side.
+
+    Composite reconstruction is only attempted when all of the following
+    hold — otherwise ``reported_model_id`` is returned as-is (a bare id, the
+    correct behavior for providers that don't split, or a session where the
+    tracked id was never actually pushed to the server so there is nothing
+    trustworthy to reconcile against):
+
+    - ``model_override_applied`` is ``True`` — the tracked id is one we know
+      was actually applied on the wire, not merely inherited from the
+      server's own default.
+    - ``agent_name`` resolves to one of the composite-id providers gated by
+      :func:`_model_config_options` (``codex`` / ``claude-code``).
+    - ``reported_effort`` is present — the update also reports an effort
+      option; without one there is no effort component to recompose.
+
+    Within that composite-aware case: if ``tracked_model_id`` splits (on the
+    last ``/``) into exactly ``(reported_model_id, reported_effort)``, the
+    server's report matches what we already track — nothing changed, so the
+    tracked composite is returned verbatim. Any other outcome — a different
+    base model (e.g. a rate-limit fallback to another model), a different
+    effort level, or no usable tracked composite to compare against — means
+    the server state genuinely moved; the *server's* report is adopted,
+    re-composed as ``reported_model_id + "/" + reported_effort`` so the
+    result keeps the composite shape callers (Canvas) expect from these two
+    providers.
+
+    Returns ``None`` when ``reported_model_id`` is ``None`` (nothing to
+    reconcile against — callers should not invoke this in that case, but the
+    function stays total as a safety net).
+    """
+    if reported_model_id is None:
+        return None
+    provider = detect_acp_provider_by_agent_name(agent_name or "")
+    composite_provider = provider is not None and provider.key in (
+        "codex",
+        "claude-code",
+    )
+    if not (model_override_applied and composite_provider and reported_effort):
+        return reported_model_id
+    if tracked_model_id:
+        base, sep, effort = tracked_model_id.rpartition("/")
+        if sep and base == reported_model_id and effort == reported_effort:
+            return tracked_model_id
+    return f"{reported_model_id}/{reported_effort}"
 
 
 # The ACP MCP server union accepted by new_session() / load_session().
@@ -1227,6 +1333,16 @@ class _OpenHandsACPBridge:
         # event stream in cleartext. ``None`` ⇒ no-op (bridge used standalone).
         self.mask: Callable[[str], str] | None = None
         self.before_mask: Callable[[], None] | None = None
+        # Live model/effort config-option sink — fired from session_update on
+        # every ConfigOptionUpdate notification (the agent MUST resend the
+        # full configOptions state after set_config_option, and MAY push
+        # spontaneous updates, e.g. a model fallback on rate limit). Bound
+        # once for the conversation's lifetime by
+        # ACPAgent._bind_config_option_update_callback (same lifecycle as
+        # ``mask``/``before_mask`` above — NOT rewired per-turn like
+        # on_event/on_token, since a config update can arrive with no turn in
+        # flight). ``None`` ⇒ no-op (bridge used standalone, e.g. tests).
+        self.on_config_options_update: Callable[[list[Any]], None] | None = None
         self._masking_error: CredentialBindingError | None = None
         self._last_activity_signal: float = float("-inf")
         # Monotonic timestamp of the most recent ``session_update``. Unlike the
@@ -1454,6 +1570,24 @@ class _OpenHandsACPBridge:
             )
             if target is not None and became_terminal:
                 self._emit_tool_call_event(target)
+            self._maybe_signal_activity()
+        elif isinstance(update, ConfigOptionUpdate):
+            # Per the ACP spec the agent MUST resend the complete
+            # configOptions state after set_config_option, and MAY push this
+            # spontaneously (e.g. a model fallback on rate limit). Relay the
+            # full list to the agent-side sink so model/effort state stays
+            # live between turns, not just at session start/resume.
+            logger.debug(
+                "ACP config_option_update: %d option(s)",
+                len(update.config_options),
+            )
+            if self.on_config_options_update is not None:
+                try:
+                    self.on_config_options_update(update.config_options)
+                except Exception:
+                    logger.debug(
+                        "on_config_options_update callback failed", exc_info=True
+                    )
             self._maybe_signal_activity()
         else:
             logger.debug("ACP session update: %s", type(update).__name__)
@@ -2687,6 +2821,108 @@ class ACPAgent(AgentBase):
 
         client.before_mask = track_file_credentials
 
+    def _bind_config_option_update_callback(self) -> None:
+        """Wire the bridge's live ``config_option_update`` sink to this agent.
+
+        Same weakref-indirection pattern as :meth:`_bind_file_credential_masking`
+        immediately above: the bridge is a plain object with no reference back
+        to the agent, so a closure capturing a *weak* reference is handed to
+        it instead of ``self`` directly — a strong reference from the
+        long-lived bridge back to the agent would keep the agent (and its
+        subprocess/executor) alive past what ``__del__``/``release_runtime``
+        expect. Bound once here, for the conversation's lifetime, alongside
+        ``client.mask`` — not per-turn like ``on_event``/``on_token`` — since
+        a config update can arrive with no turn in flight (see
+        :attr:`_OpenHandsACPBridge.on_config_options_update`).
+        """
+        client = self._client
+        if client is None:
+            return
+        agent_ref = weakref.ref(self)
+
+        def on_config_options_update(config_options: list[Any]) -> None:
+            agent = agent_ref()
+            if agent is not None:
+                agent._on_config_options_update(config_options)
+
+        client.on_config_options_update = on_config_options_update
+
+    def _on_config_options_update(self, config_options: list[Any]) -> None:
+        """Apply a live ``config_option_update`` notification's model/effort
+        state to this agent's runtime attrs.
+
+        Per the ACP spec the agent MUST resend the complete ``configOptions``
+        list after ``set_config_option``, and MAY push this spontaneously
+        (e.g. a model fallback on rate limit) — see
+        :class:`acp.schema.ConfigOptionUpdate`. Invoked by the bridge (via
+        :meth:`_bind_config_option_update_callback`) for every such
+        notification on the *main* session; a notification on an
+        ``ask_agent`` fork session never reaches here (see the fork
+        short-circuit at the top of
+        :meth:`_OpenHandsACPBridge.session_update`).
+
+        Re-runs the same extraction ``init_state`` performs at session
+        start/resume (:func:`_extract_session_models` /
+        :func:`_extract_session_efforts`) over the updated list, wrapped in a
+        minimal object exposing ``.config_options`` since both helpers only
+        ever read that one attribute off their ``response`` argument. Keeps
+        the file's established None-vs-absent convention: a value is only
+        overwritten when *this* update actually reports that option
+        (``available_models`` / ``available_efforts`` not ``None``) — an
+        update that, say, only touches an unrelated boolean config option
+        leaves model/effort state untouched rather than clearing it.
+
+        ``_current_model_id`` is resolved through
+        :func:`_reconcile_current_model_id` rather than a plain overwrite, so
+        a composite id tracked locally (e.g. ``"sonnet/high"``) survives a
+        report that — correctly, per-protocol — echoes only its base
+        component plus a separate effort value, instead of being clobbered
+        down to the bare base id every time the server resends state.
+
+        Threading: this runs on the ACP client's async portal thread, inside
+        ``session_update`` (see the concurrency-model docstring on
+        :class:`_OpenHandsACPBridge`). Like
+        ``_track_file_credentials_for_masking`` (also invoked from that
+        thread, via ``before_mask``), it touches agent state with plain
+        attribute writes and no additional locking: the caller thread is
+        either parked inside ``portal.call()``/``run_async`` for the
+        duration of any turn that could read these attrs, or there is no
+        turn in flight at all, so nothing else in-process races these
+        writes.
+
+        Persistence: unlike
+        :meth:`~openhands.sdk.conversation.impl.local_conversation.LocalConversation.switch_acp_model`,
+        there is no established hook from here into
+        ``ConversationState.agent_state`` — that write happens only in
+        :meth:`init_state` (session start/resume), and this method (reached
+        from the bridge, not the conversation) has no reference to
+        ``ConversationState`` to reuse it safely off the portal thread.
+        Refreshed values therefore live in-memory only until the next
+        ``init_state`` (fresh process, or a resumed session) recomputes and
+        persists them from the server's response at that point; a mid-life
+        update is not durable across an agent-server restart. This is a
+        deliberate scope cut, not an oversight.
+        """
+        response = SimpleNamespace(config_options=config_options)
+        reported_model_id, available_models, _ = _extract_session_models(
+            response, default_via_config_option=self._model_via_config_option
+        )
+        reported_effort, available_efforts = _extract_session_efforts(response)
+
+        if available_models is not None:
+            self._current_model_id = _reconcile_current_model_id(
+                self._current_model_id,
+                reported_model_id,
+                reported_effort,
+                agent_name=self._agent_name,
+                model_override_applied=self._model_override_applied,
+            )
+            self._available_models = available_models
+
+        if available_efforts is not None:
+            self._current_effort = reported_effort
+            self._available_efforts = available_efforts
+
     async def _flush_file_credentials(self) -> None:
         with self._file_credential_lock:
             if not self._file_credential_lifecycles:
@@ -2736,6 +2972,7 @@ class ACPAgent(AgentBase):
         # client and may fire while no step()/astep() turn is active.
         client.mask = state.secret_registry.mask_secrets_in_output
         self._bind_file_credential_masking()
+        self._bind_config_option_update_callback()
 
         # Build the subprocess environment. Precedence, highest first:
         #   state.secret_registry > os.environ > default_environment

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -387,6 +387,12 @@ def _with_codex_base_url(
 # (codex-acp, claude-agent-acp 0.44+) rather than the UNSTABLE ``models``
 # capability + ``session/set_model`` (gemini-cli, older codex/claude).
 _MODEL_CONFIG_OPTION_ID = "model"
+# Session config-option ids that select the reasoning/thinking effort level,
+# gated by provider: claude-agent-acp exposes ``effort``, codex-acp exposes
+# ``reasoning_effort``. Recognized generically (id membership only) by
+# ``_extract_session_efforts`` so either provider's select is picked up
+# without provider detection at read time.
+_EFFORT_CONFIG_OPTION_IDS: Final[tuple[str, ...]] = ("effort", "reasoning_effort")
 _CODEX_REASONING_EFFORTS: Final[frozenset[str]] = frozenset(
     {"low", "medium", "high", "xhigh"}
 )
@@ -554,6 +560,90 @@ def _extract_session_models(
         usable = _usable_models(ACPModelInfo.from_protocol(m) for m in raw)
         return current, usable, False
     return None, None, default_via_config_option
+
+
+def _effort_config_option(response: Any) -> Any | None:
+    """Return the first ``configOptions`` select whose id names an effort
+    level (see :data:`_EFFORT_CONFIG_OPTION_IDS`), or ``None``.
+
+    Mirrors :func:`_model_config_option`: unwraps the ``agent-client-protocol``
+    0.8.x ``SessionConfigOption`` RootModel wrapper (access via ``.root``) so
+    detection works on either 0.8.x or 0.10.x of the vendored lib.
+    """
+    for raw in getattr(response, "config_options", None) or []:
+        opt = getattr(raw, "root", raw)
+        if (
+            getattr(opt, "type", None) == "select"
+            and getattr(opt, "id", None) in _EFFORT_CONFIG_OPTION_IDS
+        ):
+            return opt
+    return None
+
+
+def _extract_session_efforts(response: Any) -> tuple[str | None, list[str] | None]:
+    """Extract the effort/reasoning-effort state off a session response.
+
+    Returns ``(current_effort, available_efforts)``, best-effort. Reads the
+    ``effort`` (claude-agent-acp) or ``reasoning_effort`` (codex-acp)
+    ``configOptions`` select — only plain (ungrouped) select options are
+    handled, mirroring :func:`_model_config_option`. There is no legacy
+    ``models``-capability equivalent for effort, so unlike
+    :func:`_extract_session_models` this has a single mechanism to check.
+
+    ``available_efforts`` distinguishes **absent** from **empty**, same as
+    ``_extract_session_models``'s ``available_models``:
+
+    - ``None``  — no effort-like select was present in the response (older
+      agent, a provider without effort selection, or a ``load_session`` not
+      carrying it).
+    - ``[]``    — the select was present but offered no usable (non-empty
+      string) values.
+    - ``[...]`` — the reported effort levels, in the order the server sent
+      them. The ``"default"`` value is a real selectable option and is kept.
+
+    ``getattr`` keeps the helper tolerant of agents that emit a partial
+    structure.
+    """
+    if response is None:
+        return None, None
+    opt = _effort_config_option(response)
+    if opt is None:
+        return None, None
+    current = getattr(opt, "current_value", None)
+    current = current if isinstance(current, str) and current else None
+    options = getattr(opt, "options", None) or []
+    available = [
+        value
+        for o in options
+        if isinstance((value := getattr(o, "value", None)), str) and value
+    ]
+    return current, available
+
+
+def _model_config_option_effort(
+    agent_name: str | None,
+    model: str,
+    *,
+    via_config_option: bool,
+) -> str | None:
+    """Return the effort value ``_apply_acp_model`` would actually push for
+    ``model``, or ``None`` if none.
+
+    Mirrors the branch in :func:`_apply_acp_model` that splits a composite
+    Canvas model id (e.g. ``"sonnet/high"``) into ``configOptions`` pairs:
+    that split — and with it, an effort component — only happens when the
+    session uses the configOptions mechanism (``via_config_option``); a
+    session on the legacy ``set_session_model`` call sends the id whole, with
+    no way to express effort separately. ``None`` also covers a bare model id
+    (no effort suffix) and a provider :func:`_model_config_options` doesn't
+    split (e.g. gemini-cli).
+    """
+    if not via_config_option:
+        return None
+    for config_id, value in _model_config_options(agent_name, model):
+        if config_id in _EFFORT_CONFIG_OPTION_IDS:
+            return value
+    return None
 
 
 # The ACP MCP server union accepted by new_session() / load_session().
@@ -1733,6 +1823,24 @@ class ACPAgent(AgentBase):
     # in ``init_state`` uses that distinction to preserve vs clear the stored
     # list on resume. The public ``available_models`` property coerces to ``[]``.
     _available_models: list[ACPModelInfo] | None = PrivateAttr(default=None)
+    # The effort/reasoning-effort level the ACP server reported as active for
+    # this session, captured from the ``effort`` (claude-agent-acp) or
+    # ``reasoning_effort`` (codex-acp) ``configOptions`` select on the
+    # new_session / load_session response — see ``_extract_session_efforts``.
+    # Also updated when a composite ``model/effort`` id (e.g. ``"sonnet/high"``)
+    # is applied via ``set_config_option``, at session init, resume, and
+    # runtime switch — see ``_model_config_option_effort``. ``None`` when the
+    # server/provider doesn't surface effort state.
+    #
+    # Same PrivateAttr rationale as ``_current_model_id``: ``AgentBase`` is
+    # frozen, and the agent-server lifts this onto ``ConversationInfo`` for
+    # cross-process consumers.
+    _current_effort: str | None = PrivateAttr(default=None)
+    # The effort select's ``options`` from the same session response,
+    # normalized to a plain list of level strings. ``None``/``[]`` distinction
+    # mirrors ``_available_models`` (see ``_extract_session_efforts``); the
+    # public ``available_efforts`` property coerces to ``[]``.
+    _available_efforts: list[str] | None = PrivateAttr(default=None)
     # Whether the caller's ``acp_model`` was actually pushed to the server in
     # the most recent session init (via session ``_meta`` or ``set_session_model``).
     # ``False`` when there's no override, the provider can't apply it (unknown
@@ -1979,6 +2087,45 @@ class ACPAgent(AgentBase):
         return list(self._available_models or [])
 
     @property
+    def current_effort(self) -> str | None:
+        """The effort/reasoning-effort level the ACP server is currently
+        using for this session.
+
+        Captured from the ``effort`` (claude-agent-acp) or ``reasoning_effort``
+        (codex-acp) ``configOptions`` select on the ``new_session`` /
+        ``load_session`` response, or updated to match the effort component of
+        a composite ``model/effort`` id (e.g. ``"sonnet/high"``) applied via
+        ``set_config_option`` — at session init, resume, and runtime switch
+        (:meth:`set_acp_model`). ``None`` for providers/servers that don't
+        surface effort state — callers should treat the value as best-effort.
+
+        Note: this is in-process runtime state; it does not round-trip
+        through ``model_dump()``. Consumers that need to read it across the
+        API boundary should look at ``ConversationInfo.current_effort``,
+        which the agent-server lifts off the agent into the response.
+        """
+        return self._current_effort
+
+    @property
+    def available_efforts(self) -> list[str]:
+        """Effort/reasoning-effort levels the ACP server offers for this
+        session.
+
+        Captured verbatim from the ``effort``/``reasoning_effort``
+        ``configOptions`` select's ``options`` on the ``new_session`` /
+        ``load_session`` response; empty for providers/servers that don't
+        surface it. Enough for a client to render an effort picker and
+        resolve ``current_effort`` against it — the SDK does no curation.
+
+        Same lifecycle and serialization caveats as ``current_effort``:
+        in-process runtime state, lifted onto
+        ``ConversationInfo.available_efforts`` by the agent-server for
+        cross-process consumers. Always a list (the internal ``None``
+        "not-reported" sentinel is coerced to ``[]`` here).
+        """
+        return list(self._available_efforts or [])
+
+    @property
     def supports_runtime_model_switch(self) -> bool:
         """Whether a live, mid-conversation model switch will be attempted.
 
@@ -2190,6 +2337,22 @@ class ACPAgent(AgentBase):
             ]
         elif not truly_resumed:
             new_agent_state.pop("acp_available_models", None)
+        # Effort state tracking: same gating as the model fields above — an
+        # override attempted-but-not-applied invalidates a stale persisted
+        # effort just like it does the model, since both ride the same
+        # configOptions call.
+        if self._current_effort is not None:
+            new_agent_state["acp_current_effort"] = self._current_effort
+        elif (
+            not truly_resumed
+            or self._available_efforts is not None
+            or override_attempted_not_applied
+        ):
+            new_agent_state.pop("acp_current_effort", None)
+        if self._available_efforts is not None:
+            new_agent_state["acp_available_efforts"] = list(self._available_efforts)
+        elif not truly_resumed:
+            new_agent_state.pop("acp_available_efforts", None)
         state.agent_state = new_agent_state
 
         if self._installed_suffix:
@@ -2679,7 +2842,14 @@ class ACPAgent(AgentBase):
             prior_session_id = None
 
         async def _init() -> tuple[
-            str, str, str, str | None, list[ACPModelInfo] | None, bool
+            str,
+            str,
+            str,
+            str | None,
+            list[ACPModelInfo] | None,
+            str | None,
+            list[str] | None,
+            bool,
         ]:
             # Spawn the subprocess directly so we can install a
             # filtering reader that skips non-JSON-RPC lines some
@@ -2818,6 +2988,8 @@ class ACPAgent(AgentBase):
             session_id: str | None = None
             reported_model_id: str | None = None
             available_models: list[ACPModelInfo] | None = None
+            reported_effort: str | None = None
+            available_efforts: list[str] | None = None
             if prior_session_id is not None:
                 try:
                     load_response = await conn.load_session(
@@ -2841,6 +3013,9 @@ class ACPAgent(AgentBase):
                     ) = _extract_session_models(
                         load_response,
                         default_via_config_option=persisted_via_config_option,
+                    )
+                    reported_effort, available_efforts = _extract_session_efforts(
+                        load_response
                     )
                     logger.info(
                         "Resumed ACP session %s (cwd=%s)",
@@ -2880,6 +3055,7 @@ class ACPAgent(AgentBase):
                     available_models,
                     self._model_via_config_option,
                 ) = _extract_session_models(response)
+                reported_effort, available_efforts = _extract_session_efforts(response)
                 # Initial-model protocol call for every built-in provider
                 # (codex, gemini, claude-code). The pinned claude/codex CLIs
                 # ignore the _meta above, so this protocol call is what actually
@@ -2921,6 +3097,22 @@ class ACPAgent(AgentBase):
                 else reported_model_id
             )
 
+            # Resolve effort the same way: the server's report is the base
+            # value, overridden by the effort component of a composite
+            # ``acp_model`` (e.g. ``"sonnet/high"``) when that override was
+            # actually applied via the configOptions mechanism. A bare model
+            # id (no effort suffix) or a legacy ``set_session_model`` session
+            # yields no override here, leaving the server-reported value.
+            current_effort = reported_effort
+            if self.acp_model and override_applied:
+                applied_effort = _model_config_option_effort(
+                    agent_name,
+                    self.acp_model,
+                    via_config_option=self._model_via_config_option,
+                )
+                if applied_effort is not None:
+                    current_effort = applied_effort
+
             # Resolve the permission mode. Known providers each have their own
             # mode ID; unknown/custom servers get None — skip the call rather
             # than sending a provider-specific string they won't recognise.
@@ -2938,6 +3130,8 @@ class ACPAgent(AgentBase):
                 agent_version,
                 current_model_id,
                 available_models,
+                current_effort,
+                available_efforts,
                 override_applied,
             )
 
@@ -2951,6 +3145,8 @@ class ACPAgent(AgentBase):
                 self._agent_version,
                 self._current_model_id,
                 self._available_models,
+                self._current_effort,
+                self._available_efforts,
                 self._model_override_applied,
             ) = self._executor.run_async(_init, timeout=self.acp_startup_timeout)
         except TimeoutError:
@@ -4065,6 +4261,19 @@ class ACPAgent(AgentBase):
         # this updated value onto the persisted agent. ``available_models`` is
         # unchanged by a model switch, so it is intentionally left alone.
         self._current_model_id = model
+        # Keep effort in sync when ``model`` is a composite ``model/effort`` id
+        # (e.g. ``"sonnet/high"``) applied via the configOptions mechanism —
+        # mirrors ``_current_model_id`` above. A bare model id (no effort
+        # component actually applied on the wire) leaves ``_current_effort``
+        # untouched rather than clearing it: this switch said nothing about
+        # effort, so the previously-known value is still the best guess.
+        # ``_available_efforts`` is intentionally left alone, same as
+        # ``available_models``.
+        applied_effort = _model_config_option_effort(
+            self._agent_name, model, via_config_option=self._model_via_config_option
+        )
+        if applied_effort is not None:
+            self._current_effort = applied_effort
         logger.info(
             "Switched ACP session model to %s (provider=%s, session=%s)",
             model,

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -390,6 +390,13 @@ _MODEL_CONFIG_OPTION_ID = "model"
 _CODEX_REASONING_EFFORTS: Final[frozenset[str]] = frozenset(
     {"low", "medium", "high", "xhigh"}
 )
+# claude-agent-acp's ``effort`` config option (thought_level category) adds
+# ``max`` on top of the levels codex-acp's ``reasoning_effort`` accepts — do
+# not fold this into ``_CODEX_REASONING_EFFORTS``, the two are gated to
+# different providers below.
+_CLAUDE_EFFORT_LEVELS: Final[frozenset[str]] = frozenset(
+    {"low", "medium", "high", "xhigh", "max"}
+)
 
 
 def _codex_model_config_options(model: str) -> tuple[tuple[str, str], ...]:
@@ -403,6 +410,26 @@ def _codex_model_config_options(model: str) -> tuple[tuple[str, str], ...]:
     return ((_MODEL_CONFIG_OPTION_ID, model),)
 
 
+def _claude_model_config_options(model: str) -> tuple[tuple[str, str], ...]:
+    """Map combined Canvas Claude Code model IDs to claude-agent-acp config
+    options.
+
+    Mirrors :func:`_codex_model_config_options`, but claude-agent-acp exposes
+    thinking effort as its own ``effort`` config option (not
+    ``reasoning_effort``). Splitting on the last ``/`` also handles ids that
+    themselves contain a ``/`` in the base (none of the curated Claude ids
+    do today, but ``opus[1m]/max`` still splits into base ``opus[1m]`` +
+    effort ``max`` since ``max`` is only valid for Claude, not Codex).
+    """
+    base_model, sep, effort = model.rpartition("/")
+    if sep and base_model and effort in _CLAUDE_EFFORT_LEVELS:
+        return (
+            (_MODEL_CONFIG_OPTION_ID, base_model),
+            ("effort", effort),
+        )
+    return ((_MODEL_CONFIG_OPTION_ID, model),)
+
+
 def _model_config_options(
     agent_name: str | None,
     model: str,
@@ -410,6 +437,8 @@ def _model_config_options(
     provider = detect_acp_provider_by_agent_name(agent_name or "")
     if provider is not None and provider.key == "codex":
         return _codex_model_config_options(model)
+    if provider is not None and provider.key == "claude-code":
+        return _claude_model_config_options(model)
     return ((_MODEL_CONFIG_OPTION_ID, model),)
 
 
@@ -451,9 +480,11 @@ async def _apply_acp_model(
     servers (codex-acp, claude-agent-acp 0.44+), else ``set_session_model``.
 
     The model id is normally the bare preset id listed by the server. For
-    Codex, callers may still pass a combined Canvas id such as ``gpt-5.5/high``;
-    codex-acp exposes reasoning effort as a separate config option, so split it
-    only on the config-options mechanism.
+    Codex and Claude Code, callers may still pass a combined Canvas id such as
+    ``gpt-5.5/high`` or ``sonnet/high``; codex-acp exposes reasoning effort as
+    a separate ``reasoning_effort`` config option and claude-agent-acp exposes
+    thinking effort as a separate ``effort`` config option, so split it only
+    on the config-options mechanism (see :func:`_model_config_options`).
     """
     if via_config_option:
         for config_id, value in _model_config_options(agent_name, model):

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1739,10 +1739,18 @@ class LocalConversation(BaseConversation):
             # otherwise still name the pre-switch model until the next resume.
             # Write unconditionally: a successful switch is authoritative even
             # for an older/custom server that reported no ``models`` at init
-            # (so the key may not exist yet).
+            # (so the key may not exist yet). Same for ``acp_current_effort``:
+            # ``new_agent.current_effort`` already carries whatever the live
+            # switch resolved (see ``ACPAgent.set_acp_model``) — the effort
+            # component of a composite ``model/effort`` id when the switch
+            # applied one, or the prior value unchanged otherwise (a bare
+            # model id, or a deferred pre-session switch that made no
+            # protocol call yet) — so persisting it here keeps the cold-read
+            # hint from lagging the (correctly refreshed) live PrivateAttr.
             self._state.agent_state = {
                 **self._state.agent_state,
                 "acp_current_model_id": model,
+                "acp_current_effort": new_agent.current_effort,
             }
 
     @observe(name="conversation.send_message")

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -390,7 +390,7 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
-CLAUDE_AGENT_ACP_VERSION = "0.44.0"
+CLAUDE_AGENT_ACP_VERSION = "0.64.2"
 CODEX_ACP_VERSION = "1.1.2"
 GEMINI_CLI_VERSION = "0.46.0"
 

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -309,6 +309,112 @@ def test_current_model_id_falls_back_to_acp_model_on_cold_read():
     assert info.current_model_id == "enterprise-x"
 
 
+def test_current_effort_is_lifted_from_acp_agent():
+    """When the ACP agent has resolved an effort level, it surfaces on the
+    response, mirroring ``current_model_id``.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"])
+    agent._current_effort = "high"
+    state = _make_state(agent)
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort == "high"
+
+
+def test_current_effort_is_none_when_acp_agent_has_no_effort():
+    """Providers/servers without effort selection (or older ACP servers)
+    leave ``_current_effort`` at its default -> ``None``.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"])
+    state = _make_state(agent)
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort is None
+    assert info.available_efforts is None
+
+
+def test_available_efforts_lifted_from_acp_agent():
+    """``ConversationInfo.available_efforts`` mirrors the agent's effort
+    level list verbatim, resolving ``current_effort`` against it is left to
+    the client.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"])
+    agent._current_effort = "high"
+    agent._available_efforts = ["low", "medium", "high", "max", "default"]
+    state = _make_state(agent)
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort == "high"
+    assert info.available_efforts == ["low", "medium", "high", "max", "default"]
+
+
+def test_effort_fields_read_from_persisted_agent_state():
+    """Cold conversation list: the live agent's PrivateAttrs are still None
+    because ``init_state`` hasn't fired, but ``agent_state`` persisted the
+    values from the last session — the lift should source from there,
+    mirroring ``test_current_model_fields_read_from_persisted_agent_state``.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"])
+    state = _make_state(agent)
+    state.agent_state = {
+        "acp_session_id": "prior-session",
+        "acp_current_effort": "high",
+        "acp_available_efforts": ["low", "medium", "high"],
+    }
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort == "high"
+    assert info.available_efforts == ["low", "medium", "high"]
+
+
+def test_live_effort_attrs_take_precedence_over_persisted_state():
+    """Within an active session, the live agent is the freshest source for
+    effort state too — mirrors
+    ``test_live_agent_attrs_take_precedence_over_persisted_state``.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"])
+    agent._current_effort = "high"
+    agent._available_efforts = ["low", "high"]
+    state = _make_state(agent)
+    # Stale persisted state from a prior session that picked a different
+    # effort level.
+    state.agent_state = {
+        "acp_current_effort": "low",
+        "acp_available_efforts": ["low"],
+    }
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort == "high"
+    assert info.available_efforts == ["low", "high"]
+
+
+def test_current_effort_does_not_fall_back_to_acp_model_on_cold_read():
+    """Unlike ``current_model_id``, ``current_effort`` has no third fallback
+    that parses the effort component out of a composite ``acp_model`` (e.g.
+    ``"sonnet/high"``) — that split lives in ``acp_agent`` and isn't
+    reproduced here. A pure cold read (no live PrivateAttr, no persisted
+    hint) honestly reports ``None`` rather than guessing.
+    """
+    agent = ACPAgent(acp_command=["echo", "test"], acp_model="sonnet/high")
+    # _initialized defaults to False (cold read); _current_effort defaults None.
+    state = _make_state(agent)
+    stored = _make_stored(state)
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.current_effort is None
+
+
 def test_supports_runtime_model_switch_lifted_from_agent_state():
     """The static provider capability is read from persisted ``agent_state``
     (written at session init), so it's correct on cold list reads too.

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -1126,6 +1126,49 @@ def test_conversation_stats_with_live_server(
     conv.close()
 
 
+def test_conversation_effort_fields_round_trip_over_rest(server_env):
+    """GET /api/conversations/{id} surfaces the ACP effort fields end-to-end.
+
+    A native agent leaves current_effort/available_efforts unset. Seeding the
+    server-side conversation's persisted agent_state (the acp_current_effort /
+    acp_available_efforts keys ACPAgent._init writes, read on cold list reads)
+    makes them round-trip through the REST ConversationInfo payload — mirrors
+    tests/agent_server/test_conversation_info_model.py::
+    test_effort_fields_read_from_persisted_agent_state, but over the real HTTP
+    stack instead of calling _compose_conversation_info directly.
+    """
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test"))
+    agent = Agent(llm=llm, tools=[])
+    workspace = RemoteWorkspace(
+        host=server_env["host"], working_dir="/tmp/workspace/project"
+    )
+    conv: RemoteConversation = Conversation(agent=agent, workspace=workspace)
+
+    with httpx.Client(base_url=server_env["host"]) as client:
+        response = client.get(f"/api/conversations/{conv.id}", timeout=5.0)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["current_effort"] is None
+        assert body["available_efforts"] is None
+
+        event_service = server_env["conversation_service"]._event_services[conv.id]
+        assert event_service._conversation is not None
+        with event_service._conversation._state as state:
+            state.agent_state = {
+                **state.agent_state,
+                "acp_current_effort": "high",
+                "acp_available_efforts": ["low", "medium", "high", "default"],
+            }
+
+        response = client.get(f"/api/conversations/{conv.id}", timeout=5.0)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["current_effort"] == "high"
+        assert body["available_efforts"] == ["low", "medium", "high", "default"]
+
+    conv.close()
+
+
 def test_events_not_lost_during_client_disconnection(
     server_env, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -31,6 +31,7 @@ from openhands.sdk.agent.acp_agent import (
     _apply_acp_model,
     _classify_acp_init_error,
     _classify_acp_turn_error,
+    _claude_model_config_options,
     _codex_model_config_options,
     _estimate_cost_from_tokens,
     _extract_session_models,
@@ -39,6 +40,7 @@ from openhands.sdk.agent.acp_agent import (
     _mask_json_value,
     _maybe_set_session_model,
     _mcp_config_to_acp_servers,
+    _model_config_options,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
     _select_auth_method,
@@ -5062,6 +5064,73 @@ class TestCodexModelConfigOptions:
             ("model", "custom/provider/model"),
         )
 
+    def test_rejects_max_effort_which_is_claude_only(self):
+        # "max" is a valid thought_level for claude-agent-acp's ``effort``
+        # config option but not codex-acp's ``reasoning_effort`` — codex must
+        # not split it.
+        assert _codex_model_config_options("gpt-5.5/max") == (("model", "gpt-5.5/max"),)
+
+
+class TestClaudeModelConfigOptions:
+    def test_splits_combined_model_and_effort(self):
+        assert _claude_model_config_options("sonnet/high") == (
+            ("model", "sonnet"),
+            ("effort", "high"),
+        )
+
+    def test_splits_max_effort_which_is_claude_only(self):
+        # "max" is only valid for claude-agent-acp's ``effort`` config option
+        # (not codex-acp's ``reasoning_effort``), and the composite id itself
+        # contains a ``/`` before the effort suffix (``opus[1m]``).
+        assert _claude_model_config_options("opus[1m]/max") == (
+            ("model", "opus[1m]"),
+            ("effort", "max"),
+        )
+
+    def test_leaves_base_model_id_unchanged(self):
+        assert _claude_model_config_options("sonnet") == (("model", "sonnet"),)
+
+    def test_leaves_unknown_effort_suffix_unchanged(self):
+        # "turbo" is not a recognised thought_level, so the full original
+        # string is kept as a single ``model`` value rather than mis-split.
+        assert _claude_model_config_options("sonnet/turbo") == (
+            ("model", "sonnet/turbo"),
+        )
+
+
+class TestModelConfigOptionsProviderGating:
+    """``_model_config_options`` dispatches the composite-id splitter by
+    detected provider; every other provider gets a single, unsplit pair."""
+
+    def test_claude_provider_splits_via_effort(self):
+        assert _model_config_options("claude-agent-acp", "sonnet/high") == (
+            ("model", "sonnet"),
+            ("effort", "high"),
+        )
+
+    def test_codex_provider_splits_via_reasoning_effort(self):
+        assert _model_config_options("codex-acp", "gpt-5.5/high") == (
+            ("model", "gpt-5.5"),
+            ("reasoning_effort", "high"),
+        )
+
+    def test_codex_provider_rejects_max(self):
+        assert _model_config_options("codex-acp", "gpt-5.5/max") == (
+            ("model", "gpt-5.5/max"),
+        )
+
+    def test_gemini_provider_never_splits(self):
+        # gemini-cli is neither codex nor claude-code, so a composite-looking
+        # id is passed through verbatim as a single ``model`` value.
+        assert _model_config_options("gemini-cli", "gemini-3-pro-preview/high") == (
+            ("model", "gemini-3-pro-preview/high"),
+        )
+
+    def test_unknown_provider_never_splits(self):
+        assert _model_config_options("some-custom-acp", "sonnet/high") == (
+            ("model", "sonnet/high"),
+        )
+
 
 # ---------------------------------------------------------------------------
 # ACP model overrides
@@ -5459,6 +5528,32 @@ class TestSetACPModel:
             config_id="model", value="sonnet", session_id="sess-1"
         )
         assert agent._current_model_id == "sonnet"
+
+    def test_switches_claude_via_config_option_splits_effort(self):
+        # Canvas may persist Claude ids as ``model/effort``; claude-agent-acp
+        # exposes thinking effort as its own ``effort`` config option
+        # (symmetric with codex's ``reasoning_effort`` split above, but "max"
+        # is a valid level here too).
+        agent = self._wire(_make_agent(), "claude-agent-acp", via_config_option=True)
+        agent.set_acp_model("sonnet/high")
+        _agent_conn(agent).set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="sonnet", session_id="sess-1"),
+                call(
+                    config_id="effort",
+                    value="high",
+                    session_id="sess-1",
+                ),
+            ]
+        )
+        assert _agent_conn(agent).set_config_option.await_count == 2
+        _agent_conn(agent).set_session_model.assert_not_called()
+        # The sentinel LLM + persisted current_model_id store the full
+        # composite id (matching codex's symmetric behavior above), not just
+        # the base model — downstream consumers (e.g. Canvas) read the
+        # composite back from ``current_model_id``.
+        assert agent.llm.model == "sonnet/high"
+        assert agent._current_model_id == "sonnet/high"
 
     def test_switch_method_not_found_raises_no_fallback(self):
         # No cross-mechanism fallback: a -32601 surfaces as a ValueError naming
@@ -8178,6 +8273,71 @@ class TestApplyAcpModel:
                 call(
                     config_id="reasoning_effort",
                     value="xhigh",
+                    session_id="sess-1",
+                ),
+            ]
+        )
+        assert conn.set_config_option.await_count == 2
+        conn.set_session_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_codex_config_option_rejects_max_effort(self):
+        # "max" is claude-only; codex's split must not fire for it, so the
+        # full composite id is sent as a single ``model`` value.
+        conn = AsyncMock()
+        await _apply_acp_model(
+            conn,
+            "sess-1",
+            "gpt-5.5/max",
+            agent_name="codex-acp",
+            via_config_option=True,
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="model", value="gpt-5.5/max", session_id="sess-1"
+        )
+        conn.set_session_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_claude_config_option_splits_effort(self):
+        conn = AsyncMock()
+        await _apply_acp_model(
+            conn,
+            "sess-1",
+            "sonnet/high",
+            agent_name="claude-agent-acp",
+            via_config_option=True,
+        )
+        conn.set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="sonnet", session_id="sess-1"),
+                call(
+                    config_id="effort",
+                    value="high",
+                    session_id="sess-1",
+                ),
+            ]
+        )
+        assert conn.set_config_option.await_count == 2
+        conn.set_session_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_claude_config_option_splits_max_effort(self):
+        # "max" is valid for claude's ``effort`` option (unlike codex's
+        # ``reasoning_effort``).
+        conn = AsyncMock()
+        await _apply_acp_model(
+            conn,
+            "sess-1",
+            "opus[1m]/max",
+            agent_name="claude-agent-acp",
+            via_config_option=True,
+        )
+        conn.set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="opus[1m]", session_id="sess-1"),
+                call(
+                    config_id="effort",
+                    value="max",
                     session_id="sess-1",
                 ),
             ]

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -34,12 +34,14 @@ from openhands.sdk.agent.acp_agent import (
     _claude_model_config_options,
     _codex_model_config_options,
     _estimate_cost_from_tokens,
+    _extract_session_efforts,
     _extract_session_models,
     _extract_token_usage,
     _image_url_to_acp_block,
     _mask_json_value,
     _maybe_set_session_model,
     _mcp_config_to_acp_servers,
+    _model_config_option_effort,
     _model_config_options,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
@@ -5501,6 +5503,8 @@ class TestSetACPModel:
         _agent_conn(agent).set_session_model.assert_not_called()
         assert agent.llm.model == "gpt-5.5"
         assert agent._current_model_id == "gpt-5.5"
+        # No effort component in this switch -> _current_effort untouched.
+        assert agent._current_effort is None
 
     def test_switches_codex_via_config_option_splits_reasoning_effort(self):
         agent = self._wire(_make_agent(), "codex-acp", via_config_option=True)
@@ -5519,6 +5523,7 @@ class TestSetACPModel:
         _agent_conn(agent).set_session_model.assert_not_called()
         assert agent.llm.model == "gpt-5.5/high"
         assert agent._current_model_id == "gpt-5.5/high"
+        assert agent._current_effort == "high"
 
     def test_switches_claude_via_config_option_single_call(self):
         # A bare id (no `/`) applies as a single `model` selection — no effort.
@@ -5528,6 +5533,7 @@ class TestSetACPModel:
             config_id="model", value="sonnet", session_id="sess-1"
         )
         assert agent._current_model_id == "sonnet"
+        assert agent._current_effort is None
 
     def test_switches_claude_via_config_option_splits_effort(self):
         # Canvas may persist Claude ids as ``model/effort``; claude-agent-acp
@@ -5554,6 +5560,19 @@ class TestSetACPModel:
         # composite back from ``current_model_id``.
         assert agent.llm.model == "sonnet/high"
         assert agent._current_model_id == "sonnet/high"
+        # ...and _current_effort tracks the split-off effort component.
+        assert agent._current_effort == "high"
+
+    def test_switch_without_effort_leaves_prior_current_effort_unchanged(self):
+        # A subsequent switch to a bare id says nothing about effort, so the
+        # previously-known value is preserved rather than cleared — mirrors
+        # how ``_available_models``/``_available_efforts`` are left alone by
+        # a switch, but for the *current* value: "no signal" isn't "reset".
+        agent = self._wire(_make_agent(), "claude-agent-acp", via_config_option=True)
+        agent._current_effort = "high"
+        agent.set_acp_model("haiku")
+        assert agent._current_model_id == "haiku"
+        assert agent._current_effort == "high"
 
     def test_switch_method_not_found_raises_no_fallback(self):
         # No cross-mechanism fallback: a -32601 surfaces as a ValueError naming
@@ -7130,6 +7149,77 @@ class TestACPSessionIdPersistence:
         conn2.new_session.assert_not_awaited()
         assert agent2._session_id == "roundtrip-sess"
 
+    def test_init_state_persists_effort_state_from_config_option(self, tmp_path):
+        """A fresh session whose ``configOptions`` include an effort select
+        persists both ``acp_current_effort`` and ``acp_available_efforts``
+        into agent_state, mirroring ``acp_current_model_id`` /
+        ``acp_available_models``.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = self._make_conn(new_session_id="fresh-sess")
+        conn.new_session.return_value.config_options = [
+            SimpleNamespace(
+                id="model",
+                type="select",
+                current_value="sonnet",
+                options=[SimpleNamespace(value="sonnet", name="Sonnet")],
+            ),
+            SimpleNamespace(
+                id="effort",
+                type="select",
+                current_value="high",
+                options=[
+                    SimpleNamespace(value="low", name=None),
+                    SimpleNamespace(value="high", name=None),
+                ],
+            ),
+        ]
+
+        agent._executor = AsyncExecutor()
+        with self._transport_patches(conn):
+            agent.init_state(state, on_event=lambda _: None)
+
+        assert state.agent_state["acp_current_effort"] == "high"
+        assert state.agent_state["acp_available_efforts"] == ["low", "high"]
+
+    def test_resume_preserves_persisted_effort_when_load_session_omits_effort_option(
+        self, tmp_path
+    ):
+        """Resume must not blank the persisted ``acp_current_effort`` /
+        ``acp_available_efforts`` when ``load_session`` returns no effort
+        ``configOptions`` select — mirrors the model-state preservation
+        contract (see
+        ``test_resume_preserves_persisted_model_when_load_session_omits_models``).
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "resumable-sess",
+            "acp_session_cwd": str(tmp_path),
+            "acp_current_effort": "high",
+            "acp_available_efforts": ["low", "medium", "high"],
+        }
+        conn = self._make_conn()
+        load_response = MagicMock(spec=[])  # no .config_options / .models attrs
+        conn.load_session = AsyncMock(return_value=load_response)
+
+        agent._executor = AsyncExecutor()
+        with self._transport_patches(conn):
+            agent.init_state(state, on_event=lambda _: None)
+
+        assert state.agent_state["acp_current_effort"] == "high"
+        assert state.agent_state["acp_available_efforts"] == [
+            "low",
+            "medium",
+            "high",
+        ]
+
     def test_start_acp_server_bounds_a_hung_handshake_call(self, tmp_path):
         """A hung ACP call during the handshake (e.g. codex-acp blocking on an
         expired id_token inside authenticate(), #3629) used to freeze
@@ -7808,6 +7898,50 @@ class TestACPAgentCurrentModelIdProperty:
         assert clone.current_model_id is None
 
 
+class TestACPAgentCurrentEffortProperty:
+    """``current_effort`` mirrors ``current_model_id``: a read-only property
+    backed by a PrivateAttr, populated from the session's ``effort`` /
+    ``reasoning_effort`` configOptions select (or the composite ``acp_model``
+    override once applied).
+    """
+
+    def test_defaults_to_none(self):
+        agent = _make_agent()
+        assert agent.current_effort is None
+
+    def test_reflects_private_attr(self):
+        agent = _make_agent()
+        agent._current_effort = "high"
+        assert agent.current_effort == "high"
+
+    def test_does_not_round_trip_through_json(self):
+        agent = _make_agent()
+        agent._current_effort = "high"
+        clone = ACPAgent.model_validate_json(agent.model_dump_json())
+        assert clone.current_effort is None
+
+
+class TestACPAgentAvailableEffortsProperty:
+    """``available_efforts`` mirrors ``available_models``: the server's
+    reported effort levels, exposed verbatim as a plain list of strings.
+    """
+
+    def test_defaults_to_empty(self):
+        assert _make_agent().available_efforts == []
+
+    def test_reflects_private_attr(self):
+        agent = _make_agent()
+        agent._available_efforts = ["low", "medium", "high", "max", "default"]
+        assert agent.available_efforts == ["low", "medium", "high", "max", "default"]
+
+    def test_returns_a_copy(self):
+        agent = _make_agent()
+        agent._available_efforts = ["low", "high"]
+        got = agent.available_efforts
+        got.append("injected")
+        assert agent.available_efforts == ["low", "high"]
+
+
 class TestExtractSessionModels:
     """``_extract_session_models`` reads the model the ACP server reports.
 
@@ -8080,6 +8214,191 @@ class TestConfigOptionModelMechanism:
         )
         assert (
             _extract_session_models(present, default_via_config_option=False)[2] is True
+        )
+
+
+class TestExtractSessionEfforts:
+    """``_extract_session_efforts`` reads effort/reasoning-effort state off a
+    session response's ``configOptions``.
+
+    Recognizes claude-agent-acp's ``effort`` id and codex-acp's
+    ``reasoning_effort`` id. ``available_efforts`` distinguishes **absent**
+    (``None`` — no effort-like select present) from **present-but-empty**
+    (``[]`` — select present, no usable values), mirroring
+    ``_extract_session_models``'s ``available_models``.
+    """
+
+    def _select(self, *, id, current_value, options):
+        return SimpleNamespace(
+            id=id, type="select", current_value=current_value, options=options
+        )
+
+    def _opt(self, value, name=None):
+        return SimpleNamespace(value=value, name=name)
+
+    def _response(self, *, config_options):
+        return SimpleNamespace(config_options=config_options)
+
+    def test_extracts_effort_from_claude_style_option(self):
+        # claude-agent-acp: thought_level category exposed as an "effort"
+        # config option, with "max" among the levels.
+        response = self._response(
+            config_options=[
+                self._select(id="model", current_value="sonnet", options=[]),
+                self._select(
+                    id="effort",
+                    current_value="high",
+                    options=[
+                        self._opt("low"),
+                        self._opt("medium"),
+                        self._opt("high"),
+                        self._opt("max"),
+                        self._opt("default"),
+                    ],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur == "high"
+        # "default" is a real selectable option and must be kept.
+        assert avail == ["low", "medium", "high", "max", "default"]
+
+    def test_extracts_effort_from_codex_style_option(self):
+        # codex-acp: "reasoning_effort" config option, no "max" level.
+        response = self._response(
+            config_options=[
+                self._select(
+                    id="reasoning_effort",
+                    current_value="medium",
+                    options=[
+                        self._opt("low"),
+                        self._opt("medium"),
+                        self._opt("high"),
+                        self._opt("xhigh"),
+                    ],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur == "medium"
+        assert avail == ["low", "medium", "high", "xhigh"]
+
+    def test_returns_none_when_response_is_none(self):
+        assert _extract_session_efforts(None) == (None, None)
+
+    def test_returns_none_when_no_effort_option_present(self):
+        # Only a "model" select — no effort-like id -> absent, not empty.
+        response = self._response(
+            config_options=[
+                self._select(id="model", current_value="sonnet", options=[]),
+            ]
+        )
+        assert _extract_session_efforts(response) == (None, None)
+
+    def test_returns_none_when_config_options_absent(self):
+        response = SimpleNamespace()
+        assert _extract_session_efforts(response) == (None, None)
+
+    def test_drops_non_string_and_empty_string_option_values(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    id="effort",
+                    current_value="high",
+                    options=[
+                        self._opt(42),  # non-string -> dropped
+                        self._opt("high"),
+                        self._opt(""),  # empty -> dropped
+                        self._opt(None),  # missing -> dropped
+                    ],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur == "high"
+        assert avail == ["high"]
+
+    def test_current_value_empty_string_is_none_but_options_survive(self):
+        # An empty current value is treated as "no current selection", same
+        # as the model select — but the block IS present, so the options list
+        # is [] rather than None.
+        response = self._response(
+            config_options=[
+                self._select(id="effort", current_value="", options=[]),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur is None
+        assert avail == []
+
+    def test_current_value_non_string_is_none(self):
+        response = self._response(
+            config_options=[
+                self._select(id="reasoning_effort", current_value=7, options=[]),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur is None
+        assert avail == []
+
+    def test_ignores_non_select_config_options_with_effort_id(self):
+        # Defensive: only "select"-typed options are considered.
+        response = self._response(
+            config_options=[
+                SimpleNamespace(
+                    id="effort", type="boolean", current_value=True, options=[]
+                ),
+            ]
+        )
+        assert _extract_session_efforts(response) == (None, None)
+
+
+class TestModelConfigOptionEffort:
+    """``_model_config_option_effort`` mirrors the effort split
+    ``_apply_acp_model`` actually pushes to the wire for a composite id.
+    """
+
+    def test_claude_composite_id_via_config_option(self):
+        assert (
+            _model_config_option_effort(
+                "claude-agent-acp", "sonnet/high", via_config_option=True
+            )
+            == "high"
+        )
+
+    def test_codex_composite_id_via_config_option(self):
+        assert (
+            _model_config_option_effort(
+                "codex-acp", "gpt-5.5/high", via_config_option=True
+            )
+            == "high"
+        )
+
+    def test_bare_model_id_has_no_effort(self):
+        assert (
+            _model_config_option_effort(
+                "claude-agent-acp", "sonnet", via_config_option=True
+            )
+            is None
+        )
+
+    def test_legacy_set_session_model_mechanism_has_no_effort(self):
+        # via_config_option=False -> the wire call sends the composite id
+        # whole via set_session_model; no configOptions pair is applied.
+        assert (
+            _model_config_option_effort(
+                "claude-agent-acp", "sonnet/high", via_config_option=False
+            )
+            is None
+        )
+
+    def test_unrecognized_effort_suffix_has_no_effort(self):
+        # "ultra" isn't a recognized Claude effort level -> no split.
+        assert (
+            _model_config_option_effort(
+                "claude-agent-acp", "sonnet/ultra", via_config_option=True
+            )
+            is None
         )
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from acp.exceptions import RequestError as ACPRequestError
-from acp.schema import NewSessionResponse, PromptResponse
+from acp.schema import ConfigOptionUpdate, NewSessionResponse, PromptResponse
 from pydantic import SecretStr
 
 import openhands.sdk.agent.acp_agent as acp_agent_module
@@ -37,6 +37,7 @@ from openhands.sdk.agent.acp_agent import (
     _extract_session_efforts,
     _extract_session_models,
     _extract_token_usage,
+    _flatten_select_options,
     _image_url_to_acp_block,
     _mask_json_value,
     _maybe_set_session_model,
@@ -45,6 +46,7 @@ from openhands.sdk.agent.acp_agent import (
     _model_config_options,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
+    _reconcile_current_model_id,
     _select_auth_method,
     _serialize_tool_content,
     _stringify_acp_error_data,
@@ -1111,6 +1113,135 @@ class TestOpenHandsACPClient:
     async def test_ext_notification_is_noop(self):
         client = _OpenHandsACPBridge()
         await client.ext_notification("test", {})  # Should not raise
+
+
+class TestConfigOptionUpdateBridge:
+    """``_OpenHandsACPBridge.session_update`` relays ``ConfigOptionUpdate``
+    notifications (the agent MUST resend the full ``configOptions`` state
+    after ``set_config_option``, and MAY push updates spontaneously — e.g. a
+    model fallback on rate limit) to ``on_config_options_update``.
+
+    Bound once per conversation by
+    ``ACPAgent._bind_config_option_update_callback`` (see
+    ``TestConfigOptionUpdateCallbackBinding`` below) — unlike ``on_event``
+    it is not rewired per-turn, since a config update can arrive with no
+    turn in flight.
+    """
+
+    def _update(self, config_options: list[Any]) -> Any:
+        # ConfigOptionUpdate.config_options validates its entries against the
+        # real SessionConfigOptionSelect/Boolean union, which the
+        # SimpleNamespace stand-ins used elsewhere in this file don't satisfy
+        # — mirrors the MagicMock(spec=UsageUpdate) pattern used for the
+        # other notification types in TestACPAgentTelemetry.
+        update = MagicMock(spec=ConfigOptionUpdate)
+        update.config_options = config_options
+        return update
+
+    @pytest.mark.asyncio
+    async def test_dispatches_config_options_to_callback(self):
+        client = _OpenHandsACPBridge()
+        received: list[Any] = []
+        client.on_config_options_update = received.append
+        options = [
+            SimpleNamespace(id="model", type="select", current_value="x", options=[])
+        ]
+        await client.session_update("sess-1", self._update(options))
+        assert len(received) == 1
+        assert received[0][0].id == "model"
+
+    @pytest.mark.asyncio
+    async def test_no_callback_registered_is_noop(self):
+        client = _OpenHandsACPBridge()
+        await client.session_update("sess-1", self._update([]))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_callback_error_is_swallowed(self):
+        client = _OpenHandsACPBridge()
+
+        def boom(_config_options: list[Any]) -> None:
+            raise RuntimeError("boom")
+
+        client.on_config_options_update = boom
+        await client.session_update("sess-1", self._update([]))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_fork_session_update_does_not_reach_callback(self):
+        # A config-option update on the ask_agent() fork session must not
+        # leak into the main session's tracked model/effort state.
+        client = _OpenHandsACPBridge()
+        client._fork_session_id = "fork-1"
+        received: list[Any] = []
+        client.on_config_options_update = received.append
+        await client.session_update(
+            "fork-1",
+            self._update(
+                [
+                    SimpleNamespace(
+                        id="model", type="select", current_value="x", options=[]
+                    )
+                ]
+            ),
+        )
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_signals_activity(self):
+        client = _OpenHandsACPBridge()
+        signals: list[None] = []
+        client.on_activity = lambda: signals.append(None)
+        await client.session_update("sess-1", self._update([]))
+        assert signals == [None]
+
+
+class TestConfigOptionUpdateCallbackBinding:
+    """``ACPAgent._bind_config_option_update_callback`` wires the bridge's
+    live sink to ``ACPAgent._on_config_options_update`` via a weakref
+    indirection, mirroring ``_bind_file_credential_masking``.
+    """
+
+    def test_bind_wires_agent_state_update(self):
+        agent = _make_agent()
+        agent._agent_name = "codex-acp"
+        agent._client = _OpenHandsACPBridge()
+        agent._bind_config_option_update_callback()
+
+        config_options = [
+            SimpleNamespace(
+                id="model",
+                type="select",
+                current_value="gpt-5.5",
+                options=[
+                    SimpleNamespace(value="gpt-5.5", name="GPT-5.5", description=None)
+                ],
+            )
+        ]
+        agent._client.on_config_options_update(config_options)
+
+        assert agent._current_model_id == "gpt-5.5"
+        assert agent._available_models is not None
+        assert [m.model_id for m in agent._available_models] == ["gpt-5.5"]
+
+    def test_bind_without_client_is_noop(self):
+        agent = _make_agent()
+        agent._client = None
+        agent._bind_config_option_update_callback()  # must not raise
+
+    def test_bind_does_not_retain_agent(self):
+        # Same weak-reference contract as _bind_file_credential_masking's
+        # before_mask: once the agent is gone, the bridge's stored callback
+        # becomes a no-op rather than keeping the agent alive.
+        agent = _make_agent()
+        agent._client = _OpenHandsACPBridge()
+        agent._bind_config_option_update_callback()
+        callback = agent._client.on_config_options_update
+        agent_ref = weakref.ref(agent)
+
+        del agent
+        gc.collect()
+
+        assert agent_ref() is None
+        assert callback([]) is None  # no-op once the agent is gone
 
 
 # ---------------------------------------------------------------------------
@@ -7942,6 +8073,79 @@ class TestACPAgentAvailableEffortsProperty:
         assert agent.available_efforts == ["low", "high"]
 
 
+class TestFlattenSelectOptions:
+    """``_flatten_select_options`` normalizes a ``configOptions`` select's
+    ``options`` into a flat list of leaf options.
+
+    The pinned acp lib (0.10.1) types ``SessionConfigSelect.options`` as
+    ``List[SessionConfigSelectOption] | List[SessionConfigSelectGroup]``: an
+    agent may group its selectable values under a labelled heading instead
+    of listing them flat. A flat entry has no nested ``options`` of its own
+    and passes through unchanged; a group is replaced by its nested leaf
+    options, in order.
+    """
+
+    def test_flat_list_is_unchanged(self):
+        opts = [SimpleNamespace(value="a"), SimpleNamespace(value="b")]
+        assert _flatten_select_options(opts) == opts
+
+    def test_groups_flatten_in_order(self):
+        g1 = SimpleNamespace(
+            group="anthropic",
+            name="Anthropic",
+            options=[SimpleNamespace(value="sonnet"), SimpleNamespace(value="opus")],
+        )
+        g2 = SimpleNamespace(
+            group="bedrock",
+            name="Bedrock",
+            options=[SimpleNamespace(value="sonnet-bedrock")],
+        )
+        flattened = _flatten_select_options([g1, g2])
+        assert [o.value for o in flattened] == ["sonnet", "opus", "sonnet-bedrock"]
+
+    def test_mixed_flat_and_grouped_entries(self):
+        # Not how the wire schema shapes ``options`` (it's one arm of a
+        # union, flat XOR grouped) but the helper decides per-entry, by
+        # shape, so a mixed list still flattens correctly.
+        flat = SimpleNamespace(value="solo")
+        group = SimpleNamespace(
+            group="g", name="G", options=[SimpleNamespace(value="nested")]
+        )
+        assert [o.value for o in _flatten_select_options([flat, group])] == [
+            "solo",
+            "nested",
+        ]
+
+    def test_empty_group_contributes_nothing(self):
+        empty_group = SimpleNamespace(group="g", name="G", options=[])
+        assert _flatten_select_options([empty_group]) == []
+
+    def test_all_empty_groups_yield_empty_list(self):
+        g1 = SimpleNamespace(group="g1", name="G1", options=[])
+        g2 = SimpleNamespace(group="g2", name="G2", options=[])
+        assert _flatten_select_options([g1, g2]) == []
+
+    def test_empty_input_yields_empty_list(self):
+        assert _flatten_select_options([]) == []
+
+    def test_real_acp_types(self):
+        # Sanity check against the actual pinned lib classes, not just
+        # duck-typed SimpleNamespace stand-ins used elsewhere in this file.
+        from acp.schema import SessionConfigSelectGroup, SessionConfigSelectOption
+
+        group = SessionConfigSelectGroup(
+            group="anthropic",
+            name="Anthropic",
+            options=[
+                SessionConfigSelectOption(value="sonnet", name="Sonnet"),
+                SessionConfigSelectOption(value="opus", name="Opus"),
+            ],
+        )
+        flat = SessionConfigSelectOption(value="haiku", name="Haiku")
+        flattened = _flatten_select_options([flat, group])
+        assert [o.value for o in flattened] == ["haiku", "sonnet", "opus"]
+
+
 class TestExtractSessionModels:
     """``_extract_session_models`` reads the model the ACP server reports.
 
@@ -8197,6 +8401,73 @@ class TestConfigOptionModelMechanism:
     def test_none_response_is_not_config_option(self):
         assert _extract_session_models(None)[2] is False
 
+    def test_extracts_models_from_grouped_select(self):
+        # A provider may group its model options under labelled headings
+        # (e.g. by backend/region) rather than a flat list — the pinned acp
+        # lib types this arm of ``options`` as List[SessionConfigSelectGroup].
+        response = self._response(
+            config_options=[
+                self._select(
+                    current_value="sonnet",
+                    options=[
+                        SimpleNamespace(
+                            group="anthropic",
+                            name="Anthropic",
+                            options=[
+                                self._opt("sonnet", "Sonnet"),
+                                self._opt("opus", "Opus"),
+                            ],
+                        ),
+                        SimpleNamespace(
+                            group="bedrock",
+                            name="Bedrock",
+                            options=[self._opt("sonnet-bedrock", "Sonnet (Bedrock)")],
+                        ),
+                    ],
+                )
+            ],
+        )
+        cur, avail, via = _extract_session_models(response)
+        assert cur == "sonnet"
+        assert via is True
+        assert avail is not None
+        assert [m.model_id for m in avail] == ["sonnet", "opus", "sonnet-bedrock"]
+
+    def test_mixed_flat_and_grouped_options(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    current_value="haiku",
+                    options=[
+                        self._opt("haiku", "Haiku"),
+                        SimpleNamespace(
+                            group="anthropic",
+                            name="Anthropic",
+                            options=[self._opt("sonnet", "Sonnet")],
+                        ),
+                    ],
+                )
+            ],
+        )
+        _cur, avail, _via = _extract_session_models(response)
+        assert avail is not None
+        assert [m.model_id for m in avail] == ["haiku", "sonnet"]
+
+    def test_empty_groups_yield_no_usable_models(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    current_value="",
+                    options=[
+                        SimpleNamespace(group="g1", name="G1", options=[]),
+                        SimpleNamespace(group="g2", name="G2", options=[]),
+                    ],
+                )
+            ],
+        )
+        _cur, avail, _via = _extract_session_models(response)
+        assert avail == []
+
     def test_default_via_config_option_used_when_no_block_present(self):
         # On resume a load_session that omits both the models capability and the
         # model config-option must not blindly default to set_session_model: the
@@ -8352,6 +8623,70 @@ class TestExtractSessionEfforts:
         )
         assert _extract_session_efforts(response) == (None, None)
 
+    def test_extracts_efforts_from_grouped_select(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    id="effort",
+                    current_value="high",
+                    options=[
+                        SimpleNamespace(
+                            group="thinking",
+                            name="Thinking",
+                            options=[
+                                self._opt("low"),
+                                self._opt("medium"),
+                                self._opt("high"),
+                            ],
+                        ),
+                        SimpleNamespace(
+                            group="extended",
+                            name="Extended",
+                            options=[self._opt("max")],
+                        ),
+                    ],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur == "high"
+        assert avail == ["low", "medium", "high", "max"]
+
+    def test_mixed_flat_and_grouped_effort_options(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    id="reasoning_effort",
+                    current_value="low",
+                    options=[
+                        self._opt("low"),
+                        SimpleNamespace(
+                            group="extended",
+                            name="Extended",
+                            options=[self._opt("xhigh")],
+                        ),
+                    ],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur == "low"
+        assert avail == ["low", "xhigh"]
+
+    def test_empty_effort_groups_yield_empty_list(self):
+        response = self._response(
+            config_options=[
+                self._select(
+                    id="reasoning_effort",
+                    current_value="",
+                    options=[SimpleNamespace(group="g", name="G", options=[])],
+                ),
+            ]
+        )
+        cur, avail = _extract_session_efforts(response)
+        assert cur is None
+        assert avail == []
+
 
 class TestModelConfigOptionEffort:
     """``_model_config_option_effort`` mirrors the effort split
@@ -8400,6 +8735,292 @@ class TestModelConfigOptionEffort:
             )
             is None
         )
+
+
+class TestReconcileCurrentModelId:
+    """``_reconcile_current_model_id`` reconciles a tracked (possibly
+    composite) ``_current_model_id`` against a fresh server report of
+    ``(model, effort)`` — e.g. from a live ``config_option_update``
+    notification — without clobbering a composite id that's still accurate.
+    """
+
+    def test_composite_preserved_when_split_matches_report(self):
+        # Tracked "sonnet/high"; server reports model="sonnet" + effort="high"
+        # (an unchanged resend) -> the tracked composite survives verbatim.
+        result = _reconcile_current_model_id(
+            "sonnet/high",
+            "sonnet",
+            "high",
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "sonnet/high"
+
+    def test_fallback_to_different_model_adopts_server_state(self):
+        # Genuine server-side change (e.g. a rate-limit fallback): the base
+        # model differs from what's tracked -> adopt the server's report,
+        # still recomposed as a composite since an effort is present.
+        result = _reconcile_current_model_id(
+            "sonnet/high",
+            "opus",
+            "high",
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "opus/high"
+
+    def test_effort_change_adopts_server_state(self):
+        result = _reconcile_current_model_id(
+            "sonnet/high",
+            "sonnet",
+            "medium",
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "sonnet/medium"
+
+    def test_codex_provider_same_gating(self):
+        result = _reconcile_current_model_id(
+            "gpt-5.5/high",
+            "gpt-5.5",
+            "high",
+            agent_name="codex-acp",
+            model_override_applied=True,
+        )
+        assert result == "gpt-5.5/high"
+
+    def test_no_effort_reported_adopts_bare_server_model(self):
+        # No effort option present in this update -> nothing to recompose;
+        # take the server's bare id as-is.
+        result = _reconcile_current_model_id(
+            "sonnet/high",
+            "sonnet",
+            None,
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "sonnet"
+
+    def test_override_not_applied_adopts_bare_server_model(self):
+        # The tracked id was never actually pushed to the server -> nothing
+        # trustworthy to reconcile against; adopt the server's bare report.
+        result = _reconcile_current_model_id(
+            "sonnet/high",
+            "sonnet",
+            "high",
+            agent_name="claude-agent-acp",
+            model_override_applied=False,
+        )
+        assert result == "sonnet"
+
+    def test_non_composite_provider_adopts_bare_server_model(self):
+        # gemini-cli doesn't split composite ids -> always bare.
+        result = _reconcile_current_model_id(
+            "gemini-2.5-pro/high",
+            "gemini-2.5-pro",
+            "high",
+            agent_name="gemini-cli",
+            model_override_applied=True,
+        )
+        assert result == "gemini-2.5-pro"
+
+    def test_no_tracked_model_id_builds_fresh_composite(self):
+        result = _reconcile_current_model_id(
+            None,
+            "sonnet",
+            "high",
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "sonnet/high"
+
+    def test_tracked_model_id_without_slash_adopts_server_composite(self):
+        # A previously-tracked bare id ("sonnet", no effort suffix) can't
+        # split into (base, effort) -> treated as a mismatch, so the server's
+        # composite is adopted.
+        result = _reconcile_current_model_id(
+            "sonnet",
+            "sonnet",
+            "high",
+            agent_name="claude-agent-acp",
+            model_override_applied=True,
+        )
+        assert result == "sonnet/high"
+
+    def test_unknown_provider_adopts_bare_server_model(self):
+        result = _reconcile_current_model_id(
+            "custom/high",
+            "custom",
+            "high",
+            agent_name="some-custom-acp",
+            model_override_applied=True,
+        )
+        assert result == "custom"
+
+    def test_reported_model_id_none_returns_none(self):
+        assert (
+            _reconcile_current_model_id(
+                "sonnet/high",
+                None,
+                "high",
+                agent_name="claude-agent-acp",
+                model_override_applied=True,
+            )
+            is None
+        )
+
+
+class TestOnConfigOptionsUpdate:
+    """``ACPAgent._on_config_options_update`` — applied when a live
+    ``config_option_update`` notification arrives on the bridge (see
+    ``TestConfigOptionUpdateBridge``), refreshing model/effort runtime state
+    without clobbering an override-applied composite id still in effect.
+    """
+
+    def _model_select(self, current_value, options):
+        return SimpleNamespace(
+            id="model", type="select", current_value=current_value, options=options
+        )
+
+    def _effort_select(self, id, current_value, options):
+        return SimpleNamespace(
+            id=id, type="select", current_value=current_value, options=options
+        )
+
+    def _opt(self, value, name=None):
+        return SimpleNamespace(value=value, name=name)
+
+    def test_updates_available_models_and_current_model_id(self):
+        agent = _make_agent()
+        agent._agent_name = "codex-acp"
+        config_options = [
+            self._model_select(
+                "gpt-5.5",
+                [self._opt("gpt-5.5", "GPT-5.5"), self._opt("gpt-5.4", "GPT-5.4")],
+            )
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_model_id == "gpt-5.5"
+        assert agent._available_models is not None
+        assert [m.model_id for m in agent._available_models] == [
+            "gpt-5.5",
+            "gpt-5.4",
+        ]
+
+    def test_updates_available_efforts_and_current_effort(self):
+        agent = _make_agent()
+        agent._agent_name = "codex-acp"
+        config_options = [
+            self._effort_select(
+                "reasoning_effort",
+                "high",
+                [self._opt("low"), self._opt("medium"), self._opt("high")],
+            )
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_effort == "high"
+        assert agent._available_efforts == ["low", "medium", "high"]
+
+    def test_composite_preserved_when_report_matches_tracked_split(self):
+        # Tracked composite "sonnet/high" must survive a resend that reports
+        # the base id + effort separately -- per protocol, not a real change.
+        agent = _make_agent()
+        agent._agent_name = "claude-agent-acp"
+        agent._model_via_config_option = True
+        agent._model_override_applied = True
+        agent._current_model_id = "sonnet/high"
+        config_options = [
+            self._model_select("sonnet", [self._opt("sonnet"), self._opt("opus")]),
+            self._effort_select(
+                "effort", "high", [self._opt("low"), self._opt("high")]
+            ),
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_model_id == "sonnet/high"
+        assert agent._current_effort == "high"
+
+    def test_genuine_fallback_adopts_new_model(self):
+        # A spontaneous update (e.g. a rate-limit fallback) reports a
+        # different base model -> a real change, so the tracked composite is
+        # rebuilt around the server's new state instead of being kept.
+        agent = _make_agent()
+        agent._agent_name = "claude-agent-acp"
+        agent._model_via_config_option = True
+        agent._model_override_applied = True
+        agent._current_model_id = "sonnet/high"
+        config_options = [
+            self._model_select("opus", [self._opt("sonnet"), self._opt("opus")]),
+            self._effort_select(
+                "effort", "high", [self._opt("low"), self._opt("high")]
+            ),
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_model_id == "opus/high"
+        assert agent._current_effort == "high"
+
+    def test_update_without_model_option_leaves_model_state_untouched(self):
+        agent = _make_agent()
+        agent._agent_name = "claude-agent-acp"
+        agent._current_model_id = "sonnet/high"
+        agent._available_models = [ACPModelInfo(model_id="sonnet", name="Sonnet")]
+        config_options = [
+            SimpleNamespace(
+                id="permission-mode", type="select", current_value="x", options=[]
+            ),
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_model_id == "sonnet/high"
+        assert agent._available_models == [
+            ACPModelInfo(model_id="sonnet", name="Sonnet")
+        ]
+
+    def test_update_without_effort_option_leaves_effort_state_untouched(self):
+        agent = _make_agent()
+        agent._agent_name = "codex-acp"
+        agent._current_effort = "high"
+        agent._available_efforts = ["low", "high"]
+        config_options = [self._model_select("gpt-5.5", [self._opt("gpt-5.5")])]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._current_effort == "high"
+        assert agent._available_efforts == ["low", "high"]
+
+    def test_grouped_model_options_flow_through(self):
+        # End-to-end through _on_config_options_update: grouped selects are
+        # flattened the same way init_state's extraction path handles them.
+        agent = _make_agent()
+        agent._agent_name = "claude-agent-acp"
+        config_options = [
+            self._model_select(
+                "sonnet",
+                [
+                    SimpleNamespace(
+                        group="anthropic",
+                        name="Anthropic",
+                        options=[
+                            self._opt("sonnet", "Sonnet"),
+                            self._opt("opus", "Opus"),
+                        ],
+                    ),
+                ],
+            )
+        ]
+
+        agent._on_config_options_update(config_options)
+
+        assert agent._available_models is not None
+        assert [m.model_id for m in agent._available_models] == ["sonnet", "opus"]
 
 
 # Real ``session/new`` wire payloads (by-alias) captured from the pinned CLIs.

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -201,6 +201,31 @@ def test_switch_acp_model_refreshes_surfaced_current_model_id(tmp_path):
     assert conv.state.agent_state["acp_current_model_id"] == "model-b"
 
 
+def test_switch_acp_model_refreshes_surfaced_current_effort(tmp_path):
+    """A live switch to a composite ``model/effort`` id refreshes
+    ``current_effort`` the same way it refreshes ``current_model_id``.
+
+    Mirrors ``test_switch_acp_model_refreshes_surfaced_current_model_id`` for
+    the effort component: the chip/picker reads
+    ``ACPAgent.current_effort`` (and the persisted ``acp_current_effort``
+    hint on cold reads), both of which must reflect the switch.
+    """
+    conv, agent = _make_acp_conversation(tmp_path)
+    agent._agent_name = "claude-agent-acp"
+    agent._model_via_config_option = True
+    agent._current_effort = "low"  # what _init captured at session start
+    assert "acp_current_effort" not in conv.state.agent_state
+
+    conv.switch_acp_model("sonnet/high")
+
+    switched = conv.agent
+    assert isinstance(switched, ACPAgent)
+    # Live PrivateAttr (carried onto the persisted agent by the model_copy).
+    assert switched.current_effort == "high"
+    # Persisted hint written unconditionally for cold reads before re-init.
+    assert conv.state.agent_state["acp_current_effort"] == "high"
+
+
 def test_switch_acp_model_disarms_discarded_agent_finalizer(tmp_path):
     """The pre-switch agent must not tear down the shared live session.
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1179,7 +1179,7 @@ def test_acp_create_agent_uses_server_default_command(
     assert agent.acp_command == [
         "npx",
         "-y",
-        "@agentclientprotocol/claude-agent-acp@0.44.0",
+        "@agentclientprotocol/claude-agent-acp@0.64.2",
     ]
     assert agent.acp_model == "claude-opus-4-6"
     # The authoritative provider key is carried onto the agent.


### PR DESCRIPTION
HUMAN:
👋 I've been trying to use OpenHands with Claude Code but found the existing ACP implementation to be a little out of date and lacking in features (like model/effort switching) that I'd really like to see in a daily driver. I've tested this in my local fork and it works as expected.

---

AGENT:
End-to-end evidence beyond unit tests:

- Real-stack e2e (Agent Canvas + this agent-server branch via editable install + mock ACP agent over stdio JSON-RPC, real chromium): live model lists reach the client, mid-session model switches apply, the effort select's current/available values surface on `ConversationInfo`, and composite `base/effort` switches split into `session/set_config_option` calls (`model` + `effort`) — 7/7 e2e tests green. The same client suite against the published 1.40.1 agent-server confirms behavior is additive (3/3 with effort features degrading as designed).
- Live manual test against real Claude Code via `@agentclientprotocol/claude-agent-acp` 0.64.2.
- Targeted suites on this branch: `tests/sdk/agent/test_acp_agent.py` (508), `tests/agent_server/test_conversation_info_model.py` (28), `tests/sdk/conversation/test_switch_model.py` (26), `tests/agent_server/test_conversation_router.py`, `tests/sdk/settings/test_acp_providers.py`, `tests/sdk/test_settings.py`, `tests/cross/test_remote_conversation_live_server.py` (new live-server case) — all passing locally.
- `make test-server-schema` green (deterministic export, weak-schema allowlist unchanged — new fields strictly typed); `uv run pre-commit run` green on every changed file.

## Why

ACP agents advertise their models and reasoning-effort levels as session config options, but the SDK only consumed the `model` option and had no effort concept at all — clients could not show which effort levels an agent supports or what's currently active, grouped select options silently produced empty model lists, and `config_option_update` notifications were dropped. Codex already had composite `model/effort` id handling; Claude Code (whose adapter exposes an `effort` config option) had none.

## Summary

- `_model_config_options` gains a claude-code branch mirroring the codex splitter: `acp_model` ids like `sonnet/high` or `opus[1m]/max` apply as two `set_config_option` calls (`model` + `effort`; claude accepts `max`, codex still rejects it). Composes through init, resume-reapply, and runtime switch with no schema/API changes; `current_model_id` keeps the composite, matching codex semantics.
- Effort state is surfaced like model state: `_extract_session_efforts` reads the `effort`/`reasoning_effort` select, stored as `ACPAgent.current_effort`/`available_efforts`, persisted in `agent_state`, and lifted onto `ConversationInfo` as additive optional fields (`current_effort: str | None`, `available_efforts: list[str] | None`) with live→persisted precedence.
- Robustness: grouped select options (`SessionConfigSelectGroup`) are flattened instead of yielding empty lists; `ConfigOptionUpdate` session notifications now refresh model/effort state in memory (weakref-bound bridge callback; composite-id reconciliation keeps a tracked `base/effort` when the server reports the same split state).
- `CLAUDE_AGENT_ACP_VERSION` 0.44.0 → 0.64.2 (the version the `effort`/thought_level config option surface was verified against), kept in sync with the Docker image's npm pin per the comment in `acp_providers.py`.

## Issue Number

N/A

## How to Test

1. `make build`, then run any ACP client against the agent-server with a claude-code agent: `GET /api/conversations/{id}` now includes `current_effort`/`available_efforts` alongside `available_models`.
2. `POST /api/conversations/{id}/switch_acp_model` with `{"model": "sonnet/high"}` on a live claude-code session applies model + effort as separate config options; a bare id leaves effort unchanged.
3. `uv run pytest tests/sdk/agent/test_acp_agent.py tests/agent_server/test_conversation_info_model.py tests/cross/test_remote_conversation_live_server.py`.
4. `make test-server-schema`.

## Video/Screenshots

N/A (server-side; UI screenshots live on the paired Agent Canvas PR, linked above).

## Type

- [x] Feature

## Notes

- Everything is additive: no removals, no version bumps, weak-schema allowlist untouched.
- Documented scope cuts (in code comments): the notification-path refresh does not write `agent_state` (no ConversationState reference there; persisted on next `init_state`), and composite reconciliation gates on `_model_override_applied`, so a post-runtime-switch server push may demote a tracked composite to its base id — harmless since effort is tracked separately.
- The `agent-client-protocol` dependency is not touched. Note for maintainers: acp 0.12 removed `ClientSideConnection.set_session_model`, which the legacy non-config-option fallback branch still calls — worth a guard before any future bump.
- Paired client PR: OpenHands/OpenHands (Agent Canvas) — linked in the first comment.
