### PR TITLE
chore(acp): bump pinned claude-agent-acp to 0.63.0, codex-acp to 1.1.7

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -180,8 +180,8 @@ RUN set -ux; \
          && "$ACP_NODE_DIR/bin/node" --version; then \
         PATH="$ACP_NODE_DIR/bin:$PATH"; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
-            @agentclientprotocol/claude-agent-acp@0.65.0 \
-            @agentclientprotocol/codex-acp@1.1.9 \
+            @agentclientprotocol/claude-agent-acp@0.63.0 \
+            @agentclientprotocol/codex-acp@1.1.7 \
             @google/gemini-cli@0.46.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -180,8 +180,8 @@ RUN set -ux; \
          && "$ACP_NODE_DIR/bin/node" --version; then \
         PATH="$ACP_NODE_DIR/bin:$PATH"; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
-            @agentclientprotocol/claude-agent-acp@0.44.0 \
-            @agentclientprotocol/codex-acp@1.1.2 \
+            @agentclientprotocol/claude-agent-acp@0.65.0 \
+            @agentclientprotocol/codex-acp@1.1.9 \
             @google/gemini-cli@0.46.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -313,7 +313,7 @@ _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
 )
 
 # Bare preset ids advertised by the Codex app server through
-# ``@agentclientprotocol/codex-acp`` 1.1.2. The reasoning-effort tier is a
+# ``@agentclientprotocol/codex-acp``. The reasoning-effort tier is a
 # separate ``reasoning_effort`` configOption, not part of the model id, so it is
 # not encoded here. GPT-5.6 variants are rollout/account-dependent suggestions;
 # the adapter's live model list remains authoritative.
@@ -390,8 +390,8 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
-CLAUDE_AGENT_ACP_VERSION = "0.65.0"
-CODEX_ACP_VERSION = "1.1.9"
+CLAUDE_AGENT_ACP_VERSION = "0.63.0"
+CODEX_ACP_VERSION = "1.1.7"
 GEMINI_CLI_VERSION = "0.46.0"
 
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -390,8 +390,8 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
-CLAUDE_AGENT_ACP_VERSION = "0.44.0"
-CODEX_ACP_VERSION = "1.1.2"
+CLAUDE_AGENT_ACP_VERSION = "0.65.0"
+CODEX_ACP_VERSION = "1.1.9"
 GEMINI_CLI_VERSION = "0.46.0"
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4970,7 +4970,7 @@ class TestWithCodexBaseUrl:
         original = env.copy()
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"]) == {
@@ -5006,7 +5006,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"])["openai_base_url"] == (
@@ -5021,7 +5021,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
             env,
         )
         assert result == env

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4970,7 +4970,7 @@ class TestWithCodexBaseUrl:
         original = env.copy()
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"]) == {
@@ -5006,7 +5006,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"])["openai_base_url"] == (
@@ -5021,7 +5021,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.1.9"],
             env,
         )
         assert result == env

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1179,7 +1179,7 @@ def test_acp_create_agent_uses_server_default_command(
     assert agent.acp_command == [
         "npx",
         "-y",
-        "@agentclientprotocol/claude-agent-acp@0.65.0",
+        "@agentclientprotocol/claude-agent-acp@0.63.0",
     ]
     assert agent.acp_model == "claude-opus-4-6"
     # The authoritative provider key is carried onto the agent.
@@ -1335,7 +1335,7 @@ def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
     monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
     for pkg in (
         "@agentclientprotocol/codex-acp",
-        "@agentclientprotocol/codex-acp@1.1.9",
+        "@agentclientprotocol/codex-acp@1.1.7",
     ):
         settings = ACPAgentSettings(
             acp_server="codex",
@@ -1357,7 +1357,7 @@ def test_acp_resolve_command_keeps_npx_when_binary_absent(
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
-        "@agentclientprotocol/codex-acp@1.1.9",
+        "@agentclientprotocol/codex-acp@1.1.7",
     ]
 
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1179,7 +1179,7 @@ def test_acp_create_agent_uses_server_default_command(
     assert agent.acp_command == [
         "npx",
         "-y",
-        "@agentclientprotocol/claude-agent-acp@0.44.0",
+        "@agentclientprotocol/claude-agent-acp@0.65.0",
     ]
     assert agent.acp_model == "claude-opus-4-6"
     # The authoritative provider key is carried onto the agent.
@@ -1335,7 +1335,7 @@ def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
     monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
     for pkg in (
         "@agentclientprotocol/codex-acp",
-        "@agentclientprotocol/codex-acp@1.1.2",
+        "@agentclientprotocol/codex-acp@1.1.9",
     ):
         settings = ACPAgentSettings(
             acp_server="codex",
@@ -1357,7 +1357,7 @@ def test_acp_resolve_command_keeps_npx_when_binary_absent(
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
-        "@agentclientprotocol/codex-acp@1.1.2",
+        "@agentclientprotocol/codex-acp@1.1.9",
     ]
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Testing whether the review bot's freshness gate blocks a legit bump.

---

AGENT:

Ran a live end-to-end test on the developer's own machine against the exact pinned versions (not just unit tests, and not just a trivial reply): constructed an `ACPAgent` directly with `acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp@0.63.0"]` and separately with `acp_command=["npx", "-y", "@agentclientprotocol/codex-acp@1.1.7"]`, bypassing the settings-layer PATH-binary rewrite so the exact pinned versions were exercised. No `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` were set, so each CLI fell back to the developer's own locally logged-in subscription auth (Claude Code session / ChatGPT-Codex login).

For each provider: (1) **real tool use** — asked the agent to `ls` a directory and read a file through the ACP server's own tools (not SDK-mocked), grounded against a known-correct answer (the pinned version string itself); (2) **multi-turn session continuity** — a follow-up question referencing turn 1's file in the same session; (3) **live runtime model switch mid-session** (`LocalConversation.switch_acp_model`, the `configOptions`/`set_model` protocol path) followed by a further turn on the new model. All three passed for both providers:

```
[claude-code] ACP server initialized: agent_name='@agentclientprotocol/claude-agent-acp', agent_version='0.63.0'
[claude-code] turn1 (tool use) finish: '0.63.0'
[claude-code] turn2 (continuity) finish: '1.1.7'
[claude-code] switching model -> haiku
[claude-code] turn3 (post-switch) finish: 'ACP_BUMP_POST_SWITCH_OK'
RESULT[claude-code]: PASS — {'tool_use_grounded': True, 'multi_turn_continuity': True, 'switch_no_exception': True, 'post_switch_turn': True}

[codex] ACP server initialized: agent_name='@agentclientprotocol/codex-acp', agent_version='1.1.7'
[codex] Authenticating with ACP method: chat-gpt
[codex] turn1 (tool use) finish: '0.63.0'
[codex] turn2 (continuity) finish: '1.1.7'
[codex] switching model -> gpt-5.4-mini
[codex] turn3 (post-switch) finish: 'ACP_BUMP_POST_SWITCH_OK'
RESULT[codex]: PASS — {'tool_use_grounded': True, 'multi_turn_continuity': True, 'switch_no_exception': True, 'post_switch_turn': True}
```

## Why

The pinned `claude-agent-acp` (`0.44.0`) and `codex-acp` (`1.1.2`) npm versions are several months behind their current releases. This is a standalone dependency bump, decoupled from any feature work, so it can be reviewed and landed independently.

An earlier revision of this PR bumped both to their absolute latest release (`0.65.0` / `1.1.9`). The review bot correctly flagged both as inside the 7-day supply-chain freshness window and requested changes. This revision instead pins to the newest release of each that is already more than 7 days old: `claude-agent-acp@0.63.0` (published 2026-07-27, ~10 days old) and `codex-acp@1.1.7` (published 2026-07-22, ~15 days old) — so the freshness gate should clear without waiting on the calendar.

## Summary
- Bump `CLAUDE_AGENT_ACP_VERSION` from `0.44.0` → `0.63.0` in `acp_providers.py` and the agent-server Dockerfile.
- Bump `CODEX_ACP_VERSION` from `1.1.2` → `1.1.7` in the same two places.
- Update the tests asserting the literal pinned version strings.
- Drop the stray `1.1.2` version reference from the `_CODEX_MODELS` docstring (flagged in review) so the prose doesn't go stale on the next bump.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `4e7d5b0fd9a7` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -746 +745,0 @@
-schema AgentDefinition property mcp_servers optional schema=anyOf=[type="object" additionalProperties=true,type="null"]
@@ -793 +791,0 @@
-schema AgentProfileDiagnostics property resolved_mcp_servers optional schema=type="array" items=type="string"
@@ -2667 +2664,0 @@
-schema _RemoteMCPServerSpec property api_key optional schema=anyOf=[type="string",type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

N/A

## How to Test

1. `uv run pytest tests/sdk/test_settings.py tests/sdk/settings/test_acp_providers.py tests/sdk/agent/test_acp_agent.py` — 600 passed.
2. `pre-commit run` on the changed files — ruff/pyright/pep8 clean, no `uv.lock` churn.
3. Live e2e (see AGENT section above): both ACP CLIs launch at the new pinned version and complete real turns using local subscription auth, including real tool use, multi-turn continuity, and a live mid-session model switch.

## Video/Screenshots

N/A — CLI-only change, see AGENT section for log evidence.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Both `0.63.0` and `1.1.7` were published more than 7 days ago (2026-07-27 and 2026-07-22 respectively, as of 2026-08-06), so this revision should clear the review bot's supply-chain freshness gate without a calendar wait, unlike the prior revision pinned to the absolute-latest releases.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9220314-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9220314-python \
  ghcr.io/openhands/agent-server:9220314-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9220314-golang-amd64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-golang-amd64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-golang-amd64
ghcr.io/openhands/agent-server:9220314-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9220314-golang-arm64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-golang-arm64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-golang-arm64
ghcr.io/openhands/agent-server:9220314-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9220314-java-amd64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-java-amd64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-java-amd64
ghcr.io/openhands/agent-server:9220314-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9220314-java-arm64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-java-arm64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-java-arm64
ghcr.io/openhands/agent-server:9220314-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9220314-python-amd64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-python-amd64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-python-amd64
ghcr.io/openhands/agent-server:9220314-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9220314-python-arm64
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-python-arm64
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-python-arm64
ghcr.io/openhands/agent-server:9220314-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9220314-golang
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-golang
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-golang
ghcr.io/openhands/agent-server:9220314-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9220314-java
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-java
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-java
ghcr.io/openhands/agent-server:9220314-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9220314-python
ghcr.io/openhands/agent-server:92203149f9b55217ce8353f40747d539c08f30f1-python
ghcr.io/openhands/agent-server:bump-acp-claude-codex-versions-python
ghcr.io/openhands/agent-server:9220314-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9220314-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9220314-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->