### PR TITLE
fix(agent-server): do not force-cancel the run task finally block during close()

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -83,6 +83,13 @@ LEASE_RENEW_INTERVAL_SECONDS = 15.0
 # Bounds initial-state push so subscribe_to_events does not stall on a
 # subscriber whose __call__ blocks (e.g. WS with a full TCP send buffer).
 INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
+# Ceiling for draining pending per-event callbacks in the run task's finally
+# block before the terminal state update is published.
+RUN_CALLBACK_DRAIN_TIMEOUT_SECONDS = 30.0
+# close() must wait at least as long as the drain ceiling, or its timeout would
+# force-cancel the run task while its finally block is still draining and the
+# terminal state update would never be published (#4387).
+RUN_TASK_CLOSE_TIMEOUT_SECONDS = RUN_CALLBACK_DRAIN_TIMEOUT_SECONDS + 5.0
 
 
 logger = get_logger(__name__)
@@ -1211,9 +1218,21 @@ class EventService:
                     # This prevents a race condition where the conversation status
                     # becomes FINISHED before agent events (MessageEvent, ActionEvent,
                     # etc.) are published to WebSocket subscribers.
-                    if self._callback_wrapper:
-                        await loop.run_in_executor(
-                            None, self._callback_wrapper.wait_for_pending, 30.0
+                    # If close() cancels this task while it is parked in the
+                    # drain await, swallow that cancellation so the terminal
+                    # _publish_state_update() below still runs before
+                    # close() tears down the pub_sub (#4387).
+                    try:
+                        if self._callback_wrapper:
+                            await loop.run_in_executor(
+                                None,
+                                self._callback_wrapper.wait_for_pending,
+                                RUN_CALLBACK_DRAIN_TIMEOUT_SECONDS,
+                            )
+                    except asyncio.CancelledError:
+                        logger.warning(
+                            "Callback drain interrupted; publishing final "
+                            "state update anyway"
                         )
 
                     # Clear task reference and publish state update
@@ -1678,10 +1697,19 @@ class EventService:
             # path the underlying thread keeps running but the wrapper
             # task still settles, unblocking the wait below.
             self._run_task.cancel()
+            # Shield the wait so a timeout gives up on *waiting* without
+            # force-cancelling the task a second time: that second cancel
+            # would abort the task's finally block mid-drain and skip the
+            # terminal _publish_state_update() (#4387). The timeout must
+            # exceed RUN_CALLBACK_DRAIN_TIMEOUT_SECONDS, the finally
+            # block's drain ceiling.
             try:
-                await asyncio.wait_for(self._run_task, timeout=10.0)
+                await asyncio.wait_for(
+                    asyncio.shield(self._run_task),
+                    timeout=RUN_TASK_CLOSE_TIMEOUT_SECONDS,
+                )
             except asyncio.CancelledError:
-                pass  # Expected after cancel()
+                pass  # close() itself was cancelled; shield re-raised it here
             except Exception as exc:
                 logger.warning("Run task did not exit cleanly during close: %s", exc)
             self._run_task = None

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2962,7 +2962,7 @@ async def test_close_blocks_until_executor_thread_finishes(
     (tmp_path / "ws").mkdir()
     parent_llm = SlowTestLLM.from_messages(
         [text_message("done")],
-        latency_s=12.0,  # > the 10 s wait_for in close()
+        latency_s=12.0,  # long enough that a close() stuck on the step is caught
     )
     info = await start_conversation_with_test_llm(
         real_conversation_service,
@@ -3310,6 +3310,76 @@ async def test_run_false_message_in_cleanup_tail_is_not_run(
         f"(call_count={parent_llm._call_count})"
     )
     assert es._run_task is None
+
+
+@pytest.mark.timeout(30)
+async def test_close_during_drain_still_publishes_final_state_update(
+    real_conversation_service, tmp_path, monkeypatch
+):
+    """close() while the run task is parked in its wait_for_pending() drain
+    must still deliver a terminal ConversationStateUpdateEvent to subscribers
+    before the pub_sub is torn down.
+
+    Regression test for #4387: close() awaited the cancelled run task without
+    a shield, so a cancellation landing on the drain await inside the run
+    task's finally block aborted it before _publish_state_update() —
+    subscribers never saw the terminal status and remote clients considered
+    the conversation running forever.
+    """
+    (tmp_path / "ws").mkdir()
+    parent_llm = SlowTestLLM.from_messages([text_message("done")], latency_s=0.0)
+    info = await start_conversation_with_test_llm(
+        real_conversation_service,
+        parent_llm=parent_llm,
+        workspace_dir=str(tmp_path / "ws"),
+        usage_id="close-drain",
+        initial_text=None,
+    )
+    es = await real_conversation_service.get_event_service(info.id)
+    assert es is not None and es._callback_wrapper is not None
+
+    # Spy on the terminal publish rather than counting subscriber-side
+    # ConversationStateUpdateEvents: per-field status changes (RUNNING,
+    # FINISHED, PAUSED) also arrive as ConversationStateUpdateEvents via the
+    # normal callback path, so a subscriber count cannot distinguish the
+    # terminal full snapshot from those.
+    publish_calls: list[bool] = []
+    orig_publish = es._publish_state_update
+
+    async def _spy_publish() -> None:
+        publish_calls.append(True)
+        await orig_publish()
+
+    monkeypatch.setattr(es, "_publish_state_update", _spy_publish)
+
+    # Park the run in its wait_for_pending() tail until released. It runs in
+    # a thread-pool worker, so block on a threading.Event there and signal
+    # entry back to the test.
+    entered_tail = threading.Event()
+    release_tail = threading.Event()
+
+    def _blocking_wait(timeout: float) -> None:
+        entered_tail.set()
+        release_tail.wait(timeout)
+
+    monkeypatch.setattr(es._callback_wrapper, "wait_for_pending", _blocking_wait)
+
+    await es.send_message(
+        Message(role="user", content=[TextContent(text="hi")]), run=True
+    )
+    assert await asyncio.to_thread(entered_tail.wait, 10.0), (
+        "run never reached its wait_for_pending tail"
+    )
+
+    try:
+        await es.close()
+    finally:
+        release_tail.set()  # unblock the abandoned drain thread
+
+    assert publish_calls, (
+        "terminal _publish_state_update() never ran: close() aborted the run "
+        "task's finally block mid-drain"
+    )
 
 
 def test_emit_event_from_thread_uses_captured_loop(event_service: EventService) -> None:


### PR DESCRIPTION
HUMAN:

Fixes #4387. I hit this while running the agent-server locally — conversations stayed RUNNING in the client after shutdown. Reviewed the fix and test myself.

---

AGENT:

## Why

`EventService.close()` cancels the run task and awaits it with a bare
`asyncio.wait_for(..., timeout=10.0)`, but the task's `finally` block first
drains pending WebSocket callbacks for up to 30 s
(`AsyncCallbackWrapper.wait_for_pending`) before publishing the terminal
state snapshot. When the drain outlasts the 10 s budget, `wait_for` issues a
**second** `task.cancel()` that lands on the drain await and aborts the
`finally` mid-flight — `_publish_state_update()` never runs, and `close()`
tears down the pub_sub immediately after. Remote clients never receive the
terminal FINISHED/PAUSED/ERROR snapshot and see the conversation as RUNNING
forever. Related structural recurrences of the same 10-vs-30 mismatch:
#3842, #3363.

## Summary

- Shield the wait in `close()` (`asyncio.wait_for(asyncio.shield(...))`) —
  the same idiom `interrupt()` already uses — so a timeout gives up on
  *waiting* without force-cancelling the task's cleanup.
- Swallow a cancellation landing on the drain await itself, so the terminal
  `_publish_state_update()` still runs even when `close()` cancels a task
  parked in its drain tail (the shield only prevents the *second* cancel).
- Replace both magic numbers with named constants and derive the close
  budget from the drain ceiling
  (`RUN_TASK_CLOSE_TIMEOUT_SECONDS = RUN_CALLBACK_DRAIN_TIMEOUT_SECONDS + 5.0`),
  so the mismatch cannot silently reappear.

## Issue Number

Fixes #4387

## How to Test

New deterministic regression test (no long sleeps, ~0.3 s):

```bash
uv run pytest tests/agent_server/test_event_service.py::test_close_during_drain_still_-q
```

It parks a real conversation's run task in its `wait_for_pending()` tail,
calls `close()`, and asserts the terminal `_publish_state_update()` still
ran. Verified red on `main` (`1 failed in 0.30s` — the cancel aborts the
finally before the publish) and green with this fix (`1 passed`).

Full file: `uv run pytest tests/agent_server/test_event_service.py -q` →
**111 passed in 17.57s**, including the pre-existing
`test_close_proceeds_on_run_task_timeout` (best-effort shutdown semantics
preserved) and `test_close_blocks_until_executor_thread_finishes` (close()
still returns promptly because cancellation works — only its stale comment
referencing the old 10 s literal was updated).

Pre-commit (ruff format/lint, pycodestyle, pyright, import rules) passes on
both changed files.

## Video/Screenshots

N/A — server-internal lifecycle fix; test output above is the evidence.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Out of scope, noted for a follow-up: `AsyncCallbackWrapper.wait_for_pending`
  treats `timeout` as per-future rather than a total budget (N stuck futures
  ⇒ N×30 s), and its docstring claims `TimeoutError` propagates but the bare
  `except Exception` swallows it. SDK-side change, kept out of this PR to
  stay focused.
- No REST/OpenAPI contract change; timeouts are not part of the public
  surface. No docs-repo PR needed.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.44s · commit 4dc88d5  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 7.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature c1d0bc1d90a8bcdcac71ec8a7ad432eac27e6cde1f2ae9ec7c5f9ebd55b44c55 -->
<!-- jev-fast-audit:end -->
