### PR TITLE
feat: derive automation conversation tags in base RemoteWorkspace

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -1,3 +1,5 @@
+import json
+import os
 from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -242,13 +244,43 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     def default_conversation_tags(self) -> dict[str, str] | None:
         """Default tags to apply to conversations created with this workspace.
 
-        Subclasses (e.g., OpenHandsCloudWorkspace) can override this to provide
-        context-specific tags like automation metadata.
+        Derives automation metadata from environment variables injected by the
+        automation dispatcher, so any remote workspace (local agent servers
+        included) stamps automation context onto the conversations it creates.
+
+        The tags include (keys are lowercase alphanumeric per API requirements):
+          - automationtrigger: The trigger type (e.g., 'cron', 'webhook', 'manual')
+          - automationid: The automation's unique identifier
+          - automationname: Human-readable automation name
+          - automationrunid: The specific run identifier
 
         Returns:
-            Dictionary of tag key-value pairs, or None if no default tags.
+            Dictionary of tag key-value pairs (empty when no automation env
+            vars are present). Subclasses (e.g., OpenHandsCloudWorkspace) can
+            extend this with additional context.
         """
-        return None
+        tags: dict[str, str] = {}
+
+        # Parse AUTOMATION_EVENT_PAYLOAD (injected by dispatcher)
+        payload_str = os.environ.get("AUTOMATION_EVENT_PAYLOAD")
+        if payload_str:
+            try:
+                payload = json.loads(payload_str)
+                if isinstance(payload, dict):
+                    if payload.get("trigger"):
+                        tags["automationtrigger"] = str(payload["trigger"])
+                    if payload.get("automation_id"):
+                        tags["automationid"] = str(payload["automation_id"])
+                    if payload.get("automation_name"):
+                        tags["automationname"] = str(payload["automation_name"])
+            except (json.JSONDecodeError, TypeError):
+                logger.error("Failed to parse AUTOMATION_EVENT_PAYLOAD")
+
+        run_id = os.environ.get("AUTOMATION_RUN_ID")
+        if run_id:
+            tags["automationrunid"] = run_id
+
+        return tags
 
     def register_conversation(self, conversation_id: str) -> None:
         """Register a conversation ID with this workspace.

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -164,15 +163,9 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
     def default_conversation_tags(self) -> dict[str, str]:
         """Build default tags from automation env vars for conversation creation.
 
-        When running inside an OpenHands Cloud Runtime (local_agent_server_mode=True),
-        this property extracts automation metadata from environment variables and
-        returns them as tags that can be attached to conversations.
-
-        The tags include (keys are lowercase alphanumeric per API requirements):
-          - automationtrigger: The trigger type (e.g., 'cron', 'webhook', 'manual')
-          - automationid: The automation's unique identifier
-          - automationname: Human-readable automation name
-          - automationrunid: The specific run identifier
+        Extends ``RemoteWorkspace.default_conversation_tags`` (derived from the
+        dispatcher-injected automation env vars) with the sandbox-scoped
+        ``_automation_run_id`` fallback captured in local agent-server mode.
 
         Note: Skills/plugins are NOT included here - they are passed when creating
         the RemoteConversation and merged at that level.
@@ -180,28 +173,9 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         These tags are automatically merged into conversations created via this
         workspace, allowing the Cloud platform to track automation context.
         """
-        tags: dict[str, str] = {}
-
-        # Parse AUTOMATION_EVENT_PAYLOAD (injected by dispatcher)
-        payload_str = os.environ.get("AUTOMATION_EVENT_PAYLOAD")
-        if payload_str:
-            try:
-                payload = json.loads(payload_str)
-                if isinstance(payload, dict):
-                    if payload.get("trigger"):
-                        tags["automationtrigger"] = str(payload["trigger"])
-                    if payload.get("automation_id"):
-                        tags["automationid"] = str(payload["automation_id"])
-                    if payload.get("automation_name"):
-                        tags["automationname"] = str(payload["automation_name"])
-            except (json.JSONDecodeError, TypeError):
-                logger.error("Failed to parse AUTOMATION_EVENT_PAYLOAD")
-
-        # Add run_id from env var or private attr
-        run_id = os.environ.get("AUTOMATION_RUN_ID") or self._automation_run_id
-        if run_id:
-            tags["automationrunid"] = run_id
-
+        tags = dict(super().default_conversation_tags or {})
+        if "automationrunid" not in tags and self._automation_run_id:
+            tags["automationrunid"] = self._automation_run_id
         return tags
 
     @property

--- a/tests/workspace/test_cloud_workspace_automation_tags.py
+++ b/tests/workspace/test_cloud_workspace_automation_tags.py
@@ -120,6 +120,50 @@ class TestDefaultConversationTags:
             assert "skills" not in tags
 
 
+class TestRemoteWorkspaceDefaultConversationTags:
+    """Tests for automation tags on the base RemoteWorkspace.
+
+    Local-mode automation runs use a plain RemoteWorkspace against the local
+    agent server, so the base class itself must derive the automation tags
+    from the dispatcher-injected env vars (the derivation edge cases are
+    covered above through the OpenHandsCloudWorkspace subclass, which
+    inherits this implementation).
+    """
+
+    @pytest.fixture
+    def workspace(self):
+        """Create a plain RemoteWorkspace (constructing makes no requests)."""
+        from openhands.sdk.workspace import RemoteWorkspace
+
+        return RemoteWorkspace(host="http://localhost:1", working_dir="/tmp")
+
+    def test_empty_tags_when_no_env_vars(self, workspace):
+        """Should return empty dict when no automation env vars are set."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert workspace.default_conversation_tags == {}
+
+    def test_derives_automation_tags_from_env_vars(self, workspace):
+        """Should stamp all four automation tags from the dispatcher env vars."""
+        payload = {
+            "trigger": "cron",
+            "automation_id": "auto-abc",
+            "automation_name": "Nightly Audit",
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "AUTOMATION_EVENT_PAYLOAD": json.dumps(payload),
+                "AUTOMATION_RUN_ID": "run-xyz",
+            },
+        ):
+            assert workspace.default_conversation_tags == {
+                "automationtrigger": "cron",
+                "automationid": "auto-abc",
+                "automationname": "Nightly Audit",
+                "automationrunid": "run-xyz",
+            }
+
+
 class TestConversationTagMerging:
     """Tests for automatic tag merging in Conversation factory."""
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

I have verified the changes.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

Conversations created by automations on a **local** agent server carry no automation tags, so they are indistinguishable from manual conversations in the Agent Canvas conversation panel (Linear OSS-9089). The automation dispatcher injects `AUTOMATION_EVENT_PAYLOAD` + `AUTOMATION_RUN_ID` for every backend, but the tag derivation lived only in `OpenHandsCloudWorkspace.default_conversation_tags` — local-mode preset scripts use a plain `RemoteWorkspace`, whose hook returned `None`. This PR fixes that asymmetry at its root so local runs are tagged exactly like cloud runs.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Move the automation-tag derivation (`automationtrigger`/`automationid`/`automationname` from `AUTOMATION_EVENT_PAYLOAD`, `automationrunid` from `AUTOMATION_RUN_ID`) into the base `RemoteWorkspace.default_conversation_tags` (`openhands-sdk/openhands/sdk/workspace/remote/base.py`); returns `{}` when the env vars are absent — behaviorally identical to the previous `None` for the `Conversation()` factory merge.
- Shrink `OpenHandsCloudWorkspace.default_conversation_tags` to a thin override: `super()` plus its sandbox-scoped `_automation_run_id` fallback (`openhands-workspace/openhands/workspace/cloud/workspace.py`); drop the now-unused `json` import.
- Add `TestRemoteWorkspaceDefaultConversationTags` covering the base-class behavior (all four tags derived from env vars; empty dict without them); the existing derivation edge-case tests keep covering the shared implementation through the cloud subclass, which now inherits it.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
uv run python -m pytest tests/workspace/test_cloud_workspace_automation_tags.py -v

AUTOMATION_EVENT_PAYLOAD='{"trigger":"cron","automation_id":"a-1","automation_name":"Nightly Audit"}' \
AUTOMATION_RUN_ID=run-42 uv run python -c "from openhands.sdk.workspace import RemoteWorkspace; \
print(RemoteWorkspace(host='http://localhost:1', working_dir='/tmp').default_conversation_tags)"
# expect: {'automationtrigger': 'cron', 'automationid': 'a-1', 'automationname': 'Nightly Audit', 'automationrunid': 'run-42'}
```

For a full end-to-end check, run a local-mode automation with this SDK (e.g. `UV_OVERRIDE` on an Agent Canvas box) and confirm the created conversation's `GET /api/conversations/{id}` response carries the four automation tags.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/b6e088d3-e6ef-41c8-a183-997c9d8ba5c0

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:14a1e42-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-14a1e42-python \
  ghcr.io/openhands/agent-server:14a1e42-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:14a1e42-golang-amd64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-golang-amd64
ghcr.io/openhands/agent-server:hieptl-oss-9123-golang-amd64
ghcr.io/openhands/agent-server:14a1e42-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:14a1e42-golang-arm64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-golang-arm64
ghcr.io/openhands/agent-server:hieptl-oss-9123-golang-arm64
ghcr.io/openhands/agent-server:14a1e42-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:14a1e42-java-amd64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-java-amd64
ghcr.io/openhands/agent-server:hieptl-oss-9123-java-amd64
ghcr.io/openhands/agent-server:14a1e42-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:14a1e42-java-arm64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-java-arm64
ghcr.io/openhands/agent-server:hieptl-oss-9123-java-arm64
ghcr.io/openhands/agent-server:14a1e42-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:14a1e42-python-amd64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-python-amd64
ghcr.io/openhands/agent-server:hieptl-oss-9123-python-amd64
ghcr.io/openhands/agent-server:14a1e42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:14a1e42-python-arm64
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-python-arm64
ghcr.io/openhands/agent-server:hieptl-oss-9123-python-arm64
ghcr.io/openhands/agent-server:14a1e42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:14a1e42-golang
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-golang
ghcr.io/openhands/agent-server:hieptl-oss-9123-golang
ghcr.io/openhands/agent-server:14a1e42-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:14a1e42-java
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-java
ghcr.io/openhands/agent-server:hieptl-oss-9123-java
ghcr.io/openhands/agent-server:14a1e42-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:14a1e42-python
ghcr.io/openhands/agent-server:14a1e42ab1c1e208174d82919661e85be1bbe19a-python
ghcr.io/openhands/agent-server:hieptl-oss-9123-python
ghcr.io/openhands/agent-server:14a1e42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `14a1e42-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `14a1e42-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->