### PR TITLE
fix(profiles): store acp_command as a token list, not a shell string

### DIFF
--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -9,6 +9,7 @@ See epic #3713 for the resolution model.
 
 from __future__ import annotations
 
+import shlex
 from collections.abc import Callable, Mapping
 from typing import Annotated, Any, Literal
 from uuid import UUID, uuid4
@@ -33,7 +34,7 @@ from openhands.sdk.settings.model import (
 from openhands.sdk.tool import Tool
 
 
-AGENT_PROFILE_SCHEMA_VERSION = 2
+AGENT_PROFILE_SCHEMA_VERSION = 3
 
 
 class ProfileVerificationSettings(BaseModel):
@@ -264,11 +265,14 @@ class ACPAgentProfile(AgentProfileBase):
             "initialize/authenticate, and new_session()/load_session()."
         ),
     )
-    acp_command: str | None = Field(
+    acp_command: list[str] | None = Field(
         default=None,
         description=(
-            "Optional explicit command to launch the ACP subprocess. Leave "
-            "blank to use the default for ``acp_server``."
+            "Optional explicit command to launch the ACP subprocess, as an "
+            "argv token list (e.g. ``['npx', '-y', 'some-acp@1.2.3']``). The "
+            "tokens are passed to the subprocess verbatim — no shell is "
+            "involved, so nothing needs quoting or escaping. Leave unset to "
+            "use the default for ``acp_server``."
         ),
     )
     acp_args: list[str] | None = Field(
@@ -335,8 +339,39 @@ def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
+    """``acp_command`` moved from a shell string to an argv token list.
+
+    Legacy strings are split with the same POSIX ``shlex.split`` the resolver
+    used to apply, so a profile resolves to exactly the tokens it resolved to
+    before. That is an exact inverse for everything this codebase wrote — the
+    strings came from ``shlex.join`` in ``profiles/seed.py`` — and matches what
+    a hand-written POSIX string already resolved to.
+
+    A Windows path typed unquoted (``C:\\Users\\me\\x.js``) was already being
+    destroyed by that same split, so it cannot be recovered here; such a
+    profile has never launched and the command has to be re-entered. Splitting
+    it is still the honest migration: it changes nothing about what the profile
+    does. Removing the split for *new* values is the point of the change.
+
+    Malformed input (unbalanced quotes) becomes ``None`` rather than raising:
+    loading a stored profile must not fail. Today the failure surfaces from
+    ``resolve_agent_profile`` as a diagnostic, and ``None`` keeps it there — a
+    ``custom`` server with no command still reports the same resolver error.
+    """
+    command = payload.get("acp_command")
+    if isinstance(command, str):
+        try:
+            payload["acp_command"] = shlex.split(command) or None
+        except ValueError:
+            payload["acp_command"] = None
+    payload["schema_version"] = 3
+    return payload
+
+
 _AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {
     1: _migrate_v1_to_v2,
+    2: _migrate_v2_to_v3,
 }
 
 

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -36,6 +36,17 @@ from openhands.sdk.tool import Tool
 
 AGENT_PROFILE_SCHEMA_VERSION = 3
 
+_UNVERSIONED_AGENT_PROFILE_SCHEMA_VERSION = 2
+"""Assumed ``schema_version`` for a payload that carries none.
+
+The store has always persisted ``schema_version`` (it has a model default), so
+an absent one means a hand-written or API-supplied payload — the shape a client
+built against an older release still sends. Such a payload is migrated forward
+from here rather than assumed current, so a legacy field shape is upgraded
+instead of rejected. Migrations are no-ops on values already in the new shape,
+so a current client that simply omits the field is unaffected.
+"""
+
 
 class ProfileVerificationSettings(BaseModel):
     """Secret-free critic/refinement policy for a profile.
@@ -354,17 +365,22 @@ def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
     it is still the honest migration: it changes nothing about what the profile
     does. Removing the split for *new* values is the point of the change.
 
-    Malformed input (unbalanced quotes) becomes ``None`` rather than raising:
-    loading a stored profile must not fail. Today the failure surfaces from
-    ``resolve_agent_profile`` as a diagnostic, and ``None`` keeps it there — a
-    ``custom`` server with no command still reports the same resolver error.
+    Malformed input (unbalanced quotes) falls back to a whitespace split rather
+    than raising or dropping the value. Loading a stored profile must not fail,
+    but ``None`` would be worse than a rough tokenization: ``None`` means "use
+    the server default", so for any ``acp_server`` other than ``custom`` a
+    configured override would be silently replaced by the provider's own
+    command. Such a command never launched on ``main`` either — ``shlex.split``
+    raised on it — so keeping the tokens only changes *where* it fails, from a
+    resolver error to a spawn error naming the command the user actually typed.
     """
     command = payload.get("acp_command")
     if isinstance(command, str):
         try:
-            payload["acp_command"] = shlex.split(command) or None
+            tokens = shlex.split(command)
         except ValueError:
-            payload["acp_command"] = None
+            tokens = command.split()
+        payload["acp_command"] = tokens or None
     payload["schema_version"] = 3
     return payload
 
@@ -380,8 +396,8 @@ def _apply_persisted_migrations(payload: dict[str, Any]) -> dict[str, Any]:
     migrated = dict(payload)
     version_raw = migrated.get("schema_version")
     if version_raw is None:
-        migrated["schema_version"] = AGENT_PROFILE_SCHEMA_VERSION
-        version = AGENT_PROFILE_SCHEMA_VERSION
+        version = _UNVERSIONED_AGENT_PROFILE_SCHEMA_VERSION
+        migrated["schema_version"] = version
     elif isinstance(version_raw, int) and not isinstance(version_raw, bool):
         version = version_raw
     else:

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -35,9 +35,6 @@ from openhands.sdk.tool import Tool
 
 
 AGENT_PROFILE_SCHEMA_VERSION = 3
-
-# The store always writes schema_version, so a payload without one came from
-# outside it (an API body). Migrate it forward instead of assuming it current.
 _UNVERSIONED_AGENT_PROFILE_SCHEMA_VERSION = 2
 
 
@@ -342,19 +339,11 @@ def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
-    """``acp_command`` moved from a shell string to an argv token list.
-
-    Splits with the same ``shlex.split`` the resolver used to apply, so a stored
-    profile resolves to the tokens it resolved to before.
-    """
     command = payload.get("acp_command")
     if isinstance(command, str):
         try:
             tokens = shlex.split(command)
         except ValueError:
-            # Unbalanced quotes. Keep the tokens rather than dropping to None,
-            # which means "use the server default" and would silently replace
-            # the user's command on a non-custom server.
             tokens = command.split()
         payload["acp_command"] = tokens or None
     payload["schema_version"] = 3

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -36,16 +36,9 @@ from openhands.sdk.tool import Tool
 
 AGENT_PROFILE_SCHEMA_VERSION = 3
 
+# The store always writes schema_version, so a payload without one came from
+# outside it (an API body). Migrate it forward instead of assuming it current.
 _UNVERSIONED_AGENT_PROFILE_SCHEMA_VERSION = 2
-"""Assumed ``schema_version`` for a payload that carries none.
-
-The store has always persisted ``schema_version`` (it has a model default), so
-an absent one means a hand-written or API-supplied payload — the shape a client
-built against an older release still sends. Such a payload is migrated forward
-from here rather than assumed current, so a legacy field shape is upgraded
-instead of rejected. Migrations are no-ops on values already in the new shape,
-so a current client that simply omits the field is unaffected.
-"""
 
 
 class ProfileVerificationSettings(BaseModel):
@@ -280,10 +273,8 @@ class ACPAgentProfile(AgentProfileBase):
         default=None,
         description=(
             "Optional explicit command to launch the ACP subprocess, as an "
-            "argv token list (e.g. ``['npx', '-y', 'some-acp@1.2.3']``). The "
-            "tokens are passed to the subprocess verbatim — no shell is "
-            "involved, so nothing needs quoting or escaping. Leave unset to "
-            "use the default for ``acp_server``."
+            "argv token list (e.g. ``['npx', '-y', 'some-acp@1.2.3']``). Leave "
+            "unset to use the default for ``acp_server``."
         ),
     )
     acp_args: list[str] | None = Field(
@@ -353,32 +344,17 @@ def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
 def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
     """``acp_command`` moved from a shell string to an argv token list.
 
-    Legacy strings are split with the same POSIX ``shlex.split`` the resolver
-    used to apply, so a profile resolves to exactly the tokens it resolved to
-    before. That is an exact inverse for everything this codebase wrote — the
-    strings came from ``shlex.join`` in ``profiles/seed.py`` — and matches what
-    a hand-written POSIX string already resolved to.
-
-    A Windows path typed unquoted (``C:\\Users\\me\\x.js``) was already being
-    destroyed by that same split, so it cannot be recovered here; such a
-    profile has never launched and the command has to be re-entered. Splitting
-    it is still the honest migration: it changes nothing about what the profile
-    does. Removing the split for *new* values is the point of the change.
-
-    Malformed input (unbalanced quotes) falls back to a whitespace split rather
-    than raising or dropping the value. Loading a stored profile must not fail,
-    but ``None`` would be worse than a rough tokenization: ``None`` means "use
-    the server default", so for any ``acp_server`` other than ``custom`` a
-    configured override would be silently replaced by the provider's own
-    command. Such a command never launched on ``main`` either — ``shlex.split``
-    raised on it — so keeping the tokens only changes *where* it fails, from a
-    resolver error to a spawn error naming the command the user actually typed.
+    Splits with the same ``shlex.split`` the resolver used to apply, so a stored
+    profile resolves to the tokens it resolved to before.
     """
     command = payload.get("acp_command")
     if isinstance(command, str):
         try:
             tokens = shlex.split(command)
         except ValueError:
+            # Unbalanced quotes. Keep the tokens rather than dropping to None,
+            # which means "use the server default" and would silently replace
+            # the user's command on a non-custom server.
             tokens = command.split()
         payload["acp_command"] = tokens or None
     payload["schema_version"] = 3

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -28,7 +28,6 @@ Resource-specific secret channels:
 
 from __future__ import annotations
 
-import shlex
 from collections.abc import Container
 from typing import TYPE_CHECKING, Any
 
@@ -264,8 +263,8 @@ def _build_acp_settings(
 ) -> AgentSettingsConfig:
     """Compose the resolved ``ACPAgentSettings`` from a profile.
 
-    ``acp_command`` is stored as a shell string and split into the settings'
-    token list. No credential is set — provider creds ride
+    ``acp_command`` is an argv token list on both sides and is copied across
+    verbatim — no shell parsing. No credential is set — provider creds ride
     ``state.secret_registry``. ACP profiles carry no user/public skills (the ACP
     subprocess owns its context), so ``agent_context`` has no discovered skills;
     it is always built (never ``None``) only so ``load_project_skills=True``
@@ -274,7 +273,7 @@ def _build_acp_settings(
     files (e.g. AGENTS.md) may then see that content twice (#4019). A ``custom``
     server has no default command, so one must be supplied.
     """
-    command = shlex.split(profile.acp_command) if profile.acp_command else []
+    command = list(profile.acp_command) if profile.acp_command else []
     if profile.acp_server == "custom" and not command:
         raise ValueError(
             "acp_command is required when acp_server='custom' — there is no "
@@ -416,9 +415,9 @@ def resolve_agent_profile_dry_run(
     diagnostics.valid = not diagnostics.errors
     if diagnostics.valid:
         # Building settings can still fail on input that passes profile
-        # validation (e.g. an acp_command with unbalanced shell quotes, which
-        # shlex.split rejects). Keep the dry-run total: surface such failures as
-        # diagnostics rather than raising, matching the API contract.
+        # validation (e.g. acp_server='custom' with no acp_command). Keep the
+        # dry-run total: surface such failures as diagnostics rather than
+        # raising, matching the API contract.
         try:
             if isinstance(profile, OpenHandsAgentProfile):
                 # valid here implies the LLM load above succeeded; gate

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -263,8 +263,7 @@ def _build_acp_settings(
 ) -> AgentSettingsConfig:
     """Compose the resolved ``ACPAgentSettings`` from a profile.
 
-    ``acp_command`` is an argv token list on both sides and is copied across
-    verbatim — no shell parsing. No credential is set — provider creds ride
+    No credential is set — provider creds ride
     ``state.secret_registry``. ACP profiles carry no user/public skills (the ACP
     subprocess owns its context), so ``agent_context`` has no discovered skills;
     it is always built (never ``None``) only so ``load_project_skills=True``

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -46,8 +46,7 @@ def build_seed_profile(
             acp_session_mode=agent_settings.acp_session_mode,
             acp_prompt_timeout=agent_settings.acp_prompt_timeout,
             acp_startup_timeout=agent_settings.acp_startup_timeout,
-            # Both sides hold an argv token list. Empty list => use the server
-            # default.
+            # Empty list => use the server default.
             acp_command=list(agent_settings.acp_command) or None,
             acp_args=list(agent_settings.acp_args) or None,
             mcp_server_refs=None,

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -7,7 +7,6 @@ migration (lazy on the local agent-server, eager backfill on the cloud one).
 
 from __future__ import annotations
 
-import shlex
 from typing import TYPE_CHECKING
 
 from openhands.sdk.profiles.agent_profile import (
@@ -47,13 +46,9 @@ def build_seed_profile(
             acp_session_mode=agent_settings.acp_session_mode,
             acp_prompt_timeout=agent_settings.acp_prompt_timeout,
             acp_startup_timeout=agent_settings.acp_startup_timeout,
-            # Settings store the command as a token list; the profile holds a
-            # single (re-parseable) string. Empty list => use the server default.
-            acp_command=(
-                shlex.join(agent_settings.acp_command)
-                if agent_settings.acp_command
-                else None
-            ),
+            # Both sides hold an argv token list. Empty list => use the server
+            # default.
+            acp_command=list(agent_settings.acp_command) or None,
             acp_args=list(agent_settings.acp_args) or None,
             mcp_server_refs=None,
             # ACP profiles carry no skill field — the subprocess owns its context.

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -46,7 +46,6 @@ def build_seed_profile(
             acp_session_mode=agent_settings.acp_session_mode,
             acp_prompt_timeout=agent_settings.acp_prompt_timeout,
             acp_startup_timeout=agent_settings.acp_startup_timeout,
-            # Empty list => use the server default.
             acp_command=list(agent_settings.acp_command) or None,
             acp_args=list(agent_settings.acp_args) or None,
             mcp_server_refs=None,

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -530,6 +530,49 @@ def test_save_extra_field_returns_422(client):
     assert response.status_code == 422
 
 
+def test_save_unversioned_body_upgrades_legacy_acp_command_string(client):
+    """A client built against schema v2 POSTs ``acp_command`` as a shell string.
+
+    Such a body carries no ``schema_version`` — the store writes one, but an
+    API caller has no reason to — so it must be migrated forward rather than
+    rejected. Before the migration gate was fixed this returned 422.
+    """
+    response = client.post(
+        "/api/agent-profiles/legacy-acp",
+        json={
+            "agent_kind": "acp",
+            "acp_server": "custom",
+            "acp_command": "cmd /c claude-agent-acp",
+        },
+    )
+    assert response.status_code == 201
+
+    profile = client.get("/api/agent-profiles/legacy-acp").json()["profile"]
+    assert profile["acp_command"] == ["cmd", "/c", "claude-agent-acp"]
+
+
+def test_save_unversioned_body_keeps_acp_command_token_list(client):
+    """The same unversioned shape from a current client is untouched.
+
+    The v2->v3 migration only rewrites ``str``, so a Windows path in an argv
+    list survives the round trip verbatim — the bug the token list exists to
+    fix stays fixed for callers that omit ``schema_version``.
+    """
+    command = ["C:\\Program Files\\nodejs\\node.exe", "C:\\Users\\me\\dist\\index.js"]
+    response = client.post(
+        "/api/agent-profiles/winpath-acp",
+        json={
+            "agent_kind": "acp",
+            "acp_server": "custom",
+            "acp_command": command,
+        },
+    )
+    assert response.status_code == 201
+
+    profile = client.get("/api/agent-profiles/winpath-acp").json()["profile"]
+    assert profile["acp_command"] == command
+
+
 def test_save_invalid_name_returns_422(client):
     response = client.post(
         "/api/agent-profiles/.hidden",

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -531,7 +531,6 @@ def test_save_extra_field_returns_422(client):
 
 
 def test_save_unversioned_body_upgrades_legacy_acp_command_string(client):
-    """A v2-era client POSTs a shell string and no ``schema_version``."""
     response = client.post(
         "/api/agent-profiles/legacy-acp",
         json={

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -531,12 +531,7 @@ def test_save_extra_field_returns_422(client):
 
 
 def test_save_unversioned_body_upgrades_legacy_acp_command_string(client):
-    """A client built against schema v2 POSTs ``acp_command`` as a shell string.
-
-    Such a body carries no ``schema_version`` — the store writes one, but an
-    API caller has no reason to — so it must be migrated forward rather than
-    rejected. Before the migration gate was fixed this returned 422.
-    """
+    """A v2-era client POSTs a shell string and no ``schema_version``."""
     response = client.post(
         "/api/agent-profiles/legacy-acp",
         json={
@@ -549,28 +544,6 @@ def test_save_unversioned_body_upgrades_legacy_acp_command_string(client):
 
     profile = client.get("/api/agent-profiles/legacy-acp").json()["profile"]
     assert profile["acp_command"] == ["cmd", "/c", "claude-agent-acp"]
-
-
-def test_save_unversioned_body_keeps_acp_command_token_list(client):
-    """The same unversioned shape from a current client is untouched.
-
-    The v2->v3 migration only rewrites ``str``, so a Windows path in an argv
-    list survives the round trip verbatim — the bug the token list exists to
-    fix stays fixed for callers that omit ``schema_version``.
-    """
-    command = ["C:\\Program Files\\nodejs\\node.exe", "C:\\Users\\me\\dist\\index.js"]
-    response = client.post(
-        "/api/agent-profiles/winpath-acp",
-        json={
-            "agent_kind": "acp",
-            "acp_server": "custom",
-            "acp_command": command,
-        },
-    )
-    assert response.status_code == 201
-
-    profile = client.get("/api/agent-profiles/winpath-acp").json()["profile"]
-    assert profile["acp_command"] == command
 
 
 def test_save_invalid_name_returns_422(client):

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -349,12 +349,10 @@ _WIN_COMMAND = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js
     ("stored", "expected"),
     [
         ("codex-acp --foo bar", ["codex-acp", "--foo", "bar"]),
-        # Every persisted v2 string came from shlex.join, so invert it exactly.
         (
             shlex.join(["/opt/my acp/bin/server", "--flag", "a b"]),
             ["/opt/my acp/bin/server", "--flag", "a b"],
         ),
-        # Unbalanced quotes must not raise, and must not drop to None.
         ("unterminated 'quote", ["unterminated", "'quote"]),
         (None, None),
         ("", None),
@@ -375,7 +373,6 @@ def test_v2_acp_command_migrates_to_token_list(stored, expected) -> None:
     ],
 )
 def test_unversioned_payload_still_migrates(stored, expected) -> None:
-    """An API body carries no ``schema_version``, so it still has to migrate."""
     payload = _v2_acp_payload(stored)
     del payload["schema_version"]
     profile = validate_agent_profile(payload)
@@ -385,7 +382,6 @@ def test_unversioned_payload_still_migrates(stored, expected) -> None:
 
 
 def test_windows_path_command_survives_round_trip() -> None:
-    """The bug this schema change removes: ``shlex`` ate every backslash."""
     profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=_WIN_COMMAND)
     reloaded = validate_agent_profile(profile.model_dump(mode="json"))
     assert isinstance(reloaded, ACPAgentProfile)

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -342,105 +342,54 @@ def _v2_acp_payload(command: object) -> dict[str, object]:
     }
 
 
-def test_v2_acp_command_string_migrates_to_token_list() -> None:
-    profile = validate_agent_profile(_v2_acp_payload("codex-acp --foo bar"))
+_WIN_COMMAND = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        ("codex-acp --foo bar", ["codex-acp", "--foo", "bar"]),
+        # Every persisted v2 string came from shlex.join, so invert it exactly.
+        (
+            shlex.join(["/opt/my acp/bin/server", "--flag", "a b"]),
+            ["/opt/my acp/bin/server", "--flag", "a b"],
+        ),
+        # Unbalanced quotes must not raise, and must not drop to None.
+        ("unterminated 'quote", ["unterminated", "'quote"]),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_v2_acp_command_migrates_to_token_list(stored, expected) -> None:
+    profile = validate_agent_profile(_v2_acp_payload(stored))
     assert isinstance(profile, ACPAgentProfile)
     assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
-    assert profile.acp_command == ["codex-acp", "--foo", "bar"]
+    assert profile.acp_command == expected
 
 
-def test_v2_acp_command_migration_inverts_shlex_join() -> None:
-    """Every persisted v2 string came from ``shlex.join`` in profiles/seed.py.
-
-    The migration must return the exact tokens that produced it, including for
-    arguments containing spaces.
-    """
-    tokens = ["/opt/my acp/bin/server", "--flag", "a b"]
-    profile = validate_agent_profile(_v2_acp_payload(shlex.join(tokens)))
-    assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command == tokens
-
-
-def test_v2_acp_command_malformed_quotes_falls_back_to_whitespace_split() -> None:
-    """Loading a stored profile must not raise, whatever is in the field.
-
-    ``None`` is not an option here: it means "use the server default", so a
-    configured override would be silently discarded. A whitespace split never
-    raises and keeps the tokens the user typed.
-    """
-    profile = validate_agent_profile(_v2_acp_payload("unterminated 'quote"))
-    assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command == ["unterminated", "'quote"]
-
-
-def test_v2_malformed_command_does_not_fall_back_to_provider_default() -> None:
-    """A malformed command must not silently hand the launch to the provider.
-
-    An ``acp_server`` other than ``custom`` has a default launch command, and
-    ``None`` is the value that selects it (see
-    ``test_acp_blank_command_resolves_empty_list`` in ``test_resolver.py``), so
-    migrating a malformed override to ``None`` would start the agent with the
-    provider's command instead of the user's. On ``main`` this input raised
-    ``No closing quotation`` from ``shlex.split`` — loud, but never silent.
-    """
-    payload = _v2_acp_payload('npx -y "unbalanced')
-    payload["acp_server"] = "claude-code"
-    profile = validate_agent_profile(payload)
-    assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command == ["npx", "-y", '"unbalanced']
-
-
-def test_unversioned_payload_migrates_legacy_command_string() -> None:
-    """A payload with no ``schema_version`` is an external one, so migrate it.
-
-    The store always persists ``schema_version``, so an absent one means a
-    hand-written or API-supplied body — the shape a client built against v2
-    still POSTs to ``/api/agent-profiles``. Assuming it is already current
-    rejects a legacy string with a 422 instead of upgrading it.
-    """
-    payload = _v2_acp_payload("cmd /c claude-agent-acp")
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        ("cmd /c claude-agent-acp", ["cmd", "/c", "claude-agent-acp"]),
+        (_WIN_COMMAND, _WIN_COMMAND),
+    ],
+)
+def test_unversioned_payload_still_migrates(stored, expected) -> None:
+    """An API body carries no ``schema_version``, so it still has to migrate."""
+    payload = _v2_acp_payload(stored)
     del payload["schema_version"]
     profile = validate_agent_profile(payload)
     assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command == ["cmd", "/c", "claude-agent-acp"]
+    assert profile.acp_command == expected
     assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
-
-
-def test_unversioned_payload_leaves_a_token_list_alone() -> None:
-    """Migrating an unversioned payload must be a no-op on current-shape data.
-
-    A modern client that simply omits ``schema_version`` sends a token list;
-    the v2->v3 migration only touches ``str``, so the value survives verbatim —
-    including the Windows path the token list exists to protect.
-    """
-    command = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]
-    payload = _v2_acp_payload(command)
-    del payload["schema_version"]
-    profile = validate_agent_profile(payload)
-    assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command == command
-    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
-
-
-@pytest.mark.parametrize("command", [None, ""])
-def test_v2_acp_command_empty_migrates_to_none(command: object) -> None:
-    profile = validate_agent_profile(_v2_acp_payload(command))
-    assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command is None
 
 
 def test_windows_path_command_survives_round_trip() -> None:
-    """The bug this schema change removes.
-
-    As a v2 shell string, POSIX ``shlex.split`` ate every backslash, so the
-    launch failed on a path the user never typed. As a token list there is no
-    parsing step to corrupt it.
-    """
-    command = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]
-    profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=command)
+    """The bug this schema change removes: ``shlex`` ate every backslash."""
+    profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=_WIN_COMMAND)
     reloaded = validate_agent_profile(profile.model_dump(mode="json"))
     assert isinstance(reloaded, ACPAgentProfile)
-    assert reloaded.acp_command == command
+    assert reloaded.acp_command == _WIN_COMMAND
 
 
 def test_rejects_newer_schema_version() -> None:

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -7,6 +7,7 @@ distinction. Adds the profile-specific contract: secret-free at rest.
 """
 
 import json
+import shlex
 from uuid import UUID, uuid4
 
 import pytest
@@ -119,7 +120,7 @@ def test_acp_profile_round_trips() -> None:
         acp_model="gpt-5.5/medium",
         acp_session_mode="full-access",
         acp_prompt_timeout=600.0,
-        acp_command="codex-acp",
+        acp_command=["codex-acp"],
         acp_args=["--flag"],
         mcp_server_refs=None,
     )
@@ -130,7 +131,7 @@ def test_acp_profile_round_trips() -> None:
     assert reloaded.agent_kind == "acp"
     assert reloaded.acp_server == "codex"
     assert reloaded.acp_model == "gpt-5.5/medium"
-    assert reloaded.acp_command == "codex-acp"
+    assert reloaded.acp_command == ["codex-acp"]
     assert reloaded.acp_args == ["--flag"]
     assert reloaded.mcp_server_refs is None
 
@@ -329,6 +330,68 @@ def test_v1_explicit_empty_tools_remain_empty(payload: dict[str, object]) -> Non
     )
     assert isinstance(profile, OpenHandsAgentProfile)
     assert profile.tools == []
+
+
+def _v2_acp_payload(command: object) -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "agent_kind": "acp",
+        "name": "acp",
+        "acp_server": "custom",
+        "acp_command": command,
+    }
+
+
+def test_v2_acp_command_string_migrates_to_token_list() -> None:
+    profile = validate_agent_profile(_v2_acp_payload("codex-acp --foo bar"))
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+    assert profile.acp_command == ["codex-acp", "--foo", "bar"]
+
+
+def test_v2_acp_command_migration_inverts_shlex_join() -> None:
+    """Every persisted v2 string came from ``shlex.join`` in profiles/seed.py.
+
+    The migration must return the exact tokens that produced it, including for
+    arguments containing spaces.
+    """
+    tokens = ["/opt/my acp/bin/server", "--flag", "a b"]
+    profile = validate_agent_profile(_v2_acp_payload(shlex.join(tokens)))
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command == tokens
+
+
+def test_v2_acp_command_malformed_quotes_becomes_none() -> None:
+    """Loading a stored profile must not raise, whatever is in the field.
+
+    Before v3 an unbalanced quote surfaced from ``resolve_agent_profile`` as a
+    diagnostic; ``None`` keeps it there (a ``custom`` server with no command
+    reports the same resolver error) instead of failing the load.
+    """
+    profile = validate_agent_profile(_v2_acp_payload("unterminated 'quote"))
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command is None
+
+
+@pytest.mark.parametrize("command", [None, ""])
+def test_v2_acp_command_empty_migrates_to_none(command: object) -> None:
+    profile = validate_agent_profile(_v2_acp_payload(command))
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command is None
+
+
+def test_windows_path_command_survives_round_trip() -> None:
+    """The bug this schema change removes.
+
+    As a v2 shell string, POSIX ``shlex.split`` ate every backslash, so the
+    launch failed on a path the user never typed. As a token list there is no
+    parsing step to corrupt it.
+    """
+    command = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]
+    profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=command)
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+    assert isinstance(reloaded, ACPAgentProfile)
+    assert reloaded.acp_command == command
 
 
 def test_rejects_newer_schema_version() -> None:

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -361,16 +361,65 @@ def test_v2_acp_command_migration_inverts_shlex_join() -> None:
     assert profile.acp_command == tokens
 
 
-def test_v2_acp_command_malformed_quotes_becomes_none() -> None:
+def test_v2_acp_command_malformed_quotes_falls_back_to_whitespace_split() -> None:
     """Loading a stored profile must not raise, whatever is in the field.
 
-    Before v3 an unbalanced quote surfaced from ``resolve_agent_profile`` as a
-    diagnostic; ``None`` keeps it there (a ``custom`` server with no command
-    reports the same resolver error) instead of failing the load.
+    ``None`` is not an option here: it means "use the server default", so a
+    configured override would be silently discarded. A whitespace split never
+    raises and keeps the tokens the user typed.
     """
     profile = validate_agent_profile(_v2_acp_payload("unterminated 'quote"))
     assert isinstance(profile, ACPAgentProfile)
-    assert profile.acp_command is None
+    assert profile.acp_command == ["unterminated", "'quote"]
+
+
+def test_v2_malformed_command_does_not_fall_back_to_provider_default() -> None:
+    """A malformed command must not silently hand the launch to the provider.
+
+    An ``acp_server`` other than ``custom`` has a default launch command, and
+    ``None`` is the value that selects it (see
+    ``test_acp_blank_command_resolves_empty_list`` in ``test_resolver.py``), so
+    migrating a malformed override to ``None`` would start the agent with the
+    provider's command instead of the user's. On ``main`` this input raised
+    ``No closing quotation`` from ``shlex.split`` — loud, but never silent.
+    """
+    payload = _v2_acp_payload('npx -y "unbalanced')
+    payload["acp_server"] = "claude-code"
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command == ["npx", "-y", '"unbalanced']
+
+
+def test_unversioned_payload_migrates_legacy_command_string() -> None:
+    """A payload with no ``schema_version`` is an external one, so migrate it.
+
+    The store always persists ``schema_version``, so an absent one means a
+    hand-written or API-supplied body — the shape a client built against v2
+    still POSTs to ``/api/agent-profiles``. Assuming it is already current
+    rejects a legacy string with a 422 instead of upgrading it.
+    """
+    payload = _v2_acp_payload("cmd /c claude-agent-acp")
+    del payload["schema_version"]
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command == ["cmd", "/c", "claude-agent-acp"]
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+
+
+def test_unversioned_payload_leaves_a_token_list_alone() -> None:
+    """Migrating an unversioned payload must be a no-op on current-shape data.
+
+    A modern client that simply omits ``schema_version`` sends a token list;
+    the v2->v3 migration only touches ``str``, so the value survives verbatim —
+    including the Windows path the token list exists to protect.
+    """
+    command = [r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]
+    payload = _v2_acp_payload(command)
+    del payload["schema_version"]
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_command == command
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
 
 
 @pytest.mark.parametrize("command", [None, ""])

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -894,8 +894,6 @@ def test_custom_acp_without_command_is_invalid(
 def test_dry_run_normalizes_settings_build_failure(
     llm_store: LLMProfileStore,
 ) -> None:
-    # Validates, but a custom server has no default command to fall back on, so
-    # settings construction raises and the dry-run must report it instead.
     profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=None)
     diag = resolve_agent_profile_dry_run(
         profile,

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -564,7 +564,6 @@ def test_acp_resolves_to_settings_without_credentials(
     assert settings.acp_server == "codex"
     assert settings.acp_model == "gpt-5.5/medium"
     assert settings.acp_session_mode == "full-access"
-    # Token list is copied across verbatim — no shell parsing on either side.
     assert settings.acp_command == ["codex-acp", "--foo"]
     assert settings.acp_args == ["--flag"]
     assert settings.mcp_config != {}
@@ -895,10 +894,8 @@ def test_custom_acp_without_command_is_invalid(
 def test_dry_run_normalizes_settings_build_failure(
     llm_store: LLMProfileStore,
 ) -> None:
-    # A custom server with no acp_command passes profile validation (the field
-    # is optional) but has no default launch command to fall back on, so
-    # settings construction raises; the dry-run must report it as invalid
-    # rather than raising (its contract is total).
+    # Validates, but a custom server has no default command to fall back on, so
+    # settings construction raises and the dry-run must report it instead.
     profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=None)
     diag = resolve_agent_profile_dry_run(
         profile,

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -549,7 +549,7 @@ def test_acp_resolves_to_settings_without_credentials(
         acp_server="codex",
         acp_model="gpt-5.5/medium",
         acp_session_mode="full-access",
-        acp_command="codex-acp --foo",
+        acp_command=["codex-acp", "--foo"],
         acp_args=["--flag"],
         mcp_server_refs=["fetch"],
     )
@@ -851,7 +851,7 @@ def test_dry_run_acp_custom_server_has_no_credential_channels(
     llm_store: LLMProfileStore,
 ) -> None:
     profile = ACPAgentProfile(
-        name="acp", acp_server="custom", acp_command="my-acp-server"
+        name="acp", acp_server="custom", acp_command=["my-acp-server"]
     )
     diag = resolve_agent_profile_dry_run(
         profile,
@@ -895,12 +895,11 @@ def test_custom_acp_without_command_is_invalid(
 def test_dry_run_normalizes_settings_build_failure(
     llm_store: LLMProfileStore,
 ) -> None:
-    # An unbalanced-quote acp_command passes profile validation but breaks
-    # shlex.split during settings construction; the dry-run must report it as
-    # invalid rather than raising (its contract is total).
-    profile = ACPAgentProfile(
-        name="acp", acp_server="custom", acp_command="unterminated 'quote"
-    )
+    # A custom server with no acp_command passes profile validation (the field
+    # is optional) but has no default launch command to fall back on, so
+    # settings construction raises; the dry-run must report it as invalid
+    # rather than raising (its contract is total).
+    profile = ACPAgentProfile(name="acp", acp_server="custom", acp_command=None)
     diag = resolve_agent_profile_dry_run(
         profile,
         llm_store=llm_store,

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -564,7 +564,7 @@ def test_acp_resolves_to_settings_without_credentials(
     assert settings.acp_server == "codex"
     assert settings.acp_model == "gpt-5.5/medium"
     assert settings.acp_session_mode == "full-access"
-    # str command is tokenized into the settings' list[str] field.
+    # Token list is copied across verbatim — no shell parsing on either side.
     assert settings.acp_command == ["codex-acp", "--foo"]
     assert settings.acp_args == ["--flag"]
     assert settings.mcp_config != {}


### PR DESCRIPTION
HUMAN:

Had issues installing OpenHands on windows. Putting up some PRs to help the community

---

AGENT:

## Why

`ACPAgentProfile.acp_command` was the only place a launch command existed as a
shell string. `_build_acp_settings` parsed it with POSIX-mode `shlex`
(`profiles/resolver.py:277`), where backslash is an escape character, so every
separator in a Windows path was eaten:

```python
>>> shlex.split(r'node C:\Users\me\dist\index.js')
['node', 'C:Usersmedistindex.js']
```

The launch then failed with a file-not-found naming a path the user never typed,
which reads as a missing file rather than a mangled argument. Quoting worked
around it, but nothing indicated quoting was required and the unquoted form is
what people type. It bites hardest on Windows, where an absolute path in
`acp_command` is the standard way out when the provider presets can't launch.

**Both ends of the round trip were already token lists**, so the string was a
lossy intermediate that nothing needed:

```
ACPAgentSettings.acp_command: list[str]      # settings/model.py:1444
        │  shlex.join   (profiles/seed.py:53)
        ▼
ACPAgentProfile.acp_command: str | None      # profiles/agent_profile.py:267
        │  shlex.split  (profiles/resolver.py:277)
        ▼
ACPAgentSettings.acp_command: list[str]
```

Profiles persist as JSON (`agent_profile_store.py:116`, `:154`, `:173`), which
represents a string list natively; the sibling `acp_args` on the same model is
already `list[str] | None`; and the tokens go straight to
`create_subprocess_exec` — no shell is ever involved.

## Summary

- `ACPAgentProfile.acp_command` becomes `list[str] | None`.
- Both `shlex` calls are gone — `shlex.split` in `profiles/resolver.py` and
  `shlex.join` in `profiles/seed.py`. Neither module imports `shlex` any more.
- `_migrate_v2_to_v3` in the existing `_AGENT_PROFILE_MIGRATIONS` registry
  splits a legacy string with the same POSIX `shlex.split` the resolver used to
  apply, so a stored profile resolves to exactly the tokens it resolved to
  before. That is an exact inverse for every string this codebase wrote, since
  they all came from `shlex.join`.
- Malformed input (unbalanced quotes) falls back to a whitespace split rather
  than raising or dropping the value: loading a stored profile must not fail,
  and `None` would be worse than a rough tokenization — it means "use the server
  default", so for any `acp_server` other than `custom` a configured override
  would be silently replaced by the provider's own command. Such a command never
  launched on `main` either (`shlex.split` raised on it), so keeping the tokens
  only moves *where* it fails, from a resolver error to a spawn error naming the
  command the user typed.
- A payload with no `schema_version` is migrated forward from
  `_UNVERSIONED_AGENT_PROFILE_SCHEMA_VERSION` rather than assumed current. The
  store always persists `schema_version`, so an absent one means a hand-written
  or API-supplied body — the shape a client built against v2 still POSTs. The
  migrations are no-ops on already-current values, so a modern client that
  simply omits the field is unaffected.

A Windows path that was typed unquoted was already being destroyed by that same
split, so it can't be recovered in the migration — such a profile has never
launched and the command has to be re-entered. Splitting it changes nothing
about what the profile does; removing the split for new values is the point.

## Issue Number

<!-- none filed; happy to open one if you'd prefer it tracked separately -->

## How to Test

```
uv run pytest tests/sdk/profiles -q
```

`155 passed` on this branch. New cases in `tests/sdk/profiles/test_agent_profile.py`:

- `test_v2_acp_command_string_migrates_to_token_list`
- `test_v2_malformed_command_does_not_fall_back_to_provider_default` — the
  regression test for the first review finding: a malformed override on a
  non-`custom` server must not resolve to the provider's default command
- `test_unversioned_payload_migrates_legacy_command_string` and
  `test_unversioned_payload_leaves_a_token_list_alone` — the second finding,
  plus the no-op guarantee for current-shape values. Mirrored at the REST layer
  by `test_save_unversioned_body_upgrades_legacy_acp_command_string` and
  `test_save_unversioned_body_keeps_acp_command_token_list` in
  `tests/agent_server/test_agent_profiles_router.py`
- `test_v2_acp_command_migration_inverts_shlex_join` — round-trips
  `shlex.join(["/opt/my acp/bin/server", "--flag", "a b"])` back to the original
  tokens, including the arguments containing spaces
- `test_v2_acp_command_malformed_quotes_falls_back_to_whitespace_split`
- `test_v2_acp_command_empty_migrates_to_none` (`None` and `""`)
- `test_windows_path_command_survives_round_trip` — the regression test for the
  bug: `[r"C:\Program Files\nodejs\node.exe", r"C:\Users\me\dist\index.js"]`
  survives a save/load round trip verbatim

Four existing tests changed:

- three that passed a shell string now pass the equivalent token list;
- `test_dry_run_normalizes_settings_build_failure` used an unbalanced-quote
  command to produce a settings-build failure that the dry-run must report
  rather than raise. That input can no longer fail, so it now uses
  `acp_server="custom"` with no `acp_command` — still a profile that validates
  but cannot build settings, so the test keeps asserting the same contract.

Also green: `tests/agent_server/test_agent_profiles_router.py` and
`tests/agent_server/test_agent_profile_conv_start.py` (`95 passed`), the two
files outside `tests/sdk/profiles` that construct `ACPAgentProfile`. Ruff check
and format clean on the touched paths.

**End-to-end**, on Windows 10 19045 / Python 3.13. Drives the whole chain a user
hits — a profile JSON on disk → `AgentProfileStore.load` (schema migration) →
`resolve_agent_profile` → `resolve_acp_command()` →
`asyncio.create_subprocess_exec` → a real ACP `initialize` handshake (pre-auth,
so no credentials involved):

```
schema_version=3

1. legacy v2 shell string  ->  migration  ->  spawn
  stored acp_command : 'cmd /c claude-agent-acp'
  loaded profile     : ['cmd', '/c', 'claude-agent-acp']
  schema_version     : 3
  resolved settings  : ['cmd', '/c', 'claude-agent-acp']
  spawn              : OK   handshake ok, agent=@agentclientprotocol/claude-agent-acp v0.65.0

2. Windows absolute path as a token list  ->  spawn
  stored acp_command : ['C:\\Users\\<user>\\AppData\\Roaming\\npm\\claude-agent-acp.CMD']
  resolved settings  : ['C:\\Users\\<user>\\AppData\\Roaming\\npm\\claude-agent-acp.CMD']
  survived verbatim  : True
  spawn              : OK   handshake ok, agent=@agentclientprotocol/claude-agent-acp v0.65.0

3. the same absolute path stored the OLD way (shell string)
  stored acp_command : 'C:\\Users\\<user>\\AppData\\Roaming\\npm\\claude-agent-acp.CMD'
  resolved settings  : ['C:Users<user>AppDataRoamingnpmclaude-agent-acp.CMD']
  mangled by shlex   : True
  spawn              : FAIL FileNotFoundError: [WinError 2] The system cannot find the file specified
```

(2) is the capability this adds; (3) is the same command expressed the old way,
and is the bug. (3) stays broken through the migration on purpose — the string
was already destroyed before this change, so the profile has never launched and
the command has to be re-entered.

**The migration is faithful**, checked against `main` rather than asserted. Both
stored strings above, loaded and resolved on unmodified `main` (`701a21f`):

```
schema_version on main: 2
  legacy   stored='cmd /c claude-agent-acp'
           main resolves to -> ['cmd', '/c', 'claude-agent-acp']
  winpath  stored='C:\\Users\\<user>\\AppData\\Roaming\\npm\\claude-agent-acp.CMD'
           main resolves to -> ['C:Users<user>AppDataRoamingnpmclaude-agent-acp.CMD']
```

Identical to what the v2→v3 migration produces in both cases, well-formed and
mangled alike. Script available on request; it imports the store and resolver
from the checkout, so it exercises the shipped code path.

## Video/Screenshots

n/a — terminal only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Python-API-visible; REST schema unchanged, REST behaviour was not.**
  `ACPAgentProfile` is a public `openhands.sdk.profiles` export, so anything
  constructing one in Python has to pass a list. An earlier revision of this
  description claimed the REST contract was unaffected; that was only true of
  the generated *document*. `save_agent_profile` validates the raw POST body
  through `validate_agent_profile`, so a body carrying a legacy `acp_command`
  string and no `schema_version` started returning 422 where `main` accepted
  it. Caught in review, fixed by migrating unversioned payloads forward (see
  Summary). Profile payloads still cross `/api/agent-profiles` as an opaque
  object
  (`AgentProfileDetailResponse.profile` is `{"type": "object",
  "additionalProperties": true}`), and `ACPAgentProfile` has no component in
  either the public or the full FastAPI schema.
  `.github/scripts/export_agent_server_openapi.py` emits a **byte-identical**
  document on this branch and on `main` (both md5 `659e5b53eae5…`), so the
  generated ts-client is unchanged and `oasdiff` has nothing to report. The two
  surfaces that do change are the Python constructor and the on-disk profile
  JSON — the latter is what the migration is for. `acp_args` on the same model
  is already `list[str] | None`, so the shape isn't new here either.
- **Repo gates, run locally against the touched files** — ruff format, ruff
  check, pycodestyle, pyright (0 errors), `scripts/check_import_rules.py`,
  `scripts/check_tool_registration.py`, `.github/scripts/check_docstrings.py`:
  all clean. `check_persisted_settings_compat.py` validates its 9 checked-in
  fixtures (its PyPI-baseline half needs a Linux runner). Replicating the
  curated-`__all__` pairing `check_sdk_api_breakage.py` performs, griffe reports
  **0 counted breakages relative to `main`**: the `acp_command` `Field(...)`
  diff classifies as metadata-only, and `AGENT_PROFILE_SCHEMA_VERSION` is not in
  `openhands.sdk.__all__`. That's a local ref-to-ref check, not the PyPI
  baseline CI uses.
- **Why not a deprecation runway instead?** CONTRIBUTING points at the
  deprecation mechanism for changes that could break downstream clients, so to
  be explicit about the choice: the persisted surface *does* get a runway — the
  v2→v3 migration means no stored profile breaks. What has no runway is the
  Python constructor, for callers passing `acp_command="..."` directly. The
  softer landing is one line: keep the annotation `list[str] | str | None` with
  a `field_validator` that `shlex.split`s a string and warns, then narrow it in
  a later release. I didn't do that because it re-admits the ambiguous form at
  the boundary this PR exists to close, and because the only in-tree writer is
  `profiles/seed.py`. If you'd rather have the runway, say so and I'll push the
  validator — it doesn't change anything else here.
- `AGENT_PROFILE_SCHEMA_VERSION` goes 2 → 3. Migration is forward-only, matching
  `_migrate_v1_to_v2`; a v3 profile loaded by older code fails the existing
  "newer than supported" check rather than silently misreading the field.
- Independent of the two other Windows ACP PRs — #4408 (`PATHEXT` spawn
  resolution) and #4409 (process-tree teardown). Different files, any order.

