### PR TITLE
feat: add pre-flight LLM validation endpoint (POST /api/profiles/{name}/validate)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -284,15 +284,20 @@ async def validate_profile(
             await llm.aresponses(messages=messages, max_tokens=1)
         else:
             await llm.acompletion(messages=messages, max_tokens=1)
-    except _TRANSIENT_ERROR_TYPES:
+    except _TRANSIENT_ERROR_TYPES as exc:
         # Transient — don't block the save
         logger.info(
-            f"Profile '{name}' pre-flight hit a transient error; not blocking save."
+            f"Profile '{name}' pre-flight hit a transient error "
+            f"({type(exc).__name__}); not blocking save."
         )
         return ValidateProfileResponse(valid=True)
     except (
         LLMAuthenticationError,
         LLMBadRequestError,
+        # LLMServiceUnavailableError (provider 503) is intentionally treated as
+        # a blocking config error: at this layer a provider outage is
+        # indistinguishable from a wrong base URL, so we prefer a false
+        # negative over silently saving a misconfigured profile.
         LLMServiceUnavailableError,
         LLMError,
     ) as exc:

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -278,7 +278,12 @@ async def validate_profile(
     ]
 
     try:
-        llm.completion(messages=messages, max_tokens=1)
+        # Mirror the runtime dispatch (see ``amake_llm_completion``) and stay
+        # async so provider I/O doesn't pin the FastAPI event loop.
+        if llm.uses_responses_api():
+            await llm.aresponses(messages=messages, max_tokens=1)
+        else:
+            await llm.acompletion(messages=messages, max_tokens=1)
     except _TRANSIENT_ERROR_TYPES:
         # Transient — don't block the save
         logger.info(

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -22,8 +22,6 @@ from openhands.agent_server.persistence import (
 )
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.exceptions import (
-    LLMAuthenticationError,
-    LLMBadRequestError,
     LLMError,
     LLMRateLimitError,
     LLMServiceUnavailableError,
@@ -292,8 +290,6 @@ async def validate_profile(
         )
         return ValidateProfileResponse(valid=True)
     except (
-        LLMAuthenticationError,
-        LLMBadRequestError,
         # LLMServiceUnavailableError (provider 503) is intentionally treated as
         # a blocking config error: at this layer a provider outage is
         # indistinguishable from a wrong base URL, so we prefer a false

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -20,7 +20,15 @@ from openhands.agent_server.persistence import (
     get_llm_profile_store,
     get_settings_store,
 )
-from openhands.sdk.llm import LLM
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm.exceptions import (
+    LLMAuthenticationError,
+    LLMBadRequestError,
+    LLMError,
+    LLMRateLimitError,
+    LLMServiceUnavailableError,
+    LLMTimeoutError,
+)
 from openhands.sdk.llm.llm_profile_store import (
     PROFILE_NAME_PATTERN,
     ProfileLimitExceeded,
@@ -209,6 +217,103 @@ async def save_profile(
 
     logger.info(f"Saved profile '{name}' (include_secrets={body.include_secrets})")
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
+
+
+class ValidateProfileRequest(BaseModel):
+    """Request body for LLM pre-flight validation.
+
+    Accepts an LLM config (same shape as ``SaveProfileRequest.llm``) so the
+    frontend can validate a draft *before* persisting it.
+    """
+
+    llm: LLM
+
+
+class ValidateProfileError(BaseModel):
+    """Structured error returned when validation fails."""
+
+    type: str
+    message: str
+
+
+class ValidateProfileResponse(BaseModel):
+    """Result of an LLM pre-flight check."""
+
+    valid: bool
+    error: ValidateProfileError | None = None
+
+
+# Errors that should NOT block saving — they are transient and unrelated to
+# the correctness of the configuration itself.
+_TRANSIENT_ERROR_TYPES = (LLMRateLimitError, LLMTimeoutError)
+
+
+@profiles_router.post(
+    "/{name}/validate",
+    response_model=ValidateProfileResponse,
+)
+async def validate_profile(
+    request: Request,
+    name: ProfileName,
+    body: ValidateProfileRequest,
+) -> ValidateProfileResponse:
+    """Pre-flight check: fire a minimal LLM completion to catch misconfigurations.
+
+    Instantiates the submitted LLM config and sends a 1-token completion to
+    surface errors like invalid model names, missing provider prefixes, bad
+    base URLs, and invalid API keys — *before* the profile is saved.
+
+    Transient errors (rate limits, timeouts) are treated as non-blocking: the
+    response is ``valid=True`` with no error, since those don't indicate a
+    misconfigured profile.
+    """
+    cipher = get_cipher(request)
+    llm = decrypt_incoming_llm_secrets(body.llm, cipher) if cipher else body.llm
+
+    messages = [
+        Message(
+            role="user",
+            content=[TextContent(text="ping")],
+        )
+    ]
+
+    try:
+        llm.completion(messages=messages, max_tokens=1)
+    except _TRANSIENT_ERROR_TYPES:
+        # Transient — don't block the save
+        logger.info(
+            f"Profile '{name}' pre-flight hit a transient error; not blocking save."
+        )
+        return ValidateProfileResponse(valid=True)
+    except (
+        LLMAuthenticationError,
+        LLMBadRequestError,
+        LLMServiceUnavailableError,
+        LLMError,
+    ) as exc:
+        error_type = type(exc).__name__
+        logger.info(f"Profile '{name}' pre-flight failed: {error_type}: {exc.message}")
+        return ValidateProfileResponse(
+            valid=False,
+            error=ValidateProfileError(
+                type=error_type,
+                message=exc.message,
+            ),
+        )
+    except Exception as exc:
+        # Unknown errors — block the save and surface the raw message so the
+        # user can debug, but classify generically.
+        msg = str(exc) or type(exc).__name__
+        logger.info(f"Profile '{name}' pre-flight failed (unknown): {msg}")
+        return ValidateProfileResponse(
+            valid=False,
+            error=ValidateProfileError(
+                type=type(exc).__name__,
+                message=msg,
+            ),
+        )
+
+    return ValidateProfileResponse(valid=True)
 
 
 @profiles_router.delete("/{name}", response_model=ProfileMutationResponse)

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1257,9 +1257,12 @@ def test_validate_profile_success(client):
     """POST /api/profiles/{name}/validate returns valid=True when the LLM works."""
     from unittest.mock import MagicMock
 
-    with patch(
-        "openhands.sdk.llm.llm.LLM.completion",
-        return_value=MagicMock(),
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            return_value=MagicMock(),
+        ),
     ):
         response = client.post(
             "/api/profiles/test-profile/validate",
@@ -1272,15 +1275,53 @@ def test_validate_profile_success(client):
     assert body["error"] is None
 
 
+def test_validate_profile_responses_api(client):
+    """Pre-flight uses the Responses API when the profile model requires it.
+
+    Regression: the endpoint must route through ``aresponses`` for profiles
+    where ``uses_responses_api()`` is true, matching the runtime dispatch used
+    by real conversations (`amake_llm_completion`) — otherwise preflight would
+    validate a different path than the server actually calls.
+    """
+    from unittest.mock import MagicMock
+
+    traced: dict[str, bool] = {}
+
+    def fake_append(messages, **kwargs):
+        traced["called"] = True
+        return MagicMock()
+
+    with (
+        patch(
+            "openhands.sdk.llm.llm.LLM.uses_responses_api",
+            return_value=True,
+        ),
+        patch("openhands.sdk.llm.llm.LLM.aresponses", side_effect=fake_append),
+    ):
+        response = client.post(
+            "/api/profiles/responses-profile/validate",
+            json={"llm": {"model": "gpt-4o", "api_mode": "responses", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is True
+    assert body["error"] is None
+    assert traced["called"], "expected aresponses to be used for responses-api profiles"
+
+
 def test_validate_profile_invalid_model_returns_error(client):
     """POST /api/profiles/{name}/validate returns valid=False on bad model."""
     from openhands.sdk.llm.exceptions import LLMBadRequestError
 
-    with patch(
-        "openhands.sdk.llm.llm.LLM.completion",
-        side_effect=LLMBadRequestError(
-            "The supported API model names are deepseek-v4-pro or "
-            "deepseek-v4-flash, but you passed deepseek-chat"
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            side_effect=LLMBadRequestError(
+                "The supported API model names are deepseek-v4-pro or "
+                "deepseek-v4-flash, but you passed deepseek-chat"
+            ),
         ),
     ):
         response = client.post(
@@ -1299,9 +1340,12 @@ def test_validate_profile_auth_error_returns_error(client):
     """POST /api/profiles/{name}/validate returns valid=False on bad API key."""
     from openhands.sdk.llm.exceptions import LLMAuthenticationError
 
-    with patch(
-        "openhands.sdk.llm.llm.LLM.completion",
-        side_effect=LLMAuthenticationError("Invalid or missing API credentials"),
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            side_effect=LLMAuthenticationError("Invalid or missing API credentials"),
+        ),
     ):
         response = client.post(
             "/api/profiles/bad-key/validate",
@@ -1318,9 +1362,12 @@ def test_validate_profile_rate_limit_does_not_block(client):
     """POST /api/profiles/{name}/validate returns valid=True on rate limit."""
     from openhands.sdk.llm.exceptions import LLMRateLimitError
 
-    with patch(
-        "openhands.sdk.llm.llm.LLM.completion",
-        side_effect=LLMRateLimitError("Rate limit exceeded"),
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            side_effect=LLMRateLimitError("Rate limit exceeded"),
+        ),
     ):
         response = client.post(
             "/api/profiles/rate-limited/validate",
@@ -1336,9 +1383,12 @@ def test_validate_profile_rate_limit_does_not_block(client):
 def test_validate_profile_unknown_error_returns_error(client):
     """POST /api/profiles/{name}/validate catches unexpected exceptions."""
 
-    with patch(
-        "openhands.sdk.llm.llm.LLM.completion",
-        side_effect=RuntimeError("Connection refused"),
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            side_effect=RuntimeError("Connection refused"),
+        ),
     ):
         response = client.post(
             "/api/profiles/unknown-err/validate",

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1248,3 +1248,115 @@ def test_list_profiles_no_auto_create_after_deleting_active_profile(client, stor
     body = response.json()
     assert body["profiles"] == []
     assert body["active_profile"] is None
+
+
+# ── Pre-flight validation: POST /api/profiles/{name}/validate ────────────────
+
+
+def test_validate_profile_success(client):
+    """POST /api/profiles/{name}/validate returns valid=True when the LLM works."""
+    from unittest.mock import MagicMock
+
+    with patch(
+        "openhands.sdk.llm.llm.LLM.completion",
+        return_value=MagicMock(),
+    ):
+        response = client.post(
+            "/api/profiles/test-profile/validate",
+            json={"llm": {"model": "gpt-4o", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is True
+    assert body["error"] is None
+
+
+def test_validate_profile_invalid_model_returns_error(client):
+    """POST /api/profiles/{name}/validate returns valid=False on bad model."""
+    from openhands.sdk.llm.exceptions import LLMBadRequestError
+
+    with patch(
+        "openhands.sdk.llm.llm.LLM.completion",
+        side_effect=LLMBadRequestError(
+            "The supported API model names are deepseek-v4-pro or "
+            "deepseek-v4-flash, but you passed deepseek-chat"
+        ),
+    ):
+        response = client.post(
+            "/api/profiles/bad-model/validate",
+            json={"llm": {"model": "deepseek-chat", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["error"]["type"] == "LLMBadRequestError"
+    assert "deepseek" in body["error"]["message"]
+
+
+def test_validate_profile_auth_error_returns_error(client):
+    """POST /api/profiles/{name}/validate returns valid=False on bad API key."""
+    from openhands.sdk.llm.exceptions import LLMAuthenticationError
+
+    with patch(
+        "openhands.sdk.llm.llm.LLM.completion",
+        side_effect=LLMAuthenticationError("Invalid or missing API credentials"),
+    ):
+        response = client.post(
+            "/api/profiles/bad-key/validate",
+            json={"llm": {"model": "gpt-4o", "api_key": "sk-invalid"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["error"]["type"] == "LLMAuthenticationError"
+
+
+def test_validate_profile_rate_limit_does_not_block(client):
+    """POST /api/profiles/{name}/validate returns valid=True on rate limit."""
+    from openhands.sdk.llm.exceptions import LLMRateLimitError
+
+    with patch(
+        "openhands.sdk.llm.llm.LLM.completion",
+        side_effect=LLMRateLimitError("Rate limit exceeded"),
+    ):
+        response = client.post(
+            "/api/profiles/rate-limited/validate",
+            json={"llm": {"model": "gpt-4o", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is True
+    assert body["error"] is None
+
+
+def test_validate_profile_unknown_error_returns_error(client):
+    """POST /api/profiles/{name}/validate catches unexpected exceptions."""
+
+    with patch(
+        "openhands.sdk.llm.llm.LLM.completion",
+        side_effect=RuntimeError("Connection refused"),
+    ):
+        response = client.post(
+            "/api/profiles/unknown-err/validate",
+            json={"llm": {"model": "gpt-4o", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["error"]["type"] == "RuntimeError"
+    assert "Connection refused" in body["error"]["message"]
+
+
+def test_validate_profile_invalid_name(client):
+    """POST /api/profiles/{name}/validate returns 422 for invalid profile names."""
+    response = client.post(
+        "/api/profiles/invalid name/validate",
+        json={"llm": {"model": "gpt-4o", "api_key": "sk-test"}},
+    )
+
+    assert response.status_code == 422

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1386,6 +1386,28 @@ def test_validate_profile_rate_limit_does_not_block(client):
     assert body["error"] is None
 
 
+def test_validate_profile_service_unavailable_blocks(client):
+    """POST /api/profiles/{name}/validate returns valid=False on provider 503."""
+    from openhands.sdk.llm.exceptions import LLMServiceUnavailableError
+
+    with (
+        patch("openhands.sdk.llm.llm.LLM.uses_responses_api", return_value=False),
+        patch(
+            "openhands.sdk.llm.llm.LLM.acompletion",
+            side_effect=LLMServiceUnavailableError("Service unavailable"),
+        ),
+    ):
+        response = client.post(
+            "/api/profiles/unavailable/validate",
+            json={"llm": {"model": "gpt-4o", "api_key": "sk-test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["error"]["type"] == "LLMServiceUnavailableError"
+
+
 def test_validate_profile_unknown_error_returns_error(client):
     """POST /api/profiles/{name}/validate catches unexpected exceptions."""
 

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1300,7 +1300,13 @@ def test_validate_profile_responses_api(client):
     ):
         response = client.post(
             "/api/profiles/responses-profile/validate",
-            json={"llm": {"model": "gpt-4o", "api_mode": "responses", "api_key": "sk-test"}},
+            json={
+                "llm": {
+                    "model": "gpt-4o",
+                    "api_mode": "responses",
+                    "api_key": "sk-test",
+                }
+            },
         )
 
     assert response.status_code == 200


### PR DESCRIPTION
HUMAN:
Validated the endpoint behavior with the listed focused pytest cases.

## Summary

Adds a POST /api/profiles/{name}/validate endpoint to the agent-server that fires a minimal 1-token LLM completion call to catch misconfigurations before a profile is saved.

This resolves the backend half of OpenHands/OpenHands#16416.

AGENT:

## Why

PostHog error tracking shows thousands of recurring exceptions from LLM misconfigurations — invalid model names, missing provider prefixes, bad base URLs, and invalid API keys — that only surface when a conversation starts and the first LLM call fails. All of these could be caught at save time.

## Summary

- New POST /api/profiles/{name}/validate endpoint in profiles_router.py
- Accepts an LLM config (same shape as SaveProfileRequest.llm)
- Decrypts incoming secrets (same as save_profile)
- Fires llm.completion(messages=[ping], max_tokens=1)
- Returns ValidateProfileResponse with {valid, error?: {type, message}}
- Uses the SDK typed exception hierarchy (LLMAuthenticationError, LLMBadRequestError, etc.)
- Transient errors (LLMRateLimitError, LLMTimeoutError) are non-blocking

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `c7e270aae43a` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -93,0 +94 @@
+operation POST /api/file/create_directory operationId=create_directory_api_file_create_directory_post
@@ -108,0 +110 @@
+operation POST /api/profiles/{name}/validate operationId=validate_profile_api_profiles__name__validate_post
@@ -228,0 +231 @@
+parameter POST /api/file/create_directory query:path required=true schema=type="string"
@@ -234,0 +238 @@
+parameter POST /api/profiles/{name}/validate path:name required=true schema=type="string" minLength=1 maxLength=64 pattern="^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
@@ -272,0 +277 @@
+requestBody POST /api/profiles/{name}/validate application/json required=true schema=ValidateProfileRequest
@@ -487,0 +493,2 @@
+response POST /api/file/create_directory 200 application/json schema=Success
+response POST /api/file/create_directory 422 application/json schema=HTTPValidationError
@@ -518,0 +526,2 @@
+response POST /api/profiles/{name}/validate 200 application/json schema=ValidateProfileResponse
+response POST /api/profiles/{name}/validate 422 application/json schema=HTTPValidationError
@@ -2565,0 +2575,8 @@
+schema ValidateProfileError property message required schema=type="string"
+schema ValidateProfileError property type required schema=type="string"
+schema ValidateProfileError type="object"
+schema ValidateProfileRequest property llm required schema=LLM-Input
+schema ValidateProfileRequest type="object"
+schema ValidateProfileResponse property error optional schema=anyOf=[ValidateProfileError,type="null"]
+schema ValidateProfileResponse property valid required schema=type="boolean"
+schema ValidateProfileResponse type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

## How to Test

- [x] pytest tests/agent_server/test_profiles_router.py -k validate_profile — all 6 pass
- [ ] Frontend PR (OpenHands/OpenHands) will wire this into the save flow

This PR was created by an AI agent (OpenHands) on behalf of the user.




<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:03dab92-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-03dab92-python \
  ghcr.io/openhands/agent-server:03dab92-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:03dab92-golang-amd64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-golang-amd64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-golang-amd64
ghcr.io/openhands/agent-server:03dab92-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:03dab92-golang-arm64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-golang-arm64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-golang-arm64
ghcr.io/openhands/agent-server:03dab92-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:03dab92-java-amd64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-java-amd64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-java-amd64
ghcr.io/openhands/agent-server:03dab92-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:03dab92-java-arm64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-java-arm64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-java-arm64
ghcr.io/openhands/agent-server:03dab92-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:03dab92-python-amd64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-python-amd64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-python-amd64
ghcr.io/openhands/agent-server:03dab92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:03dab92-python-arm64
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-python-arm64
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-python-arm64
ghcr.io/openhands/agent-server:03dab92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:03dab92-golang
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-golang
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-golang
ghcr.io/openhands/agent-server:03dab92-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:03dab92-java
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-java
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-java
ghcr.io/openhands/agent-server:03dab92-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:03dab92-python
ghcr.io/openhands/agent-server:03dab921876a8c5aef27f202a1c39eeb24924ca2-python
ghcr.io/openhands/agent-server:feat-llm-preflight-validation-python
ghcr.io/openhands/agent-server:03dab92-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `03dab92-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `03dab92-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

Closes #4429
<!-- description validation refresh -->


<!-- re-evaluate review-thread gate: all threads resolved (281490e4) -->
