### PR TITLE
test: stop ambient LMNR env vars deciding what the tracing tests measure

### DIFF
--- a/tests/sdk/agent/test_parallel_tool_span_context.py
+++ b/tests/sdk/agent/test_parallel_tool_span_context.py
@@ -18,6 +18,7 @@ Two configurations behave differently and are covered separately here:
 
 import asyncio
 import contextvars
+import inspect
 import threading
 from collections.abc import Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -481,6 +482,12 @@ def test_agent_step_tool_spans_nest_under_dispatcher_without_lmnr(tracing) -> No
         patch(
             "openhands.sdk.agent.agent.should_enable_observability", return_value=True
         ),
+        # Run the undecorated ``step``. Its ``@observe`` wrapper builds a real
+        # lmnr span once observability is on anywhere in the process — and caches
+        # it — which interposes between this test's parent span and the tool
+        # spans. Without this, ambient ``LMNR_*`` env vars decide whether the test
+        # measures what its name claims.
+        patch.object(Agent, "step", inspect.unwrap(Agent.step)),
         patch("openhands.sdk.agent.agent.observe", side_effect=fake_observe),
     ):
         conversation.send_message(

--- a/tests/sdk/agent/test_tool_span_input.py
+++ b/tests/sdk/agent/test_tool_span_input.py
@@ -68,44 +68,59 @@ register_tool("SpanInputEchoTool", _SpanInputTool)
 
 @pytest.fixture
 def exported():
-    """Real Laminar tracer writing to an in-memory exporter, torn down after.
+    """Capture the spans this test emits, whatever the ambient lmnr state.
 
-    The exporter is installed *before* ``initialize`` so no OTLP endpoint is ever
-    created; an unreachable one leaves every later test in the process retrying
-    exports with backoff.
+    Two paths, because this test must never skip — a skipped tracing test is
+    indistinguishable from a passing one, and ``LMNR_*`` env vars are set in real
+    CI. When lmnr is already up its span processor is borrowed and restored,
+    which also keeps test spans off whatever real endpoint it was configured
+    with. Otherwise one is built here, with the in-memory exporter installed
+    *before* ``initialize`` so no OTLP endpoint is created — an unreachable one
+    leaves later tests retrying exports with backoff.
     """
     from lmnr import Laminar
     from lmnr.opentelemetry_lib.opentelemetry.instrumentation.threading import (
         ThreadingInstrumentor,
     )
     from lmnr.opentelemetry_lib.tracing import TracerWrapper
-
-    if TracerWrapper.verify_initialized():
-        pytest.skip("lmnr already initialized by another test in this process")
+    from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
     exporter = InMemorySpanExporter()
+    borrowed = TracerWrapper.verify_initialized()
     original_thread_init = threading.Thread.__init__
-    TracerWrapper(
-        exporter=exporter,
-        disable_batch=True,
-        instruments=set(),
-        set_global_tracer_provider=False,
-    )
-    Laminar.initialize(
-        project_api_key="test-key",
-        disable_batch=True,
-        instruments=set(),
-        set_global_tracer_provider=False,
-    )
+
+    if not borrowed:
+        TracerWrapper(
+            exporter=exporter,
+            disable_batch=True,
+            instruments=set(),
+            set_global_tracer_provider=False,
+        )
+    if not Laminar.is_initialized():
+        # Respects an existing TracerWrapper rather than building a second one.
+        Laminar.initialize(
+            project_api_key="test-key",
+            disable_batch=True,
+            instruments=set(),
+            set_global_tracer_provider=False,
+        )
+
+    processor = TracerWrapper.instance._span_processor
+    assert isinstance(processor, LaminarSpanProcessor)
+    previous = processor.instance
+    processor.instance = SimpleSpanProcessor(exporter)
     try:
         yield exporter.get_finished_spans
     finally:
-        Laminar.shutdown()
-        ThreadingInstrumentor().uninstrument()
-        threading.Thread.__init__ = original_thread_init  # type: ignore[method-assign]
-        TracerWrapper._original_thread_init = None
-        if hasattr(TracerWrapper, "instance"):
-            del TracerWrapper.instance
+        processor.instance = previous
+        if not borrowed:
+            Laminar.shutdown()
+            ThreadingInstrumentor().uninstrument()
+            threading.Thread.__init__ = original_thread_init  # type: ignore[method-assign]
+            TracerWrapper._original_thread_init = None
+            if hasattr(TracerWrapper, "instance"):
+                del TracerWrapper.instance
 
 
 def _responses() -> Any:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix Laminar tests:  ambient LMNR_* state was changing what the tracing tests measured.

---

AGENT:

## Why

Two tracing test files on `main` behave differently depending on whether `LMNR_*`
env vars happen to be set — the normal state anywhere tracing is configured,
including CI and the automation environment. Neither failure is visible in a
default local run:

```
                                          clean env    LMNR_PROJECT_API_KEY set
tests/sdk/agent + tests/sdk/observability  856 passed   1 failed, 854 passed, 1 skipped
```

**`test_tool_span_input.py` skipped wholesale.** Its fixture bailed out with
`pytest.skip` whenever lmnr was already initialized. A skipped tracing test is
indistinguishable from a passing one in a CI summary, so the assertion it exists to
make simply stopped happening in exactly the environments that have tracing on.

**`test_parallel_tool_span_context.py::test_agent_step_tool_spans_nest_under_dispatcher_without_lmnr`
failed.** `Agent.step` carries the lazy `@observe` wrapper. Once observability is
enabled anywhere in the process, that wrapper builds a real lmnr span, which
interposes between the test's own parent span and the tool spans — so the
`trace_id` assertion compares against the wrong ancestor:

```
E   assert 207883464541316575612700684987220977331 == 137876110781008933591910052811977992012
```

The test's name says `without_lmnr`, but whether it actually measured that was
decided by the ambient environment.

Found while addressing a review on #4376, which flagged the same class of defect in
that PR's tests.

## Summary

- **`test_tool_span_input.py`**: the fixture no longer skips. When lmnr is already
  up it borrows the existing `LaminarSpanProcessor`, swaps in an
  `InMemorySpanExporter`, and restores it in `finally` — which also keeps test spans
  off whatever real endpoint that tracer was configured with. Only when nothing is
  initialized does it build (and tear down) its own, with the exporter installed
  *before* `Laminar.initialize` so no OTLP exporter is ever constructed.
- **`test_parallel_tool_span_context.py`**: the `without_lmnr` end-to-end test runs
  `inspect.unwrap(Agent.step)`, so the decorator cannot interpose regardless of
  ambient env.

Patching `should_enable_observability` is *not* sufficient for the second one: the
`@observe` wrapper caches its built form on first use (`if wrapped is not None`), so
once any earlier test in the process has triggered the build, the check is never
consulted again. That is why the fix removes the decorator rather than the flag —
verified by trying the flag first and watching the full-suite run still fail while
the single-test run passed.

## Issue Number

None. Follow-up to review feedback on #4376; the two files were introduced by #4360
and #4379.

## How to Test

```bash
uv run pytest tests/sdk/agent/ tests/sdk/observability/ -q
LMNR_PROJECT_API_KEY=fake-key uv run pytest tests/sdk/agent/ tests/sdk/observability/ -q
```

| | before | after |
|---|---|---|
| clean environment | 856 passed | 856 passed |
| `LMNR_PROJECT_API_KEY` set | 1 failed, 854 passed, **1 skipped** | **856 passed** |

Also `uv run ruff check` / `ruff format --check` clean and `uv run pyright` 0 errors on
both files.

## Video/Screenshots

Not applicable — test-only change; the pass/skip/fail counts above are the observable
behaviour.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Test-only.** No production code is touched, so there is no runtime behaviour change.

**Why `inspect.unwrap` rather than `Agent.step.__wrapped__`.** Both work at runtime,
but `__wrapped__` is not in the type stubs for `FunctionType` and pyright rejects it;
`inspect.unwrap` is the documented API and states the intent more plainly.

**The remaining asymmetry is deliberate.** The `*_with_lmnr` tests in
`test_parallel_tool_span_context.py` still assert lmnr's threading instrumentation is
live via `_assert_lmnr_wraps_submit()`, so they fail loudly rather than degrade if
that ever stops being true. Only the `without_lmnr` case needed pinning.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c090a80-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c090a80-python \
  ghcr.io/openhands/agent-server:c090a80-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c090a80-golang-amd64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-golang-amd64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-golang-amd64
ghcr.io/openhands/agent-server:c090a80-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c090a80-golang-arm64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-golang-arm64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-golang-arm64
ghcr.io/openhands/agent-server:c090a80-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c090a80-java-amd64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-java-amd64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-java-amd64
ghcr.io/openhands/agent-server:c090a80-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c090a80-java-arm64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-java-arm64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-java-arm64
ghcr.io/openhands/agent-server:c090a80-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c090a80-python-amd64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-python-amd64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-python-amd64
ghcr.io/openhands/agent-server:c090a80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c090a80-python-arm64
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-python-arm64
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-python-arm64
ghcr.io/openhands/agent-server:c090a80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c090a80-golang
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-golang
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-golang
ghcr.io/openhands/agent-server:c090a80-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c090a80-java
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-java
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-java
ghcr.io/openhands/agent-server:c090a80-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c090a80-python
ghcr.io/openhands/agent-server:c090a80c130e6a0a6cf25cd76df7086b234f8b60-python
ghcr.io/openhands/agent-server:fix-without-lmnr-env-dep-python
ghcr.io/openhands/agent-server:c090a80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c090a80-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c090a80-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->