### PR TITLE
fix(tools): shim mcp 1.x Server decorators so browser_use constructs under mcp 2.x

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/logging_fix.py
+++ b/openhands-tools/openhands/tools/browser_use/logging_fix.py
@@ -28,6 +28,82 @@ warn_cleanup(
     ),
 )
 
+warn_cleanup(
+    "Shim mcp 1.x Server handler decorators for browser_use under mcp 2.x",
+    cleanup_by="2.0.0",
+    details=(
+        "browser_use (<=0.13.x) pins mcp==1.26.0 and registers MCP handlers "
+        "with the decorator-style API (@server.list_tools(), "
+        "@server.call_tool(), ...) that mcp 2.x removed in favor of "
+        "constructor-based handlers plus add_request_handler(). OpenHands "
+        "never speaks MCP to this server (it calls the server's private "
+        "methods directly), but BrowserUseServer.__init__ still executes the "
+        "decorator registrations, so under mcp 2.x construction fails with "
+        "AttributeError: 'Server' object has no attribute 'list_tools'. "
+        "Remove this shim once browser_use supports mcp 2.x natively."
+    ),
+)
+
+
+def _patch_mcp2_server_compat() -> None:
+    """Re-add the mcp 1.x decorator-style handler registration under mcp 2.x.
+
+    mcp 2.x replaced the ``@server.list_tools()`` / ``@server.call_tool()``
+    decorators with constructor-based ``on_*`` handlers plus
+    ``add_request_handler``. This faithfully re-implements the decorators on
+    top of ``add_request_handler``. Under mcp 1.x the decorators already
+    exist and this is a no-op.
+    """
+    try:
+        from mcp.server.lowlevel.server import Server
+    except Exception:
+        return  # mcp not installed: nothing to shim.
+
+    if hasattr(Server, "list_tools"):
+        return  # mcp 1.x already provides the decorators; nothing to do.
+
+    import mcp.types as types
+
+    def _make_list_decorator(method, result_cls, field_name):
+        def decorator_factory(self):
+            def register(fn):
+                async def handler(_ctx, _params):
+                    items = await fn()
+                    return result_cls(**{field_name: items})
+
+                self.add_request_handler(method, types.PaginatedRequestParams, handler)
+                return fn
+
+            return register
+
+        return decorator_factory
+
+    Server.list_tools = _make_list_decorator(  # type: ignore[attr-defined]
+        "tools/list", types.ListToolsResult, "tools"
+    )
+    Server.list_resources = _make_list_decorator(  # type: ignore[attr-defined]
+        "resources/list", types.ListResourcesResult, "resources"
+    )
+    Server.list_prompts = _make_list_decorator(  # type: ignore[attr-defined]
+        "prompts/list", types.ListPromptsResult, "prompts"
+    )
+
+    def call_tool(self):
+        def register(fn):
+            async def handler(_ctx, params):
+                content = await fn(params.name, params.arguments)
+                return types.CallToolResult(content=content)
+
+            self.add_request_handler("tools/call", types.CallToolRequestParams, handler)
+            return fn
+
+        return register
+
+    Server.call_tool = call_tool  # type: ignore[attr-defined]
+
+
+_patch_mcp2_server_compat()
+
 
 def _noop(*args, **kwargs):
     """No-op replacement for functions"""

--- a/tests/tools/browser_use/test_logging_fix.py
+++ b/tests/tools/browser_use/test_logging_fix.py
@@ -1,0 +1,95 @@
+"""Tests for the mcp 2.x compatibility shim in logging_fix.
+
+browser_use (<=0.13.x) pins mcp==1.26.0 and registers MCP handlers with the
+decorator-style Server API (@server.list_tools(), @server.call_tool(), ...)
+that mcp 2.x removed in favor of add_request_handler(). logging_fix re-adds
+those decorators on top of add_request_handler() so that BrowserUseServer can
+be constructed under either mcp major version.
+"""
+
+import mcp.types as types
+import pytest
+from mcp.server.lowlevel.server import Server
+
+from openhands.tools.browser_use import logging_fix
+
+
+def _shim_active() -> bool:
+    """True when Server.list_tools comes from the shim, not from mcp itself."""
+    return getattr(Server, "list_tools", None) is not None and (
+        Server.list_tools.__module__ == logging_fix.__name__
+    )
+
+
+def _shimmed_server() -> Server:
+    if hasattr(Server, "list_tools") and not _shim_active():
+        pytest.skip("mcp 1.x environment: decorators exist natively, shim is a no-op")
+    logging_fix._patch_mcp2_server_compat()
+    assert _shim_active()
+    return Server("test")
+
+
+def test_shim_is_noop_when_mcp_decorators_exist():
+    """On mcp 1.x the native decorators must not be replaced."""
+    if not hasattr(Server, "list_tools") or _shim_active():
+        pytest.skip("requires an mcp 1.x environment")
+    native = Server.list_tools
+    logging_fix._patch_mcp2_server_compat()
+    assert Server.list_tools is native
+
+
+async def test_list_tools_decorator_registers_handler():
+    server = _shimmed_server()
+
+    @server.list_tools()
+    async def handle_list_tools() -> list[types.Tool]:
+        return [types.Tool(name="echo", inputSchema={"type": "object"})]
+
+    handlers = server._request_handlers  # type: ignore[attr-defined]
+    entry = handlers.get("tools/list")
+    assert entry is not None
+    result = await entry.handler(None, types.PaginatedRequestParams())  # type: ignore[arg-type]
+    assert isinstance(result, types.ListToolsResult)
+    assert [t.name for t in result.tools] == ["echo"]
+
+
+async def test_list_resources_and_prompts_register_handlers():
+    server = _shimmed_server()
+
+    @server.list_resources()
+    async def handle_list_resources() -> list[types.Resource]:
+        return []
+
+    @server.list_prompts()
+    async def handle_list_prompts() -> list[types.Prompt]:
+        return []
+
+    handlers = server._request_handlers  # type: ignore[attr-defined]
+    assert handlers.get("resources/list") is not None
+    assert handlers.get("prompts/list") is not None
+
+
+async def test_call_tool_decorator_registers_handler():
+    server = _shimmed_server()
+
+    @server.call_tool()
+    async def handle_call_tool(
+        name: str, arguments: dict | None
+    ) -> list[types.TextContent]:
+        return [types.TextContent(type="text", text=f"called {name} with {arguments}")]
+
+    handlers = server._request_handlers  # type: ignore[attr-defined]
+    entry = handlers.get("tools/call")
+    assert entry is not None
+    params = types.CallToolRequestParams(name="echo", arguments={"x": 1})
+    result = await entry.handler(None, params)  # type: ignore[arg-type]
+    assert isinstance(result, types.CallToolResult)
+    assert result.content[0].text == "called echo with {'x': 1}"
+
+
+def test_shimmed_decorators_support_browser_use_server_construction():
+    """End-to-end: BrowserUseServer.__init__ must succeed under mcp 2.x."""
+    from openhands.tools.browser_use.server import CustomBrowserUseServer
+
+    server = CustomBrowserUseServer(session_timeout_minutes=1)
+    assert server is not None


### PR DESCRIPTION
HUMAN:

We run the SDK in an environment where mcp 2.x is installed; there the browser tool cannot be constructed at all (`AttributeError: 'Server' object has no attribute 'list_tools'`). This shim has been running locally as a manual patch and is verified working; submitting it upstream so upgrades stop requiring the manual patch. (Submitted by @Lin-Artificial; prepared on his behalf by an AI agent.)

---

AGENT:

## Why

`browser_use` (<= 0.13.x) pins `mcp==1.26.0` and registers MCP handlers in `BrowserUseServer.__init__` using the decorator-style API (`@server.list_tools()`, `@server.call_tool()`, ...) that mcp 2.x removed in favor of constructor-based handlers plus `add_request_handler()`. OpenHands never speaks MCP to this server (it calls the server's private methods directly), but construction still executes the decorator registrations, so under mcp 2.x the browser tool fails with `AttributeError: 'Server' object has no attribute 'list_tools'`.

## Summary

- Re-implement the four removed mcp 1.x decorators (`list_tools`, `call_tool`, `list_resources`, `list_prompts`) on top of `add_request_handler()` inside `logging_fix`, preserving the semantics `browser_use` relies on (`call_tool` wraps results in `CallToolResult`, mirroring mcp 1.x).
- Under mcp 1.x the shim detects the native decorators and is a no-op; tracked via `warn_cleanup(cleanup_by="2.0.0")`, alongside the existing browser_use logging workaround (#4072).
- Add `tests/tools/browser_use/test_logging_fix.py` covering handler registration, result wrapping, mcp 1.x no-op detection, and end-to-end `CustomBrowserUseServer` construction.

## Issue Number

Related: #4072 (tracks removal of the browser_use workarounds)

## How to Test

Verified in an environment with `mcp 2.0.0` installed:

1. Reproduce on unpatched code:
   ```python
   from openhands.tools.browser_use.server import CustomBrowserUseServer
   CustomBrowserUseServer(session_timeout_minutes=1)
   # AttributeError: 'Server' object has no attribute 'list_tools'
   ```
2. With the shim applied, the same snippet constructs successfully.
3. New tests plus existing suite:
   ```
   pytest tests/tools/browser_use/test_logging_fix.py -v
   # 4 passed, 1 skipped (mcp-1.x-only case)

   pytest tests/tools/browser_use/ --ignore=tests/tools/browser_use/test_browser_executor_e2e.py
   # 132 passed, 1 skipped
   ```
4. `ruff check` / `ruff format --check` clean (ruff 0.12.10).

CI runs the pinned environment (mcp 1.26.0): shim-functional tests self-skip there, while the no-op and construction tests pass — the suite is green under both mcp majors.

## Video/Screenshots

N/A — headless tooling change; see test commands and outputs above.

## Type

- [x] Bug fix

## Notes

- `browser_use` 0.13.7 (latest release) still pins `mcp==1.26.0`, so this incompatibility is current.
- The shim only activates when `mcp.server.lowlevel.server.Server` lacks the decorator attributes; zero behavior change for existing mcp 1.x installs.

_This PR was prepared by an AI agent (OpenHands) on behalf of @Lin-Artificial._

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.41s · commit 47871c0  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 5.0% | No direct hunk selected |
| Weakened authorization | 6.0% | No direct hunk selected |
| Contract regression | 17.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 85.0% | No primary concern to locate |

</details>


<!-- jev-input-signature ec887547a1d506e8dce72cc4127b982c99b2dbfbae00ebcedc066c98d082eafe -->
<!-- jev-fast-audit:end -->
