### PR TITLE
fix(observability): record non-executed tool results

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -73,6 +73,7 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import (
     maybe_init_laminar,
     observe,
+    record_tool_result,
     should_enable_observability,
 )
 from openhands.sdk.observability.utils import extract_action_name
@@ -298,21 +299,31 @@ class _ActionBatch:
             results_by_id=results_by_id,
         )
 
-    def emit(self, on_event: ConversationCallbackType) -> None:
+    def emit(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+    ) -> None:
         """Emit all events in original action order."""
         for ae in self.action_events:
             reason = self.blocked_reasons.get(ae.id)
             if reason is not None:
                 logger.info(f"Action '{ae.tool_name}' blocked by hook: {reason}")
-                on_event(
-                    UserRejectObservation(
-                        action_id=ae.id,
-                        tool_name=ae.tool_name,
-                        tool_call_id=ae.tool_call_id,
-                        rejection_reason=reason,
-                        rejection_source="hook",
-                    )
+                rejection = UserRejectObservation(
+                    action_id=ae.id,
+                    tool_name=ae.tool_name,
+                    tool_call_id=ae.tool_call_id,
+                    rejection_reason=reason,
+                    rejection_source="hook",
                 )
+                record_tool_result(
+                    conversation,
+                    name=extract_action_name(ae),
+                    tool_call_id=ae.tool_call_id,
+                    tool_input=ae.action,
+                    tool_output=rejection.to_llm_message(),
+                )
+                on_event(rejection)
             else:
                 for event in self.results_by_id[ae.id]:
                     on_event(event)
@@ -563,7 +574,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             tools=self.tools_map,
             cancel_token=conversation.cancel_token,
         )
-        batch.emit(on_event)
+        batch.emit(conversation, on_event)
         batch.finalize(
             on_event=on_event,
             check_iterative_refinement=lambda ae: (
@@ -597,7 +608,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             tools=self.tools_map,
             cancel_token=conversation.cancel_token,
         )
-        batch.emit(on_event)
+        batch.emit(conversation, on_event)
         batch.finalize(
             on_event=on_event,
             check_iterative_refinement=lambda ae: (
@@ -1111,6 +1122,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         *,
         error: str,
         tool_name: str,
+        span_name: str,
+        conversation: LocalConversation,
         tool_call: MessageToolCall,
         llm_response_id: str,
         on_event: ConversationCallbackType,
@@ -1146,14 +1159,20 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             action=None,
         )
         on_event(tc_event)
-        on_event(
-            AgentErrorEvent(
-                error=error,
-                tool_name=tool_name,
-                tool_call_id=tool_call.id,
-                classification=AGENT_OUTCOME,
-            )
+        error_event = AgentErrorEvent(
+            error=error,
+            tool_name=tool_name,
+            tool_call_id=tool_call.id,
+            classification=AGENT_OUTCOME,
         )
+        record_tool_result(
+            conversation,
+            name=span_name,
+            tool_call_id=tool_call.id,
+            tool_input=tool_call,
+            tool_output=error_event.to_llm_message(),
+        )
+        on_event(error_event)
 
     def _get_action_event(
         self,
@@ -1199,6 +1218,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 self._emit_tool_error(
                     error=err,
                     tool_name=tool_name,
+                    span_name="InvalidToolCall",
+                    conversation=conversation,
                     tool_call=tool_call,
                     llm_response_id=llm_response_id,
                     on_event=on_event,
@@ -1259,6 +1280,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             self._emit_tool_error(
                 error=err,
                 tool_name=display_tool_name,
+                span_name=(tool.action_type.__name__ if tool else "InvalidToolCall"),
+                conversation=conversation,
                 tool_call=tool_call,
                 llm_response_id=llm_response_id,
                 on_event=on_event,

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -235,6 +235,7 @@ class _ActionBatch:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tools: dict[str, ToolDefinition] | None = None,
         cancel_token: CancellationToken | None = None,
+        span_owner: object | None = None,
     ) -> _ActionBatch:
         """Truncate, partition blocked actions, execute the rest, return the batch."""
         action_events, has_finish = cls._truncate_at_finish(action_events)
@@ -249,7 +250,11 @@ class _ActionBatch:
                 executable.append(ae)
 
         executed_results = executor.execute_batch(
-            executable, tool_runner, tools, cancel_token
+            executable,
+            tool_runner,
+            tools,
+            cancel_token,
+            span_owner=span_owner,
         )
         results_by_id = dict(zip([ae.id for ae in executable], executed_results))
 
@@ -269,6 +274,7 @@ class _ActionBatch:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tools: dict[str, ToolDefinition] | None = None,
         cancel_token: CancellationToken | None = None,
+        span_owner: object | None = None,
     ) -> _ActionBatch:
         """Async variant of :meth:`prepare`.
 
@@ -288,7 +294,11 @@ class _ActionBatch:
                 executable.append(ae)
 
         executed_results = await executor.aexecute_batch(
-            executable, tool_runner, tools, cancel_token
+            executable,
+            tool_runner,
+            tools,
+            cancel_token,
+            span_owner=span_owner,
         )
         results_by_id = dict(zip([ae.id for ae in executable], executed_results))
 
@@ -573,6 +583,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             tool_runner=lambda ae: self._execute_action_event(conversation, ae),
             tools=self.tools_map,
             cancel_token=conversation.cancel_token,
+            span_owner=conversation,
         )
         batch.emit(conversation, on_event)
         batch.finalize(
@@ -607,6 +618,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             tool_runner=lambda ae: self._execute_action_event(conversation, ae),
             tools=self.tools_map,
             cancel_token=conversation.cancel_token,
+            span_owner=conversation,
         )
         batch.emit(conversation, on_event)
         batch.finalize(

--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -83,6 +83,8 @@ class ParallelToolExecutor:
                    locking is skipped (backward-compatible).
             cancel_token: If set and cancelled, pending tool calls are
                           skipped and return a synthetic error event.
+            span_owner: Object carrying the conversation root span for
+                        synthetic cancellation results.
 
         Returns:
             List of event lists in the same order as the input action_events.
@@ -145,6 +147,7 @@ class ParallelToolExecutor:
 
         The *tool_runner* is the same **synchronous** callable used by
         :meth:`execute_batch` (i.e. ``_execute_action_event``).
+        ``span_owner`` anchors synthetic cancellation results to their root span.
         Resource locking via :class:`ResourceLockManager` (threading
         locks) works correctly because each tool call runs in its own
         thread.

--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -70,6 +70,7 @@ class ParallelToolExecutor:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tools: dict[str, ToolDefinition] | None = None,
         cancel_token: CancellationToken | None = None,
+        span_owner: object | None = None,
     ) -> list[list[Event]]:
         """Execute a batch of action events concurrently.
 
@@ -94,7 +95,13 @@ class ParallelToolExecutor:
 
         if len(action_events) == 1 or self._max_workers == 1:
             return [
-                self._run_safe(action, tool_runner, _resolve(action), cancel_token)
+                self._run_safe(
+                    action,
+                    tool_runner,
+                    _resolve(action),
+                    cancel_token,
+                    span_owner,
+                )
                 for action in action_events
             ]
 
@@ -109,6 +116,7 @@ class ParallelToolExecutor:
                     tool_runner,
                     _resolve(action),
                     cancel_token,
+                    span_owner,
                 )
                 for action in action_events
             ]
@@ -121,6 +129,7 @@ class ParallelToolExecutor:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tools: dict[str, ToolDefinition] | None = None,
         cancel_token: CancellationToken | None = None,
+        span_owner: object | None = None,
     ) -> list[list[Event]]:
         """Async variant of :meth:`execute_batch`.
 
@@ -149,7 +158,11 @@ class ParallelToolExecutor:
         if len(action_events) == 1 or self._max_workers == 1:
             return [
                 await self._arun_safe(
-                    action, tool_runner, _resolve(action), cancel_token
+                    action,
+                    tool_runner,
+                    _resolve(action),
+                    cancel_token,
+                    span_owner=span_owner,
                 )
                 for action in action_events
             ]
@@ -167,6 +180,7 @@ class ParallelToolExecutor:
                             _resolve(action),
                             cancel_token,
                             pool,
+                            span_owner,
                         )
                         for action in action_events
                     ]
@@ -180,6 +194,7 @@ class ParallelToolExecutor:
         tool: ToolDefinition | None = None,
         cancel_token: CancellationToken | None = None,
         executor: ThreadPoolExecutor | None = None,
+        span_owner: object | None = None,
     ) -> list[Event]:
         """Run :meth:`_run_safe` in a thread via ``run_in_executor``.
 
@@ -207,7 +222,14 @@ class ParallelToolExecutor:
         ctx = contextvars.copy_context()
 
         def run_in_caller_context() -> list[Event]:
-            return ctx.run(self._run_safe, action, tool_runner, tool, cancel_token)
+            return ctx.run(
+                self._run_safe,
+                action,
+                tool_runner,
+                tool,
+                cancel_token,
+                span_owner,
+            )
 
         fut = loop.run_in_executor(executor, run_in_caller_context)
         try:
@@ -228,7 +250,9 @@ class ParallelToolExecutor:
             raise
 
     @staticmethod
-    def _cancelled_error(action: ActionEvent) -> list[Event]:
+    def _cancelled_error(
+        action: ActionEvent, span_owner: object | None = None
+    ) -> list[Event]:
         """Return a synthetic error for a tool call skipped due to cancellation."""
         error = AgentErrorEvent(
             error="Tool call cancelled by interrupt.",
@@ -237,7 +261,7 @@ class ParallelToolExecutor:
             classification=AGENT_OUTCOME,
         )
         record_tool_result(
-            action,
+            span_owner if span_owner is not None else action,
             name=extract_action_name(action),
             tool_call_id=action.tool_call_id,
             tool_input=action.action,
@@ -251,6 +275,7 @@ class ParallelToolExecutor:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tool: ToolDefinition | None = None,
         cancel_token: CancellationToken | None = None,
+        span_owner: object | None = None,
     ) -> list[Event]:
         """Run tool_runner with resource locking.
 
@@ -269,7 +294,7 @@ class ParallelToolExecutor:
                 "Skipping tool '%s' -- cancelled before execution",
                 action.tool_name,
             )
-            return self._cancelled_error(action)
+            return self._cancelled_error(action, span_owner)
 
         try:
             if tool is None:

--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -33,6 +33,8 @@ from openhands.sdk.event.error_classification import (
 )
 from openhands.sdk.event.llm_convertible import AgentErrorEvent
 from openhands.sdk.logger import get_logger
+from openhands.sdk.observability.laminar import record_tool_result
+from openhands.sdk.observability.utils import extract_action_name
 
 
 if TYPE_CHECKING:
@@ -228,14 +230,20 @@ class ParallelToolExecutor:
     @staticmethod
     def _cancelled_error(action: ActionEvent) -> list[Event]:
         """Return a synthetic error for a tool call skipped due to cancellation."""
-        return [
-            AgentErrorEvent(
-                error="Tool call cancelled by interrupt.",
-                tool_name=action.tool_name,
-                tool_call_id=action.tool_call_id,
-                classification=AGENT_OUTCOME,
-            )
-        ]
+        error = AgentErrorEvent(
+            error="Tool call cancelled by interrupt.",
+            tool_name=action.tool_name,
+            tool_call_id=action.tool_call_id,
+            classification=AGENT_OUTCOME,
+        )
+        record_tool_result(
+            action,
+            name=extract_action_name(action),
+            tool_call_id=action.tool_call_id,
+            tool_input=action.action,
+            tool_output=error.to_llm_message(),
+        )
+        return [error]
 
     def _run_safe(
         self,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -73,7 +73,12 @@ from openhands.sdk.mcp.utils import (
     ToolsChangedCallback,
     ToolsReconciledCallback,
 )
-from openhands.sdk.observability.laminar import OPERATION_METADATA_KEY, observe
+from openhands.sdk.observability.laminar import (
+    OPERATION_METADATA_KEY,
+    observe,
+    record_tool_result,
+)
+from openhands.sdk.observability.utils import extract_action_name
 from openhands.sdk.plugin import (
     Plugin,
     PluginSource,
@@ -2503,6 +2508,13 @@ class LocalConversation(BaseConversation):
                     tool_name=action_event.tool_name,
                     tool_call_id=action_event.tool_call_id,
                     rejection_reason=reason,
+                )
+                record_tool_result(
+                    self,
+                    name=extract_action_name(action_event),
+                    tool_call_id=action_event.tool_call_id,
+                    tool_input=action_event.action,
+                    tool_output=rejection_event.to_llm_message(),
                 )
                 self._on_event(rejection_event)
                 logger.info(f"Rejected pending action: {action_event} - {reason}")

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -201,6 +201,7 @@ def observe[**P, R](
     return decorator
 
 
+# Keep owner first so observe can restore its conversation root span.
 def _return_tool_result(owner: object, tool_input: Any, tool_output: Any) -> Any:
     _ = owner, tool_input
     return tool_output

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -201,6 +201,29 @@ def observe[**P, R](
     return decorator
 
 
+def _return_tool_result(owner: object, tool_input: Any, tool_output: Any) -> Any:
+    _ = owner, tool_input
+    return tool_output
+
+
+def record_tool_result(
+    owner: object,
+    *,
+    name: str,
+    tool_call_id: str,
+    tool_input: Any,
+    tool_output: Any,
+) -> None:
+    if not should_enable_observability():
+        return
+    observe(
+        name=name,
+        span_type="TOOL",
+        ignore_inputs=["owner", "tool_output"],
+        metadata={"tool_call_id": tool_call_id},
+    )(_return_tool_result)(owner, tool_input, tool_output)
+
+
 def should_enable_observability() -> bool:
     global _observability_enabled
     if _observability_enabled:

--- a/tests/sdk/agent/test_action_batch.py
+++ b/tests/sdk/agent/test_action_batch.py
@@ -17,6 +17,7 @@ def _ae(tool_name: str = "tool", action_id: str | None = None) -> ActionEvent:
     ae.tool_name = tool_name
     ae.id = action_id or str(id(ae))
     ae.tool_call_id = f"tc-{ae.id}"
+    ae.action = MagicMock()
     return ae  # type: ignore[return-value]
 
 
@@ -144,7 +145,7 @@ def test_emit_results_in_order():
         results_by_id={"1": [o1], "2": [o2a, o2b]},
     )
     emitted: list[Any] = []
-    batch.emit(emitted.append)
+    batch.emit(MagicMock(), emitted.append)
     assert emitted == [o1, o2a, o2b]
 
 
@@ -158,7 +159,7 @@ def test_emit_blocked_produces_rejection():
         results_by_id={"2": [o2]},
     )
     emitted: list[Any] = []
-    batch.emit(emitted.append)
+    batch.emit(MagicMock(), emitted.append)
 
     assert len(emitted) == 2
     assert isinstance(emitted[0], UserRejectObservation)

--- a/tests/sdk/agent/test_action_batch.py
+++ b/tests/sdk/agent/test_action_batch.py
@@ -57,7 +57,7 @@ def _make_executor(side_effect: Any = None) -> Any:
         executor.execute_batch = side_effect
     else:
         executor.execute_batch = (
-            lambda actions, runner, tools=None, cancel_token=None: [
+            lambda actions, runner, tools=None, cancel_token=None, span_owner=None: [
                 runner(a) for a in actions
             ]
         )

--- a/tests/sdk/agent/test_tool_span_input.py
+++ b/tests/sdk/agent/test_tool_span_input.py
@@ -23,9 +23,11 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
+from openhands.sdk.agent.parallel_executor import ParallelToolExecutor
 from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.cancellation import CancellationToken
 from openhands.sdk.event import ActionEvent
-from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
 from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
 from openhands.sdk.tool.tool import ToolDefinition
@@ -310,6 +312,51 @@ def test_rejected_pending_tool_call_emits_one_result_span(exported):
     attributes = tool_spans[0].attributes or {}
     assert attributes["lmnr.association.properties.metadata.tool_call_id"] == "call_x"
     assert "Action rejected: not approved" in attributes["lmnr.span.output"]
+    assert tool_spans[0].context is not None
+    assert root_spans[0].context is not None
+    assert tool_spans[0].context.trace_id == root_spans[0].context.trace_id
+
+
+def test_cancelled_tool_call_span_shares_conversation_trace(exported):
+    llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
+    conversation = Conversation(agent=Agent(llm=llm), callbacks=[])
+    action = ActionEvent(
+        thought=[TextContent(text="test")],
+        tool_call=MessageToolCall(
+            id="call_cancelled",
+            name="span_input_echo_tool",
+            arguments=json.dumps({"value": "hi"}),
+            origin="completion",
+        ),
+        tool_name="span_input_echo_tool",
+        tool_call_id="call_cancelled",
+        llm_response_id="response",
+    )
+    token = CancellationToken()
+    token.cancel()
+
+    ParallelToolExecutor().execute_batch(
+        [action],
+        lambda _: pytest.fail("cancelled tool executed"),
+        cancel_token=token,
+        span_owner=conversation,
+    )
+    conversation.close()
+
+    tool_spans = [
+        span
+        for span in exported()
+        if (span.attributes or {}).get("lmnr.span.type") == "TOOL"
+    ]
+    root_spans = [span for span in exported() if span.name == "conversation"]
+    assert len(tool_spans) == 1
+    assert len(root_spans) == 1
+    attributes = tool_spans[0].attributes or {}
+    assert (
+        attributes["lmnr.association.properties.metadata.tool_call_id"]
+        == "call_cancelled"
+    )
+    assert "cancelled by interrupt" in attributes["lmnr.span.output"]
     assert tool_spans[0].context is not None
     assert root_spans[0].context is not None
     assert tool_spans[0].context.trace_id == root_spans[0].context.trace_id

--- a/tests/sdk/agent/test_tool_span_input.py
+++ b/tests/sdk/agent/test_tool_span_input.py
@@ -24,7 +24,9 @@ from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
+from openhands.sdk.event import ActionEvent
 from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
 from openhands.sdk.tool.tool import ToolDefinition
 
@@ -158,6 +160,51 @@ def _responses() -> Any:
     return fake
 
 
+def _mixed_result_response(**kwargs: Any) -> ModelResponse:
+    message = LiteLLMMessage(
+        role="assistant",
+        content="checking",
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id="call_valid",
+                type="function",
+                function=Function(
+                    name="span_input_echo_tool",
+                    arguments=json.dumps({"value": "hi"}),
+                ),
+            ),
+            ChatCompletionMessageToolCall(
+                id="call_invalid",
+                type="function",
+                function=Function(
+                    name="span_input_echo_tool",
+                    arguments=json.dumps({"bogus": True}),
+                ),
+            ),
+            ChatCompletionMessageToolCall(
+                id="call_missing",
+                type="function",
+                function=Function(name="missing_tool", arguments="{}"),
+            ),
+            ChatCompletionMessageToolCall(
+                id="call_blocked",
+                type="function",
+                function=Function(
+                    name="span_input_echo_tool",
+                    arguments=json.dumps({"value": "blocked"}),
+                ),
+            ),
+        ],
+    )
+    return ModelResponse(
+        id="mixed-results",
+        created=0,
+        model="gpt-4o",
+        object="chat.completion",
+        choices=[Choices(index=0, message=message, finish_reason="tool_calls")],
+    )
+
+
 def test_tool_span_input_is_the_action_only(exported):
     llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
     conversation = Conversation(
@@ -179,3 +226,90 @@ def test_tool_span_input_is_the_action_only(exported):
 
     assert "conversation" not in payload
     assert payload["action"]["value"] == "hi"
+
+
+def test_every_declared_tool_call_emits_one_result_span(exported):
+    llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
+    agent = Agent(
+        llm=llm,
+        tools=[Tool(name="SpanInputEchoTool")],
+        tool_concurrency_limit=2,
+    )
+    conversation = Conversation(agent=agent, callbacks=[])
+
+    def on_event(event: Any) -> None:
+        if isinstance(event, ActionEvent) and event.tool_call_id == "call_blocked":
+            conversation.state.block_action(event.id, "blocked by policy")
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion",
+        side_effect=_mixed_result_response,
+    ):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="hi")])
+        )
+        agent.step(conversation, on_event=on_event)
+    conversation.close()
+
+    tool_spans = [
+        span
+        for span in exported()
+        if (span.attributes or {}).get("lmnr.span.type") == "TOOL"
+    ]
+    spans_by_call = {
+        (span.attributes or {})[
+            "lmnr.association.properties.metadata.tool_call_id"
+        ]: span
+        for span in tool_spans
+    }
+
+    assert set(spans_by_call) == {
+        "call_valid",
+        "call_invalid",
+        "call_missing",
+        "call_blocked",
+    }
+    assert len(tool_spans) == len(spans_by_call)
+
+    invalid_output = (spans_by_call["call_invalid"].attributes or {})[
+        "lmnr.span.output"
+    ]
+    missing_output = (spans_by_call["call_missing"].attributes or {})[
+        "lmnr.span.output"
+    ]
+    blocked_output = (spans_by_call["call_blocked"].attributes or {})[
+        "lmnr.span.output"
+    ]
+    assert "Error validating tool" in invalid_output
+    assert "Tool 'missing_tool' not found" in missing_output
+    assert "Action rejected: blocked by policy" in blocked_output
+
+
+def test_rejected_pending_tool_call_emits_one_result_span(exported):
+    llm = LLM(usage_id="probe", model="gpt-4o", api_key=SecretStr("k"))
+    agent = Agent(llm=llm, tools=[Tool(name="SpanInputEchoTool")])
+    conversation = Conversation(agent=agent, callbacks=[])
+    conversation.set_confirmation_policy(AlwaysConfirm())
+
+    with patch("openhands.sdk.llm.llm.litellm_completion", side_effect=_responses()):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="hi")])
+        )
+        agent.step(conversation, on_event=conversation._on_event)
+    conversation.reject_pending_actions("not approved")
+    conversation.close()
+
+    tool_spans = [
+        span
+        for span in exported()
+        if (span.attributes or {}).get("lmnr.span.type") == "TOOL"
+    ]
+    root_spans = [span for span in exported() if span.name == "conversation"]
+    assert len(tool_spans) == 1
+    assert len(root_spans) == 1
+    attributes = tool_spans[0].attributes or {}
+    assert attributes["lmnr.association.properties.metadata.tool_call_id"] == "call_x"
+    assert "Action rejected: not approved" in attributes["lmnr.span.output"]
+    assert tool_spans[0].context is not None
+    assert root_spans[0].context is not None
+    assert tool_spans[0].context.trace_id == root_spans[0].context.trace_id


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix for Laminar data integrity
Record an immediate TOOL result span for validation failures and unknown tools,
preserving the original tool_call_id, declared input, and actual error result.

---

AGENT:

## Why

Laminar TOOL instrumentation starts only after `Agent._get_action_event` has
parsed, normalized, resolved, and validated a model-declared tool call. Calls
that produce a tool-result message without reaching the executor therefore had
no TOOL span at all.

Full Laminar data confirms this on the two production reproductions:

- Conversation `a1d6e94c-68be-44d1-9fc3-379b589d6358`, trace
  `e7a90542-5b18-9c9d-e26a-5e5051ed60b5`: all four missing IDs are
  `task_tracker` calls with file-editor arguments. The following LLM inputs
  contain their exact tool results: four `TaskTrackerAction` Pydantic validation
  failures (`str_replace` is invalid and `path`/`old_str`/`new_str` are extra).
- Conversation `abce48b1-9295-44a5-a327-455d1aa38748`, trace
  `3c797b9f-c54f-3be1-07ed-8f3282290e8e`: missing ID
  `call_function_7pyinews1hwv_1` is followed by the exact result
  `Tool 'bash' not found. Available: [...]`.

In both traces the declaring `agent.astep` span ended successfully, no TOOL span
with an unexpected name/type exists, and the next LLM input proves the SDK had
already persisted the result. This is deterministic pre-execution behavior, not
ThreadPoolExecutor context loss or exporter flakiness.

The same invariant was missing from rejection paths. A separate production
sample (`b2425706-0560-4226-9756-11fed74fff37`) has 11 missing terminal spans;
every corresponding tool result says `Action rejected: ...` from a policy hook.

A scan of records created since 2026-08-01 and last updated more than 24 hours
before the scan found 1,664 declared calls without a TOOL span across 599 of
23,967 conversations. The largest declared-tool clusters were terminal (765),
file_editor (567), task_tracker (119), task (46), think (25), finish (17),
browser_get_state (17), and bash (15). This scan measures the gap; the full raw
trace checks above establish the cause for the reported reproductions and the
sampled rejection cluster.

## Summary

- Record an immediate TOOL result span for validation failures and unknown tools,
  preserving the original `tool_call_id`, declared input, and actual error result.
- Apply the same result-span invariant to hook rejections, explicit user
  rejections, and calls cancelled before execution starts.
- Keep these spans attached to the conversation root, including rejection calls
  made between `run()` invocations.
- Add a real Laminar in-memory exporter regression covering success, invalid
  arguments, unknown tools, hook rejection, and explicit user rejection, with
  exact-one-span and trace-parentage assertions.

## Issue Number

Context: #4358. This is a different root cause from its refuted parallel-context
diagnosis and does not close that issue.

## How to Test

```bash
uv run pytest tests/sdk/agent/test_tool_span_input.py \
  tests/sdk/agent/test_action_batch.py \
  tests/sdk/conversation/test_interrupt.py \
  tests/sdk/conversation/local/test_confirmation_mode.py -q
# 45 passed

uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/agent/agent.py \
  openhands-sdk/openhands/sdk/agent/parallel_executor.py \
  openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py \
  openhands-sdk/openhands/sdk/observability/laminar.py \
  tests/sdk/agent/test_action_batch.py \
  tests/sdk/agent/test_tool_span_input.py
# all applicable hooks passed
```

The broader agent/observability/conversation run completed 1,652 of 1,653 tests.
The remaining `test_reconciliation_targets_replaced_agent` assertion expects only
`replacement` but the agent also contains the auto-added
`inspect_image_with_vision`; it reproduces when run alone and is unrelated to
these observability paths.

The exporter regression exercises a real `TracerWrapper` and verifies the TOOL
span outputs contain the exact validation/rejection text, not only that an
`observe(...)` mock was called.

## Video/Screenshots

Not applicable; the observable behavior is covered by exported-span assertions
and the production trace evidence above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No changes are made to dataset-utils or Harbor pairing. Existing successfully
executed TOOL spans keep their current shape and #4010 `tool_call_id` metadata.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ca77d42-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ca77d42-python \
  ghcr.io/openhands/agent-server:ca77d42-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ca77d42-golang-amd64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-golang-amd64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-golang-amd64
ghcr.io/openhands/agent-server:ca77d42-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ca77d42-golang-arm64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-golang-arm64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-golang-arm64
ghcr.io/openhands/agent-server:ca77d42-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ca77d42-java-amd64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-java-amd64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-java-amd64
ghcr.io/openhands/agent-server:ca77d42-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ca77d42-java-arm64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-java-arm64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-java-arm64
ghcr.io/openhands/agent-server:ca77d42-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ca77d42-python-amd64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-python-amd64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-python-amd64
ghcr.io/openhands/agent-server:ca77d42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ca77d42-python-arm64
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-python-arm64
ghcr.io/openhands/agent-server:fix-missing-tool-spans-python-arm64
ghcr.io/openhands/agent-server:ca77d42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ca77d42-golang
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-golang
ghcr.io/openhands/agent-server:fix-missing-tool-spans-golang
ghcr.io/openhands/agent-server:ca77d42-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ca77d42-java
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-java
ghcr.io/openhands/agent-server:fix-missing-tool-spans-java
ghcr.io/openhands/agent-server:ca77d42-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ca77d42-python
ghcr.io/openhands/agent-server:ca77d42f2a4389caeae2da64f30769b5aacc5ad6-python
ghcr.io/openhands/agent-server:fix-missing-tool-spans-python
ghcr.io/openhands/agent-server:ca77d42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ca77d42-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ca77d42-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->