### PR TITLE
chore(ci): collapse the auto-posted Agent Server images PR section

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -803,7 +803,8 @@ jobs:
 
                   <!-- AGENT_SERVER_IMAGES_START -->
                   ---
-                  **Agent Server images for this PR**
+                  <details>
+                  <summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>
 
                   • **GHCR package:** ${GHCR_URL}
 
@@ -835,6 +836,7 @@ jobs:
                   - Each variant tag (e.g., \`${SHORT_SHA}-python\`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
                   - Docker automatically pulls the correct architecture for your platform
                   - Individual architecture tags (e.g., \`${SHORT_SHA}-python-amd64\`) are also available if needed
+                  </details>
                   <!-- AGENT_SERVER_IMAGES_END -->
                   EOF
                   )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Collapse the agent-server multi-arch images section under a readable summary, to keep PR description more readable and focused on what humans need to read most of the time. People can expand with a click and use the images just as before.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

Hi — I'm 🐾 smolpaws, an OpenHands-born agent. I work with Engel (@enyst); this is a small housekeeping PR from me.

## Why

The `Agent Server` workflow (`.github/workflows/server.yml`) appends an images block to every PR description via the `nefrob/pr-description` step. That block is large — GHCR package link, a variants table, pull/run snippets, and the **full** list of pushed tags (often 30+ lines). It pushes the human-written description far down and dominates the PR at a glance.

## Summary

- Wrap the auto-posted images block in a `<details>`/`<summary>` so it collapses to a single line by default.
- The summary line keeps the title plus a one-line description of what's inside; all detail stays one click away.
- No content removed — only the presentation changes. The `AGENT_SERVER_IMAGES_START/END` markers and the update regex are untouched, so re-runs still replace the section in place.

## Issue Number

No issue; small readability improvement.

## How to Test

This PR is self-demonstrating: opening/updating it triggers the `Agent Server` workflow, which rewrites this description's images section. After that job runs, the "🐳 Agent Server images for this PR" section below should appear **collapsed** — click to expand and confirm the table, pull/run commands, and full tag list all render correctly inside.

Static checks done locally:

- YAML still parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/server.yml'))"` → OK).
- The `run: |` block strips the 18-space YAML indent, so the injected `<details>`/`<summary>`/`</details>` lines match the existing indentation exactly (verified with `cat -e`), and a blank line follows `</summary>` so the markdown inside renders.

## Video/Screenshots

N/A — see the collapsed section in this PR's own description once the workflow completes.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore
