### PR TITLE
fix(agent-server): initialize observability after deferred env

### DIFF
--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -31,6 +31,7 @@ from openhands.agent_server.telemetry import (
     shutdown_telemetry_sink,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.observability import maybe_init_laminar
 
 
 logger = get_logger(__name__)
@@ -226,6 +227,7 @@ class InitService:
                 # tools pick up credentials.
                 for key, value in req.env.items():
                     os.environ[key] = value
+            maybe_init_laminar()
 
             # Must precede get_instance(), which captures the sink. The
             # matching emit_server_started() is deferred until the ``ready``

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -197,6 +197,16 @@ class TestInitServiceTransitions:
         _reset_conversation_singleton()
         # Pre-clean so the env var truly comes from /api/init.
         monkeypatch.delenv("DEFERRED_INIT_TEST_VAR", raising=False)
+        observed_env = None
+
+        def capture_observability_env():
+            nonlocal observed_env
+            observed_env = os.environ.get("DEFERRED_INIT_TEST_VAR")
+
+        monkeypatch.setattr(
+            "openhands.agent_server.init_router.maybe_init_laminar",
+            capture_observability_env,
+        )
         base = Config(
             deferred_init=True,
             conversations_path=tmp_path / "convs",
@@ -214,6 +224,7 @@ class TestInitServiceTransitions:
         )
         try:
             assert os.environ.get("DEFERRED_INIT_TEST_VAR") == "hello"
+            assert observed_env == "hello"
         finally:
             await svc.teardown()
             monkeypatch.delenv("DEFERRED_INIT_TEST_VAR", raising=False)


### PR DESCRIPTION
<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
We use deferred-init agent servers and need runtime observability configuration to take effect before conversations start.
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

In deferred-init mode, the agent server imports the SDK before `POST /api/init` supplies runtime environment variables. Observability initialization therefore runs before `LMNR_*` or generic OTEL variables exist, and later conversations produce non-recording spans even though the init request accepted the variables.

## Summary

- Call the existing idempotent `maybe_init_laminar()` after deferred-init environment variables are applied and before conversation services start.
- Extend the deferred-init environment test to verify observability sees the injected values.
- Leave the normal startup path and public REST contract unchanged.

## Issue Number

None.

## How to Test

```bash
uv run pytest tests/sdk/observability/test_laminar.py tests/agent_server/test_init_router.py -q
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/init_router.py tests/agent_server/test_init_router.py
```

Result: 57 tests passed; all targeted pre-commit checks passed.

I also exercised the real FastAPI application through `TestClient`: started it with `deferred_init=True` and no observability environment, then posted `LMNR_PROJECT_API_KEY`, `LMNR_BASE_URL`, `LMNR_HTTP_PORT`, and `LMNR_FORCE_HTTP` through `/api/init`.

```text
before_init=False
init_status=200
after_init=True
```

Before this change, the regression test fails because deferred init never invokes the observability initializer.

## Video/Screenshots

Not applicable; server lifecycle change only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The change adds no Laminar-specific request field or workspace abstraction. `maybe_init_laminar()` already handles both Laminar and generic OTEL configuration and is idempotent when observability was initialized during normal startup.