### PR TITLE
fix(acp): recover credential monitor after transient errors

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -239,6 +239,7 @@ class _CodexAuthLifecycle:
             self._closed = True
 
     def _monitor_loop(self) -> None:
+        failure_logged = False
         while not self._stop.wait(_MONITOR_INTERVAL_SECONDS):
             try:
                 with self._sync_lock:
@@ -246,6 +247,7 @@ class _CodexAuthLifecycle:
                     value = self._read_stable(attempts=1)
                     if value is not None:
                         self._sync_value(value)
+                        failure_logged = False
             except (
                 CredentialNeedsReauthentication,
                 CredentialConflict,
@@ -255,12 +257,16 @@ class _CodexAuthLifecycle:
                 return
             except CredentialSyncError as exc:
                 self._set_error(exc)
-                logger.warning("credential_binding_monitor_failed", exc_info=exc)
+                if not failure_logged:
+                    logger.warning("credential_binding_monitor_failed", exc_info=exc)
+                    failure_logged = True
             except Exception as exc:
                 self._set_error(
                     CredentialSyncError("Codex credential monitoring failed.")
                 )
-                logger.warning("credential_binding_monitor_failed", exc_info=exc)
+                if not failure_logged:
+                    logger.warning("credential_binding_monitor_failed", exc_info=exc)
+                    failure_logged = True
 
     def _read_current(self) -> str | None:
         with self._lock:

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -31,6 +31,7 @@ CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
 
 _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 _MONITOR_INTERVAL_SECONDS = 0.1
+_MONITOR_MAX_RETRY_INTERVAL_SECONDS = 5.0
 _MONITOR_JOIN_TIMEOUT_SECONDS = 2.0
 _STABLE_READ_DELAY_SECONDS = 0.01
 _SYNC_RETRY_DELAYS: tuple[float, ...] = (0.1, 0.5)
@@ -240,7 +241,8 @@ class _CodexAuthLifecycle:
 
     def _monitor_loop(self) -> None:
         failure_logged = False
-        while not self._stop.wait(_MONITOR_INTERVAL_SECONDS):
+        retry_interval = _MONITOR_INTERVAL_SECONDS
+        while not self._stop.wait(retry_interval):
             try:
                 with self._sync_lock:
                     self._raise_sticky_error()
@@ -248,6 +250,7 @@ class _CodexAuthLifecycle:
                     if value is not None:
                         self._sync_value(value)
                         failure_logged = False
+                    retry_interval = _MONITOR_INTERVAL_SECONDS
             except (
                 CredentialNeedsReauthentication,
                 CredentialConflict,
@@ -260,6 +263,10 @@ class _CodexAuthLifecycle:
                 if not failure_logged:
                     logger.warning("credential_binding_monitor_failed", exc_info=exc)
                     failure_logged = True
+                retry_interval = min(
+                    retry_interval * 2,
+                    _MONITOR_MAX_RETRY_INTERVAL_SECONDS,
+                )
             except Exception as exc:
                 self._set_error(
                     CredentialSyncError("Codex credential monitoring failed.")
@@ -267,6 +274,10 @@ class _CodexAuthLifecycle:
                 if not failure_logged:
                     logger.warning("credential_binding_monitor_failed", exc_info=exc)
                     failure_logged = True
+                retry_interval = min(
+                    retry_interval * 2,
+                    _MONITOR_MAX_RETRY_INTERVAL_SECONDS,
+                )
 
     def _read_current(self) -> str | None:
         with self._lock:
@@ -461,6 +472,16 @@ class _CodexAuthLifecycle:
                 return
         try:
             self._load()
+        except (
+            CredentialAuthorizationRejected,
+            CredentialConflict,
+            CredentialInvalidResponse,
+            CredentialNeedsReauthentication,
+        ) as exc:
+            with self._lock:
+                if self._error is error:
+                    self._error = exc
+            return
         except CredentialBindingError:
             return
         with self._lock:

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -15,6 +15,7 @@ from openhands.sdk.credential import (
     CredentialAuthorizationRejected,
     CredentialBindingError,
     CredentialConflict,
+    CredentialInvalidResponse,
     CredentialNeedsReauthentication,
     CredentialSyncError,
     ResolvedCredential,
@@ -245,15 +246,21 @@ class _CodexAuthLifecycle:
                     value = self._read_stable(attempts=1)
                     if value is not None:
                         self._sync_value(value)
-            except (CredentialNeedsReauthentication, CredentialSyncError) as exc:
+            except (
+                CredentialNeedsReauthentication,
+                CredentialConflict,
+                CredentialInvalidResponse,
+            ) as exc:
                 self._set_error(exc)
                 return
+            except CredentialSyncError as exc:
+                self._set_error(exc)
+                logger.warning("credential_binding_monitor_failed", exc_info=exc)
             except Exception as exc:
                 self._set_error(
                     CredentialSyncError("Codex credential monitoring failed.")
                 )
                 logger.warning("credential_binding_monitor_failed", exc_info=exc)
-                return
 
     def _read_current(self) -> str | None:
         with self._lock:
@@ -426,13 +433,32 @@ class _CodexAuthLifecycle:
 
     def _refresh_authorization_state(self) -> None:
         revision = self._authorization_revision()
-        if revision is None:
+        with self._lock:
+            error = self._error
+            if (
+                revision is not None
+                and revision != self._binding_authorization_revision
+            ):
+                self._binding_authorization_revision = revision
+                if isinstance(error, CredentialAuthorizationRejected):
+                    self._error = None
+                    return
+            if error is None or isinstance(
+                error,
+                (
+                    CredentialAuthorizationRejected,
+                    CredentialConflict,
+                    CredentialInvalidResponse,
+                    CredentialNeedsReauthentication,
+                ),
+            ):
+                return
+        try:
+            self._load()
+        except CredentialBindingError:
             return
         with self._lock:
-            if revision == self._binding_authorization_revision:
-                return
-            self._binding_authorization_revision = revision
-            if isinstance(self._error, CredentialAuthorizationRejected):
+            if self._error is error:
                 self._error = None
 
     def _authorization_revision(self) -> int | None:

--- a/tests/sdk/agent/test_acp_file_credentials.py
+++ b/tests/sdk/agent/test_acp_file_credentials.py
@@ -268,6 +268,26 @@ def test_monitor_recovers_after_transient_writeback_failure() -> None:
         lifecycle.close()
 
 
+def test_monitor_logs_persistent_writeback_failure_once() -> None:
+    binding = FailingBinding(_auth("refresh-r0"))
+    lifecycle, _ = _lifecycle(binding, SecretRegistry())
+    assert lifecycle.path is not None
+    runtime = cast(Any, lifecycle)
+    try:
+        with patch(
+            "openhands.sdk.agent.acp_file_credentials.logger.warning"
+        ) as warning:
+            lifecycle.path.write_text(_auth("refresh-r1"), encoding="utf-8")
+            deadline = time.monotonic() + 2
+            while binding.replace_calls < 2 and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert binding.replace_calls >= 2
+            assert runtime._monitor.is_alive()
+            assert warning.call_count == 1
+    finally:
+        lifecycle.discard()
+
+
 def test_unchanged_file_does_not_write() -> None:
     binding = MemoryBinding(_auth("refresh-r0"))
     lifecycle, _ = _lifecycle(binding, SecretRegistry())

--- a/tests/sdk/agent/test_acp_file_credentials.py
+++ b/tests/sdk/agent/test_acp_file_credentials.py
@@ -85,9 +85,11 @@ class RevokedBinding(MemoryBinding):
         super().__init__(value)
         self.authorization_revision = 0
         self.rejected = True
+        self.rejection_observed = threading.Event()
 
     async def replace(self, expected_version: str, value: str) -> str:
         if self.rejected:
+            self.rejection_observed.set()
             raise CredentialAuthorizationRejected("rejected")
         return await super().replace(expected_version, value)
 
@@ -112,6 +114,25 @@ class FlakyBinding(MemoryBinding):
             self.first_replace_failed.set()
             raise CredentialSyncError("temporarily unavailable")
         return await super().replace(expected_version, value)
+
+
+class DisappearingBinding(MemoryBinding):
+    def __init__(self, value: str) -> None:
+        super().__init__(value)
+        self.failed_replace = False
+        self.failed_loads = 0
+
+    async def load(self) -> ResolvedCredential:
+        if not self.failed_replace:
+            return await super().load()
+        self.failed_loads += 1
+        if self.failed_loads == 1:
+            raise CredentialSyncError("unavailable")
+        raise CredentialNeedsReauthentication("missing")
+
+    async def replace(self, expected_version: str, value: str) -> str:
+        self.failed_replace = True
+        raise CredentialSyncError("unavailable")
 
 
 def _lifecycle(binding: MemoryBinding, registry: SecretRegistry):
@@ -288,6 +309,21 @@ def test_monitor_logs_persistent_writeback_failure_once() -> None:
         lifecycle.discard()
 
 
+def test_monitor_stops_when_recovery_probe_requires_reauthentication() -> None:
+    binding = DisappearingBinding(_auth("refresh-r0"))
+    lifecycle, _ = _lifecycle(binding, SecretRegistry())
+    assert lifecycle.path is not None
+    runtime = cast(Any, lifecycle)
+    lifecycle.path.write_text(_auth("refresh-r1"), encoding="utf-8")
+    assert runtime._monitor is not None
+    runtime._monitor.join(timeout=2)
+
+    assert not runtime._monitor.is_alive()
+    with pytest.raises(CredentialNeedsReauthentication, match="missing"):
+        lifecycle.flush()
+    lifecycle.discard()
+
+
 def test_unchanged_file_does_not_write() -> None:
     binding = MemoryBinding(_auth("refresh-r0"))
     lifecycle, _ = _lifecycle(binding, SecretRegistry())
@@ -379,6 +415,22 @@ def test_reauthorization_clears_authorization_rejection() -> None:
 
     assert binding.value == _auth("refresh-r1")
     lifecycle.close()
+
+
+def test_monitor_recovers_after_reauthorization() -> None:
+    rotated = _auth("refresh-r1")
+    binding = RevokedBinding(_auth("refresh-r0"))
+    lifecycle, _ = _lifecycle(binding, SecretRegistry())
+    assert lifecycle.path is not None
+    runtime = cast(Any, lifecycle)
+    try:
+        lifecycle.path.write_text(rotated, encoding="utf-8")
+        assert binding.rejection_observed.wait(2)
+        assert runtime._monitor.is_alive()
+        binding.reauthorize()
+        _wait_for_value(binding, rotated)
+    finally:
+        lifecycle.close()
 
 
 def test_runtime_state_does_not_serialize_binding_values() -> None:

--- a/tests/sdk/agent/test_acp_file_credentials.py
+++ b/tests/sdk/agent/test_acp_file_credentials.py
@@ -98,7 +98,20 @@ class RevokedBinding(MemoryBinding):
 
 class FailingBinding(MemoryBinding):
     async def replace(self, expected_version: str, value: str) -> str:
+        self.replace_calls += 1
         raise CredentialSyncError("unavailable")
+
+
+class FlakyBinding(MemoryBinding):
+    def __init__(self, value: str) -> None:
+        super().__init__(value)
+        self.first_replace_failed = threading.Event()
+
+    async def replace(self, expected_version: str, value: str) -> str:
+        if not self.first_replace_failed.is_set():
+            self.first_replace_failed.set()
+            raise CredentialSyncError("temporarily unavailable")
+        return await super().replace(expected_version, value)
 
 
 def _lifecycle(binding: MemoryBinding, registry: SecretRegistry):
@@ -239,6 +252,22 @@ def test_unstable_read_does_not_poison_lifecycle() -> None:
     lifecycle.close()
 
 
+def test_monitor_recovers_after_transient_writeback_failure() -> None:
+    rotated = _auth("refresh-r1")
+    binding = FlakyBinding(_auth("refresh-r0"))
+    lifecycle, _ = _lifecycle(binding, SecretRegistry())
+    assert lifecycle.path is not None
+    runtime = cast(Any, lifecycle)
+    try:
+        lifecycle.path.write_text(rotated, encoding="utf-8")
+        assert binding.first_replace_failed.wait(2)
+        assert runtime._monitor.is_alive()
+        _wait_for_value(binding, rotated)
+        lifecycle.flush()
+    finally:
+        lifecycle.close()
+
+
 def test_unchanged_file_does_not_write() -> None:
     binding = MemoryBinding(_auth("refresh-r0"))
     lifecycle, _ = _lifecycle(binding, SecretRegistry())
@@ -259,7 +288,7 @@ def test_ambiguous_committed_write_converges() -> None:
     lifecycle.close()
 
 
-def test_exhausted_writeback_failure_is_sticky() -> None:
+def test_writeback_failure_is_retried_after_successful_load() -> None:
     binding = FailingBinding(_auth("refresh-r0"))
     lifecycle, _ = _lifecycle(binding, SecretRegistry())
     assert lifecycle.path is not None
@@ -274,6 +303,7 @@ def test_exhausted_writeback_failure_is_sticky() -> None:
     with pytest.raises(CredentialSyncError, match="unavailable"):
         lifecycle.close()
 
+    assert binding.replace_calls == 3
     assert runtime_dir.exists()
     lifecycle.discard()
     assert not runtime_dir.exists()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

recover credential monitor after transient errors

---

AGENT:

## Why

The Codex credential monitor permanently stopped after any `CredentialSyncError`, leaving a sticky error that blocked every later `track_current()` and `flush()` call. A temporary file-store or binding outage could therefore disable credential synchronization for the rest of a conversation.

This defect was identified while investigating [OpenHands/enterprise#120](https://github.com/OpenHands/enterprise/issues/120), but this PR is a standalone defect fix independent of that issue's broader Codex-auth investigation.

## Summary

- Keep the credential monitor alive after recoverable synchronization and unexpected errors, while retaining terminal behavior for missing credentials, invalid source responses, and version conflicts.
- Clear a recoverable sticky error after a later canonical credential read succeeds; retain authorization-rejection errors until the authorization revision changes.
- Cover a transient write-back failure followed by successful monitor recovery, and verify persistent failures are retried after successful reads.

## Issue Number

Context: https://github.com/OpenHands/enterprise/issues/120

## How to Test

Automated regression and integration suites:

```console
$ uv run pytest tests/sdk/agent/test_acp_file_credentials.py tests/agent_server/test_credential_binding.py -q
46 passed, 6 warnings in 7.12s
```

Repository checks:

```console
$ uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/acp_file_credentials.py tests/sdk/agent/test_acp_file_credentials.py
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

Manual end-to-end reproduction used the real `HttpVersionedCredentialBinding`, a mock HTTP credential endpoint that returned 503 for the first PUT, the real file lifecycle, and its background monitor. After writing a rotated `auth.json`, the output was:

```console
credential_binding_monitor_failed ... CredentialSyncError: Credential source request failed.
replace_attempts=2
monitor_alive=True
credential_synced=True
```

## Video/Screenshots

Not applicable; this is a background credential synchronization fix. The reproduction output above shows the transient failure and successful recovery.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The monitor remains terminal for errors that need external intervention or cannot be safely retried. No public API or configuration changes are included.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:407ee4f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-407ee4f-python \
  ghcr.io/openhands/agent-server:407ee4f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:407ee4f-golang-amd64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-golang-amd64
ghcr.io/openhands/agent-server:407ee4f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:407ee4f-golang-arm64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-golang-arm64
ghcr.io/openhands/agent-server:407ee4f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:407ee4f-java-amd64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-java-amd64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-java-amd64
ghcr.io/openhands/agent-server:407ee4f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:407ee4f-java-arm64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-java-arm64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-java-arm64
ghcr.io/openhands/agent-server:407ee4f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:407ee4f-python-amd64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-python-amd64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-python-amd64
ghcr.io/openhands/agent-server:407ee4f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:407ee4f-python-arm64
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-python-arm64
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-python-arm64
ghcr.io/openhands/agent-server:407ee4f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:407ee4f-golang
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-golang
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-golang
ghcr.io/openhands/agent-server:407ee4f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:407ee4f-java
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-java
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-java
ghcr.io/openhands/agent-server:407ee4f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:407ee4f-python
ghcr.io/openhands/agent-server:407ee4f0ed1dea2c1f0c3749096d69e34411ea34-python
ghcr.io/openhands/agent-server:fix-acp-credential-monitor-sticky-error-python
ghcr.io/openhands/agent-server:407ee4f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `407ee4f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `407ee4f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->