### PR TITLE
docs(examples): add runnable structured output example

### DIFF
--- a/examples/01_standalone_sdk/56_structured_output.py
+++ b/examples/01_standalone_sdk/56_structured_output.py
@@ -1,0 +1,112 @@
+"""Structured output via ``response_schema``.
+
+Attach a Pydantic model to *any* tool spec and the agent must populate those
+fields when calling that tool. The schema is sent to the LLM as the tool's
+JSON-schema parameters and validated on receipt.
+
+Demonstrated here on two tools:
+  - ``TerminalTool`` (existing SDK tool) — every command must come with a
+    ``purpose`` and ``expected_outcome``, on top of the tool's own ``command``
+    field. No subclassing required: the schema is merged in via the spec.
+  - ``FinishTool`` (built-in) — the final answer comes back as a typed object.
+"""
+
+import os
+from typing import cast
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.tool.builtins.finish import FinishTool
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+
+# --- Structured-output schemas ------------------------------------------------
+
+
+class CommandRationale(BaseModel):
+    """Forced-annotation schema attached to TerminalTool."""
+
+    purpose: str = Field(description="Why this command is being run, in one line.")
+    expected_outcome: str = Field(
+        description="What the assistant expects to observe from running it."
+    )
+
+
+class ProjectFacts(BaseModel):
+    # NOTE: ``kind``, ``security_risk``, ``structured_output`` and ``summary``
+    # are reserved, as are the tool's own field names; using one raises at
+    # resolution time.
+    description: str = Field(description="One-paragraph description of the project.")
+    facts: list[str] = Field(description="Three concise, distinct facts.")
+
+
+# Register FinishTool so we can attach a response_schema via Tool spec.
+register_tool("FinishTool", FinishTool)
+
+
+# --- Agent setup --------------------------------------------------------------
+
+
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    api_key=os.getenv("LLM_API_KEY"),
+    base_url=os.getenv("LLM_BASE_URL", None),
+)
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        # Existing tool, augmented with a forced-annotation schema:
+        Tool(name=TerminalTool.name, params={"response_schema": CommandRationale}),
+        Tool(name=FileEditorTool.name),
+        Tool(name="FinishTool", params={"response_schema": ProjectFacts}),
+    ],
+    # Skip the auto-injected default FinishTool so our schema-bound one is used.
+    include_default_tools=["ThinkTool"],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message(
+    "Inspect the repo using terminal commands, then finish with three facts "
+    "about the project."
+)
+conversation.run()
+
+
+# --- Recover typed outputs from any tool with a response_schema ---------------
+
+events = conversation.state.events
+terminal_tool = agent.tools_map[TerminalTool.name]
+finish_tool = agent.tools_map["finish"]
+
+# Every TerminalTool call now carries our annotation fields. Walk all events to
+# show that the LLM populated them on every invocation.
+print("\n[Terminal commands with rationale]")
+
+for event in events:
+    if (
+        isinstance(event, ActionEvent)
+        and event.tool_name == TerminalTool.name
+        and event.action is not None
+    ):
+        rationale = cast(CommandRationale, terminal_tool.parse_response(event.action))
+        # action.command is the tool's own field; rationale.* came from the schema.
+        print(f"  $ {getattr(event.action, 'command', '?')}")
+        print(f"    purpose:          {rationale.purpose}")
+        print(f"    expected_outcome: {rationale.expected_outcome}")
+
+# And the typed final answer:
+facts = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
+if facts:
+    print("\n[Finish]")
+    print(f"  description: {facts.description}")
+    for fact in facts.facts:
+        print(f"  - {fact}")
+
+# Report cost
+cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
+print(f"\nEXAMPLE_COST: {cost}")


### PR DESCRIPTION
HUMAN:
Added example code for https://github.com/OpenHands/software-agent-sdk/pull/4207

Referenced by the structured output guide in OpenHands/docs#695.

---

AGENT:

## Why

#4207 landed `response_schema` but shipped without a runnable example — the one
written for it was deferred out of the PR to unblock the docs-example CI gate.
The docs guide for the feature (OpenHands/docs#695) needs it: the other SDK
guides all embed a synced `examples/...` block, and @VascoSch92 asked for the
same treatment there.

## Summary

Adds `examples/01_standalone_sdk/56_structured_output.py`, restored from the
deferred version and updated for the merged API. It demonstrates both halves of
the feature on one run:

- **`TerminalTool` with a schema** — every command must carry a `purpose` and
  an `expected_outcome` on top of the tool's own `command` field, showing that
  a schema can force per-call annotations on an existing tool with no
  subclassing.
- **`FinishTool` with a schema** — the final answer comes back as a typed
  `ProjectFacts` object, read via `parse_last_response()`.

It also shows reading a specific call with `parse_response(event.action)` while
walking the event stream.

## Issue Number

Relates to #2566, follows up #4207. Docs counterpart: OpenHands/docs#695

## How to Test

```bash
export LLM_MODEL="gemini/gemini-2.5-flash"   # or any model you have a key for
export LLM_API_KEY="..."
uv run python examples/01_standalone_sdk/56_structured_output.py
```

The run should print a rationale for each terminal command and a typed final
answer. `ruff check` / `ruff format` are clean and the file's imports and API
calls were verified against current `main`.

## Video/Screenshots

<!-- Incolla qui l'output della tua run. -->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The example is numbered `56_` (55 was the highest in use). The docs guide
already references this path; `sync_code_blocks.py` only warns when the file is
missing, so OpenHands/docs#695 is not blocked by merge order — once this lands,
the sync workflow fills in the code block.
