### PR TITLE
fix(sdk): disable switch_llm by default (#16442)

### DIFF
--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -189,10 +189,10 @@ class OpenHandsAgentProfile(AgentProfileBase):
         description="Enable sub-agent delegation via TaskToolSet.",
     )
     enable_switch_llm_tool: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Enable the built-in switch_llm tool for switching between saved "
-            "LLM profiles. Defaults True to match the global agent settings "
+            "LLM profiles. Defaults False to match the global agent settings "
             "default (AgentSettingsConfig.enable_switch_llm_tool)."
         ),
     )

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1230,7 +1230,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         },
     )
     enable_switch_llm_tool: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Enable the built-in switch_llm tool for switching between saved "
             "LLM profiles."

--- a/openhands-sdk/openhands/sdk/tool/builtins/switch_llm.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/switch_llm.py
@@ -171,7 +171,7 @@ class SwitchLLMTool(ToolDefinition[SwitchLLMAction, SwitchLLMObservation]):
                 executor=SwitchLLMExecutor(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
-                    destructiveHint=False,
+                    destructiveHint=True,
                     idempotentHint=False,
                     openWorldHint=False,
                 ),

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -58,18 +58,18 @@ def test_openhands_profile_round_trips() -> None:
 
 
 def test_openhands_profile_new_field_defaults() -> None:
-    """``enable_switch_llm_tool`` defaults True (global parity); ``disabled_skills``
+    """``enable_switch_llm_tool`` defaults False (global parity); ``disabled_skills``
     defaults ``[]`` — the deny-list starts empty, so an unset field means "all
     discovered skills" (#4017). Skills are selected by exclusion, never an
     allow-list of names that could dangle."""
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
-    assert profile.enable_switch_llm_tool is True
+    assert profile.enable_switch_llm_tool is False
     assert profile.disabled_skills == []
     reloaded = validate_agent_profile(
         {"agent_kind": "openhands", "name": "oh", "llm_profile_ref": "default"}
     )
     assert isinstance(reloaded, OpenHandsAgentProfile)
-    assert reloaded.enable_switch_llm_tool is True
+    assert reloaded.enable_switch_llm_tool is False
     assert reloaded.disabled_skills == []
 
 

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -233,7 +233,7 @@ def test_missing_llm_ref_raises_profile_not_found(
 # --------------------------------------------------------------------------- #
 
 
-def test_enable_switch_llm_tool_defaults_true_threads_through(
+def test_enable_switch_llm_tool_defaults_false_threads_through(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
@@ -245,15 +245,15 @@ def test_enable_switch_llm_tool_defaults_true_threads_through(
         cipher=None,
     )
     assert isinstance(settings, OpenHandsAgentSettings)
-    # Defaults True to match the global agent settings default.
-    assert settings.enable_switch_llm_tool is True
+    # Defaults False to match the global agent settings default.
+    assert settings.enable_switch_llm_tool is False
 
 
-def test_enable_switch_llm_tool_false_threads_through(
+def test_enable_switch_llm_tool_true_threads_through(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
     profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", enable_switch_llm_tool=False
+        name="oh", llm_profile_ref="default", enable_switch_llm_tool=True
     )
     settings = resolve_agent_profile(
         profile,
@@ -263,7 +263,7 @@ def test_enable_switch_llm_tool_false_threads_through(
         cipher=None,
     )
     assert isinstance(settings, OpenHandsAgentSettings)
-    assert settings.enable_switch_llm_tool is False
+    assert settings.enable_switch_llm_tool is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -83,7 +83,7 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     assert general_fields["enable_sub_agents"].default is False
     assert general_fields["enable_sub_agents"].prominence is SettingProminence.MAJOR
     assert general_fields["enable_switch_llm_tool"].value_type == "boolean"
-    assert general_fields["enable_switch_llm_tool"].default is True
+    assert general_fields["enable_switch_llm_tool"].default is False
     assert (
         general_fields["enable_switch_llm_tool"].prominence is SettingProminence.MINOR
     )

--- a/tests/sdk/tool/test_switch_llm.py
+++ b/tests/sdk/tool/test_switch_llm.py
@@ -54,25 +54,9 @@ def test_switch_llm_tool_description_lists_available_profiles(profile_store):
     assert "- slow" in tool.description
 
 
-def test_agent_settings_includes_switch_llm_tool_when_profiles_exist(profile_store):
-    # tools=[] (not the None default): these tests resolve tools for real via
-    # _ensure_agent_ready and tests/sdk registers no exec tools.
+def test_agent_settings_omits_switch_llm_tool_by_default(profile_store):
     agent = OpenHandsAgentSettings(
         llm=_make_llm("default-model", "default"), tools=[]
-    ).create_agent()
-
-    assert "SwitchLLMTool" in agent.include_default_tools
-
-    conversation = LocalConversation(agent=agent, workspace=Path.cwd())
-    conversation._ensure_agent_ready()
-    assert "switch_llm" in agent.tools_map
-
-
-def test_agent_settings_omits_switch_llm_tool_when_disabled(profile_store):
-    agent = OpenHandsAgentSettings(
-        llm=_make_llm("default-model", "default"),
-        tools=[],
-        enable_switch_llm_tool=False,
     ).create_agent()
 
     assert "SwitchLLMTool" not in agent.include_default_tools
@@ -82,9 +66,11 @@ def test_agent_settings_omits_switch_llm_tool_when_disabled(profile_store):
     assert "switch_llm" not in agent.tools_map
 
 
-def test_agent_settings_includes_switch_llm_tool_without_profiles(empty_profile_store):
+def test_agent_settings_includes_switch_llm_tool_when_enabled(profile_store):
     agent = OpenHandsAgentSettings(
-        llm=_make_llm("default-model", "default"), tools=[]
+        llm=_make_llm("default-model", "default"),
+        tools=[],
+        enable_switch_llm_tool=True,
     ).create_agent()
 
     assert "SwitchLLMTool" in agent.include_default_tools
@@ -92,6 +78,18 @@ def test_agent_settings_includes_switch_llm_tool_without_profiles(empty_profile_
     conversation = LocalConversation(agent=agent, workspace=Path.cwd())
     conversation._ensure_agent_ready()
     assert "switch_llm" in agent.tools_map
+
+
+def test_agent_settings_omits_switch_llm_tool_without_profiles(empty_profile_store):
+    agent = OpenHandsAgentSettings(
+        llm=_make_llm("default-model", "default"), tools=[]
+    ).create_agent()
+
+    assert "SwitchLLMTool" not in agent.include_default_tools
+
+    conversation = LocalConversation(agent=agent, workspace=Path.cwd())
+    conversation._ensure_agent_ready()
+    assert "switch_llm" not in agent.tools_map
 
 
 def test_switch_llm_tool_switches_conversation_profile(profile_store):


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Fixes #16442 by disabling `switch_llm` by default in the SDK agent settings and profiles, and annotating `SwitchLLMTool` with `destructiveHint=True` to require user confirmation when enabled.

## Summary

- Changed `enable_switch_llm_tool` default value from `True` to `False` in `OpenHandsAgentSettings` and `AgentProfile`.
- Annotated `SwitchLLMTool` with `destructiveHint=True` so model switching operations trigger confirmation flows under policies requiring user approval.
- Updated SDK unit tests in `test_switch_llm.py`, `test_settings.py`, `test_resolver.py`, and `test_agent_profile.py`.

## Issue Number

Fixes #16442

## How to Test

Run SDK unit tests:
```bash
poetry run pytest software-agent-sdk/tests/sdk/tool/test_switch_llm.py software-agent-sdk/tests/sdk/test_settings.py software-agent-sdk/tests/sdk/profiles/test_resolver.py software-agent-sdk/tests/sdk/profiles/test_agent_profile.py
