### PR TITLE
fix(acp): reap the ACP subprocess tree on shutdown via a Job Object

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -102,6 +102,7 @@ from openhands.sdk.settings.acp_providers import (
 from openhands.sdk.tool import Tool  # noqa: TC002
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishObservation
 from openhands.sdk.utils import maybe_truncate
+from openhands.sdk.utils.process_tree import ProcessTreeGuard
 from openhands.sdk.utils.pydantic_secrets import (
     serialize_secret,
     validate_secret,
@@ -1673,6 +1674,9 @@ class ACPAgent(AgentBase):
     _conn: ClientSideConnection | None = PrivateAttr(default=None)
     _session_id: str | None = PrivateAttr(default=None)
     _process: Any = PrivateAttr(default=None)  # asyncio subprocess
+    # Windows Job Object holding _process and its descendants, so teardown reaps
+    # the whole tree instead of just the PID we spawned. None off Windows.
+    _process_tree_guard: Any = PrivateAttr(default=None)
     _client: Any = PrivateAttr(default=None)  # _OpenHandsACPBridge
     _filtered_reader: Any = PrivateAttr(default=None)  # StreamReader
     _closed: bool = PrivateAttr(default=False)
@@ -2674,6 +2678,13 @@ class ACPAgent(AgentBase):
             )
             assert process.stdin is not None
             assert process.stdout is not None
+
+            # Hold the subprocess in a kill-on-close Job Object so shutdown
+            # reaps its descendants too (see _shutdown_runtime). No-op off
+            # Windows, where terminate() on a dead stdio pipe is enough.
+            self._process_tree_guard = ProcessTreeGuard.for_process(
+                getattr(process, "pid", None)
+            )
 
             # Wrap the subprocess stdout in a filtering reader that
             # only passes lines starting with '{' (JSON-RPC messages).
@@ -4146,6 +4157,19 @@ class ACPAgent(AgentBase):
                 except Exception as kill_error:
                     logger.debug("Error killing ACP process: %s", kill_error)
             self._process = None
+
+        # Closing the job terminates anything the server spawned that outlived
+        # the terminate/kill above — on Windows those are single-PID
+        # TerminateProcess calls, so descendants are otherwise orphaned. Done
+        # after the graceful path so a well-behaved server still exits on its
+        # own. Best-effort and idempotent; None when no job was created.
+        guard = self._process_tree_guard
+        if guard is not None:
+            self._process_tree_guard = None
+            try:
+                guard.close()
+            except Exception as e:
+                logger.debug("Error closing ACP process tree guard: %s", e)
 
         credential_failures = self._release_file_credentials_collect()
         failures.update(credential_failures)

--- a/openhands-sdk/openhands/sdk/utils/process_tree.py
+++ b/openhands-sdk/openhands/sdk/utils/process_tree.py
@@ -1,0 +1,202 @@
+"""Tie a spawned process tree to a Windows Job Object so teardown reaps all of it.
+
+``Popen.terminate()`` / ``.kill()`` map to ``TerminateProcess`` on Windows, which
+acts on a single PID. There is no process-group equivalent, so anything the child
+spawned below itself survives. On POSIX this is usually masked — a child dies on
+the broken stdio pipe when its parent goes — but on Windows the grandchildren keep
+running.
+
+A Job Object is the OS mechanism for this. A process assigned to a job carries its
+descendants into the job with it, so a job created with
+``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` terminates the whole tree when its last
+handle closes — including if the owning process dies without cleaning up.
+
+Everything here is best-effort: teardown must not fail because a Win32 call did.
+:meth:`ProcessTreeGuard.for_process` returns ``None`` on non-Windows platforms and
+on any failure, and callers fall back to their existing single-PID terminate.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import ClassVar
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+# winnt.h
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_JobObjectExtendedLimitInformation = 9
+_PROCESS_TERMINATE = 0x0001
+_PROCESS_SET_QUOTA = 0x0100
+
+
+def _build_extended_limit_information():
+    """Build ``JOBOBJECT_EXTENDED_LIMIT_INFORMATION`` with kill-on-close set.
+
+    Declared lazily so this module stays importable on non-Windows platforms,
+    where ``ctypes.wintypes`` is unavailable.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    ULONG_PTR = ctypes.c_size_t
+
+    class _BasicLimitInformation(ctypes.Structure):
+        _fields_: ClassVar = [
+            ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ULONG_PTR),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class _IoCounters(ctypes.Structure):
+        _fields_: ClassVar = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class _ExtendedLimitInformation(ctypes.Structure):
+        _fields_: ClassVar = [
+            ("BasicLimitInformation", _BasicLimitInformation),
+            ("IoInfo", _IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    info = _ExtendedLimitInformation()
+    info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    return info
+
+
+class ProcessTreeGuard:
+    """Owns a Windows Job Object holding one process and its descendants.
+
+    Construct via :meth:`for_process`. :meth:`close` terminates the tree; it is
+    idempotent, so callers may invoke it alongside their existing terminate/kill
+    without ordering concerns.
+    """
+
+    __slots__ = ("_handle",)
+
+    def __init__(self, handle: int) -> None:
+        self._handle = handle
+
+    @classmethod
+    def for_process(cls, pid: int | None) -> ProcessTreeGuard | None:
+        """Create a kill-on-close job and assign *pid* to it.
+
+        Returns ``None`` on non-Windows platforms, when *pid* is absent, or when
+        any step fails — the caller keeps whatever teardown it already had.
+
+        Assignment happens after the process exists, which leaves a window in
+        which it could spawn a child that escapes the job. In practice ACP
+        servers spawn their provider CLI well after the protocol handshake, long
+        past this call.
+        """
+        if sys.platform != "win32" or not isinstance(pid, int):
+            return None
+
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.AssignProcessToJobObject.argtypes = [
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+        ]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+        job = kernel32.CreateJobObjectW(None, None)
+        if not job:
+            logger.debug(
+                "CreateJobObject failed (err=%s); process tree will not be "
+                "reaped as a group",
+                ctypes.get_last_error(),
+            )
+            return None
+
+        try:
+            info = _build_extended_limit_information()
+            if not kernel32.SetInformationJobObject(
+                job,
+                _JobObjectExtendedLimitInformation,
+                ctypes.byref(info),
+                ctypes.sizeof(info),
+            ):
+                logger.debug(
+                    "SetInformationJobObject failed (err=%s)",
+                    ctypes.get_last_error(),
+                )
+                kernel32.CloseHandle(job)
+                return None
+
+            handle = kernel32.OpenProcess(
+                _PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, pid
+            )
+            if not handle:
+                logger.debug(
+                    "OpenProcess(pid=%s) failed (err=%s)",
+                    pid,
+                    ctypes.get_last_error(),
+                )
+                kernel32.CloseHandle(job)
+                return None
+
+            try:
+                if not kernel32.AssignProcessToJobObject(job, handle):
+                    logger.debug(
+                        "AssignProcessToJobObject(pid=%s) failed (err=%s)",
+                        pid,
+                        ctypes.get_last_error(),
+                    )
+                    kernel32.CloseHandle(job)
+                    return None
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Job object setup failed for pid=%s: %s", pid, e)
+            try:
+                kernel32.CloseHandle(job)
+            except Exception:
+                pass
+            return None
+
+        logger.debug("Assigned pid=%s to job object for tree teardown", pid)
+        return cls(job)
+
+    def close(self) -> None:
+        """Close the job handle, terminating every process still in the job."""
+        handle, self._handle = self._handle, 0
+        if not handle:
+            return
+        import ctypes
+
+        try:
+            ctypes.WinDLL("kernel32", use_last_error=True).CloseHandle(handle)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Closing job object handle failed: %s", e)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -3235,6 +3235,41 @@ class TestACPAgentCleanup:
         # terminate/kill should only be called once
         mock_process.terminate.assert_called_once()
 
+    def test_close_reaps_process_tree_after_terminate(self):
+        """terminate() is single-PID on Windows; the job object is what takes
+        the descendants. It must close after the graceful path, so a
+        well-behaved server still gets to exit on its own."""
+        agent = _make_agent()
+        calls: list[str] = []
+        mock_process = MagicMock()
+        mock_process.terminate.side_effect = lambda: calls.append("terminate")
+        mock_guard = MagicMock()
+        mock_guard.close.side_effect = lambda: calls.append("guard")
+        agent._process = mock_process
+        agent._process_tree_guard = mock_guard
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        agent.close()
+
+        assert calls == ["terminate", "guard"]
+        assert agent._process_tree_guard is None
+
+    def test_close_survives_a_failing_process_tree_guard(self):
+        """Teardown is best-effort: a Win32 failure must not propagate."""
+        agent = _make_agent()
+        mock_guard = MagicMock()
+        mock_guard.close.side_effect = OSError("CloseHandle failed")
+        agent._process = MagicMock()
+        agent._process_tree_guard = mock_guard
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        agent.close()
+
+        mock_guard.close.assert_called_once()
+        assert agent._process_tree_guard is None
+
     def test_close_closes_executor(self):
         agent = _make_agent()
         mock_executor = MagicMock()

--- a/tests/sdk/utils/test_process_tree.py
+++ b/tests/sdk/utils/test_process_tree.py
@@ -1,0 +1,121 @@
+"""Tests for ProcessTreeGuard.
+
+The behaviour that matters — a Job Object reaping grandchildren — can only be
+observed on Windows, so that assertion lives in a platform-gated test. The rest
+runs everywhere so the contract stays covered by the Linux jobs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from openhands.sdk.utils.process_tree import ProcessTreeGuard
+
+
+class TestForProcessContract:
+    def test_returns_none_off_windows(self, monkeypatch: pytest.MonkeyPatch):
+        """Callers keep their existing single-PID teardown on POSIX, where a
+        child dies with its parent's stdio pipes anyway."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert ProcessTreeGuard.for_process(1234) is None
+
+    def test_close_is_idempotent(self):
+        """_shutdown_runtime may run more than once (close() after _cleanup()),
+        so a second close must not raise or double-free the handle."""
+        guard = ProcessTreeGuard(0)
+        guard.close()
+        guard.close()
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only API")
+    def test_returns_none_for_nonexistent_pid(self):
+        """OpenProcess fails; setup degrades to None rather than raising into
+        the spawn path."""
+        assert ProcessTreeGuard.for_process(0xFFFFFFF) is None
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Job Objects are Windows-only")
+class TestReapsProcessTree:
+    """The actual defect: terminate() is single-PID TerminateProcess, so a
+    grandchild outlives it."""
+
+    CHILD = textwrap.dedent(
+        """
+        import subprocess, sys, time
+        subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+        time.sleep(120)
+        """
+    )
+
+    def _spawn_tree(self):
+        parent = subprocess.Popen(
+            [sys.executable, "-c", self.CHILD],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            out = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    "Get-CimInstance Win32_Process | Where-Object "
+                    f"{{ $_.ParentProcessId -eq {parent.pid} }} | "
+                    "Select-Object -ExpandProperty ProcessId",
+                ],
+                capture_output=True,
+                text=True,
+            ).stdout.split()
+            if out:
+                return parent, int(out[0])
+            time.sleep(0.5)
+        parent.kill()
+        pytest.skip("child process did not start in time")
+
+    @staticmethod
+    def _alive(pid: int) -> bool:
+        return (
+            subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    f"(Get-Process -Id {pid} -ErrorAction SilentlyContinue) -ne $null",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            .stdout.strip()
+            .lower()
+            .startswith("true")
+        )
+
+    # Note: there is deliberately no "terminate() alone orphans the grandchild"
+    # test here. A synthetic python-spawns-python tree does not reliably
+    # reproduce the orphaning — the real case involves wrapper layers (npx/cmd)
+    # and a provider CLI that outlives them. That before/after was measured
+    # against the real ACP server and is recorded in the PR description; a
+    # flaky assertion about platform behaviour would not add to it.
+
+    def test_guard_close_reaps_the_grandchild(self):
+        parent, child = self._spawn_tree()
+        guard = ProcessTreeGuard.for_process(parent.pid)
+        assert guard is not None, "job object should be creatable"
+        try:
+            parent.terminate()
+            parent.wait(timeout=10)
+            guard.close()
+            deadline = time.time() + 15
+            while time.time() < deadline and self._alive(child):
+                time.sleep(0.5)
+            assert not self._alive(child), "grandchild survived the job close"
+        finally:
+            subprocess.run(
+                ["taskkill", "/PID", str(child), "/F"],
+                capture_output=True,
+            )


### PR DESCRIPTION
HUMAN:

Had issues installing OpenHands on windows. Putting up some PRs to help the community

---

AGENT:

## Why

`_shutdown_runtime` tears the ACP server down with `process.terminate()`, falling back to
`process.kill()`. On Windows both are `TerminateProcess` against a single PID — there is no
process-group equivalent — so everything the server spawned below itself is orphaned. On POSIX
this is mostly masked, because children die on the broken stdio pipe when the parent goes; on
Windows they keep running, on every interrupt, restart and teardown.

Measured against the real server (`claude-agent-acp` behind the registry's `npx` launcher),
`terminate()` leaves the entire tree behind:

```
tree below pid: node.exe, cmd.exe, node.exe, claude.exe, conhost.exe
-> terminate()
root pid dead
  node.exe    ALIVE (orphan)
  cmd.exe     ALIVE (orphan)
  node.exe    ALIVE (orphan)
  claude.exe  ALIVE (orphan)
  conhost.exe ALIVE (orphan)
RESULT: 5 orphan(s)
```

These are not small processes — the `claude.exe` instances on this machine have a median
working set of 107 MB (range 27–556 MB). They accumulate until something collides with them;
here that was `npm install -g` emitting `EPERM` while cleaning up a directory a stray
`claude.exe` still had open.

## Summary

- New `openhands/sdk/utils/process_tree.py`: `ProcessTreeGuard` creates a Job Object with
  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and assigns the spawned process to it. Descendants are
  inherited into the job, so closing the handle terminates the whole tree — including if the
  owning process dies without cleaning up.
- `ACPAgent` creates the guard right after `create_subprocess_exec` and closes it in
  `_shutdown_runtime`, **after** the existing terminate/kill path so a well-behaved server
  still gets to exit on its own.

Pure `ctypes`, so no new runtime dependency — `psutil` is in the `dev` dependency group only,
not a runtime dependency of any workspace package. Best-effort throughout:
`for_process()` returns `None` off Windows, when no pid is available, and on any Win32 failure;
`close()` logs failures rather than raising, so teardown never fails because of this. Callers
that get `None` keep exactly the behaviour they have today.

## Issue Number

<!-- none filed; happy to open one if you'd prefer it tracked separately -->

## How to Test

Unit:

```
uv run pytest tests/sdk/utils/test_process_tree.py tests/sdk/agent/test_acp_agent.py -q
```

`tests/sdk/utils/test_process_tree.py` covers the contract on every platform (returns `None`
off Windows, `close()` idempotent) and gates the real reaping assertion on Windows, where it
spawns a python→python tree, assigns the parent, closes the job, and asserts the grandchild is
gone. `tests/sdk/agent/test_acp_agent.py` covers the wiring: the guard closes *after*
`terminate()`, and a guard that raises doesn't break `close()`.

End-to-end against the real ACP server, same script for both arms — spawn, handshake,
`session/new`, let the provider CLI start, then run the exact teardown `_shutdown_runtime` does:

```
WITHOUT guard (current main)
  tree below pid: node.exe, cmd.exe, node.exe, claude.exe, conhost.exe
  -> terminate()
  RESULT: 5 orphan(s)

WITH guard
  tree below pid: node.exe, cmd.exe, node.exe, claude.exe, conhost.exe
  -> terminate()
  -> guard.close()
  RESULT: 0 orphan(s)
```

Script available on request; it imports `ProcessTreeGuard` from this branch.

## Video/Screenshots

n/a — terminal only, output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **There is deliberately no "terminate() alone orphans the grandchild" unit test.** A synthetic
  python-spawns-python tree doesn't reliably reproduce the orphaning — the real case needs the
  wrapper layers and a provider CLI that outlives them. I tried it, it passed for the wrong
  reason, and I removed it rather than tune it into agreement. The before/after above is the
  evidence for that half; the unit test covers only that the job reaps what it holds.
- **Known race:** the process is assigned to the job after it exists, so a child spawned in
  that window escapes. Not reachable in practice here — ACP servers start their provider CLI
  well after the protocol handshake — but worth stating. Closing it properly would mean
  spawning `CREATE_SUSPENDED`, assigning, then resuming. `create_subprocess_exec` does forward
  `**kwds` to `Popen`, so the flag itself is reachable; the obstacle is that `Popen` closes the
  process's thread handle immediately (`_winapi.CloseHandle(ht)` in `_execute_child`), leaving
  no supported way to resume it. That seemed a worse trade than the residual race.
- **Windows CI doesn't cover this.** The `windows-tests` job in `tests.yml` only runs when
  `openhands-tools/**`, `tests/tools/**`, `pyproject.toml`, `uv.lock` or the workflow itself
  changed, and its pytest invocation targets `tests/tools` — so nothing under `openhands-sdk`
  ever runs on a Windows runner, including these tests. The Windows-gated assertion will be
  skipped in the Ubuntu `sdk-tests` job; the rest of the file runs there. For scale, `tests/sdk`
  on Windows against unmodified `main` (701a21f) is `44 failed, 5698 passed`; I haven't triaged
  those and mention the number only as context for why widening the filter isn't part of this
  PR.
- The repo's own pre-commit gates run clean against the touched files: ruff format, ruff check,
  pycodestyle, pyright (0 errors), `check_import_rules.py`, `check_tool_registration.py`,
  `check_docstrings.py`. Reproducing the curated-`__all__` pairing `check_sdk_api_breakage.py`
  performs, griffe reports 0 counted breakages relative to `main` — `process_tree.py` is a new
  private module and nothing exported changes shape.
- Independent of #4408 (PATHEXT spawn resolution) — that one fixes launching, this one fixes
  teardown. They touch `acp_agent.py` in different places and can land in either order.
