### PR TITLE
fix(sdk): prevent double provider-prefix strip for namespaced model IDs

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
@@ -73,7 +73,16 @@ class LLMProvider:
         return api_key
 
     def as_litellm_call_kwargs(self, *, api_key: str | None = None) -> dict[str, str]:
-        kwargs = {"model": self.model}
+        # When the parsed model still starts with the provider prefix (e.g.
+        # "openai/example-model" for provider "openai"), LiteLLM re-parses and
+        # strips the prefix again on the Responses API path, sending the wrong
+        # model upstream (e.g. "example-model" instead of "openai/example-
+        # model"). Re-prefix so LiteLLM strips exactly one prefix and lands on
+        # the parsed model.
+        model = self.model
+        if self.name is not None and model.startswith(f"{self.name}/"):
+            model = f"{self.name}/{model}"
+        kwargs = {"model": model}
         if self.name is not None:
             kwargs["custom_llm_provider"] = self.name
         normalized_api_key = self.api_key_for_litellm(api_key)

--- a/tests/sdk/llm/test_litellm_provider.py
+++ b/tests/sdk/llm/test_litellm_provider.py
@@ -60,6 +60,34 @@ def test_llm_provider_keeps_requested_api_base_verbatim():
     assert provider.api_base == "https://myproxy.example.com"
 
 
+def test_llm_provider_preserves_namespaced_model_after_litellm_reparse():
+    # LiteLLM strips the first "openai/" prefix from "openai/openai/example-
+    # model", leaving parsed model "openai/example-model" with provider
+    # "openai". Without re-prefixing, LiteLLM's Responses API path strips the
+    # "openai/" prefix again and sends "example-model" upstream (400 Model not
+    # found). The kwargs from as_litellm_call_kwargs must resolve back to the
+    # parsed model, not the double-stripped one.
+    provider = LLMProvider.from_model(
+        model="openai/openai/example-model",
+        api_base="https://myproxy.example.com/v1",
+    )
+
+    assert provider.name == "openai"
+    assert provider.model == "openai/example-model"
+
+    kwargs = provider.as_litellm_call_kwargs()
+    assert kwargs["custom_llm_provider"] == "openai"
+
+    resolved = litellm.get_llm_provider(
+        model=kwargs["model"],
+        custom_llm_provider=kwargs["custom_llm_provider"],
+        api_base=provider.api_base,
+        api_key=None,
+    )
+    assert resolved[0] == "openai/example-model"
+    assert resolved[1] == "openai"
+
+
 @pytest.mark.parametrize(
     ("model", "api_base"),
     [


### PR DESCRIPTION
HUMAN:

Santhi Prakash — small SDK fix for namespaced OpenAI model IDs; see the AGENT section for the reproduction, regression test, and pre-commit verification.

---

AGENT:

## Why

`LLMProvider.from_model()` parses a model string like `openai/openai/example-model` into `model="openai/example-model"` + `provider="openai"`. When `as_litellm_call_kwargs()` forwards that as `model="openai/example-model"` + `custom_llm_provider="openai"`, LiteLLM's Responses API path re-parses and strips the `openai/` prefix again, sending `example-model` upstream instead of `openai/example-model`, which returns `400 Model not found`.

This affects any namespaced model ID where the inner segment is also a LiteLLM provider name (e.g. `openai/openai/o3-mini`, `mistral/mistral/large`). The OpenRouter nested case (`openrouter/anthropic/claude-sonnet-4`) is unaffected because LiteLLM has a dedicated OpenRouter special-case that preserves the inner `provider/model` form.

## Summary

- Re-prefix the model in `as_litellm_call_kwargs()` when the parsed model still starts with the provider prefix, so LiteLLM strips exactly one prefix and lands on the correct parsed model.
- Added regression test `test_llm_provider_preserves_namespaced_model_after_litellm_reparse` covering `openai/openai/example-model`.

## Issue Number

Fixes #4613

Upstream report: https://github.com/OpenHands/OpenHands/issues/16365

## How to Test

```bash
uv run pytest tests/sdk/llm/test_litellm_provider.py -v
```

Result (12 passed):

```
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_parses_nested_openrouter_model PASSED
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_parses_bedrock_model PASSED
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_strips_api_key_for_bedrock_calls PASSED
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_handles_unknown_model_without_provider PASSED
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_keeps_requested_api_base_verbatim PASSED
tests/sdk/llm/test_litellm_provider.py::test_llm_provider_preserves_namespaced_model_after_litellm_reparse PASSED
tests/sdk/llm/test_litellm_provider.py::test_split_kwargs_equivalent_to_full_model_string[...] PASSED (6 cases)
============================== 12 passed in 0.55s ==============================
```

Pre-commit verification:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py tests/sdk/llm/test_litellm_provider.py
```

All checks passed (Ruff format, Ruff lint, PEP8, pyright, import dependency rules, tool subclass registration).

Reproduction proof (before fix vs after fix):

```python
import litellm
# Before: double-strip
litellm.get_llm_provider(model="openai/example-model", custom_llm_provider="openai")
# -> ("example-model", "openai")  wrong, 400 Model not found

# After: re-prefix prevents double-strip
litellm.get_llm_provider(model="openai/openai/example-model", custom_llm_provider="openai")
# -> ("openai/example-model", "openai")  correct
```

## Video/Screenshots

N/A — backend correctness fix, no visual surface.

## Design Doc

Not added — this is a small one-line correctness fix with a regression test, not a new API or behavior change in the agent loop.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix is minimal and only triggers when `self.model.startswith(f"{self.name}/")` — the exact condition that causes the double-strip. All existing test cases (openrouter nested, bedrock, mistral, litellm_proxy, openai local, unknown) are unaffected because their parsed models do not start with the provider prefix.
