### PR TITLE
fix(tools): ship the browser recording JS helpers in the wheel

### DIFF
--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -40,3 +40,4 @@ namespaces = true
 [tool.setuptools.package-data]
 "*" = ["py.typed", "**/*.j2"]
 "openhands.tools.preset.subagents" = ["*.md"]
+"openhands.tools.browser_use" = ["js/*.js"]

--- a/tests/cross/test_package_data.py
+++ b/tests/cross/test_package_data.py
@@ -8,8 +8,8 @@ from the working tree and passes either way. The gap only appears once the
 wheel is built, which is how it reached a release (issue #4443).
 """
 
+import sys
 import tomllib
-from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -34,7 +34,9 @@ def _is_declared(path: Path) -> bool:
     A dotted key names a directory relative to the project root, which need not
     be an importable package: ``openhands.tools.preset.subagents`` has no
     ``__init__.py`` and still ships. ``*`` applies to every directory on the way
-    down, so its patterns are matched against each one.
+    down, so its patterns are matched against each one. Patterns are expanded
+    with ``Path.glob`` because that is what setuptools itself does, so ``*``
+    stops at a directory boundary and only ``**`` descends.
     """
     for key, patterns in _package_data_patterns().items():
         if key == "*":
@@ -50,8 +52,7 @@ def _is_declared(path: Path) -> bool:
             bases = [base]
 
         for base in bases:
-            relative_path = path.relative_to(base).as_posix()
-            if any(fnmatch(relative_path, pattern) for pattern in patterns):
+            if any(path in base.glob(pattern) for pattern in patterns):
                 return True
     return False
 
@@ -87,3 +88,20 @@ def test_browser_recording_js_helpers_are_declared():
     assert helpers, "expected browser_use/js to hold the recording helpers"
     for helper in helpers:
         assert _is_declared(helper), helper.name
+
+
+def test_a_nested_file_is_not_declared_by_a_single_star_pattern(tmp_path, monkeypatch):
+    """``js/*.js`` covers the directory it names, not the ones below it."""
+    project = tmp_path / "openhands-tools"
+    js_dir = project / "openhands" / "tools" / "browser_use" / "js"
+    (js_dir / "nested").mkdir(parents=True)
+    (js_dir / "recording.js").touch()
+    (js_dir / "nested" / "recording.js").touch()
+    (project / "pyproject.toml").write_text(
+        '[tool.setuptools.package-data]\n"openhands.tools.browser_use" = ["js/*.js"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys.modules[__name__], "TOOLS_PROJECT", project)
+
+    assert _is_declared(js_dir / "recording.js")
+    assert not _is_declared(js_dir / "nested" / "recording.js")

--- a/tests/cross/test_package_data.py
+++ b/tests/cross/test_package_data.py
@@ -1,0 +1,89 @@
+"""Runtime data files must be declared as package data.
+
+``openhands-tools`` ships helper assets next to the code that loads them (the
+browser recording JS, the subagent prompts). Those only reach an installed
+wheel if a ``[tool.setuptools.package-data]`` glob covers them, and nothing
+source checkout reveals an omission: an editable install reads them straight
+from the working tree and passes either way. The gap only appears once the
+wheel is built, which is how it reached a release (issue #4443).
+"""
+
+import tomllib
+from fnmatch import fnmatch
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_PROJECT = REPO_ROOT / "openhands-tools"
+TOOLS_PACKAGE = TOOLS_PROJECT / "openhands" / "tools"
+
+# Contributor docs that sit next to the code and are never opened at runtime.
+DEV_ONLY_FILENAMES = frozenset({"AGENTS.md", "README.md"})
+
+
+def _package_data_patterns() -> dict[str, list[str]]:
+    pyproject = tomllib.loads(
+        (TOOLS_PROJECT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    return pyproject["tool"]["setuptools"]["package-data"]
+
+
+def _is_declared(path: Path) -> bool:
+    """Whether any package-data glob ships ``path``.
+
+    A dotted key names a directory relative to the project root, which need not
+    be an importable package: ``openhands.tools.preset.subagents`` has no
+    ``__init__.py`` and still ships. ``*`` applies to every directory on the way
+    down, so its patterns are matched against each one.
+    """
+    for key, patterns in _package_data_patterns().items():
+        if key == "*":
+            bases = [
+                parent
+                for parent in path.parents
+                if parent.is_relative_to(TOOLS_PROJECT)
+            ]
+        else:
+            base = TOOLS_PROJECT.joinpath(*key.split("."))
+            if not path.is_relative_to(base):
+                continue
+            bases = [base]
+
+        for base in bases:
+            relative_path = path.relative_to(base).as_posix()
+            if any(fnmatch(relative_path, pattern) for pattern in patterns):
+                return True
+    return False
+
+
+def _runtime_data_files() -> list[Path]:
+    return sorted(
+        path
+        for path in TOOLS_PACKAGE.rglob("*")
+        if path.is_file()
+        and path.suffix != ".py"
+        and "__pycache__" not in path.parts
+        and path.name not in DEV_ONLY_FILENAMES
+    )
+
+
+def test_runtime_data_files_are_declared_as_package_data():
+    undeclared = [
+        path.relative_to(TOOLS_PROJECT).as_posix()
+        for path in _runtime_data_files()
+        if not _is_declared(path)
+    ]
+
+    assert not undeclared, (
+        "these files are read at runtime but no package-data glob ships them, "
+        "so they are missing from the built wheel: " + ", ".join(undeclared)
+    )
+
+
+def test_browser_recording_js_helpers_are_declared():
+    """The helpers ``browser_use/recording.py`` loads by name."""
+    helpers = sorted((TOOLS_PACKAGE / "browser_use" / "js").glob("*.js"))
+
+    assert helpers, "expected browser_use/js to hold the recording helpers"
+    for helper in helpers:
+        assert _is_declared(helper), helper.name


### PR DESCRIPTION
HUMAN:

I first checked whether the six JS files were the only missing runtime assets, or if something else was being left out of the wheel too. Turns out js/*.js was the whole gap; everything else is either already packaged or just contributor documentation.

---

AGENT:

## Why

Fixes #4443.

`browser_use/recording.py` loads six helpers by name from `_JS_DIR = Path(__file__).parent / "js"` (`recording.py:46`, read at `:84`). `openhands-tools/pyproject.toml` declared package-data only for `py.typed`, `**/*.j2` and the subagent prompts, so the `js/` directory never reached the built wheel. `agent-server.spec` already asks for it with `collect_data_files("openhands.tools.browser_use", includes=["js/*.js"])`, but there was nothing installed to collect, and a frozen agent-server raised `FileNotFoundError` on `browser_start_recording`.

Nothing in a source checkout surfaces this. An editable install reads the files straight from the working tree, so the tests pass and the tool works right up until someone installs a wheel.

## Summary

- `openhands-tools/pyproject.toml` declares `"openhands.tools.browser_use" = ["js/*.js"]`.
- A `tests/cross` check walks every non-Python file under `openhands/tools`, skips the contributor docs, and asserts a package-data glob covers the rest.

## Issue Number

Fixes #4443

## How to Test

Clean wheel build, before and after. The build directory has to be removed between runs or the previous build's `build/` and `.egg-info` are reused and the second measurement is meaningless:

```
cd openhands-tools
rm -rf build openhands_tools.egg-info
python -m pip wheel . --no-deps --no-build-isolation -w /tmp/w
python - <<'PY'
import zipfile, glob
w = sorted(glob.glob("/tmp/w/*.whl"))[-1]
print([n for n in zipfile.ZipFile(w).namelist() if "browser_use/js/" in n])
PY
```

On `main` that prints `[]`. With this change it prints all six helpers:

```
before (clean build)   0 js entries
after  (clean build)   6 js entries
  flush-events.js            197 b
  rrweb-loader.js           2469 b
  start-recording-simple.js  502 b
  start-recording.js         725 b
  stop-recording.js          368 b
  wait-for-rrweb.js          591 b
```

The new test fails on `main` naming exactly those six files, and passes with the change:

```
uv run pytest tests/cross/test_package_data.py
```

`tests/cross`: 327 passed, 49 skipped. Two failures are pre-existing on this Windows host and not related to this change: `test_generate_baseline_payloads_uses_uv_with_release_cutoff` fails identically with the change stashed, and `test_websocket_attach_wait_does_not_block_ready_endpoint` is a 0.5s timing bound that passes on re-run.

`ruff format --check` and `ruff check` are clean on the new file.

## Video/Screenshots

Console output above; this path has no UI surface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- I checked whether anything else was missing rather than just the reported files. The only non-Python files under `openhands/tools` are the six `.js`, six `.md` and `py.typed`; of the markdown, `terminal/README.md` and `AGENTS.md` are contributor docs that nothing reads at runtime, and the subagent prompts already ship. So `js/*.js` is the whole gap.
- The subagent prompts ship even though `openhands/tools/preset/subagents/` has no `__init__.py`, which is why the test resolves a dotted package-data key to a directory rather than to an importable package. That matches what the wheel actually contains.
- The test is a static check of the globs, not a build. It catches an undeclared asset, which is the failure mode here, but it cannot catch a build backend that ignores a correctly declared glob. Building a wheel per test run seemed too heavy for what it buys.
- `agent-server.spec` needs no change, as the reporter noted.
- Follow-up in `898b18a`: the review pointed out that `fnmatch` lets a single `*` cross a directory, so a nested `js/subdir/file.js` would have read as shipped. The check now expands each pattern with `Path.glob` against the base directory, which is the semantics setuptools itself uses, and a new test pins the nested case.
