### PR TITLE
feat(llm): support user-configurable send_reasoning_content per model

### DIFF
--- a/.pr/design.md
+++ b/.pr/design.md
@@ -1,0 +1,91 @@
+# Make `send_reasoning_content` user-configurable per LLM instance
+
+## Problem
+
+Whether the SDK sends the model's full reasoning content back in the message
+input was decided **only** by a hardcoded allow-list,
+`SEND_REASONING_CONTENT_MODELS` in
+`openhands-sdk/openhands/sdk/llm/utils/model_features.py`.
+
+Consequences of the hardcoded-only approach:
+
+- Enabling a new thinking-capable model required editing the list, cutting a
+  new SDK release, and having every consumer upgrade + migrate.
+- Users running a model behind a custom/proxy name the list does not match had
+  no way to opt in.
+- There was no way to force-disable the behavior for a listed model.
+
+## Approach
+
+Reuse the LLM's existing per-instance override channel,
+`LLM.capability_overrides` (`openhands-sdk/openhands/sdk/llm/llm.py`), which
+already flows into `get_features(..., overrides=...)` and already backs
+`supports_vision`, `supports_stop_words`, `supports_prompt_cache`, etc.
+
+`send_reasoning_content` was the one capability that ignored `overrides` and
+read the hardcoded list directly. We route it through the same `_resolved_bool`
+helper the other capabilities use, keeping the list as the fallback.
+
+Resolution precedence (unchanged pattern, now applied to this field too):
+
+1. explicit `capability_overrides["send_reasoning_content"]` (respects `False`)
+2. LiteLLM model metadata, if present
+3. fallback: `model_matches(model, SEND_REASONING_CONTENT_MODELS)`
+
+This deliberately keeps provider-specific criteria inside the feature registry
+rather than `llm.py`, matching the repo guidance that "LLM-specific behavior
+tweaks should start in `model_features.py` whenever they can be expressed as
+model/provider capabilities."
+
+## Before / After
+
+Before (`get_features`):
+
+```python
+send_reasoning_content=model_matches(model, SEND_REASONING_CONTENT_MODELS),
+```
+
+After:
+
+```python
+send_reasoning_content=_resolved_bool(
+    "send_reasoning_content",
+    overrides=overrides,
+    metadata=model_info,
+    fallback=model_matches(model, SEND_REASONING_CONTENT_MODELS),
+),
+```
+
+Usage:
+
+```python
+# Opt a not-yet-listed model in:
+LLM(model="my/new-thinking-model",
+    capability_overrides={"send_reasoning_content": True})
+
+# Force-disable for a listed model:
+LLM(model="kimi-k2-thinking",
+    capability_overrides={"send_reasoning_content": False})
+```
+
+## Why this is safe / low-risk
+
+- **Backward compatible**: default behavior is identical — with no override the
+  hardcoded list still decides. No behavior change for existing configs.
+- **No new public API surface**: `capability_overrides` already exists and is a
+  persisted `dict[str, bool | str]` field, so no settings `schema_version` bump
+  and no migration are needed.
+- **No `llm.py` logic added**: only a doc-string update listing the new
+  supported key; the resolution stays in the feature registry.
+
+## Testing
+
+- `test_send_reasoning_content_support` (existing): fallback list unchanged.
+- `test_send_reasoning_content_override` (new): override enables a non-listed
+  model (`gpt-4o`) and disables a listed one (`kimi-k2-thinking`).
+
+Run:
+
+```bash
+uv run pytest tests/sdk/llm/test_model_features.py -k send_reasoning
+```

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -410,9 +410,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "Explicit model capability overrides. Supported keys include "
             "supports_reasoning_effort, thinking_mode (adaptive, manual, none, "
             "or unknown), supports_sampling_params, supports_prompt_cache, "
-            "supports_stop_words, supports_responses_api, supports_vision, and "
-            "supports_prompt_cache_retention. Overrides take precedence over "
-            "LiteLLM metadata and SDK fallbacks."
+            "supports_stop_words, supports_responses_api, supports_vision, "
+            "send_reasoning_content, and supports_prompt_cache_retention. "
+            "Overrides take precedence over LiteLLM metadata and SDK fallbacks."
         ),
         json_schema_extra=field_meta(),
     )

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -385,7 +385,12 @@ def get_features(
         ),
         supports_responses_api=_supports_responses_api(model, model_info, overrides),
         force_string_serializer=model_matches(model, FORCE_STRING_SERIALIZER_MODELS),
-        send_reasoning_content=model_matches(model, SEND_REASONING_CONTENT_MODELS),
+        send_reasoning_content=_resolved_bool(
+            "send_reasoning_content",
+            overrides=overrides,
+            metadata=model_info,
+            fallback=model_matches(model, SEND_REASONING_CONTENT_MODELS),
+        ),
         # Extended prompt_cache_retention support follows ordered include/exclude rules.
         supports_prompt_cache_retention=_resolved_bool(
             "supports_prompt_cache_retention",

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -561,3 +561,18 @@ def test_send_reasoning_content_support(model, expected_send_reasoning):
     """Test that models like kimi-k2-thinking require send_reasoning_content."""
     features = get_features(model)
     assert features.send_reasoning_content is expected_send_reasoning
+
+
+@pytest.mark.parametrize(
+    "model, override, expected",
+    [
+        # Enable for a model that is not in the fallback list.
+        ("gpt-4o", True, True),
+        # Disable for a model that is in the fallback list.
+        ("kimi-k2-thinking", False, False),
+    ],
+)
+def test_send_reasoning_content_override(model, override, expected):
+    """capability_overrides can flip send_reasoning_content either direction."""
+    features = get_features(model, overrides={"send_reasoning_content": override})
+    assert features.send_reasoning_content is expected


### PR DESCRIPTION
Let users opt a model in/out via LLM.capability_overrides instead of only the hardcoded allow-list, which stays as the fallback.

HUMAN:

This change makes it possible for users to control, per LLM instance, whether the SDK sends a model's full reasoning content back in the message input. Previously this was decided only by a hardcoded allow-list (SEND_REASONING_CONTENT_MODELS), so enabling a new thinking-capable model — or one served under a custom/proxy name — meant editing that list, releasing a new SDK version, and waiting for consumers to upgrade, with no way to turn it off for a model already on the list. 

The fix routes send_reasoning_content through the same resolution path already used by other model capabilities, so an explicit LLM.capability_overrides value wins first, then LiteLLM metadata, and finally the hardcoded list as a fallback. It is fully backward compatible (with no override, the list behaves exactly as before) and adds no new public API or settings migration, since capability_overrides is an existing field.

---

AGENT:

## Why

Whether the SDK sends full reasoning content back in the message input was
gated only by the hardcoded `SEND_REASONING_CONTENT_MODELS` allow-list in
`openhands-sdk/openhands/sdk/llm/utils/model_features.py`. Adding a new
thinking-capable model (or one behind a custom/proxy name) required editing the
list, releasing the SDK, and having consumers upgrade — and there was no way to
force-disable it for a listed model. This makes the behavior user-configurable
per LLM instance while keeping the list as a fallback.

## Summary

- Route `send_reasoning_content` through the existing `_resolved_bool` helper in
  `get_features`, so `LLM.capability_overrides["send_reasoning_content"]` takes
  precedence, then LiteLLM metadata, then the hardcoded list fallback.
- Document `send_reasoning_content` as a supported key in the
  `LLM.capability_overrides` field description.
- Add a unit test covering enabling a non-listed model and disabling a listed
  model via the override.

## How to Test

```bash
uv run pytest tests/sdk/llm/test_model_features.py -k send_reasoning
```

Or programmatically:

```python
from openhands.sdk.llm.utils.model_features import get_features

# fallback list still works
assert get_features("kimi-k2-thinking").send_reasoning_content is True
assert get_features("gpt-4o").send_reasoning_content is False
# per-instance override, both directions
assert get_features(
    "gpt-4o", overrides={"send_reasoning_content": True}
).send_reasoning_content is True
assert get_features(
    "kimi-k2-thinking", overrides={"send_reasoning_content": False}
).send_reasoning_content is False
```

## Design Doc

See `.pr/design.md` for the before/after and rationale.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Backward compatible: with no override, the hardcoded list decides exactly as
  before.
- No new public API surface and no persisted-settings migration:
  `capability_overrides` is an existing `dict[str, bool | str]` field.
