### PR TITLE
fix(acp): resolve launch commands via PATHEXT-aware lookup so ACP can spawn on Windows

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -22,6 +22,7 @@ import inspect
 import json
 import os
 import re
+import shutil
 import threading
 import time
 import uuid
@@ -332,6 +333,29 @@ def _select_auth_method(
         if method_id in method_ids and env_var in env:
             return method_id
     return None
+
+
+def _resolve_executable(program: str) -> str:
+    """Resolve *program* against ``PATH`` before handing it to ``exec``.
+
+    ``asyncio.create_subprocess_exec`` bottoms out in ``CreateProcess`` on
+    Windows, which resolves a bare name against ``PATH`` but only ever appends
+    ``.exe`` — it never consults ``PATHEXT``. Every npm-installed CLI entry
+    point is a ``.cmd`` shim (``npx.cmd``, ``claude-agent-acp.cmd``), so the
+    registry's default ``npx -y <pkg>`` launch command raises
+    ``FileNotFoundError`` on Windows even with npm correctly on ``PATH``.
+    :func:`shutil.which` does honour ``PATHEXT``, so resolving first makes the
+    shim spawnable.
+
+    A name that already carries a directory component is returned untouched, as
+    is one ``which`` cannot resolve — the latter keeps the existing
+    ``ACPSpawnError`` behaviour for a genuinely missing CLI rather than
+    swallowing it here. On POSIX ``which`` finds the same file ``execvp`` would,
+    so this is behaviour-preserving.
+    """
+    if os.path.dirname(program):
+        return program
+    return shutil.which(program) or program
 
 
 def _with_codex_base_url(
@@ -2596,7 +2620,9 @@ class ACPAgent(AgentBase):
                 for conflict in conflicts:
                     env.pop(conflict, None)
 
-        command = self.acp_command[0]
+        # Resolve through PATHEXT-aware lookup: create_subprocess_exec cannot
+        # spawn npm's .cmd shims from a bare name on Windows. No-op on POSIX.
+        command = _resolve_executable(self.acp_command[0])
         args = list(self.acp_command[1:]) + list(self.acp_args)
         # Codex ignores OPENAI_BASE_URL; translate it into the config key read by
         # the adapter. The helper returns a child-only environment and never

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1734,11 +1734,19 @@ class ACPAgentSettings(AgentSettingsBase):
 
         When *command* is an ``npx`` invocation of this provider's package and
         the provider's ``binary_name`` resolves via :func:`shutil.which`, return
-        ``[binary_name, *extra]`` (preserving trailing args like gemini's
+        ``[<resolved path>, *extra]`` (preserving trailing args like gemini's
         ``--acp``) — running the agent-server image's pinned wrapper instead of
         downloading npm-latest. Returned unchanged otherwise: no pinned binary
         (custom server), a non-matching/non-npx command, or the binary not on
         ``PATH`` (local dev).
+
+        The *resolved* path from ``shutil.which`` is used rather than the bare
+        ``binary_name``: the caller feeds this straight to
+        ``asyncio.create_subprocess_exec``, which on Windows reaches
+        ``CreateProcess`` — that only ever appends ``.exe`` and never consults
+        ``PATHEXT``, so a bare name pointing at npm's ``binary_name.cmd`` shim
+        raises ``FileNotFoundError``. Handing over the path we already looked up
+        also removes a PATH-lookup race between resolution and spawn.
 
         Package matching ignores any ``@version`` suffix: the registry default
         is version-pinned (so the native fallback can't drift to npm ``latest``),
@@ -1760,10 +1768,13 @@ class ACPAgentSettings(AgentSettingsBase):
         same_package = self._npm_package_name(actual_pkg) == self._npm_package_name(
             default_pkg
         )
-        if not same_package or shutil.which(info.binary_name) is None:
+        if not same_package:
+            return command
+        resolved = shutil.which(info.binary_name)
+        if resolved is None:
             return command
 
-        return [info.binary_name, *extra]
+        return [resolved, *extra]
 
     def create_agent(self) -> ACPAgent:
         """Build an :class:`ACPAgent` from these settings.

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
+import os
 import threading
 import time
 import uuid
@@ -41,6 +42,7 @@ from openhands.sdk.agent.acp_agent import (
     _mcp_config_to_acp_servers,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
+    _resolve_executable,
     _select_auth_method,
     _serialize_tool_content,
     _stringify_acp_error_data,
@@ -4954,6 +4956,54 @@ class TestSelectAuthMethod:
         env = {"GEMINI_API_KEY": "g"}
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, env) == "gemini-api-key"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_executable
+# ---------------------------------------------------------------------------
+
+
+class TestResolveExecutable:
+    """``create_subprocess_exec`` reaches ``CreateProcess`` on Windows, which
+    appends only ``.exe`` and never consults ``PATHEXT``. Every npm CLI entry
+    point is a ``.cmd`` shim, so the registry's ``npx -y <pkg>`` default is
+    unspawnable from a bare name there. ``shutil.which`` does honour ``PATHEXT``.
+    """
+
+    def test_bare_name_resolves_to_pathext_aware_which_result(self):
+        with patch(
+            "openhands.sdk.agent.acp_agent.shutil.which",
+            return_value=r"C:\Program Files\nodejs\npx.cmd",
+        ):
+            assert _resolve_executable("npx") == r"C:\Program Files\nodejs\npx.cmd"
+
+    def test_unresolvable_name_passes_through(self):
+        """Kept verbatim so a genuinely missing CLI still raises ACPSpawnError
+        from the spawn rather than being swallowed here."""
+        with patch(
+            "openhands.sdk.agent.acp_agent.shutil.which", return_value=None
+        ) as which:
+            assert _resolve_executable("definitely-not-installed") == (
+                "definitely-not-installed"
+            )
+            which.assert_called_once_with("definitely-not-installed")
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "/usr/local/bin/codex-acp",
+            "./local-acp",
+            # Built with the host separator so the assertion holds on both
+            # flavours of os.path (ntpath does not treat "/" specially, and
+            # posixpath does not treat "\\" specially).
+            os.path.join("opt", "shims", "claude-agent-acp"),
+        ],
+    )
+    def test_path_qualified_program_is_not_looked_up(self, program: str):
+        """An explicit path is already what exec wants; no PATH search."""
+        with patch("openhands.sdk.agent.acp_agent.shutil.which") as which:
+            assert _resolve_executable(program) == program
+            which.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1289,10 +1289,14 @@ def _which_returning(*available: str):
 @pytest.mark.parametrize(
     ("server", "binary", "expected"),
     [
-        ("claude-code", "claude-agent-acp", ["claude-agent-acp"]),
-        ("codex", "codex-acp", ["codex-acp"]),
+        (
+            "claude-code",
+            "claude-agent-acp",
+            ["/usr/local/bin/claude-agent-acp"],
+        ),
+        ("codex", "codex-acp", ["/usr/local/bin/codex-acp"]),
         # gemini's default carries a trailing ``--acp`` that must be preserved.
-        ("gemini-cli", "gemini", ["gemini", "--acp"]),
+        ("gemini-cli", "gemini", ["/usr/local/bin/gemini", "--acp"]),
     ],
 )
 def test_acp_resolve_command_rewrites_default_to_pinned_binary(
@@ -1301,7 +1305,11 @@ def test_acp_resolve_command_rewrites_default_to_pinned_binary(
     binary: str,
     expected: list[str],
 ) -> None:
-    """(a) Registry default + binary on PATH → run the pinned binary directly."""
+    """(a) Registry default + binary on PATH → run the pinned binary directly.
+
+    The rewrite uses the path ``shutil.which`` resolved, not the bare name; see
+    ``test_acp_resolve_command_uses_resolved_path_not_bare_name``.
+    """
     monkeypatch.setattr(shutil, "which", _which_returning(binary))
     settings = ACPAgentSettings(acp_server=server)
     assert settings.resolve_acp_command() == expected
@@ -1322,7 +1330,10 @@ def test_acp_resolve_command_rewrites_explicit_npx_command(
             "--verbose",
         ],
     )
-    assert settings.resolve_acp_command() == ["codex-acp", "--verbose"]
+    assert settings.resolve_acp_command() == [
+        "/usr/local/bin/codex-acp",
+        "--verbose",
+    ]
 
 
 def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
@@ -1341,7 +1352,29 @@ def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
             acp_server="codex",
             acp_command=["npx", "-y", pkg],
         )
-        assert settings.resolve_acp_command() == ["codex-acp"], pkg
+        assert settings.resolve_acp_command() == ["/usr/local/bin/codex-acp"], pkg
+
+
+def test_acp_resolve_command_uses_resolved_path_not_bare_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rewrite emits the path ``shutil.which`` returned, not ``binary_name``.
+
+    ``ACPAgent`` feeds this command straight to
+    ``asyncio.create_subprocess_exec``. On Windows that reaches ``CreateProcess``,
+    which appends only ``.exe`` and never consults ``PATHEXT`` — so a bare name
+    pointing at npm's ``codex-acp.cmd`` shim raises ``FileNotFoundError`` even
+    though ``which`` just found it. Emitting the resolved path also closes the
+    PATH-lookup race between resolution and spawn.
+    """
+    monkeypatch.setattr(
+        shutil, "which", lambda name: rf"C:\npm\{name}.cmd" if name else None
+    )
+    settings = ACPAgentSettings(acp_server="codex")
+    command = settings.resolve_acp_command()
+
+    assert command == [r"C:\npm\codex-acp.cmd"]
+    assert command[0] != "codex-acp"
 
 
 def test_acp_resolve_command_keeps_npx_when_binary_absent(
@@ -1425,7 +1458,7 @@ def test_acp_create_agent_uses_pinned_binary_when_present(
     """End-to-end: create_agent() bakes the rewritten command into the agent."""
     monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
     agent = ACPAgentSettings(acp_server="codex").create_agent()
-    assert agent.acp_command == ["codex-acp"]
+    assert agent.acp_command == ["/usr/local/bin/codex-acp"]
 
 
 def test_acp_api_key_env_var_maps_known_servers() -> None:


### PR DESCRIPTION
HUMAN:

Had issues installing OpenHands on windows. Putting up some PRs to help the community

---

AGENT:

## Why

ACP can't start on Windows. `asyncio.create_subprocess_exec` bottoms out in `CreateProcess`,
which resolves a bare program name against `PATH` but only ever appends `.exe` — it never
consults `PATHEXT`. npm CLI entry points are `.cmd` shims, so both paths that produce a launch
command fail:

1. The registry default is `("npx", "-y", "<pkg>@<ver>")`. npm ships `npx.cmd`, so this raises
   `FileNotFoundError` / `[WinError 2]` even with npm correctly on `PATH`.
2. The pre-installed-binary path has the same defect for a different reason.
   `_prefer_pinned_binary` calls `shutil.which(info.binary_name)` — which *does* honour
   `PATHEXT` and finds the shim — then discards the resolved path and returns the bare name
   (`model.py:1766`).

So the workaround for (1) is (2), and (2) fails identically. There's no working configuration
through the provider presets on Windows.

## Summary

- `_prefer_pinned_binary` returns the path `shutil.which` resolved instead of the bare
  `binary_name`. Also removes a PATH-lookup race between resolution and spawn.
- New `_resolve_executable` helper applied to `command[0]` just before
  `create_subprocess_exec`, so the registry default and any user-supplied `acp_command` both
  get a `PATHEXT`-aware lookup.
- Tests for both, and updates to the existing `resolve_acp_command` assertions that expected
  the bare name.

No-op on POSIX: `shutil.which` returns the same file `execvp` would have found. A program name
with a directory component is passed through untouched; an unresolvable name is passed through
unchanged so a missing CLI still raises `ACPSpawnError` at the spawn rather than being
swallowed earlier. `detect_acp_provider_by_command` already reduces tokens to basenames and
documents `/opt/node_modules/.bin/codex-acp` as a supported form, so it is unaffected.

## Issue Number

<!-- none filed; happy to open one if you'd prefer it tracked separately -->

## How to Test

Unit:

```
uv run pytest tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py -q
```

End-to-end, on Windows 10 19045 / Python 3.13. For each path this builds the command the way
`main` does and the way this branch does, spawns each through
`asyncio.create_subprocess_exec` exactly as `ACPAgent` does, and runs a real ACP `initialize`
handshake (pre-auth, so no credentials involved):

```
PATH A — pinned provider binary on PATH
  main   : ['claude-agent-acp']
  patched: ['C:\\Users\\<user>\\AppData\\Roaming\\npm\\claude-agent-acp.CMD']
    main     spawn=FAIL  FileNotFoundError: [WinError 2] The system cannot find the file specified
    patched  spawn=OK    handshake ok, agent=@agentclientprotocol/claude-agent-acp v0.65.0

PATH B — no pinned binary, registry `npx -y <pkg>` default
  main   : ['npx', '-y', '@agentclientprotocol/claude-agent-acp@0.63.0']
  patched: ['C:\\Program Files\\nodejs\\npx.CMD', '-y', '@agentclientprotocol/claude-agent-acp@0.63.0']
    main     spawn=FAIL  FileNotFoundError: [WinError 2] The system cannot find the file specified
    patched  spawn=OK    handshake ok, agent=@agentclientprotocol/claude-agent-acp v0.63.0
```

Script available on request; it imports `resolve_acp_command` / `_resolve_executable` from the
branch, so it exercises the shipped code path rather than a reimplementation.

## Video/Screenshots

n/a — terminal only, output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **The MCP half of this stack already does this.** `mcp/os/win32/utilities.py::
  get_windows_executable_command` (in the `mcp` package this SDK already depends on) resolves a
  bare command via `shutil.which`, then tries `.cmd` / `.bat` / `.exe` / `.ps1`, then falls back
  to the bare name — the same shape as `_resolve_executable` here. That's why stdio MCP servers
  launch from `npx` on Windows while the ACP path doesn't: only the ACP spawn skips the lookup.
- **Known, pre-existing:** resolving to a `.cmd` means `CreateProcess` runs it through `cmd.exe`,
  so arguments containing shell metacharacters (`&`, `|`, `^`, `"`) are subject to cmd's parsing
  (the "BatBadBut" class). This PR doesn't introduce that — it's inherent to npm's `.cmd` shims
  and the `mcp` resolution above has the same property — but it does make `.cmd` execution the
  normal path on Windows rather than an error. The registry defaults are package specs with no
  metacharacters; a user-supplied `acp_args` is the exposure. Happy to add quoting hardening
  here or as a follow-up if you want it.
- `resolve_acp_command()` now returns an absolute path where it previously returned a bare name
  — `/usr/local/bin/codex-acp` rather than `codex-acp` in the agent-server image. Nothing
  in-tree compares against the bare form outside the tests updated here, but it lands in
  persisted settings, so flagging it.
- The touched files are green (`602 passed`). The repo's own pre-commit gates run clean against
  them too: ruff format, ruff check, pycodestyle, pyright (0 errors), `check_import_rules.py`,
  `check_tool_registration.py`, `check_docstrings.py`. Four other tests in
  `tests/sdk/agent/test_acp_agent.py` fail here — `TestACPFileSecretMaterialisation` (3) and
  `TestACPDataDirIsolation::test_codex_sets_codex_home_to_conversation_root` — and fail
  identically on unmodified `main`, so they're pre-existing. For scale, the wider `tests/sdk`
  suite on Windows is `44 failed, 5698 passed` on unmodified `main` (701a21f). Those 44 are
  `context/prompts/test_prompt_snapshot.py` (26), the three `git/` files (13), the four ACP ones
  above, and `utils/test_path.py` (1) — none of them touched by this PR. I haven't triaged them
  and mention the number only as context.
- None of this is visible to CI: the `windows-tests` job in `tests.yml` only runs when
  `openhands-tools/**`, `tests/tools/**`, `pyproject.toml`, `uv.lock` or the workflow itself
  changed, and its pytest invocation targets `tests/tools` — so `openhands-sdk` gets no Windows
  coverage under any condition. The tests here are platform-independent (`shutil.which`
  monkeypatched, host-neutral paths) so they do run in the Ubuntu `sdk-tests` job. I haven't
  widened the filter — that would surface the ~44 failures above and is a maintainer call.
  Happy to do it as a follow-up.
