### PR TITLE
fix(acp): price cache and thought tokens, and stop stacking derived cost

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -827,8 +827,9 @@ def _estimate_cost_from_tokens(
     counted inside ``prompt_tokens``. So each bucket is priced and added rather
     than discounted out of the input total.
 
-    Cache buckets fall back to the plain input rate when the model has no
-    cache-specific rate; thought tokens are billed as output.
+    Cache buckets fall back to the plain input rate only when the model has no
+    cache-specific rate at all; an explicit rate of 0 means free. Thought tokens
+    are billed as output.
 
     Returns 0.0 if pricing is unavailable for the model.
     """
@@ -843,8 +844,8 @@ def _estimate_cost_from_tokens(
             if input_tokens or output_tokens or cache_read_tokens or cache_write_tokens:
                 _warn_unknown_acp_pricing(model)
             return 0.0
-        cache_read_cost = info.get("cache_read_input_token_cost") or input_cost
-        cache_write_cost = info.get("cache_creation_input_token_cost") or input_cost
+        cache_read_cost = info.get("cache_read_input_token_cost", input_cost)
+        cache_write_cost = info.get("cache_creation_input_token_cost", input_cost)
         return (
             input_tokens * input_cost
             + output_tokens * output_cost

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -29,6 +29,7 @@ import uuid
 import weakref
 from collections.abc import Awaitable, Callable, Collection, Generator, Iterable
 from concurrent.futures import Future
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
@@ -802,10 +803,32 @@ def _extract_token_usage(
     return (0, 0, 0, 0, 0)
 
 
+@cache
+def _warn_unknown_acp_pricing(model: str) -> None:
+    """Warn once per model that ACP cost cannot be derived for it."""
+    logger.warning(
+        "No LiteLLM pricing for ACP model %r - cost stays 0 for this session",
+        model,
+    )
+
+
 def _estimate_cost_from_tokens(
-    model: str, input_tokens: int, output_tokens: int
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    reasoning_tokens: int = 0,
 ) -> float:
     """Estimate cost from token counts using LiteLLM's pricing database.
+
+    ACP reports every bucket separately (``Usage.total_tokens`` is documented as
+    the sum of all token types), unlike litellm/OpenAI where cached reads are
+    counted inside ``prompt_tokens``. So each bucket is priced and added rather
+    than discounted out of the input total.
+
+    Cache buckets fall back to the plain input rate when the model has no
+    cache-specific rate; thought tokens are billed as output.
 
     Returns 0.0 if pricing is unavailable for the model.
     """
@@ -816,7 +839,19 @@ def _estimate_cost_from_tokens(
         info = cost_map.get(model, {})
         input_cost = info.get("input_cost_per_token", 0) or 0
         output_cost = info.get("output_cost_per_token", 0) or 0
-        return input_tokens * input_cost + output_tokens * output_cost
+        if not input_cost and not output_cost:
+            if input_tokens or output_tokens or cache_read_tokens or cache_write_tokens:
+                _warn_unknown_acp_pricing(model)
+            return 0.0
+        cache_read_cost = info.get("cache_read_input_token_cost") or input_cost
+        cache_write_cost = info.get("cache_creation_input_token_cost") or input_cost
+        return (
+            input_tokens * input_cost
+            + output_tokens * output_cost
+            + cache_read_tokens * cache_read_cost
+            + cache_write_tokens * cache_write_cost
+            + reasoning_tokens * output_cost
+        )
     except Exception:
         return 0.0
 
@@ -1892,10 +1927,23 @@ class ACPAgent(AgentBase):
         # -- Cost derivation from tokens --------------------------------------
         # gemini-cli: no UsageUpdate cost, so derive from token counts using
         # LiteLLM's model pricing database (same source the proxy uses).
-        # claude-agent-acp, codex-acp: skipped since cost_recorded is True.
-        if not cost_recorded and (input_tokens or output_tokens) and self.acp_model:
+        # claude-agent-acp, codex-acp: skipped once the provider has reported a
+        # cost for this session. Keying on "has the provider ever reported"
+        # rather than on this call's delta keeps a repeated cumulative amount
+        # (delta == 0) from being mistaken for "no provider cost".
+        provider_cost_seen = session_id in self._client._last_cost_by_session
+        if (
+            not provider_cost_seen
+            and (input_tokens or output_tokens)
+            and self.acp_model
+        ):
             cost = _estimate_cost_from_tokens(
-                self.acp_model, input_tokens, output_tokens
+                self.acp_model,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens=cache_read,
+                cache_write_tokens=cache_write,
+                reasoning_tokens=reasoning,
             )
             if cost > 0:
                 self.llm.metrics.add_cost(cost)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
+import logging
 import threading
 import time
 import uuid
@@ -48,6 +49,7 @@ from openhands.sdk.agent.acp_agent import (
     _stringify_acp_error_data,
     _strip_inherited_npm_env,
     _warn_auth_selection_failure,
+    _warn_unknown_acp_pricing,
     _with_codex_base_url,
 )
 from openhands.sdk.agent.acp_file_credentials import (
@@ -6034,6 +6036,193 @@ class TestEstimateCostFromTokens:
             assert (
                 _estimate_cost_from_tokens("gemini-3-flash-preview", 1000, 500) == 0.0
             )
+
+    def test_cache_and_reasoning_tokens_are_priced(self):
+        """Cache and thought buckets are additive in ACP, so they add cost.
+
+        ``Usage.total_tokens`` is documented as the sum of all token types, so
+        ``cached_read_tokens`` is not contained in ``input_tokens`` the way
+        litellm/OpenAI report it.
+        """
+        mock_cost_map = {
+            "gemini-3-flash-preview": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "cache_read_input_token_cost": 1e-07,
+                "cache_creation_input_token_cost": 6e-07,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            cost = _estimate_cost_from_tokens(
+                "gemini-3-flash-preview",
+                1000,
+                500,
+                cache_read_tokens=900,
+                cache_write_tokens=50,
+                reasoning_tokens=30,
+            )
+
+        assert cost == pytest.approx(
+            1000 * 5e-07 + 500 * 3e-06 + 900 * 1e-07 + 50 * 6e-07 + 30 * 3e-06
+        )
+
+    def test_cache_tokens_fall_back_to_input_rate(self):
+        """Models without cache-specific rates price cache tokens as input."""
+        mock_cost_map = {
+            "some-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            cost = _estimate_cost_from_tokens(
+                "some-model", 0, 0, cache_read_tokens=100, cache_write_tokens=100
+            )
+
+        assert cost == pytest.approx(200 * 5e-07)
+
+    def test_unknown_model_warns(self, caplog):
+        """An unpriced model is surfaced instead of silently recording $0."""
+        _warn_unknown_acp_pricing.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            assert _estimate_cost_from_tokens("unpriced-model-abc", 100, 50) == 0.0
+
+        assert any(
+            "unpriced-model-abc" in record.message for record in caplog.records
+        ), caplog.text
+
+    def test_unknown_model_warns_only_once_per_model(self, caplog):
+        """The warning does not repeat on every turn for the same model."""
+        _warn_unknown_acp_pricing.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            _estimate_cost_from_tokens("unpriced-model-def", 100, 50)
+            _estimate_cost_from_tokens("unpriced-model-def", 100, 50)
+            _estimate_cost_from_tokens("unpriced-model-def", 100, 50)
+
+        matching = [r for r in caplog.records if "unpriced-model-def" in r.message]
+        assert len(matching) == 1, caplog.text
+
+    def test_zero_tokens_does_not_warn_for_unknown_model(self, caplog):
+        """A turn with no tokens is not an unpriced-model problem."""
+        _warn_unknown_acp_pricing.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            assert _estimate_cost_from_tokens("unpriced-model-ghi", 0, 0) == 0.0
+
+        assert not [r for r in caplog.records if "unpriced-model-ghi" in r.message]
+
+
+# ---------------------------------------------------------------------------
+# _record_usage cost derivation
+# ---------------------------------------------------------------------------
+
+
+class TestRecordUsageDerivedCost:
+    """The token-derived estimate must not stack on top of provider cost."""
+
+    @staticmethod
+    def _make_response(input_tokens=1000, output_tokens=500):
+        response = MagicMock()
+        usage = MagicMock()
+        usage.input_tokens = input_tokens
+        usage.output_tokens = output_tokens
+        usage.cached_read_tokens = 0
+        usage.cached_write_tokens = 0
+        usage.thought_tokens = 0
+        response.usage = usage
+        return response
+
+    @staticmethod
+    def _make_usage_update(amount):
+        update = MagicMock()
+        update.cost = MagicMock()
+        update.cost.amount = amount
+        return update
+
+    def _make_agent_with_pricing(self):
+        agent = _make_agent(acp_model="priced-model")
+        agent._client = _OpenHandsACPBridge()
+        return agent
+
+    def test_derived_estimate_not_stacked_on_provider_cost(self):
+        """A repeated cumulative cost must not trigger a token-derived top-up.
+
+        The provider reports cumulative cost, so a second UsageUpdate carrying
+        the same amount yields ``delta == 0``. That must not be read as "the
+        provider never reported cost".
+        """
+        agent = self._make_agent_with_pricing()
+        mock_cost_map = {
+            "priced-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            agent._record_usage(
+                self._make_response(),
+                "sess-1",
+                usage_update=self._make_usage_update(10.0),
+            )
+            assert agent.llm.metrics.accumulated_cost == pytest.approx(10.0)
+
+            agent._record_usage(
+                self._make_response(),
+                "sess-1",
+                usage_update=self._make_usage_update(10.0),
+            )
+
+        assert agent.llm.metrics.accumulated_cost == pytest.approx(10.0)
+
+    def test_derived_estimate_still_applies_without_provider_cost(self):
+        """gemini-cli style sessions keep deriving cost from tokens."""
+        agent = self._make_agent_with_pricing()
+        mock_cost_map = {
+            "priced-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            agent._record_usage(self._make_response(), "sess-2", usage_update=None)
+
+        assert agent.llm.metrics.accumulated_cost == pytest.approx(
+            1000 * 5e-07 + 500 * 3e-06
+        )
+
+    def test_derived_estimate_prices_cache_buckets(self):
+        """The derived path forwards the cache/thought buckets it extracted."""
+        agent = self._make_agent_with_pricing()
+        response = self._make_response()
+        response.usage.cached_read_tokens = 900
+        response.usage.cached_write_tokens = 50
+        response.usage.thought_tokens = 30
+        mock_cost_map = {
+            "priced-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "cache_read_input_token_cost": 1e-07,
+                "cache_creation_input_token_cost": 6e-07,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            agent._record_usage(response, "sess-3", usage_update=None)
+
+        assert agent.llm.metrics.accumulated_cost == pytest.approx(
+            1000 * 5e-07 + 500 * 3e-06 + 900 * 1e-07 + 50 * 6e-07 + 30 * 3e-06
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6208,6 +6208,27 @@ class TestRecordUsageDerivedCost:
 
         assert agent.llm.metrics.accumulated_cost == pytest.approx(10.0)
 
+    def test_provider_reporting_zero_cost_blocks_the_derived_estimate(self):
+        """A first report of 0.0 still means the provider is reporting cost."""
+        agent = self._make_agent_with_pricing()
+        mock_cost_map = {
+            "priced-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            agent._record_usage(
+                self._make_response(),
+                "sess-zero",
+                usage_update=self._make_usage_update(0.0),
+            )
+
+        assert agent.llm.metrics.accumulated_cost == pytest.approx(0.0)
+
     def test_derived_estimate_still_applies_without_provider_cost(self):
         """gemini-cli style sessions keep deriving cost from tokens."""
         agent = self._make_agent_with_pricing()

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6085,6 +6085,34 @@ class TestEstimateCostFromTokens:
 
         assert cost == pytest.approx(200 * 5e-07)
 
+    def test_explicit_zero_cache_rate_is_free(self):
+        """A rate of 0 means free, not missing.
+
+        ``deepseek/deepseek-chat`` and 30 other entries in litellm's cost map
+        set ``cache_creation_input_token_cost`` to 0, and 17 do the same for
+        ``cache_read_input_token_cost``.
+        """
+        mock_cost_map = {
+            "free-cache-model": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "cache_read_input_token_cost": 0.0,
+                "cache_creation_input_token_cost": 0.0,
+            }
+        }
+        mock_litellm = MagicMock()
+        mock_litellm.model_cost = mock_cost_map
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            cost = _estimate_cost_from_tokens(
+                "free-cache-model",
+                100,
+                0,
+                cache_read_tokens=1000,
+                cache_write_tokens=1000,
+            )
+
+        assert cost == pytest.approx(100 * 5e-07)
+
     def test_unknown_model_warns(self, caplog):
         """An unpriced model is surfaced instead of silently recording $0."""
         _warn_unknown_acp_pricing.cache_clear()


### PR DESCRIPTION
HUMAN:

Before touching any of the math I wanted to be sure cache tokens weren't already inside the input count. Turns out ACP keeps them in separate buckets, so they were going through completely unpriced. The other two were more clear cut.

---

AGENT:

## Why

Fixes #4382.

Three defects in ACP cost accounting, all reachable from `_record_usage`.

**1. Cache and thought tokens are never priced.** `_extract_token_usage` pulls five buckets out of the ACP `Usage`, but `_estimate_cost_from_tokens(model, input_tokens, output_tokens)` only ever sees two of them.

Worth being precise about the direction of this one, because it is the opposite of what it looks like. ACP reports the buckets *separately*: `Usage.total_tokens` is documented as "Sum of all token types across session", and `metrics.py` already says so out loud in `cache_hit_rate` ("litellm/OpenAI count cached reads inside `prompt_tokens`; ACP reports them separately"). So cached reads are not a discountable subset of the input total the way they are on the litellm path. They are additional tokens that were being billed at nothing, which means a cache-heavy gemini-cli session is **under-billed**, not discounted incorrectly.

**2. The derived estimate can stack on top of provider cost.** `cost_recorded` is only set when a `UsageUpdate` arrives with `delta > 0`. Provider cost is cumulative, so a second `UsageUpdate` carrying the same amount produces `delta == 0`, `cost_recorded` stays `False`, and the token-derived estimate is added on top of cost that was already recorded. `accumulated_cost` then exceeds the provider's own cumulative figure.

**3. An unpriced model records $0 in silence.** `cost_map.get(model, {})` yields empty, both rates are 0, the function returns 0.0, and the caller's `if cost > 0` drops it. Nothing is logged, so a whole session reads as free.

## Summary

- `_estimate_cost_from_tokens` takes the cache and thought buckets and prices them; cache rates fall back to the plain input rate only when the model has no rate at all (an explicit rate of 0 means free), thought tokens price as output.
- The derived branch keys off whether the provider has ever reported a cost for the session, rather than off this call's delta.
- An unpriced model warns once (`@cache` on the warn helper keeps it to one line per model, not one per turn).

## Issue Number

Fixes #4382

## How to Test

Unit tests:

```
uv run pytest tests/sdk/agent/test_acp_agent.py -k "TestEstimateCostFromTokens or TestRecordUsageDerivedCost"
```

Since unit tests alone are not sufficient here, the behaviour is also demonstrated against the real `ACPAgent._record_usage` with real litellm pricing (nothing on the pricing path is mocked), on `gemini-2.5-flash`: `input 3e-07`, `output 2.5e-06`, `cache_read 3e-08`, `cache_creation` absent.

Same script, `upstream/main` vs this branch:

```
                                                     before        after
scenario 1  cache-heavy turn, no provider cost
  1000 input / 100 output / 900 cache_read
  / 50 cache_write / 30 thought            0.00055000   0.00066700

scenario 2  provider reports cumulative 10.0 twice
  accumulated_cost                        10.00055000  10.00000000
  overcharge vs provider figure            0.00055000   0.00000000

scenario 3  unpriced model
  accumulated_cost                         0.00000000   0.00000000
  warning emitted                                 no          yes
```

Scenario 1 going **up** is the point: the missing 0.000117 is the 900 cache-read, 50 cache-write and 30 thought tokens that were previously free.

Scenario 3's warning:

```
WARNING  No LiteLLM pricing for ACP model 'totally-unknown-model-xyz' - cost stays 0 for this session
```

Full file: 441 passed. Four failures in `TestACPFileSecretMaterialisation` and `TestACPDataDirIsolation` are pre-existing on this Windows host and fail identically on unmodified `upstream/main`.

Each of the four behaviours was checked by neutralising it in turn and confirming the matching test goes red: dropping the double-count guard, unpricing cache reads, unpricing thought tokens, and removing the warning. All four are caught.

`ruff format --check`, `ruff check` and `scripts/check_import_rules.py` are clean on both touched files.

## Video/Screenshots

Console output above; this path has no UI surface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- @EvolveAegis reported this with a dynamic reproduction, which is what the two scenarios above are built on. The one thing I would flag against that report is the direction of the cache fix: it describes the cache-read gap as a lost discount, and under ACP's bucket semantics it is a lost charge.
- Follow-up commit `ed804ff` after review: the cache-rate fallback used `info.get(key) or input_cost`, which cannot tell a missing rate from a rate of 0. 17 entries in litellm's cost map set `cache_read_input_token_cost` to 0 and 31 set `cache_creation_input_token_cost` to 0 (`deepseek/deepseek-chat` among them), so those were charged at the input rate instead of being free. Now a `dict.get` default, with a test.
- `_estimate_cost_from_tokens` keeps its positional `(model, input, output)` signature, so existing callers and tests are unaffected.
- Thought tokens are priced at the output rate. That matches how Gemini and Anthropic bill reasoning, but it is a judgement call, and worth a second opinion from someone who owns the pricing side.
- Not addressed here: the issue's item 5, that failed or cancelled turns never reach `_record_usage` at all and a pending `UsageUpdate` can be dropped on the next `prepare_usage_sync`. That is a lifecycle question rather than a pricing one, and it deserves its own change.

