### PR TITLE
feat(observability): allow selecting Laminar instruments

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -103,11 +103,16 @@ def maybe_init_laminar():
     base_url = get_env("LMNR_BASE_URL") or None
     force_http = _get_bool_env("LMNR_FORCE_HTTP")
     instruments_env = get_env("LMNR_INSTRUMENTS")
-    instruments = (
-        {Instruments(value.strip()) for value in instruments_env.split(",")}
-        if instruments_env
-        else None
-    )
+    instruments = None
+    if instruments_env is not None:
+        instruments = set()
+        for value in map(str.strip, instruments_env.split(",")):
+            if not value:
+                continue
+            try:
+                instruments.add(Instruments(value))
+            except ValueError:
+                logger.warning("Ignoring invalid LMNR_INSTRUMENTS value %r", value)
 
     if _is_otel_backend_laminar():
         Laminar.initialize(

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -84,6 +84,9 @@ def maybe_init_laminar():
 
     To force HTTP instead of gRPC for Laminar communication:
     LMNR_FORCE_HTTP=true  # or 1, yes, on
+
+    To initialize only selected Laminar integrations:
+    LMNR_INSTRUMENTS=litellm,mcp
     """
     if not should_enable_observability():
         logger.debug(
@@ -99,17 +102,25 @@ def maybe_init_laminar():
 
     base_url = get_env("LMNR_BASE_URL") or None
     force_http = _get_bool_env("LMNR_FORCE_HTTP")
+    instruments_env = get_env("LMNR_INSTRUMENTS")
+    instruments = (
+        {Instruments(value.strip()) for value in instruments_env.split(",")}
+        if instruments_env
+        else None
+    )
 
     if _is_otel_backend_laminar():
         Laminar.initialize(
             base_url=base_url,
             http_port=_get_int_env("LMNR_HTTP_PORT"),
             grpc_port=_get_int_env("LMNR_GRPC_PORT"),
+            instruments=instruments,
             force_http=force_http,
         )
     else:
         # Do not enable browser session replays for non-laminar backends
         Laminar.initialize(
+            instruments=instruments,
             disabled_instruments=[
                 Instruments.BROWSER_USE_SESSION,
                 Instruments.PATCHRIGHT,

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -274,6 +274,36 @@ def test_lmnr_force_http_passed_to_laminar(force_http_value, expected_force_http
             del os.environ["LMNR_FORCE_HTTP"]
 
 
+@pytest.mark.parametrize("is_laminar_backend", [True, False])
+def test_lmnr_instruments_passed_to_laminar(is_laminar_backend):
+    """LMNR_INSTRUMENTS limits Laminar to the selected integrations."""
+    from lmnr import Instruments
+
+    with patch.dict(
+        os.environ,
+        {
+            "LMNR_PROJECT_API_KEY": "test-key",
+            "LMNR_INSTRUMENTS": "litellm,mcp",
+        },
+    ):
+        with (
+            patch("lmnr.Laminar") as mock_laminar,
+            patch(
+                "openhands.sdk.observability.laminar._is_otel_backend_laminar",
+                return_value=is_laminar_backend,
+            ),
+        ):
+            mock_laminar.is_initialized.return_value = False
+            from openhands.sdk.observability.laminar import maybe_init_laminar
+
+            maybe_init_laminar()
+
+    assert mock_laminar.initialize.call_args.kwargs["instruments"] == {
+        Instruments.LITELLM,
+        Instruments.MCP,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Cross-context root-span propagation
 # ---------------------------------------------------------------------------

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -275,7 +275,16 @@ def test_lmnr_force_http_passed_to_laminar(force_http_value, expected_force_http
 
 
 @pytest.mark.parametrize("is_laminar_backend", [True, False])
-def test_lmnr_instruments_passed_to_laminar(is_laminar_backend):
+@pytest.mark.parametrize(
+    ("instruments_env", "expected", "invalid"),
+    [
+        ("litellm,mcp", {"litellm", "mcp"}, None),
+        ("litellm,,unsupported,", {"litellm"}, "unsupported"),
+    ],
+)
+def test_lmnr_instruments_passed_to_laminar(
+    is_laminar_backend, instruments_env, expected, invalid, caplog
+):
     """LMNR_INSTRUMENTS limits Laminar to the selected integrations."""
     from lmnr import Instruments
 
@@ -283,7 +292,7 @@ def test_lmnr_instruments_passed_to_laminar(is_laminar_backend):
         os.environ,
         {
             "LMNR_PROJECT_API_KEY": "test-key",
-            "LMNR_INSTRUMENTS": "litellm,mcp",
+            "LMNR_INSTRUMENTS": instruments_env,
         },
     ):
         with (
@@ -299,9 +308,10 @@ def test_lmnr_instruments_passed_to_laminar(is_laminar_backend):
             maybe_init_laminar()
 
     assert mock_laminar.initialize.call_args.kwargs["instruments"] == {
-        Instruments.LITELLM,
-        Instruments.MCP,
+        Instruments(value) for value in expected
     }
+    if invalid:
+        assert f"Ignoring invalid LMNR_INSTRUMENTS value '{invalid}'" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
In our E2B deferred-init setup, limiting Laminar to LiteLLM reduced median POST /api/init latency from 5.971s to 0.370s across three fresh sandboxes.
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`Laminar.initialize()` enables every supported auto-instrumentation by default. Applications that only use a subset still pay the package discovery and initialization cost for the full catalog during startup.

In an OpenHands Agent Server deferred-init environment, limiting initialization to LiteLLM reduced median `POST /api/init` latency from 5.971s to 0.370s across three fresh E2B sandboxes per configuration (93.8% reduction).

## Summary

- Add the optional `LMNR_INSTRUMENTS` environment variable using comma-separated Laminar instrument values.
- Pass the selected instruments to Laminar for both Laminar and generic OTLP backends.
- Preserve the existing initialize-all behavior when the variable is unset.

## Issue Number

N/A

## How to Test

Unit coverage:

```bash
uv run pytest tests/sdk/observability/test_laminar.py -q
```

Result: 42 passed.

Repository checks:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/observability/laminar.py tests/sdk/observability/test_laminar.py
```

Result: Ruff format, Ruff lint, pycodestyle, pyright, import rules, and tool registration checks passed.

End-to-end benchmark:

1. Started a fresh `ghcr.io/openhands/agent-server:1.41.0-python`-based E2B sandbox in deferred-init mode for each run.
2. Sent the same Laminar configuration to `POST /api/init`.
3. Compared the default with `LMNR_INSTRUMENTS=litellm`.

| Configuration | Run 1 | Run 2 | Run 3 | Median |
|---|---:|---:|---:|---:|
| Default instruments | 5.971s | 6.169s | 5.527s | 5.971s |
| `litellm` only | 0.361s | 0.370s | 0.399s | 0.370s |

## Video/Screenshots

Not applicable; this is an environment configuration change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion documentation PR: https://github.com/OpenHands/docs/pull/706

Review feedback addressed in commit 6425b2c0c.