### PR TITLE
feat(sdk): register Pi as a built-in ACP provider

### DIFF
--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -31,14 +31,32 @@ describe('ACP provider credential descriptors', () => {
     }
   });
 
-  it.each<[ACPProviderKey, string, string]>([
+  it.each<[ACPProviderKey, string, string | null]>([
     ['claude-code', 'ANTHROPIC_API_KEY', 'ANTHROPIC_BASE_URL'],
     ['codex', 'OPENAI_API_KEY', 'OPENAI_BASE_URL'],
     ['gemini-cli', 'GEMINI_API_KEY', 'GEMINI_BASE_URL'],
+    // pi reads a provider key out of the environment but resolves base URLs
+    // from its own catalogue, so it has no base-URL override var.
+    ['pi', 'ANTHROPIC_API_KEY', null],
   ])('%s declares its api_key/base_url env vars', (key, apiKeyEnvVar, baseUrlEnvVar) => {
     const provider = ACP_PROVIDERS[key];
     expect(provider.api_key_env_var).toBe(apiKeyEnvVar);
     expect(provider.base_url_env_var).toBe(baseUrlEnvVar);
+  });
+
+  it('pi pins both the ACP adapter and the engine it spawns', () => {
+    const pi = ACP_PROVIDERS.pi;
+    expect(pi.default_command).toEqual([
+      'npx',
+      '-y',
+      '--prefer-offline',
+      '--package=pi-acp@0.0.33',
+      '--package=@earendil-works/pi-coding-agent@0.83.0',
+      'pi-acp',
+    ]);
+    // pi-acp maps ACP modes onto pi's thinking levels, so there is no
+    // permission-suppressing mode to set at session start.
+    expect(pi.default_session_mode).toBeNull();
   });
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {
@@ -67,6 +85,17 @@ describe('ACP provider credential descriptors', () => {
         secret_name: 'CODEX_AUTH_JSON',
         filename: 'auth.json',
         env_var: 'CODEX_HOME',
+      });
+    });
+
+    it('pi declares its auth.json credential file secret', () => {
+      const fileSecrets = ACP_PROVIDERS['pi'].file_secrets;
+      expect(fileSecrets).toHaveLength(1);
+      expect(fileSecrets[0]).toMatchObject({
+        secret_name: 'PI_AUTH_JSON',
+        filename: 'auth.json',
+        env_var: 'PI_CODING_AGENT_DIR',
+        env_points_to: 'dir',
       });
     });
 

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -205,5 +205,62 @@
     "session_meta_key": null,
     "supports_runtime_model_switch": true,
     "supports_set_session_model": true
+  },
+  "pi": {
+    "agent_name_patterns": [
+      "pi-acp"
+    ],
+    "api_key_env_var": "ANTHROPIC_API_KEY",
+    "available_models": [
+      {
+        "id": "anthropic/claude-opus-5",
+        "label": "Claude Opus 5"
+      },
+      {
+        "id": "anthropic/claude-opus-4-8",
+        "label": "Claude Opus 4.8"
+      },
+      {
+        "id": "anthropic/claude-sonnet-5",
+        "label": "Claude Sonnet 5"
+      },
+      {
+        "id": "anthropic/claude-sonnet-4-6",
+        "label": "Claude Sonnet 4.6"
+      },
+      {
+        "id": "anthropic/claude-haiku-4-5",
+        "label": "Claude Haiku 4.5"
+      }
+    ],
+    "base_url_env_var": null,
+    "binary_name": "pi-acp",
+    "data_dir_env_var": "HOME",
+    "default_command": [
+      "npx",
+      "-y",
+      "--prefer-offline",
+      "--package=pi-acp@0.0.33",
+      "--package=@earendil-works/pi-coding-agent@0.83.0",
+      "pi-acp"
+    ],
+    "default_model": null,
+    "default_session_mode": null,
+    "display_name": "Pi",
+    "env_conflicts": [],
+    "file_secrets": [
+      {
+        "env_points_to": "dir",
+        "env_var": "PI_CODING_AGENT_DIR",
+        "filename": "auth.json",
+        "secret_name": "PI_AUTH_JSON",
+        "subdir": "pi",
+        "warn_if_unset": []
+      }
+    ],
+    "key": "pi",
+    "session_meta_key": null,
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
   }
 }

--- a/clients/typescript/src/models/acp.ts
+++ b/clients/typescript/src/models/acp.ts
@@ -85,8 +85,8 @@ export interface ACPProviderInfo {
   /** `null` if the provider does not support env-based base-URL override. */
   readonly base_url_env_var: string | null;
   /**
-   * ACP session-mode ID that suppresses all permission prompts, or `null` when
-   * the server exposes no permission mode to set.
+   * ACP session-mode ID that suppresses all permission prompts, or `null` for a
+   * server that exposes no such mode (pi-acp maps modes onto thinking levels).
    */
   readonly default_session_mode: string | null;
   /** Lowercase substring fragments matched against the runtime agent name. */

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -182,12 +182,13 @@ RUN set -ux; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
             @agentclientprotocol/claude-agent-acp@0.63.0 \
             @agentclientprotocol/codex-acp@1.1.7 \
-            @google/gemini-cli@0.46.0; then \
+            @google/gemini-cli@0.46.0 \
+            pi-acp@0.0.33; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves
           # to Node 22, while the repo's own node (NVM/system) stays untouched
           # for tests.
-          for bin in claude-agent-acp codex-acp gemini; do \
+          for bin in claude-agent-acp codex-acp gemini pi-acp; do \
             if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
               printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
                 "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -183,12 +183,13 @@ RUN set -ux; \
             @agentclientprotocol/claude-agent-acp@0.63.0 \
             @agentclientprotocol/codex-acp@1.1.7 \
             @google/gemini-cli@0.46.0 \
-            pi-acp@0.0.33; then \
+            pi-acp@0.0.33 \
+            @earendil-works/pi-coding-agent@0.83.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves
           # to Node 22, while the repo's own node (NVM/system) stays untouched
           # for tests.
-          for bin in claude-agent-acp codex-acp gemini pi-acp; do \
+          for bin in claude-agent-acp codex-acp gemini pi-acp pi; do \
             if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
               printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
                 "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -150,7 +150,7 @@ RUN set -eux; \
     mkdir -p /workspace/project; \
     chown -R "${USERNAME}:${USERNAME}" /workspace
 
-# Pre-install ACP servers for ACPAgent support (Claude Code, Codex, Gemini CLI)
+# Pre-install ACP servers for ACPAgent support (Claude Code, Codex, Gemini CLI, Pi)
 # Install Node.js 22 to a dedicated prefix so ACP packages get a modern runtime
 # WITHOUT overwriting the repo-specific Node.js that test suites depend on.
 # SWE-bench images ship NVM/apt-managed Node 8-14 which cannot run ACP packages.
@@ -166,15 +166,15 @@ RUN set -ux; \
     NARCH=""; \
     NODE_SHA256=""; \
     case "$ARCH" in \
-      x86_64|amd64) NARCH=x64; NODE_SHA256=69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec;; \
-      aarch64|arm64) NARCH=arm64; NODE_SHA256=08bfbf538bad0e8cbb0269f0173cca28d705874a67a22f60b57d99dc99e30050;; \
+      x86_64|amd64) NARCH=x64; NODE_SHA256=c0649af18e6a24f6fe5535a3e86b341dd49a8e71117c8b68bde973ef834f16f2;; \
+      aarch64|arm64) NARCH=arm64; NODE_SHA256=0b2d9f564b6594222a62c82e1df2efe119dd4a4aff29644f4dd325bf360b6bcc;; \
     esac; \
     NODE_TARBALL=""; \
     if [ -z "$NARCH" ]; then \
       echo "Skipping ACP Node install: unsupported architecture '$ARCH'" >&2; \
     else \
-      NODE_TARBALL="/tmp/node-v22.14.0-linux-${NARCH}.tar.xz"; \
-      if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-${NARCH}.tar.xz" -o "$NODE_TARBALL" \
+      NODE_TARBALL="/tmp/node-v22.19.0-linux-${NARCH}.tar.xz"; \
+      if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "https://nodejs.org/dist/v22.19.0/node-v22.19.0-linux-${NARCH}.tar.xz" -o "$NODE_TARBALL" \
          && echo "$NODE_SHA256  $NODE_TARBALL" | sha256sum -c - \
          && tar -xJ --strip-components=1 -C "$ACP_NODE_DIR" -f "$NODE_TARBALL" \
          && "$ACP_NODE_DIR/bin/node" --version; then \
@@ -182,14 +182,12 @@ RUN set -ux; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
             @agentclientprotocol/claude-agent-acp@0.63.0 \
             @agentclientprotocol/codex-acp@1.1.7 \
-            @google/gemini-cli@0.46.0 \
-            pi-acp@0.0.33 \
-            @earendil-works/pi-coding-agent@0.83.0; then \
+            @google/gemini-cli@0.46.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves
           # to Node 22, while the repo's own node (NVM/system) stays untouched
           # for tests.
-          for bin in claude-agent-acp codex-acp gemini pi-acp pi; do \
+          for bin in claude-agent-acp codex-acp gemini; do \
             if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
               printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
                 "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \
@@ -197,6 +195,23 @@ RUN set -ux; \
               chmod +x /usr/local/bin/"$bin"; \
             fi; \
           done; \
+          # Separate best-effort installation for Pi
+          if "$ACP_NODE_DIR/bin/npm" install -g \
+              pi-acp@0.0.33 \
+              @earendil-works/pi-coding-agent@0.83.0; then \
+            for bin in pi-acp pi; do \
+              if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
+                printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
+                  "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \
+                  > /usr/local/bin/"$bin"; \
+                chmod +x /usr/local/bin/"$bin"; \
+              fi; \
+            done; \
+          else \
+            echo "Warning: Pi ACP npm install failed; Pi agent will not be available on this image" >&2; \
+            rm -f /usr/local/bin/pi-acp /usr/local/bin/pi 2>/dev/null || true; \
+            rm -rf "$ACP_NODE_DIR/lib/node_modules/pi-acp" "$ACP_NODE_DIR/lib/node_modules/@earendil-works" 2>/dev/null || true; \
+          fi; \
         else \
           echo "Warning: ACP npm install failed; ACP agents will not be available on this image" >&2; \
           rm -rf "$ACP_NODE_DIR"/*; \

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -349,6 +349,11 @@ def _auth_selection_failure_reason(auth_methods: list[Any], env: dict[str, str])
         env.get(name) for name in ("CODEX_API_KEY", "OPENAI_API_KEY")
     ):
         reasons.append("CODEX_API_KEY and OPENAI_API_KEY are unset")
+    if "pi_terminal_login" in method_ids:
+        reasons.append(
+            "PI_SETTINGS_JSON is missing; interactive pi_terminal_login "
+            "is unavailable in the headless runtime"
+        )
     return "; ".join(reasons) or "no supported credential source is available"
 
 
@@ -1082,6 +1087,18 @@ def _classify_acp_turn_error(exc: BaseException) -> str:
         return "ACPAuthRequired"
     return "ACPPromptError"
 
+def _has_preconfigured_terminal_auth(
+    auth_methods: list[Any],
+    env: dict[str, str],
+) -> bool:
+    """Return True when the server reports ``pi_terminal_login`` and we can see
+    a pre-existing ``$PI_CODING_AGENT_DIR/settings.json``.
+    """
+    method_ids = {method.id for method in auth_methods}
+    if "pi_terminal_login" not in method_ids:
+        return False
+    agent_dir = env.get("PI_CODING_AGENT_DIR")
+    return bool(agent_dir and (Path(agent_dir) / "settings.json").is_file())
 
 class _OpenHandsACPBridge:
     """Bridge between OpenHands and ACP that accumulates session updates.
@@ -1552,7 +1569,7 @@ class ACPAgent(AgentBase):
         default=None,
         description=(
             "Provider registry key identifying which ACP CLI this agent runs "
-            "('claude-code', 'codex', 'gemini-cli', or 'custom'); None when the "
+            "('claude-code', 'codex', 'gemini-cli', 'pi', or 'custom'); None when the "
             "agent is built directly rather than via ACPAgentSettings. Set by "
             "ACPAgentSettings.create_agent() from ACPAgentSettings.acp_server so "
             "the authoritative key survives onto the agent — and thus onto "
@@ -1573,6 +1590,7 @@ class ACPAgent(AgentBase):
             "If None (default), auto-detected from the ACP server type: "
             "'bypassPermissions' for claude-agent-acp, "
             "'agent-full-access' for codex-acp."
+            "providers without a required mode skip the protocol call."
         ),
     )
     acp_prompt_timeout: float = Field(
@@ -2353,6 +2371,7 @@ class ACPAgent(AgentBase):
 
         ``HOME`` (gemini-cli's only lever — it hard-codes ``~/.gemini`` and
         ignores ``XDG``) has a wider blast radius than the surgical
+        ``HOME`` Pi uses relocated HOME because pi-acp stores its session map under ~/.pi/pi-acp
         ``CODEX_HOME`` / ``CLAUDE_CONFIG_DIR``: it also relocates the home dir
         seen by anything the CLI subprocess itself spawns (``git``, ``npm``,
         ``node``, shells — e.g. ``~/.gitconfig``, ``~/.npmrc``, the npm cache).
@@ -2787,6 +2806,8 @@ class ACPAgent(AgentBase):
             # (e.g. codex-acp) require an explicit authenticate call
             # before session creation.  We auto-detect the method from
             # the env vars that are available to the process.
+            # If there are no env vars available, then we check if there is 
+            # a preconfigured terminal auth. (Pi-ACP)
             auth_methods = init_response.auth_methods or []
             if auth_methods:
                 method_id = _select_auth_method(auth_methods, env)
@@ -2829,7 +2850,7 @@ class ACPAgent(AgentBase):
                             "ChatGPT authentication needs to be refreshed."
                         ) from exc
                     await self._flush_file_credentials()
-                else:
+                elif not _has_preconfigured_terminal_auth(auth_methods, env):
                     _warn_auth_selection_failure(auth_methods, env)
 
             # Resume the prior ACP session if we have its id.  If the server

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -76,6 +76,7 @@ from openhands.sdk.agent.acp_file_credentials import (
     codex_auth_file,
     codex_auth_file_is_chatgpt,
     create_file_credential_lifecycle,
+    file_credential_looks_usable,
     write_secret_file,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
@@ -308,7 +309,16 @@ def _preconfigured_credentials(
         path = Path(location)
         if spec.env_points_to == "dir":
             path = path / spec.filename
-        if path.is_file():
+        if not path.is_file():
+            continue
+        # A file that exists but cannot authenticate is the case that most
+        # needs the warning, so presence alone is not enough where the SDK
+        # knows the format.
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        if file_credential_looks_usable(spec.secret_name, text):
             present.append(spec.secret_name)
     api_key_var = provider.api_key_env_var if provider is not None else None
     if api_key_var and env.get(api_key_var):
@@ -1676,8 +1686,8 @@ class ACPAgent(AgentBase):
         default=None,
         description=(
             "Provider registry key identifying which ACP CLI this agent runs "
-            "('claude-code', 'codex', 'gemini-cli', or 'custom'); None when the "
-            "agent is built directly rather than via ACPAgentSettings. Set by "
+            "('claude-code', 'codex', 'gemini-cli', 'pi', or 'custom'); None "
+            "when the agent is built directly rather than via ACPAgentSettings. Set by "
             "ACPAgentSettings.create_agent() from ACPAgentSettings.acp_server so "
             "the authoritative key survives onto the agent — and thus onto "
             "ConversationInfo.agent — because the launch command in acp_command "
@@ -1696,7 +1706,8 @@ class ACPAgent(AgentBase):
             "Session mode ID to set after creating a session. "
             "If None (default), auto-detected from the ACP server type: "
             "'bypassPermissions' for claude-agent-acp, "
-            "'agent-full-access' for codex-acp."
+            "'agent-full-access' for codex-acp; a provider with no such mode "
+            "(pi-acp) skips the call."
         ),
     )
     acp_prompt_timeout: float = Field(
@@ -2543,8 +2554,9 @@ class ACPAgent(AgentBase):
         ``ANTHROPIC_API_KEY`` — API-key Claude gets the same per-conversation
         isolation (and pause/resume continuity) as OAuth Claude (#3588).
 
-        ``HOME`` (gemini-cli's only lever — it hard-codes ``~/.gemini`` and
-        ignores ``XDG``) has a wider blast radius than the surgical
+        ``HOME`` (the only lever for gemini-cli, which hard-codes ``~/.gemini``
+        and ignores ``XDG``, and for pi-acp, whose session map is hard-coded to
+        ``~/.pi/pi-acp``) has a wider blast radius than the surgical
         ``CODEX_HOME`` / ``CLAUDE_CONFIG_DIR``: it also relocates the home dir
         seen by anything the CLI subprocess itself spawns (``git``, ``npm``,
         ``node``, shells — e.g. ``~/.gitconfig``, ``~/.npmrc``, the npm cache).

--- a/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_file_credentials.py
@@ -515,3 +515,22 @@ _FILE_CREDENTIAL_LIFECYCLES = {
 
 def supports_file_credential_binding(secret_name: str) -> bool:
     return secret_name in _FILE_CREDENTIAL_LIFECYCLES
+
+
+_FILE_CREDENTIAL_VALIDATORS: dict[str, Callable[[str], bool]] = {
+    CODEX_AUTH_SECRET_NAME: is_valid_codex_auth,
+}
+
+
+def file_credential_looks_usable(secret_name: str, text: str) -> bool:
+    """Whether a materialised credential file is plausibly usable.
+
+    Only a *present* file can be checked here, and only for the few secrets the
+    SDK knows the shape of. An unrecognised secret gets the benefit of the
+    doubt: the CLI owns the format, and refusing to believe a credential we
+    cannot parse would warn on every provider we have not special-cased —
+    which is the noise this is meant to avoid. Returning ``True`` for unknown
+    names keeps that judgement with the provider.
+    """
+    validator = _FILE_CREDENTIAL_VALIDATORS.get(secret_name)
+    return True if validator is None else validator(text)

--- a/openhands-sdk/openhands/sdk/agent/acp_tracing.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_tracing.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 
 #: Marks a span as produced by an ACP agent rather than the native loop.
 AGENT_KIND_METADATA_KEY = "agent_kind"
-#: Which ACP CLI produced it ('claude-code', 'codex', 'gemini-cli', 'custom').
+#: Which ACP CLI produced it ('claude-code', 'codex', 'gemini-cli', 'pi', 'custom').
 ACP_SERVER_METADATA_KEY = "acp_server"
 #: Model the ACP CLI reported for the turn, when it reports one.
 ACP_MODEL_METADATA_KEY = "acp_model"

--- a/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
@@ -107,6 +107,11 @@ CODEX_ACP_VERSION = "1.1.7"
 GEMINI_CLI_VERSION = "0.46.0"
 KIMI_CODE_VERSION = "0.38.0"
 
+# Pi is the one provider with two independent pins: pi-acp only adapts ACP and
+# spawns a separately installed `pi` engine off PATH.
+PI_ACP_VERSION = "0.0.33"
+PI_CODING_AGENT_VERSION = "0.83.0"
+
 
 ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
     "claude-code": ACPInstallSpec(
@@ -137,6 +142,24 @@ ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
         binary_name="kimi",
         trailing_args=("acp",),
         # @moonshot-ai/kimi-code declares `node >=22.19.0`.
+        min_node_version="22.19.0",
+    ),
+    "pi": ACPInstallSpec(
+        key="pi",
+        # Adapter first: the live conformance probe compares ``packages[0]``'s
+        # version against the ``agentInfo.version`` the server reports, which
+        # is pi-acp's, not the engine's.
+        packages=(
+            ACPPackagePin("pi-acp", PI_ACP_VERSION),
+            ACPPackagePin("@earendil-works/pi-coding-agent", PI_CODING_AGENT_VERSION),
+        ),
+        binary_name="pi-acp",
+        # @earendil-works/pi-coding-agent (and its undici dependency) declare
+        # `node >=22.19.0`. Below it the pi-acp adapter still starts, so the
+        # ACP handshake succeeds and the failure only lands at `session/new`
+        # as "Cannot call write after a stream was destroyed" — the engine
+        # having already died on `webidl.util.markAsUncloneable is not a
+        # function`.
         min_node_version="22.19.0",
     ),
 }

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -36,7 +36,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from types import MappingProxyType
-from typing import Any, Literal
+from typing import Any, Literal, Final
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -394,10 +394,10 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
-CLAUDE_AGENT_ACP_VERSION = "0.63.0"
-CODEX_ACP_VERSION = "1.1.7"
-GEMINI_CLI_VERSION = "0.46.0"
-PI_ACP_VERSION = "0.0.33"
+CLAUDE_AGENT_ACP_VERSION: Final[str] = "0.63.0"
+CODEX_ACP_VERSION: Final[str] = "1.1.7"
+GEMINI_CLI_VERSION: Final[str] = "0.46.0"
+PI_ACP_VERSION: Final[str] = "0.0.33"
 
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
@@ -495,8 +495,8 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             ),
             api_key_env_var=None,
             base_url_env_var=None,
-            default_session_mode="default",
-            agent_name_patterns=("pi-acp", "pi"),
+            default_session_mode="medium",
+            agent_name_patterns=("pi-acp",),
             supports_set_session_model=True,
             supports_runtime_model_switch=True,
             session_meta_key=None,

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -347,6 +347,10 @@ _GEMINI_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gemini-2.5-flash", label="Gemini 2.5 Flash"),
 )
 
+_PI_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="default", label="Default"),
+)
+
 
 # ---------------------------------------------------------------------------
 # Reserved file-content credential secrets for the built-in providers.
@@ -393,6 +397,7 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 CLAUDE_AGENT_ACP_VERSION = "0.63.0"
 CODEX_ACP_VERSION = "1.1.7"
 GEMINI_CLI_VERSION = "0.46.0"
+PI_ACP_VERSION = "0.0.33"
 
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
@@ -479,6 +484,26 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # Gemini CLI has no dedicated config-dir var; it hard-codes
             # ``~/.gemini`` (ignoring XDG), so only HOME relocates its state.
             data_dir_env_var="HOME",
+        ),
+        "pi": ACPProviderInfo(
+            key="pi",
+            display_name="Pi",
+            default_command=(
+                "npx",
+                "-y",
+                f"pi-acp@{PI_ACP_VERSION}",
+            ),
+            api_key_env_var=None,
+            base_url_env_var=None,
+            default_session_mode="default",
+            agent_name_patterns=("pi-acp", "pi"),
+            supports_set_session_model=True,
+            supports_runtime_model_switch=True,
+            session_meta_key=None,
+            available_models=_PI_MODELS,
+            default_model="default",
+            binary_name="pi-acp",
+            data_dir_env_var="PI_CODING_AGENT_DIR",
         ),
     }
 )

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -153,9 +153,11 @@ class ACPProviderInfo:
     ``None`` if the provider does not support env-based base-URL override.
     """
 
-    default_session_mode: str
+    default_session_mode: str | None
     """ACP session-mode ID set right after ``session/new``.
 
+    This is an optional provider-specific mode setting (which can be None),
+    rather than strictly a permission-suppressing toggle.
     For servers with a permission-suppressing mode that is the value:
     ``bypassPermissions`` (claude-agent-acp), ``agent-full-access``
     (@agentclientprotocol/codex-acp).
@@ -175,8 +177,7 @@ class ACPProviderInfo:
     """``True`` if this provider selects its *initial* model via the
     ``set_session_model`` protocol call (rather than session ``_meta``).
 
-    This governs the **session-creation** path only. ``True`` for all three
-    built-in providers, which get a one-shot ``set_session_model`` call right
+    This governs the **session-creation** path only. ``True`` for all built-in providers, which get a one-shot ``set_session_model`` call right
     after the session is created. claude-agent-acp was ``False`` until 0.30.0
     was found to silently ignore the session-``_meta`` selection it relied on
     (#3654); its ``_meta`` payload is still sent alongside (see
@@ -203,7 +204,7 @@ class ACPProviderInfo:
     :attr:`supports_runtime_model_switch`.
 
     - ``"claudeCode"`` — claude-agent-acp
-    - ``None``         — codex-acp, gemini-cli
+    - ``None``         — codex-acp, gemini-cli, pi-acp
     """
 
     available_models: tuple[ACPModelOption, ...] = field(default=(), compare=False)
@@ -228,9 +229,9 @@ class ACPProviderInfo:
     for **runtime, mid-conversation model switching**.
 
     The call applies to the live session, so subsequent turns use the new
-    model without restarting the subprocess or losing context. All three
-    built-in providers support it (verified against claude-agent-acp,
-    codex-acp, and gemini-cli).
+    model without restarting the subprocess or losing context. All built-in
+    providers support it (verified against claude-agent-acp, codex-acp,
+    gemini-cli, pi-acp).
 
     Unlike :attr:`supports_set_session_model`, this is about switching the
     model of an *already-running* session, not the initial selection. A
@@ -277,6 +278,8 @@ class ACPProviderInfo:
     - ``CLAUDE_CONFIG_DIR`` — claude-agent-acp (relocates ``~/.claude*``)
     - ``HOME``              — gemini-cli (no dedicated var; it hard-codes
       ``~/.gemini`` and ignores ``XDG``, so only ``HOME`` moves it)
+    - ``HOME``              — pi-acp keeps session/config state under
+      ``~/.pi/pi-acp`` (which requires ``HOME`` to relocate).
 
     ``None`` for providers with no known relocation lever, which then skip
     isolation. Consumed by
@@ -347,9 +350,6 @@ _GEMINI_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gemini-2.5-flash", label="Gemini 2.5 Flash"),
 )
 
-_PI_MODELS: tuple[ACPModelOption, ...] = (
-    ACPModelOption(id="default", label="Default"),
-)
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +360,8 @@ _PI_MODELS: tuple[ACPModelOption, ...] = (
 # storage). Gemini's Vertex AI service-account JSON is pointed at directly by
 # ``GOOGLE_APPLICATION_CREDENTIALS``; Vertex also needs a project/location, so
 # warn when those are unset.
+# Pi's authentication is handled by ``PI_SETTINGS_JSON``
+
 # ---------------------------------------------------------------------------
 _CODEX_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
     ACPFileSecretSpec(
@@ -380,6 +382,15 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
         warn_if_unset=("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"),
     ),
 )
+_PI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
+    ACPFileSecretSpec(
+        secret_name="PI_SETTINGS_JSON",
+        filename="settings.json",
+        env_var="PI_CODING_AGENT_DIR",
+        subdir="pi",
+        env_points_to="dir",
+    ),
+)
 
 
 # Pinned npm versions for the built-in ACP launchers. Keep in sync with the
@@ -394,10 +405,14 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
+# Pi requires two separate pins: PI_ACP_VERSION for the ACP adapter launcher
+# (pi-acp) and PI_CODING_AGENT_VERSION for the underlying CLI engine
+# (@earendil-works/pi-coding-agent).
 CLAUDE_AGENT_ACP_VERSION: Final[str] = "0.63.0"
 CODEX_ACP_VERSION: Final[str] = "1.1.7"
 GEMINI_CLI_VERSION: Final[str] = "0.46.0"
 PI_ACP_VERSION: Final[str] = "0.0.33"
+PI_CODING_AGENT_VERSION: Final[str] = "0.83.0"
 
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
@@ -491,19 +506,24 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             default_command=(
                 "npx",
                 "-y",
-                f"pi-acp@{PI_ACP_VERSION}",
+                f"--package=pi-acp@{PI_ACP_VERSION}",
+                f"--package=@earendil-works/pi-coding-agent@{PI_CODING_AGENT_VERSION}",
+                "pi-acp",
             ),
             api_key_env_var=None,
             base_url_env_var=None,
-            default_session_mode="medium",
+            default_session_mode=None,
             agent_name_patterns=("pi-acp",),
             supports_set_session_model=True,
             supports_runtime_model_switch=True,
             session_meta_key=None,
-            available_models=_PI_MODELS,
-            default_model="default",
+            # Pi-acp exposes model switching thorugh its ACP config/model methods. Tests should verify this
+            available_models=(),
+            default_model=None,
+            file_secrets=_PI_FILE_SECRETS,
             binary_name="pi-acp",
-            data_dir_env_var="PI_CODING_AGENT_DIR",
+            # pi-acp's session map remains under ~/.pi/pi-acp. Relocating HOME isolates both.
+            data_dir_env_var="HOME",
         ),
     }
 )
@@ -550,7 +570,7 @@ def detect_acp_provider_by_command(
     """Identify a provider from its launch ``command``, before the subprocess runs.
 
     Each provider's :attr:`~ACPProviderInfo.agent_name_patterns` fragments
-    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``) are prefixes of its
+    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``, ``"pi-acp"``) are prefixes of its
     npm-package / binary basename, so we can pick the provider *before* the server
     starts and reports its name (when the subprocess environment, e.g. a relocated
     data dir, must already be set).
@@ -560,7 +580,7 @@ def detect_acp_provider_by_command(
     *caller-controlled*: each token is reduced to its basename (last path segment,
     minus a trailing ``@version`` pin) and a provider matches only when that
     basename *starts with* one of its patterns. This accepts the real forms —
-    ``@agentclientprotocol/codex-acp``, ``@google/gemini-cli@0.46.0``,
+    ``@agentclientprotocol/codex-acp``, ``@google/gemini-cli@0.46.0``, ``--package=pi-acp@0.0.33``,
     ``/opt/node_modules/.bin/codex-acp`` — while rejecting incidental substrings
     like ``my-codex-acp-wrapper`` or ``/opt/shims/not-codex-acp`` that a plain
     substring test would misattribute.

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -36,7 +36,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from types import MappingProxyType
-from typing import Any, Literal, Final
+from typing import Any, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -198,8 +198,9 @@ class ACPProviderInfo:
     (@agentclientprotocol/codex-acp).
     gemini-cli uses ``default`` (its ``yolo`` mode errors at init); the ACP
     bridge auto-approves permission requests, so the mode doesn't gate prompts.
-    ``None`` for a server that exposes no permission mode at all — sending one
-    would fail session init to no purpose.
+    ``None`` for a server that exposes no permission mode at all: pi-acp maps
+    ACP modes onto pi's thinking levels (``off``..``xhigh``) and rejects any
+    other id, so sending one would fail session init to no purpose.
     """
 
     agent_name_patterns: tuple[str, ...]
@@ -214,8 +215,8 @@ class ACPProviderInfo:
     """``True`` if this provider selects its *initial* model via the
     ``set_session_model`` protocol call (rather than session ``_meta``).
 
-    This governs the **session-creation** path only. ``True`` for all three
-    built-in providers, which get a one-shot ``set_session_model`` call right
+    This governs the **session-creation** path only. ``True`` for every
+    built-in provider, which gets a one-shot ``set_session_model`` call right
     after the session is created. claude-agent-acp was ``False`` until 0.30.0
     was found to silently ignore the session-``_meta`` selection it relied on
     (#3654); its ``_meta`` payload is still sent alongside (see
@@ -242,7 +243,7 @@ class ACPProviderInfo:
     :attr:`supports_runtime_model_switch`.
 
     - ``"claudeCode"`` — claude-agent-acp
-    - ``None``         — codex-acp, gemini-cli
+    - ``None``         — codex-acp, gemini-cli, pi-acp
     """
 
     available_models: tuple[ACPModelOption, ...] = field(default=(), compare=False)
@@ -267,9 +268,9 @@ class ACPProviderInfo:
     for **runtime, mid-conversation model switching**.
 
     The call applies to the live session, so subsequent turns use the new
-    model without restarting the subprocess or losing context. All three
-    built-in providers support it (verified against claude-agent-acp,
-    codex-acp, and gemini-cli).
+    model without restarting the subprocess or losing context. Every built-in
+    provider supports it (verified against claude-agent-acp, codex-acp,
+    gemini-cli and pi-acp).
 
     Unlike :attr:`supports_set_session_model`, this is about switching the
     model of an *already-running* session, not the initial selection. A
@@ -316,6 +317,9 @@ class ACPProviderInfo:
     - ``CLAUDE_CONFIG_DIR`` — claude-agent-acp (relocates ``~/.claude*``)
     - ``HOME``              — gemini-cli (no dedicated var; it hard-codes
       ``~/.gemini`` and ignores ``XDG``, so only ``HOME`` moves it)
+    - ``HOME``              — pi-acp (its session map is hard-coded to
+      ``~/.pi/pi-acp``; ``PI_CODING_AGENT_DIR`` moves pi's own config dir but
+      not the adapter's, so only ``HOME`` relocates both)
 
     ``None`` for providers with no known relocation lever, which then skip
     isolation. Consumed by
@@ -396,6 +400,20 @@ _GEMINI_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gemini-2.5-flash", label="Gemini 2.5 Flash"),
 )
 
+# Pi model ids are ``<pi-provider>/<model-id>`` and the live catalogue depends on
+# which upstream credential is configured — pi surfaces only providers it can
+# authenticate. These mirror the Anthropic entries pi reports at ``session/new``
+# under ``ANTHROPIC_API_KEY`` (the credential channel ``api_key_env_var``
+# provisions); an ``acp_model`` outside the list, e.g. ``openai/gpt-5.5`` on an
+# OpenAI key, is still accepted.
+_PI_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="anthropic/claude-opus-5", label="Claude Opus 5"),
+    ACPModelOption(id="anthropic/claude-opus-4-8", label="Claude Opus 4.8"),
+    ACPModelOption(id="anthropic/claude-sonnet-5", label="Claude Sonnet 5"),
+    ACPModelOption(id="anthropic/claude-sonnet-4-6", label="Claude Sonnet 4.6"),
+    ACPModelOption(id="anthropic/claude-haiku-4-5", label="Claude Haiku 4.5"),
+)
+
 
 # ---------------------------------------------------------------------------
 # Reserved file-content credential secrets for the built-in providers.
@@ -404,7 +422,9 @@ _GEMINI_MODELS: tuple[ACPModelOption, ...] = (
 # is rewritten in place on token refresh, so it must live on durable, writable
 # storage). Gemini's Vertex AI service-account JSON is pointed at directly by
 # ``GOOGLE_APPLICATION_CREDENTIALS``; Vertex also needs a project/location, so
-# warn when those are unset.
+# warn when those are unset. Pi reads its credentials from ``auth.json`` under
+# ``PI_CODING_AGENT_DIR`` (``settings.json`` in the same directory holds model
+# and UI preferences and does not authenticate).
 # ---------------------------------------------------------------------------
 _CODEX_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
     ACPFileSecretSpec(
@@ -436,6 +456,15 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
         subdir="gemini-cli",
         env_points_to="file",
         warn_if_unset=("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"),
+    ),
+)
+_PI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
+    ACPFileSecretSpec(
+        secret_name="PI_AUTH_JSON",
+        filename="auth.json",
+        env_var="PI_CODING_AGENT_DIR",
+        subdir="pi",
+        env_points_to="dir",
     ),
 )
 
@@ -576,6 +605,33 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # ``KIMI_CODE_HOME`` relocates the ``~/.kimi-code`` data root.
             data_dir_env_var="KIMI_CODE_HOME",
         ),
+        "pi": ACPProviderInfo(
+            key="pi",
+            display_name="Pi",
+            # Two packages, so the catalog emits the ``--package=`` form with
+            # ``pi-acp`` as the positional npx runs — which is also the only
+            # token ``_prefer_pinned_binary`` and
+            # ``detect_acp_provider_by_command`` can match on.
+            default_command=ACP_INSTALL_CATALOG["pi"].npx_command(),
+            api_key_env_var="ANTHROPIC_API_KEY",
+            # pi resolves each provider's base URL from its own catalogue;
+            # ANTHROPIC_BASE_URL reaches only the vendored Anthropic SDK, which
+            # pi overrides. Redirecting it needs models.json or an extension.
+            base_url_env_var=None,
+            default_session_mode=None,
+            agent_name_patterns=("pi-acp",),
+            supports_set_session_model=True,
+            supports_runtime_model_switch=True,
+            session_meta_key=None,
+            available_models=_PI_MODELS,
+            # pi preselects a model from whichever catalogue the configured
+            # credential unlocks, so there is no id that is right for every
+            # account — leave the choice to the server.
+            default_model=None,
+            file_secrets=_PI_FILE_SECRETS,
+            binary_name=ACP_INSTALL_CATALOG["pi"].binary_name,
+            data_dir_env_var="HOME",
+        ),
     }
 )
 """Read-only registry of built-in ACP providers keyed by ``acp_server`` value."""
@@ -621,10 +677,10 @@ def detect_acp_provider_by_command(
     """Identify a provider from its launch ``command``, before the subprocess runs.
 
     Each provider's :attr:`~ACPProviderInfo.agent_name_patterns` fragments
-    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``) are prefixes of its
-    npm-package / binary basename, so we can pick the provider *before* the server
-    starts and reports its name (when the subprocess environment, e.g. a relocated
-    data dir, must already be set).
+    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``, ``"pi-acp"``) are
+    prefixes of its npm-package / binary basename, so we can pick the provider
+    *before* the server starts and reports its name (when the subprocess
+    environment, e.g. a relocated data dir, must already be set).
 
     Matching is deliberately stricter than
     :func:`detect_acp_provider_by_agent_name` because the launch command is

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1148,7 +1148,7 @@ class ConversationSettings(BaseModel):
 
 AgentKind = Literal["openhands", "llm", "acp"]
 
-ACPServerKind = Literal["claude-code", "codex", "gemini-cli", "custom"]
+ACPServerKind = Literal["claude-code", "codex", "gemini-cli", "pi", "custom"]
 """Known ACP backend servers the GUI can pick from.
 
 ``custom`` means the user supplies the raw ``acp_command`` themselves;

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1202,7 +1202,9 @@ class ConversationSettings(BaseModel):
 
 AgentKind = Literal["openhands", "llm", "acp"]
 
-ACPServerKind = Literal["claude-code", "codex", "gemini-cli", "kimi-code", "custom"]
+ACPServerKind = Literal[
+    "claude-code", "codex", "gemini-cli", "kimi-code", "pi", "custom"
+]
 """Known ACP backend servers the GUI can pick from.
 
 ``custom`` means the user supplies the raw ``acp_command`` themselves;

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5215,6 +5215,25 @@ class TestMaybeSetSessionModel:
         )
         assert conn.set_config_option.await_count == 2
         assert applied is True
+    
+    @pytest.mark.asyncio
+    async def test_pi_model_switch_mechanism(self):
+        """Pi-acp uses set_config_option(config_id='model') for model switches."""
+        conn = AsyncMock()
+        applied = await _maybe_set_session_model(
+            conn,
+            "pi-acp",
+            "session-1",
+            "anthropic/claude-sonnet-4-5",
+            via_config_option=True,
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="model",
+            value="anthropic/claude-sonnet-4-5",
+            session_id="session-1",
+        )
+        assert applied is True
+
 
     @pytest.mark.asyncio
     async def test_missing_model_skips_protocol_override(self):
@@ -8759,6 +8778,68 @@ class TestACPFileSecretMaterialisation:
         assert gac.parent.stat().st_mode & 0o777 == 0o700
         assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
 
+    def test_pi_settings_json_materialization(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {
+                "PI_SETTINGS_JSON": StaticSecret(
+                    value=SecretStr('{"model": "claude-3-5-sonnet"}')
+                )
+            }
+        )
+        env = self._run_start(
+            agent, state, conn=self._make_conn(agent_name="pi-acp", auth_method="pi_terminal_login")
+        )
+        settings_file = Path(persist) / "acp" / "pi" / "settings.json"
+        assert Path(env["PI_CODING_AGENT_DIR"]) == Path(persist) / "acp" / "pi"
+        assert settings_file.read_text(encoding="utf-8") == '{"model": "claude-3-5-sonnet"}'
+        assert settings_file.stat().st_mode & 0o777 == 0o600
+
+    def test_pi_terminal_login_with_materialized_settings(self, tmp_path):
+        """When settings.json is present, pi_terminal_login is accepted without calling authenticate()."""
+        from openhands.sdk.secret import StaticSecret
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"PI_SETTINGS_JSON": StaticSecret(value=SecretStr('{"key": "val"}'))}
+        )
+
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+        )
+        with patch("openhands.sdk.agent.acp_agent._warn_auth_selection_failure") as mock_warn:
+            self._run_start(agent, state, conn=conn)
+            conn.authenticate.assert_not_called()
+            mock_warn.assert_not_called()
+            conn.new_session.assert_called_once()
+
+    def test_pi_terminal_login_without_settings(self, tmp_path):
+        """When settings.json is missing, interactive auth is skipped and a warning mentions PI_SETTINGS_JSON."""
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+        )
+        with patch("openhands.sdk.agent.acp_agent._warn_auth_selection_failure") as mock_warn:
+            self._run_start(agent, state, conn=conn)
+            conn.authenticate.assert_not_called()
+            mock_warn.assert_called_once()
+
+    def test_pi_initialization_skips_set_session_mode(self, tmp_path):
+        """Pi has default_session_mode=None, so set_session_mode is not called."""
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        conn = self._make_conn(agent_name="pi-acp", auth_method="pi_terminal_login")
+        self._run_start(agent, state, conn=conn)
+        conn.set_session_mode.assert_not_called()
+
+
     def test_seed_if_absent_does_not_clobber_existing_file(self, tmp_path):
         """A non-empty existing credential file (e.g. a token the CLI refreshed)
         is preserved; the stale pasted blob does not overwrite it."""
@@ -9165,14 +9246,30 @@ class TestACPDataDirIsolation:
         assert Path(env["CLAUDE_CONFIG_DIR"]) == Path(persist) / "acp" / "claude-code"
 
     def test_pi_isolates_data_dir(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
         agent = self._agent(["npx", "-y", "pi-acp"])
         state = self._H._state(tmp_path)
         persist = state.persistence_dir
         assert persist is not None
+
+        # Base HOME isolation test (without secret, PI_CODING_AGENT_DIR is not set)
         with patch.dict("os.environ", {}, clear=True):
             env = self._H._run_start(
                 agent, state, conn=self._H._make_conn(agent_name="pi-acp")
             )
+        assert Path(env["HOME"]) == Path(persist) / "acp" / "pi"
+        assert "PI_CODING_AGENT_DIR" not in env
+
+        # Isolation when PI_SETTINGS_JSON secret is supplied
+        state.secret_registry.update_secrets(
+            {"PI_SETTINGS_JSON": StaticSecret(value=SecretStr("{}"))}
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="pi-acp")
+            )
+        assert Path(env["HOME"]) == Path(persist) / "acp" / "pi"
         assert Path(env["PI_CODING_AGENT_DIR"]) == Path(persist) / "acp" / "pi"
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -9164,6 +9164,17 @@ class TestACPDataDirIsolation:
             )
         assert Path(env["CLAUDE_CONFIG_DIR"]) == Path(persist) / "acp" / "claude-code"
 
+    def test_pi_isolates_data_dir(self, tmp_path):
+        agent = self._agent(["npx", "-y", "pi-acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="pi-acp")
+            )
+        assert Path(env["PI_CODING_AGENT_DIR"]) == Path(persist) / "acp" / "pi"
+
 
 # ---------------------------------------------------------------------------
 # Secret masking (#1023)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5392,6 +5392,24 @@ class TestMaybeSetSessionModel:
         assert applied is True
 
     @pytest.mark.asyncio
+    async def test_pi_model_switch_mechanism(self):
+        """pi-acp applies the model through set_config_option(config_id='model')."""
+        conn = AsyncMock()
+        applied = await _maybe_set_session_model(
+            conn,
+            "pi-acp",
+            "session-1",
+            "anthropic/claude-sonnet-4-6",
+            via_config_option=True,
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="model",
+            value="anthropic/claude-sonnet-4-6",
+            session_id="session-1",
+        )
+        assert applied is True
+
+    @pytest.mark.asyncio
     async def test_missing_model_skips_protocol_override(self):
         conn = AsyncMock()
         applied = await _maybe_set_session_model(
@@ -8802,7 +8820,12 @@ class TestACPFileSecretMaterialisation:
     """
 
     @staticmethod
-    def _make_conn(*, agent_name: str = "codex-acp", auth_method: str | None = None):
+    def _make_conn(
+        *,
+        agent_name: str = "codex-acp",
+        auth_method: str | None = None,
+        auth_method_type: str | None = None,
+    ):
         conn = MagicMock()
         init_response = MagicMock()
         init_response.agent_info = MagicMock()
@@ -8812,6 +8835,7 @@ class TestACPFileSecretMaterialisation:
         # MagicMock(id=...) doesn't set .id; assign explicitly.
         for m in init_response.auth_methods:
             m.id = auth_method
+            m.type = auth_method_type
         conn.initialize = AsyncMock(return_value=init_response)
         new_response = MagicMock()
         new_response.session_id = "sess-new"
@@ -8967,6 +8991,143 @@ class TestACPFileSecretMaterialisation:
         assert gac.stat().st_mode & 0o777 == 0o600
         assert gac.parent.stat().st_mode & 0o777 == 0o700
         assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
+
+    def test_pi_auth_json_materialises_into_the_agent_config_dir(self, tmp_path):
+        """PI_AUTH_JSON lands as auth.json with PI_CODING_AGENT_DIR on the dir."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {
+                "PI_AUTH_JSON": StaticSecret(
+                    value=SecretStr('{"anthropic": {"type": "api_key", "key": "k"}}')
+                )
+            }
+        )
+
+        env = self._run_start(
+            agent,
+            state,
+            conn=self._make_conn(
+                agent_name="pi-acp",
+                auth_method="pi_terminal_login",
+                auth_method_type="terminal",
+            ),
+        )
+
+        auth_file = Path(persist) / "acp" / "pi" / "auth.json"
+        assert Path(env["PI_CODING_AGENT_DIR"]) == Path(persist) / "acp" / "pi"
+        assert (
+            auth_file.read_text(encoding="utf-8")
+            == '{"anthropic": {"type": "api_key", "key": "k"}}'
+        )
+        assert auth_file.stat().st_mode & 0o777 == 0o600
+        assert "PI_AUTH_JSON" not in env
+
+    def test_terminal_only_auth_with_seeded_file_does_not_warn(self, tmp_path):
+        """pi-acp offers only an interactive login; a seeded auth.json is the
+        credential, so startup must not call authenticate() or warn."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"PI_AUTH_JSON": StaticSecret(value=SecretStr('{"anthropic": {}}'))}
+        )
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+            auth_method_type="terminal",
+        )
+
+        with patch(
+            "openhands.sdk.agent.acp_agent._warn_auth_selection_failure"
+        ) as mock_warn:
+            self._run_start(agent, state, conn=conn)
+
+        conn.authenticate.assert_not_called()
+        mock_warn.assert_not_called()
+        conn.new_session.assert_called_once()
+
+    def test_terminal_only_auth_with_the_provider_api_key_does_not_warn(self, tmp_path):
+        """pi authenticates from ANTHROPIC_API_KEY in its own environment even
+        though the server advertises only an interactive login, so the
+        no-credential warning would fire on a working configuration."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-ant-test"))}
+        )
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+            auth_method_type="terminal",
+        )
+
+        with patch(
+            "openhands.sdk.agent.acp_agent._warn_auth_selection_failure"
+        ) as mock_warn:
+            env = self._run_start(agent, state, conn=conn)
+
+        assert env["ANTHROPIC_API_KEY"] == "sk-ant-test"
+        conn.authenticate.assert_not_called()
+        mock_warn.assert_not_called()
+        conn.new_session.assert_called_once()
+
+    def test_terminal_only_auth_without_seeded_file_warns(self, tmp_path):
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+            auth_method_type="terminal",
+        )
+
+        with patch(
+            "openhands.sdk.agent.acp_agent._warn_auth_selection_failure"
+        ) as mock_warn:
+            self._run_start(agent, state, conn=conn)
+
+        conn.authenticate.assert_not_called()
+        mock_warn.assert_called_once()
+
+    def test_non_terminal_auth_still_warns_with_a_seeded_file(self, tmp_path):
+        """The suppression is scoped to terminal-only servers: codex with an
+        auth.json that isn't ChatGPT auth must keep warning."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"tokens": null}'))}
+        )
+        conn = self._make_conn(agent_name="codex-acp", auth_method="chat-gpt")
+
+        with patch(
+            "openhands.sdk.agent.acp_agent._warn_auth_selection_failure"
+        ) as mock_warn:
+            self._run_start(agent, state, conn=conn)
+
+        mock_warn.assert_called_once()
+
+    def test_pi_initialization_skips_set_session_mode(self, tmp_path):
+        """Pi has default_session_mode=None, so set_session_mode is not called."""
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        conn = self._make_conn(
+            agent_name="pi-acp",
+            auth_method="pi_terminal_login",
+            auth_method_type="terminal",
+        )
+
+        self._run_start(agent, state, conn=conn)
+
+        conn.set_session_mode.assert_not_called()
 
     def test_seed_if_absent_does_not_clobber_existing_file(self, tmp_path):
         """A non-empty existing credential file (e.g. a token the CLI refreshed)
@@ -9373,6 +9534,33 @@ class TestACPDataDirIsolation:
             )
         assert Path(env["CLAUDE_CONFIG_DIR"]) == Path(persist) / "acp" / "claude-code"
 
+    def test_pi_isolates_data_dir(self, tmp_path):
+        """pi-acp's session map follows HOME; pi's own config dir follows
+        PI_CODING_AGENT_DIR, which only the file secret sets."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = self._agent(["npx", "-y", "pi-acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="pi-acp")
+            )
+        assert Path(env["HOME"]) == Path(persist) / "acp" / "pi"
+        assert "PI_CODING_AGENT_DIR" not in env
+
+        state.secret_registry.update_secrets(
+            {"PI_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="pi-acp")
+            )
+        assert Path(env["HOME"]) == Path(persist) / "acp" / "pi"
+        assert Path(env["PI_CODING_AGENT_DIR"]) == Path(persist) / "acp" / "pi"
+
 
 # ---------------------------------------------------------------------------
 # Secret masking (#1023)
@@ -9711,9 +9899,17 @@ class TestPreconfiguredCredentials:
 
     def test_reports_a_materialised_file_secret_pointed_at_a_directory(self, tmp_path):
         spec = ACP_PROVIDERS["codex"].file_secrets[0]
-        (tmp_path / spec.filename).write_text("{}", encoding="utf-8")
+        (tmp_path / spec.filename).write_text(_CHATGPT_AUTH_JSON, encoding="utf-8")
         env = {spec.env_var: str(tmp_path)}
         assert _preconfigured_credentials(None, (spec,), env) == [spec.secret_name]
+
+    def test_ignores_a_file_secret_that_cannot_authenticate(self, tmp_path):
+        """Present but unusable is the case that most needs the warning: the
+        server offered a method that consumes this very file and declined it."""
+        spec = ACP_PROVIDERS["codex"].file_secrets[0]
+        (tmp_path / spec.filename).write_text('{"tokens": null}', encoding="utf-8")
+        env = {spec.env_var: str(tmp_path)}
+        assert _preconfigured_credentials(None, (spec,), env) == []
 
     def test_ignores_a_file_secret_whose_file_is_absent(self, tmp_path):
         spec = ACP_PROVIDERS["codex"].file_secrets[0]

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -97,12 +97,13 @@ def _skip_if_node_below_floor(provider_key: str) -> None:
     """Skip rather than fail when the host Node is below what this provider's
     packages declare.
 
-    Not a soft-pedal: below the floor the CLI's own dependencies break in ways
-    that surface as an unrelated-looking protocol error several calls later,
-    so a plain failure here would read as a conformance regression rather than
-    an unmet prerequisite. The image's own floor is asserted separately,
-    against the Dockerfile pin, in
-    tests/cross/test_agent_server_build_metadata.py.
+    Not a soft-pedal: the CLI's own dependencies break in ways that surface as
+    an unrelated-looking protocol error several calls later (pi's engine dies
+    on `webidl.util.markAsUncloneable`, and the adapter then reports
+    "Cannot call write after a stream was destroyed" from `session/new`), so a
+    plain failure here would read as a conformance regression rather than an
+    unmet prerequisite. The image's own floor is asserted separately, against
+    the Dockerfile pin, in tests/cross/test_agent_server_build_metadata.py.
     """
     floor = ACP_INSTALL_CATALOG[provider_key].min_node_version
     if floor is None:

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -777,6 +777,21 @@ def test_dry_run_acp_reports_credential_channels_by_role(
     assert diag.acp_file_secret_names == ["CODEX_AUTH_JSON"]
     assert diag.resolved_settings is not None
 
+# Test for Pi profile diagnostics
+def test_dry_run_acp_pi_profile_diagnostics(
+    llm_store: LLMProfileStore,
+) -> None:
+    profile = ACPAgentProfile(name="acp-pi", acp_server="pi")
+    diag = resolve_agent_profile_dry_run(
+        profile,
+        llm_store=llm_store,
+        mcp_config={},
+        available_skills=None, 
+    )
+    assert diag.agent_kind == "acp"
+    assert diag.valid is True
+    assert diag.acp_file_secret_names == ["PI_SETTINGS_JSON"]
+
 
 def test_dry_run_acp_reports_no_skills(
     llm_store: LLMProfileStore,

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -797,6 +797,21 @@ def test_dry_run_acp_reports_credential_channels_by_role(
     assert diag.resolved_settings is not None
 
 
+def test_dry_run_acp_pi_reports_its_credential_file(
+    llm_store: LLMProfileStore,
+) -> None:
+    profile = ACPAgentProfile(name="acp-pi", acp_server="pi")
+    diag = resolve_agent_profile_dry_run(
+        profile,
+        llm_store=llm_store,
+        mcp_config={},
+        available_skills=None,
+    )
+    assert diag.agent_kind == "acp"
+    assert diag.valid is True
+    assert diag.acp_file_secret_names == ["PI_AUTH_JSON"]
+
+
 def test_dry_run_acp_reports_the_injected_catalog(
     llm_store: LLMProfileStore,
 ) -> None:

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -14,6 +14,8 @@ from openhands.sdk.settings.acp_install_catalog import (
     CODEX_ACP_VERSION,
     DEFAULT_PREINSTALLED_ACP_PROVIDERS,
     GEMINI_CLI_VERSION,
+    PI_ACP_VERSION,
+    PI_CODING_AGENT_VERSION,
     ACPInstallSpec,
     ACPPackagePin,
     _main,
@@ -68,8 +70,8 @@ class TestACPInstallSpecNpxCommand:
         )
 
     def test_multi_package_uses_package_flags_and_entry_binary(self):
-        # Mirrors the shape Pi needs: an ACP adapter plus its engine package,
-        # both pinned, with the adapter's bin invoked positionally.
+        # The shape Pi needs: an ACP adapter plus its engine package, both
+        # pinned, with the adapter's bin invoked positionally.
         spec = ACPInstallSpec(
             key="pi",
             packages=(
@@ -86,6 +88,38 @@ class TestACPInstallSpecNpxCommand:
             "--package=@earendil-works/pi-coding-agent@0.2.0",
             "pi-acp",
         )
+
+
+class TestPiInstallSpec:
+    """Pi is the only registered provider with two independent pins: `pi-acp`
+    adapts ACP and spawns a separately installed `pi` engine off PATH."""
+
+    def test_pins_both_the_adapter_and_the_engine(self):
+        spec = ACP_INSTALL_CATALOG["pi"]
+        assert [(p.name, p.version) for p in spec.packages] == [
+            ("pi-acp", PI_ACP_VERSION),
+            ("@earendil-works/pi-coding-agent", PI_CODING_AGENT_VERSION),
+        ]
+        assert spec.binary_name == "pi-acp"
+        assert spec.trailing_args == ()
+
+    def test_adapter_is_listed_first(self):
+        """`test_acp_conformance_probe` compares `packages[0].version` to the
+        `agentInfo.version` the server reports — which is the adapter's. A
+        reorder would silently compare against the engine's version instead."""
+        spec = ACP_INSTALL_CATALOG["pi"]
+        assert spec.packages[0].name == spec.binary_name == "pi-acp"
+
+    def test_install_plan_installs_both_but_wraps_only_the_adapter(self):
+        """`pi` is never launched by OpenHands directly — pi-acp spawns it, and
+        the adapter's wrapper puts $ACP_NODE_DIR/bin on PATH for it, so a
+        second wrapper would be dead weight."""
+        packages, wrapper_bins = render_docker_install_plan(["pi"])
+        assert packages == [
+            f"pi-acp@{PI_ACP_VERSION}",
+            f"@earendil-works/pi-coding-agent@{PI_CODING_AGENT_VERSION}",
+        ]
+        assert wrapper_bins == ["pi-acp"]
 
 
 class TestACPInstallCatalogMatchesACPProviders:

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -100,7 +100,7 @@ class TestACPProviderInfo:
         assert "pi-acp" in info.default_command[-1]
         assert info.api_key_env_var is None
         assert info.base_url_env_var is None
-        assert info.default_session_mode == "default"
+        assert info.default_session_mode == "medium"
         assert "pi-acp" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.supports_runtime_model_switch is True

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -97,16 +97,24 @@ class TestACPProviderInfo:
         assert info.key == "pi"
         assert info.display_name == "Pi"
         assert info.default_command[0] == "npx"
-        assert "pi-acp" in info.default_command[-1]
+        assert any("pi-acp@" in token for token in info.default_command)
+        assert any(
+            "@earendil-works/pi-coding-agent@" in token
+            for token in info.default_command
+        )
+        assert info.default_command[-1] == "pi-acp"
         assert info.api_key_env_var is None
         assert info.base_url_env_var is None
-        assert info.default_session_mode == "medium"
+        assert info.default_session_mode is None
+        assert info.available_models == ()
+        assert info.default_model is None
+        assert info.file_secrets == ACP_PROVIDERS["pi"].file_secrets
         assert "pi-acp" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key is None
         assert info.binary_name == "pi-acp"
-        assert info.data_dir_env_var == "PI_CODING_AGENT_DIR"
+        assert info.data_dir_env_var == "HOME"
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
@@ -127,7 +135,7 @@ class TestACPProviderInfo:
 
 class TestGetACPProvider:
     def test_returns_info_for_known_keys(self):
-        for key in ("claude-code", "codex", "gemini-cli"):
+        for key in ACP_PROVIDERS.keys():
             result = get_acp_provider(key)
             assert result is not None
             assert result.key == key
@@ -221,18 +229,16 @@ class TestProviderRegistryConsistency:
 
     def test_every_provider_has_non_empty_session_mode(self):
         for key, info in ACP_PROVIDERS.items():
-            assert info.default_session_mode, (
-                f"{key}: default_session_mode must not be empty"
-            )
+            assert info.default_session_mode is None or info.default_session_mode.strip()
 
     def test_session_modes_are_distinct(self):
         modes = [
             info.default_session_mode
             for info in ACP_PROVIDERS.values()
-            if info.default_session_mode != "default"
+            if info.default_session_mode is not None
         ]
         assert len(modes) == len(set(modes)), (
-            "permission-bypassing modes should be unique"
+            "non-None default_session_mode values should be unique"
         )
 
     def test_detect_returns_matching_provider_for_all_registered_patterns(self):
@@ -250,10 +256,6 @@ class TestProviderRegistryConsistency:
 
 class TestProviderModelLists:
     """Verify the curated ``available_models`` / ``default_model`` fields."""
-
-    def test_every_builtin_provider_has_available_models(self):
-        for key, info in ACP_PROVIDERS.items():
-            assert info.available_models, f"{key}: available_models must not be empty"
 
     def test_available_models_entries_are_model_options(self):
         for info in ACP_PROVIDERS.values():
@@ -341,13 +343,15 @@ class TestACPFileSecrets:
         assert {s.secret_name for s in specs} == {
             "CODEX_AUTH_JSON",
             "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+            "PI_SETTINGS_JSON"
         }
         # Deterministic concatenation in ACP_PROVIDERS registration order
-        # (codex before gemini-cli) — downstream callers can rely on a stable
+        # (codex before gemini-cli before pi) — downstream callers can rely on a stable
         # ordering of the built-in specs.
         assert specs == (
             ACP_PROVIDERS["codex"].file_secrets
             + ACP_PROVIDERS["gemini-cli"].file_secrets
+            + ACP_PROVIDERS["pi"].file_secrets
         )
 
     def test_file_secret_spec_is_frozen(self):

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -19,7 +19,7 @@ from openhands.sdk.settings.acp_providers import (
 
 class TestACPProviderInfo:
     def test_known_providers_are_registered(self):
-        assert set(ACP_PROVIDERS) == {"claude-code", "codex", "gemini-cli"}
+        assert set(ACP_PROVIDERS) == {"claude-code", "codex", "gemini-cli", "pi"}
 
     def test_all_entries_are_acp_provider_info(self):
         for info in ACP_PROVIDERS.values():
@@ -91,6 +91,22 @@ class TestACPProviderInfo:
         assert info.binary_name == "gemini"
         # Gemini CLI has no dedicated config-dir var, so only HOME relocates it.
         assert info.data_dir_env_var == "HOME"
+
+    def test_pi_metadata(self):
+        info = ACP_PROVIDERS["pi"]
+        assert info.key == "pi"
+        assert info.display_name == "Pi"
+        assert info.default_command[0] == "npx"
+        assert "pi-acp" in info.default_command[-1]
+        assert info.api_key_env_var is None
+        assert info.base_url_env_var is None
+        assert info.default_session_mode == "default"
+        assert "pi-acp" in info.agent_name_patterns
+        assert info.supports_set_session_model is True
+        assert info.supports_runtime_model_switch is True
+        assert info.session_meta_key is None
+        assert info.binary_name == "pi-acp"
+        assert info.data_dir_env_var == "PI_CODING_AGENT_DIR"
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
@@ -210,8 +226,14 @@ class TestProviderRegistryConsistency:
             )
 
     def test_session_modes_are_distinct(self):
-        modes = [info.default_session_mode for info in ACP_PROVIDERS.values()]
-        assert len(modes) == len(set(modes)), "each provider should use a unique mode"
+        modes = [
+            info.default_session_mode
+            for info in ACP_PROVIDERS.values()
+            if info.default_session_mode != "default"
+        ]
+        assert len(modes) == len(set(modes)), (
+            "permission-bypassing modes should be unique"
+        )
 
     def test_detect_returns_matching_provider_for_all_registered_patterns(self):
         """Every registered pattern should resolve back to its own provider."""

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -7,6 +7,10 @@ from typing import get_args
 
 import pytest
 
+from openhands.sdk.settings.acp_install_catalog import (
+    PI_ACP_VERSION,
+    PI_CODING_AGENT_VERSION,
+)
 from openhands.sdk.settings.acp_providers import (
     ACP_PROVIDERS,
     ACPModelOption,
@@ -136,6 +140,43 @@ class TestACPProviderInfo:
         assert spec.env_var == "KIMI_CODE_HOME"
         assert spec.env_points_to == "dir"
 
+    def test_pi_metadata(self):
+        info = ACP_PROVIDERS["pi"]
+        assert info.key == "pi"
+        assert info.display_name == "Pi"
+        # pi-acp only adapts; it spawns the separately pinned `pi` engine off
+        # PATH, so the npx default provisions both packages and runs pi-acp.
+        assert info.default_command == (
+            "npx",
+            "-y",
+            "--prefer-offline",
+            f"--package=pi-acp@{PI_ACP_VERSION}",
+            f"--package=@earendil-works/pi-coding-agent@{PI_CODING_AGENT_VERSION}",
+            "pi-acp",
+        )
+        assert info.api_key_env_var == "ANTHROPIC_API_KEY"
+        # pi takes its base URL from its own catalogue, not the environment.
+        assert info.base_url_env_var is None
+        # pi-acp maps ACP modes onto thinking levels and has no permission mode.
+        assert info.default_session_mode is None
+        assert info.agent_name_patterns == ("pi-acp",)
+        assert info.supports_set_session_model is True
+        assert info.supports_runtime_model_switch is True
+        assert info.session_meta_key is None
+        assert info.default_model is None
+        assert info.binary_name == "pi-acp"
+        assert info.data_dir_env_var == "HOME"
+        assert [spec.secret_name for spec in info.file_secrets] == ["PI_AUTH_JSON"]
+
+    def test_pi_credential_file_is_auth_json_in_the_config_dir(self):
+        """PI_CODING_AGENT_DIR names the directory pi reads auth.json from;
+        settings.json in the same directory does not authenticate."""
+        (spec,) = ACP_PROVIDERS["pi"].file_secrets
+        assert spec.filename == "auth.json"
+        assert spec.env_var == "PI_CODING_AGENT_DIR"
+        assert spec.env_points_to == "dir"
+        assert spec.subdir == "pi"
+
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
         with pytest.raises((AttributeError, TypeError)):
@@ -155,7 +196,7 @@ class TestACPProviderInfo:
 
 class TestGetACPProvider:
     def test_returns_info_for_known_keys(self):
-        for key in ("claude-code", "codex", "gemini-cli", "kimi-code"):
+        for key in ACP_PROVIDERS:
             result = get_acp_provider(key)
             assert result is not None
             assert result.key == key
@@ -281,6 +322,24 @@ class TestProviderRegistryConsistency:
             assert mode is None or (isinstance(mode, str) and mode.strip()), (
                 f"{key}: default_session_mode must be a non-empty id or None"
             )
+
+    def test_session_mode_is_a_non_empty_string_or_none(self):
+        """``None`` skips the ``session/set_mode`` call; an empty string would
+        be sent verbatim and rejected by the server."""
+        for key, info in ACP_PROVIDERS.items():
+            assert (
+                info.default_session_mode is None or info.default_session_mode.strip()
+            ), (  # noqa: E501
+                f"{key}: default_session_mode must be None or non-blank"
+            )
+
+    def test_session_modes_are_distinct(self):
+        modes = [
+            info.default_session_mode
+            for info in ACP_PROVIDERS.values()
+            if info.default_session_mode is not None
+        ]
+        assert len(modes) == len(set(modes)), "each provider should use a unique mode"
 
     def test_detect_returns_matching_provider_for_all_registered_patterns(self):
         """Every registered pattern should resolve back to its own provider."""
@@ -421,14 +480,16 @@ class TestACPFileSecrets:
             "CODEX_AUTH_JSON",
             "GOOGLE_APPLICATION_CREDENTIALS_JSON",
             "KIMI_CODE_CONFIG_TOML",
+            "PI_AUTH_JSON",
         }
         # Deterministic concatenation in ACP_PROVIDERS registration order
-        # (codex, gemini-cli, kimi-code) — downstream callers can rely on a
+        # (codex, gemini-cli, kimi-code, pi) — downstream callers can rely on a
         # stable ordering of the built-in specs.
         assert specs == (
             ACP_PROVIDERS["codex"].file_secrets
             + ACP_PROVIDERS["gemini-cli"].file_secrets
             + ACP_PROVIDERS["kimi-code"].file_secrets
+            + ACP_PROVIDERS["pi"].file_secrets
         )
 
     def test_file_secret_subdirs_are_unique_across_providers(self):

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1359,6 +1359,7 @@ def _which_returning(*available: str):
         ("codex", "codex-acp", ["codex-acp"]),
         # gemini's default carries a trailing ``--acp`` that must be preserved.
         ("gemini-cli", "gemini", ["gemini", "--acp"]),
+        ("pi", "pi-acp", ["pi-acp"]),
     ],
 )
 def test_acp_resolve_command_rewrites_default_to_pinned_binary(
@@ -2062,6 +2063,15 @@ def test_acp_resolve_command_uses_registry_defaults(
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)
         assert settings.resolve_acp_command() == expected
+    # Explicit check for Pi's multi-package npx command
+    pi_settings = ACPAgentSettings(acp_server="pi")
+    assert pi_settings.resolve_acp_command() == [
+        "npx",
+        "-y",
+        "--package=pi-acp@0.0.33",
+        "--package=@earendil-works/pi-coding-agent@0.83.0",
+        "pi-acp",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -388,7 +388,7 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
     server_field = next(f for f in acp_section.fields if f.key == "acp_server")
     assert server_field.prominence is SettingProminence.CRITICAL
     server_choices = {c.value for c in server_field.choices}
-    assert server_choices == {"claude-code", "codex", "gemini-cli", "custom"}
+    assert server_choices == {"claude-code", "codex", "gemini-cli", "pi", "custom"}
 
     command_field = next(f for f in acp_section.fields if f.key == "acp_command")
     assert command_field.prominence is SettingProminence.MINOR
@@ -1195,7 +1195,7 @@ def test_acp_create_agent_carries_provider_key() -> None:
     directly (not from settings) defaults to ``None``; and the key survives a
     serialization round-trip through the ``AgentBase`` discriminated union.
     """
-    for server in ("claude-code", "codex", "gemini-cli", "custom"):
+    for server in ("claude-code", "codex", "gemini-cli", "pi", "custom"):
         kwargs: dict[str, Any] = {"acp_server": server}
         if server == "custom":
             kwargs["acp_command"] = ["my-acp"]
@@ -1218,7 +1218,7 @@ def test_acp_resolve_command_for_known_servers(
     default stays the ``npx`` invocation.
     """
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server in ("claude-code", "codex", "gemini-cli"):
+    for server in ("claude-code", "codex", "gemini-cli", "pi"):
         settings = ACPAgentSettings(acp_server=server)
         cmd = settings.resolve_acp_command()
         assert cmd, f"expected default command for {server}, got empty"
@@ -1992,7 +1992,7 @@ def test_acp_resolve_command_uses_registry_defaults(
 
     # No pinned binary on PATH → registry npx default is returned verbatim.
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server_key in ("claude-code", "codex", "gemini-cli"):
+    for server_key in ("claude-code", "codex", "gemini-cli", "pi"):
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)
         assert settings.resolve_acp_command() == expected

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -393,6 +393,7 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
         "codex",
         "gemini-cli",
         "kimi-code",
+        "pi",
         "custom",
     }
 
@@ -1413,7 +1414,7 @@ def test_acp_create_agent_carries_provider_key() -> None:
     directly (not from settings) defaults to ``None``; and the key survives a
     serialization round-trip through the ``AgentBase`` discriminated union.
     """
-    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "custom"):
+    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi", "custom"):
         kwargs: dict[str, Any] = {"acp_server": server}
         if server == "custom":
             kwargs["acp_command"] = ["my-acp"]
@@ -1436,7 +1437,7 @@ def test_acp_resolve_command_for_known_servers(
     default stays the ``npx`` invocation.
     """
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server in ("claude-code", "codex", "gemini-cli", "kimi-code"):
+    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi"):
         settings = ACPAgentSettings(acp_server=server)
         cmd = settings.resolve_acp_command()
         assert cmd, f"expected default command for {server}, got empty"
@@ -1511,6 +1512,7 @@ def _which_returning(*available: str):
         ("codex", "codex-acp", ["codex-acp"]),
         # gemini's default carries a trailing ``--acp`` that must be preserved.
         ("gemini-cli", "gemini", ["gemini", "--acp"]),
+        ("pi", "pi-acp", ["pi-acp"]),
     ],
 )
 def test_acp_resolve_command_rewrites_default_to_pinned_binary(
@@ -1669,6 +1671,9 @@ def test_acp_api_key_env_var_maps_known_servers() -> None:
     assert ACPAgentSettings(acp_server="gemini-cli").api_key_env_var == "GEMINI_API_KEY"
     # Kimi has no env-var API key; the credential is config.toml.
     assert ACPAgentSettings(acp_server="kimi-code").api_key_env_var is None
+    # pi is multi-provider but reads a plain provider key out of the process
+    # env; ANTHROPIC_API_KEY is the channel the registry provisions for it.
+    assert ACPAgentSettings(acp_server="pi").api_key_env_var == "ANTHROPIC_API_KEY"
     assert (
         ACPAgentSettings(acp_server="custom", acp_command=["x"]).api_key_env_var is None
     )
@@ -2225,14 +2230,29 @@ def test_acp_settings_base_url_env_var_from_registry() -> None:
 def test_acp_resolve_command_uses_registry_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from openhands.sdk.settings.acp_install_catalog import (
+        PI_ACP_VERSION,
+        PI_CODING_AGENT_VERSION,
+    )
     from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
 
     # No pinned binary on PATH → registry default is returned verbatim.
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server_key in ("claude-code", "codex", "gemini-cli", "kimi-code"):
+    for server_key in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi"):
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)
         assert settings.resolve_acp_command() == expected
+    # Pi is the only provider whose default installs two packages: the pi-acp
+    # adapter and the `pi` engine it spawns off PATH.
+    pi_settings = ACPAgentSettings(acp_server="pi")
+    assert pi_settings.resolve_acp_command() == [
+        "npx",
+        "-y",
+        "--prefer-offline",
+        f"--package=pi-acp@{PI_ACP_VERSION}",
+        f"--package=@earendil-works/pi-coding-agent@{PI_CODING_AGENT_VERSION}",
+        "pi-acp",
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:

Picked this up as a maintainer to get it over the line — @Deep070203 did the original work (live-verified auth flow, the two-package pin, the file-secret spec). Now rebased onto #4832's install catalog, which was built with Pi's adapter+engine split as its motivating case, so the image half is a catalog entry rather than a Dockerfile change. Every registry field re-verified against a running pi-acp; full log in the PR comments.

AGENT:

## Why

Adds **Pi** as a built-in ACP provider (issue #4635, epic #4820), so `acp_server: "pi"` is selectable
alongside `claude-code`, `codex`, `gemini-cli` and `kimi-code` without frontend command spoofing.

The branch was opened before `INSTALL_ACP_PROVIDERS` (#4687, #4698) and before the `npx` fallback
(#4805), so the image half needed replacing rather than merging, and several registry fields turned
out not to match the server's real behaviour.

## Summary

**Install catalog** — `pi` in `ACP_INSTALL_CATALOG` with both pins and
`PI_ACP_VERSION` / `PI_CODING_AGENT_VERSION`. Pi is the only provider needing two: `pi-acp` is only
the ACP adapter and spawns a separately installed `pi` engine off `PATH`. `ACPInstallSpec` already
handles that — `npx_command()` yields
`npx -y --prefer-offline --package=pi-acp@0.0.33 --package=@earendil-works/pi-coding-agent@0.83.0 pi-acp`,
token for token the command validated live below. **The Dockerfile needs no Pi-specific change**; the
install plan is rendered from the catalog at build time.

**Registry** — `pi` in `ACPServerKind` and `ACP_PROVIDERS`, with `default_command`/`binary_name`
derived from the catalog.

Every field was checked against pi-acp 0.0.33 + pi 0.83.0; four of them changed as a result:

| Field | Was | Now | Evidence |
|---|---|---|---|
| `api_key_env_var` | `None` | `ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY` alone takes `session/new` from `-32000 "Authentication required"` to a live session with a 16-model Anthropic catalogue |
| `file_secrets` | `PI_SETTINGS_JSON` → `settings.json` | `PI_AUTH_JSON` → `auth.json` | a seeded `settings.json` leaves `session/new` failing on auth; `auth.json` in the same directory authenticates. `settings.json` holds model/UI preferences, not credentials |
| `available_models` | `()` | 5 curated ids | restores the `every_builtin_provider_has_available_models` invariant the branch had deleted |
| `default_command` | no `--prefer-offline` | `--prefer-offline` | matches the other providers |

Confirmed unchanged: `env_var=PI_CODING_AGENT_DIR` / `env_points_to="dir"` (the var does name the
directory), `base_url_env_var=None` (pi resolves base URLs from its own catalogue —
`ANTHROPIC_BASE_URL` never reaches the wire), `data_dir_env_var="HOME"` (pi-acp's session map is
hard-coded to `~/.pi/pi-acp`), `binary_name="pi-acp"`, `agent_name_patterns=("pi-acp",)`,
`session_meta_key=None`, and both `supports_*` flags `True`.

**`default_session_mode` is now `str | None`.** pi-acp maps ACP session modes onto pi's *thinking
levels* (`off`..`xhigh`) and rejects any other id, so there is no permission-suppressing mode to
send — and it never gates ordinary tool calls behind `session/request_permission`. The TS mirror
widens to `string | null` alongside.

Pi is **not** added to `DEFAULT_PREINSTALLED_ACP_PROVIDERS`: since #4805 an absent provider falls
back to the version-pinned `npx` install cached under the conversation root, so registry membership
need not mean image membership.

**TypeScript mirror** — `acp.ts` plus `acp-providers.json` regenerated with
`check-acp-drift.py --write` (#4832's flow) rather than hand-edited.

**Node engine floor** — `min_node_version="22.19.0"` in the catalog.
`@earendil-works/pi-coding-agent` and its `undici` dependency declare it; below the floor the pi-acp
*adapter* still starts, so the handshake succeeds and the failure lands three calls later at
`session/new` as `Cannot call write after a stream was destroyed`, the engine having already died on
`webidl.util.markAsUncloneable is not a function`. The enforcement (Dockerfile pin guard, conformance
skip, `acp-live-tests` Node pin) is provider-agnostic and landed in main with #4714.

**One fix to that shared code**: `_preconfigured_credentials` treated any *present* credential file
as proof of authentication — including a Codex `auth.json` that exists but cannot authenticate,
downgrading the warning in exactly the case that needs it. It now validates where the SDK knows the
format and gives unknown secrets the benefit of the doubt. Caught by this branch's own
`test_non_terminal_auth_still_warns_with_a_seeded_file`.

## How to Test

```
uv run --frozen ruff check openhands-sdk openhands-agent-server tests
uv run --frozen ruff format --check openhands-sdk openhands-agent-server tests
uv run --frozen pytest tests/sdk/settings/test_acp_providers.py \
  tests/cross/test_agent_server_build_metadata.py tests/sdk/test_settings.py \
  tests/sdk/agent/test_acp_agent.py -q
uv run python clients/typescript/scripts/check-acp-drift.py

# the plan the Dockerfile stage evals, rendered from the catalog
python3 -S openhands-sdk/openhands/sdk/settings/acp_install_catalog.py "claude-code,codex,gemini-cli,kimi-code,pi"

# live, credential-free provider probes (non-required `acp-live-tests` job)
uv run pytest -m acp_live tests/sdk/agent/test_acp_conformance.py \
  tests/sdk/settings/test_acp_install_catalog_pins_live.py
A live ACP turn through Pi (session created, `read`/`edit`/`bash` tool calls executed against the
workspace, reply returned) was run three ways — inside the built image, on the pinned-binary path,
and on the `npx` fallback — with the credential arriving only as the `PI_AUTH_JSON` file secret.
Output is in the PR comments.

## Issue Number

Part of #4635.

Left open rather than auto-closed: that issue also covers the benchmark/evaluation-workflow half and
the five-instance smoke, which this PR does not touch. Original downstream report was
OpenHands/OpenHands#16204.

## Type

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`default_session_mode` becoming nullable propagates to `@openhands/typescript-client` consumers;
agent-canvas needs the bumped client before it can offer `pi` in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

