### PR TITLE
fix(agent-server): size bash event pages by returned events, not files read

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -149,7 +149,6 @@ class BashEventService:
             files = [file for file in files if file.name < timestamp_lt_str]
 
         # Handle pagination
-        page_files = []
         start_index = 0
 
         # Find the starting point if page_id is provided
@@ -159,27 +158,29 @@ class BashEventService:
                     start_index = i
                     break
 
-        # Collect items for this page
+        # Collect items for this page. Filtering happens inside this loop so the
+        # boundary is measured in returned events rather than files read: sizing
+        # the page by file count first lets `order__gt` empty a page while
+        # `next_page_id` is still set, walking the client through under-full or
+        # entirely empty pages.
+        page_events = []
         next_page_id = None
         for i in range(start_index, len(files)):
-            if len(page_files) >= limit:
+            if len(page_events) >= limit:
                 # We have collected enough items for this page
                 # Set next_page_id to the current file for next page
                 next_page_id = str(files[i].name)
                 break
-            page_files.append(files[i])
 
-        # Load only the page files (not all files)
-        page_events = []
-        for file_path in page_files:
-            event = self._load_event_from_file(file_path)
-            if event is not None:
-                # Filter by order if specified (only applies to BashOutput events)
-                if order__gt is not None:
-                    event_order = getattr(event, "order", None)
-                    if event_order is not None and event_order <= order__gt:
-                        continue
-                page_events.append(event)
+            event = self._load_event_from_file(files[i])
+            if event is None:
+                continue
+            # Filter by order if specified (only applies to BashOutput events)
+            if order__gt is not None:
+                event_order = getattr(event, "order", None)
+                if event_order is not None and event_order <= order__gt:
+                    continue
+            page_events.append(event)
 
         return BashEventPage(items=page_events, next_page_id=next_page_id)
 

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -202,7 +202,7 @@ async def test_run_retention_cleanup_loop_purges_old_events(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_order_filter_does_not_undersize_pages(tmp_path: Path):
+async def test_order_filter_does_not_undersize_pages(tmp_path: Path):
     """The page boundary must count returned events, not files read (#4388).
 
     Filtering after the page was already sized by file count let `order__gt`
@@ -223,17 +223,15 @@ def test_order_filter_does_not_undersize_pages(tmp_path: Path):
             )
         )
 
-    page = asyncio.run(
-        service.search_bash_events(order__gt=9, limit=5, kind__eq="BashOutput")
-    )
+    page = await service.search_bash_events(order__gt=9, limit=5, kind__eq="BashOutput")
 
-    # Files sort by name (timestamp + id), so compare the set of orders rather
-    # than their sequence.
-    assert sorted(event.order for event in page.items) == [10, 11, 12, 13, 14]
+    # `items` is typed as the event base class, so narrow before reading `order`.
+    orders = sorted(e.order for e in page.items if isinstance(e, BashOutput))
+    assert orders == [10, 11, 12, 13, 14]
     assert page.next_page_id is None
 
 
-def test_order_filter_never_returns_an_empty_page_with_a_cursor(tmp_path: Path):
+async def test_order_filter_never_returns_an_empty_page_with_a_cursor(tmp_path: Path):
     """An all-filtered range must terminate instead of handing back a cursor."""
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
     command_id = uuid4()
@@ -248,8 +246,8 @@ def test_order_filter_never_returns_an_empty_page_with_a_cursor(tmp_path: Path):
             )
         )
 
-    page = asyncio.run(
-        service.search_bash_events(order__gt=100, limit=5, kind__eq="BashOutput")
+    page = await service.search_bash_events(
+        order__gt=100, limit=5, kind__eq="BashOutput"
     )
 
     assert page.items == []

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -5,10 +5,10 @@ import contextlib
 import logging
 import time
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from openhands.agent_server import bash_router as bash_router_module
 from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
-from openhands.agent_server.models import BashCommand
+from openhands.agent_server.models import BashCommand, BashOutput
 from openhands.agent_server.server_details_router import (
     mark_initialization_complete,
     server_details_router,
@@ -194,4 +194,65 @@ async def test_run_retention_cleanup_loop_purges_old_events(tmp_path: Path):
 
     assert len(service._get_event_files_by_pattern("*")) == 0, (
         "Old event file should have been purged by the retention loop"
+    )
+
+
+# ---------------------------------------------------------------------------
+# search_bash_events pagination with order__gt
+# ---------------------------------------------------------------------------
+
+
+def test_order_filter_does_not_undersize_pages(tmp_path: Path):
+    """The page boundary must count returned events, not files read (#4388).
+
+    Filtering after the page was already sized by file count let `order__gt`
+    hand back a short (or empty) page while `next_page_id` was still set, so a
+    client following the cursor walked a run of near-empty pages.
+    """
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    command_id = uuid4()
+
+    # 10 events the filter rejects, then 5 it accepts.
+    for order in range(15):
+        service._save_event_to_file(
+            BashOutput(
+                command_id=command_id,
+                order=order,
+                stdout=f"chunk {order}",
+                timestamp=_OLD + timedelta(seconds=order),
+            )
+        )
+
+    page = asyncio.run(
+        service.search_bash_events(order__gt=9, limit=5, kind__eq="BashOutput")
+    )
+
+    # Files sort by name (timestamp + id), so compare the set of orders rather
+    # than their sequence.
+    assert sorted(event.order for event in page.items) == [10, 11, 12, 13, 14]
+    assert page.next_page_id is None
+
+
+def test_order_filter_never_returns_an_empty_page_with_a_cursor(tmp_path: Path):
+    """An all-filtered range must terminate instead of handing back a cursor."""
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    command_id = uuid4()
+
+    for order in range(10):
+        service._save_event_to_file(
+            BashOutput(
+                command_id=command_id,
+                order=order,
+                stdout=f"chunk {order}",
+                timestamp=_OLD + timedelta(seconds=order),
+            )
+        )
+
+    page = asyncio.run(
+        service.search_bash_events(order__gt=100, limit=5, kind__eq="BashOutput")
+    )
+
+    assert page.items == []
+    assert page.next_page_id is None, (
+        "an empty page must not advertise a next page, or clients loop forever"
     )


### PR DESCRIPTION
HUMAN:

Took this one because a cursor that keeps pointing at nothing is worse than an error — the client can't tell the difference between "slow" and "broken".

---

AGENT:

## Why

`search_bash_events` picks up to `limit` **files**, then applies `order__gt` while loading them. The page boundary is therefore measured before the filter runs, so a page can come back short — or completely empty — while `next_page_id` is still set. A client following the cursor walks a run of under-full pages, and in the all-filtered case never makes progress.

`order__gt` is how incremental command-output polling works ("give me output after chunk N"), so this is a live path rather than a corner case. Reported in #4388.

## Summary

- Merged the filter into the page-collection loop so the boundary counts events that will actually be returned.
- An unreadable file (`_load_event_from_file` returning `None`) no longer consumes a page slot either — previously it silently shrank the page the same way.
- `next_page_id` semantics are unchanged: it points at the first file not consumed by this page.

## Issue Number

Closes #4388

## How to Test

Two tests in `tests/agent_server/test_bash_service.py`:

- `test_order_filter_does_not_undersize_pages` — 15 outputs, `order__gt=9`, `limit=5`. Expects a full page of orders 10–14.
- `test_order_filter_never_returns_an_empty_page_with_a_cursor` — every event filtered out. Expects no items **and** no cursor.

```
$ OPENHANDS_SUPPRESS_BANNER=1 uv run pytest tests/agent_server/test_bash_service.py -k order_filter -q
2 passed
```

Both fail on `main` with the reported behaviour:

```
assert [] == [10, 11, 12, 13, 14]
AssertionError: an empty page must not advertise a next page, or clients loop forever
  assert '20200101000005000000_BashOutput_...' is None
```

The tests give each event an increasing timestamp, since files sort by name and same-timestamp events would otherwise come back in a nondeterministic order.

Full suite and checks:

```
$ OPENHANDS_SUPPRESS_BANNER=1 uv run pytest tests/agent_server -q
1918 passed, 13 deselected

$ uv run ruff check <changed files>      # All checks passed!
$ uv run ruff format --check <changed>   # unchanged
$ uv run pyright openhands-agent-server/openhands/agent_server/bash_service.py
0 errors, 0 warnings, 0 informations
```

## Note

A full page still carries a `next_page_id` even when every remaining file would be filtered out — the service cannot know that without reading them. The following request then returns an empty page with no cursor, so the client terminates after one extra round trip rather than looping. Making that last hop disappear would mean reading ahead past the page boundary, which seemed a worse trade than one predictable extra call; happy to revisit if you would rather pay that cost.
