### PR TITLE
fix(sdk): stop serializing concurrent LLM calls through modify_params lock

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -8,7 +8,6 @@ import os
 import threading
 import warnings
 from collections.abc import AsyncIterable, Callable, Iterable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -625,21 +624,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     _call_context: LLMCallContext = PrivateAttr(default_factory=LLMCallContext)
     _effective_max_input_tokens: int | None = PrivateAttr(default=None)
     _effective_max_output_tokens: int | None = PrivateAttr(default=None)
-    # Plain (non-reentrant) Lock: the async transport path acquires this off
-    # the event loop thread (see `_alitellm_modify_params_ctx`) and releases
-    # it back on the event loop thread, which an RLock would reject since it
-    # tracks a single owning thread.
+    # Guards the reference counts and the ``litellm.modify_params`` global.
+    # Held only for the brief counter update / set / restore — never across
+    # the HTTP round-trip — so concurrent sync calls no longer serialize.
     _litellm_modify_params_lock: ClassVar[threading.Lock] = threading.Lock()
-    # Waiting on the lock from the async path is offloaded to this dedicated
-    # executor rather than the event loop's default one. The coroutine that
-    # *holds* the lock may itself need a default-executor thread to make
-    # progress before it can release (e.g. draining a synchronous stream via
-    # ``run_in_executor``); if lock-waiters shared that pool they could occupy
-    # every worker and starve the holder, deadlocking instead of just
-    # serialising. Keeping the wait on its own pool prevents that.
-    _litellm_modify_params_lock_executor: ClassVar[ThreadPoolExecutor] = (
-        ThreadPoolExecutor(thread_name_prefix="llm-modify-params-lock")
-    )
+    # Reference counts of in-flight transport calls that want each
+    # ``modify_params`` value. When both drop to zero the global is restored
+    # to ``_modify_params_original``.
+    _modify_params_refs: ClassVar[dict[bool, int]] = {True: 0, False: 0}
+    # Snapshot of ``litellm.modify_params`` captured when the first in-flight
+    # call enters; restored when the last one exits. ``None`` while idle.
+    _modify_params_original: ClassVar[bool | None] = None
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="ignore", arbitrary_types_allowed=True
@@ -2271,75 +2266,85 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
     @contextmanager
     def _litellm_modify_params_ctx(self, flag: bool):
+        """Set ``litellm.modify_params`` for the duration of a transport call.
+
+        ``litellm.modify_params`` is a process-wide global that LiteLLM reads
+        synchronously during request transformation (before the HTTP call).
+        Previously a single class-level ``threading.Lock`` was held for the
+        *entire* transport call to guard the set/restore pair, which
+        serialized all concurrent sync LLM calls in the process — with local
+        models (vLLM, Ollama, llama.cpp) where one call takes 30-120s, N
+        parallel conversations took N×30-120s instead of 30-120s.
+
+        The lock is now held only briefly to bump a reference count and set
+        the global, then released so concurrent calls can overlap. When the
+        last in-flight call finishes the global is restored to its pre-call
+        value.
+
+        Race note: if two concurrent calls request *different* values, the
+        last one to enter wins the global during transformation. This is
+        inherent to LiteLLM's process-wide global and cannot be solved
+        without an upstream LiteLLM change; in practice concurrent calls in
+        the same process almost always share the same value, and local
+        models (where the serialization hurts most) use
+        ``modify_params=False``.
+        """
         with self._litellm_modify_params_lock:
-            old = getattr(litellm, "modify_params", None)
-            try:
-                litellm.modify_params = flag
-                yield
-            finally:
-                litellm.modify_params = old
+            refs = type(self)._modify_params_refs
+            if refs[True] == 0 and refs[False] == 0:
+                type(self)._modify_params_original = getattr(
+                    litellm, "modify_params", None
+                )
+            refs[flag] += 1
+            litellm.modify_params = flag
+        try:
+            yield
+        finally:
+            with self._litellm_modify_params_lock:
+                refs[flag] -= 1
+                if refs[True] == 0 == refs[False]:
+                    litellm.modify_params = type(self)._modify_params_original
+                    type(self)._modify_params_original = None
+                elif refs[True] > 0:
+                    litellm.modify_params = True
+                else:
+                    litellm.modify_params = False
 
     @asynccontextmanager
     async def _alitellm_modify_params_ctx(self, flag: bool):
         """Async variant of :meth:`_litellm_modify_params_ctx`.
 
-        ``litellm.modify_params`` is a process-wide global, so the lock must
-        stay held for the full duration of the transport call, not just the
-        moment the flag is set. A plain ``with self._litellm_modify_params_lock:``
-        would work for that, but only for the sync path: entering it here
-        with a blocking ``with`` statement would hold a real OS-level lock
-        across the ``await`` below. If a concurrent *sync* transport call
-        (e.g. a condenser or non-async agent step running in a worker
-        thread) is holding that lock at the time, this coroutine's attempt
-        to acquire it blocks the event loop thread itself -- which freezes
-        every other request the server is handling until the sync call
-        finishes (this is what makes agent-server stop responding to all
-        requests while waiting on a slow/local LLM response, most visible
-        during condensation).
+        Shares the same reference-counted approach as the sync variant: the
+        lock is held only for the brief counter update / set / restore, never
+        across the ``await`` on the transport call, so concurrent async and
+        sync calls no longer serialize through a single lock held for the
+        full HTTP round-trip.
 
-        Acquiring via ``run_in_executor`` moves the wait for the lock onto a
-        worker thread, so the event loop stays free to serve other requests
-        while this call is blocked on a concurrent transport call. The lock
-        is a plain (non-reentrant) ``threading.Lock``, so it is safe to
-        acquire on one thread and release on another.
-
-        Cancellation subtlety: if this coroutine is cancelled while waiting
-        (conversation stop/pause, timeout), the worker thread has already
-        started ``acquire()`` and cannot be interrupted -- it will still take
-        the lock. We therefore ``shield`` the acquire so the cancellation does
-        not mark it cancelled: the shielded future still resolves to the real
-        acquire result, and a done-callback releases the lock if it was
-        actually taken. Without this the lock would be acquired with nobody to
-        release it, permanently wedging every LLM call process-wide.
+        Because the lock is held for microseconds (not the full call
+        duration), a plain blocking ``with`` is safe even on the event-loop
+        thread — the previous ``run_in_executor`` / ``shield`` / cancellation
+        machinery is no longer needed.
         """
-        loop = asyncio.get_running_loop()
-        acquire = loop.run_in_executor(
-            self._litellm_modify_params_lock_executor,
-            self._litellm_modify_params_lock.acquire,
-        )
+        with self._litellm_modify_params_lock:
+            refs = type(self)._modify_params_refs
+            if refs[True] == 0 and refs[False] == 0:
+                type(self)._modify_params_original = getattr(
+                    litellm, "modify_params", None
+                )
+            refs[flag] += 1
+            litellm.modify_params = flag
         try:
-            await asyncio.shield(acquire)
-        except asyncio.CancelledError:
-            lock = self._litellm_modify_params_lock
-
-            def _release_if_acquired(fut: asyncio.Future) -> None:
-                # ``shield`` kept ``acquire`` alive, so its result reflects
-                # whether the worker thread actually took the lock. Release it
-                # if so, since the cancelled coroutine below never will.
-                if not fut.cancelled() and fut.exception() is None:
-                    lock.release()
-
-            acquire.add_done_callback(_release_if_acquired)
-            raise
-        try:
-            old = getattr(litellm, "modify_params", None)
-            try:
-                litellm.modify_params = flag
-                yield
-            finally:
-                litellm.modify_params = old
+            yield
         finally:
-            self._litellm_modify_params_lock.release()
+            with self._litellm_modify_params_lock:
+                refs[flag] -= 1
+                if refs[True] == 0 == refs[False]:
+                    litellm.modify_params = type(self)._modify_params_original
+                    type(self)._modify_params_original = None
+                elif refs[True] > 0:
+                    litellm.modify_params = True
+                else:
+                    litellm.modify_params = False
 
     # =========================================================================
     # Capabilities, formatting, and info

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import threading
+import time
 from collections.abc import Sequence
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -79,14 +80,25 @@ def default_config():
     )
 
 
-def test_litellm_modify_params_context_serializes_threads():
+def test_litellm_modify_params_ctx_allows_concurrent_threads(monkeypatch):
+    """Two threads entering ``_litellm_modify_params_ctx`` concurrently must
+    NOT serialize — the lock is held only for the brief counter update, not
+    across the body of the ``with`` block.
+
+    This was the root cause of GH #16459: a ``ClassVar[threading.Lock]`` held
+    for the full LLM call serialized all concurrent sync conversations, so N
+    parallel local-model calls took N×(30-120s) instead of 30-120s.
+    """
+    # Isolate class-level ref-count state so this test cannot pollute or be
+    # polluted by other tests.
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
     first_llm = LLM.model_construct(modify_params=True)
     second_llm = LLM.model_construct(modify_params=False)
     original = getattr(llm_module.litellm, "modify_params", None)
 
     entered_first = threading.Event()
     release_first = threading.Event()
-    started_second = threading.Event()
     entered_second = threading.Event()
     observed: list[tuple[str, bool]] = []
     errors: list[BaseException] = []
@@ -101,8 +113,6 @@ def test_litellm_modify_params_context_serializes_threads():
             errors.append(exc)
 
     def run_second():
-        entered_first.wait(timeout=2)
-        started_second.set()
         try:
             with second_llm._litellm_modify_params_ctx(False):
                 observed.append(("second", llm_module.litellm.modify_params))
@@ -116,9 +126,11 @@ def test_litellm_modify_params_context_serializes_threads():
         first_thread.start()
         assert entered_first.wait(timeout=2)
 
+        # Second thread must enter *immediately* — no serialization.
         second_thread.start()
-        assert started_second.wait(timeout=2)
-        assert not entered_second.wait(timeout=0.2)
+        assert entered_second.wait(timeout=2), (
+            "second thread was serialized behind the first (regression)"
+        )
 
         release_first.set()
         first_thread.join(timeout=2)
@@ -130,38 +142,97 @@ def test_litellm_modify_params_context_serializes_threads():
     assert not first_thread.is_alive()
     assert not second_thread.is_alive()
     assert errors == []
-    assert observed == [("first", True), ("second", False)]
+    # Both threads observed their own flag value at entry time.
+    assert ("first", True) in observed
+    assert ("second", False) in observed
+    # Global restored when all in-flight calls finish.
     assert llm_module.litellm.modify_params == original
 
 
-class _CountingLock:
-    """threading.Lock wrapper that counts successful acquires/releases.
+def test_litellm_modify_params_ctx_restores_original_after_all_done(monkeypatch):
+    """When the last in-flight call exits, ``litellm.modify_params`` is
+    restored to the value it had before the first call entered."""
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
+    llm = LLM.model_construct(modify_params=True)
+    original = getattr(llm_module.litellm, "modify_params", None)
 
-    Lets a test deterministically wait for a release that happens on a
-    different thread than the one that acquired -- here, the release scheduled
-    by the async guard's cancellation done-callback.
+    with llm._litellm_modify_params_ctx(True):
+        assert llm_module.litellm.modify_params is True
+    assert llm_module.litellm.modify_params == original
+    assert LLM._modify_params_refs == {True: 0, False: 0}
+    assert LLM._modify_params_original is None
+
+
+def test_litellm_modify_params_ctx_ref_count_nested(monkeypatch):
+    """Nested / overlapping calls keep the global alive until the last one
+    exits, then restore the original."""
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
+    llm = LLM.model_construct(modify_params=True)
+    original = getattr(llm_module.litellm, "modify_params", None)
+
+    with llm._litellm_modify_params_ctx(True):
+        assert LLM._modify_params_refs[True] == 1
+        with llm._litellm_modify_params_ctx(True):
+            assert LLM._modify_params_refs[True] == 2
+            assert llm_module.litellm.modify_params is True
+        # Still one in-flight — global must NOT be restored yet.
+        assert LLM._modify_params_refs[True] == 1
+        assert llm_module.litellm.modify_params is True
+    # All done — global restored.
+    assert llm_module.litellm.modify_params == original
+    assert LLM._modify_params_refs == {True: 0, False: 0}
+
+
+def test_litellm_modify_params_ctx_concurrent_overlap(monkeypatch):
+    """Regression for GH #16459: two concurrent sync calls must overlap
+    rather than serialize.
+
+    Simulates two conversations making LLM calls at the same time. If the
+    lock is held for the full call duration (the old behavior), the second
+    call blocks until the first finishes — total wall time ≈ 2×sleep. With
+    the reference-counted fix, both calls overlap — total wall time ≈ 1×sleep.
     """
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
+    llm = LLM.model_construct(modify_params=True)
+    original = getattr(llm_module.litellm, "modify_params", None)
 
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._counter_lock = threading.Lock()
-        self.acquired = 0
-        self.released = 0
+    call_duration = 0.3
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
 
-    def acquire(self, *args, **kwargs) -> bool:
-        got = self._lock.acquire(*args, **kwargs)
-        if got:
-            with self._counter_lock:
-                self.acquired += 1
-        return got
+    def run_call():
+        try:
+            with llm._litellm_modify_params_ctx(True):
+                barrier.wait(timeout=2)  # both threads must reach here
+                time.sleep(call_duration)
+        except BaseException as exc:
+            errors.append(exc)
 
-    def release(self) -> None:
-        self._lock.release()
-        with self._counter_lock:
-            self.released += 1
+    start = time.monotonic()
+    t1 = threading.Thread(target=run_call)
+    t2 = threading.Thread(target=run_call)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    elapsed = time.monotonic() - start
 
-    def locked(self) -> bool:
-        return self._lock.locked()
+    try:
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+        assert errors == []
+        # If serialized: ≈2×call_duration. If overlapped: ≈1×call_duration.
+        # Allow generous slack for scheduling jitter.
+        assert elapsed < 2 * call_duration, (
+            f"calls were serialized: elapsed={elapsed:.2f}s, "
+            f"expected <{2 * call_duration}s"
+        )
+        assert llm_module.litellm.modify_params == original
+    finally:
+        llm_module.litellm.modify_params = original
 
 
 async def _await_condition(pred, timeout: float = 2.0) -> bool:
@@ -173,85 +244,69 @@ async def _await_condition(pred, timeout: float = 2.0) -> bool:
     return pred()
 
 
-async def test_alitellm_modify_params_ctx_releases_lock_on_cancel(monkeypatch):
-    """Regression: cancelling the async modify-params guard while it waits for
-    the lock must not leak the lock.
-
-    The acquire runs on an uninterruptible worker thread, so it still takes the
-    lock after the coroutine is cancelled. If that acquisition is not released,
-    every subsequent LLM call in the process wedges forever -- worse than the
-    freeze this guard was added to fix.
-    """
-    # Isolate from the process-wide class lock so a regression here cannot
-    # wedge the rest of the suite.
-    lock = _CountingLock()
-    monkeypatch.setattr(LLM, "_litellm_modify_params_lock", lock)
+async def test_alitellm_modify_params_ctx_cleans_up_refs_on_cancel(monkeypatch):
+    """Cancelling the async guard while inside the ``yield`` must still
+    decrement the reference count so the global is eventually restored."""
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
     llm = LLM.model_construct(modify_params=True)
-
-    # Simulate a concurrent *sync* holder (condenser / non-async agent step)
-    # that owns the lock for the whole round trip.
-    assert lock.acquire()
-
-    async def enter_guard():
-        async with llm._alitellm_modify_params_ctx(True):
-            pass  # never reached while the sync holder owns the lock
-
-    task = asyncio.ensure_future(enter_guard())
-    # Let the coroutine reach the blocking acquire() on the worker thread.
-    await asyncio.sleep(0.1)
-    assert not task.done()
-
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    # Release the sync holder so the (uninterruptible) worker-thread acquire
-    # can now complete -- this is what would leak the lock without the fix.
-    lock.release()
-
-    # The worker acquire completes (acquired == 2); the done-callback must then
-    # release it (released == 2). Poll deterministically on the counters rather
-    # than racing the callback for the lock's state.
-    settled = await _await_condition(lambda: lock.acquired >= 2 and lock.released >= 2)
-    assert settled, "cancelled acquire never released the lock (leak)"
-    assert not lock.locked(), "modify_params lock left held after cancellation"
-
-
-async def test_alitellm_modify_params_ctx_waits_off_event_loop(monkeypatch):
-    """The async guard must wait for the lock off the event-loop thread.
-
-    While a concurrent sync holder owns the lock, entering the guard must not
-    freeze the loop: a heartbeat coroutine keeps ticking, and the guard only
-    proceeds once the holder releases.
-    """
-    lock = threading.Lock()
-    monkeypatch.setattr(LLM, "_litellm_modify_params_lock", lock)
-    llm = LLM.model_construct(modify_params=True)
-
-    assert lock.acquire()  # sync holder
+    original = getattr(llm_module.litellm, "modify_params", None)
 
     entered = asyncio.Event()
 
     async def enter_guard():
         async with llm._alitellm_modify_params_ctx(True):
             entered.set()
+            await asyncio.Event().wait()  # block forever until cancelled
 
     task = asyncio.ensure_future(enter_guard())
+    await asyncio.wait_for(entered.wait(), timeout=2)
+    assert LLM._modify_params_refs[True] == 1
 
-    # The loop stays responsive while the guard blocks on the held lock.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The finally block must have decremented the ref count and restored
+    # the global even though the coroutine was cancelled.
+    assert LLM._modify_params_refs[True] == 0
+    assert LLM._modify_params_original is None
+    assert llm_module.litellm.modify_params == original
+
+
+async def test_alitellm_modify_params_ctx_does_not_block_event_loop(monkeypatch):
+    """The async guard must not block the event loop.
+
+    The lock is held only for microseconds (counter update + set/restore),
+    so a heartbeat coroutine keeps ticking even while the guard is active.
+    """
+    monkeypatch.setattr(LLM, "_modify_params_refs", {True: 0, False: 0})
+    monkeypatch.setattr(LLM, "_modify_params_original", None)
+    llm = LLM.model_construct(modify_params=True)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def enter_guard():
+        async with llm._alitellm_modify_params_ctx(True):
+            entered.set()
+            await release.wait()
+
+    task = asyncio.ensure_future(enter_guard())
+    await asyncio.wait_for(entered.wait(), timeout=2)
+
+    # The loop stays responsive while the guard body is running.
     ticks = 0
     for _ in range(10):
         await asyncio.sleep(0.01)
         ticks += 1
     assert ticks == 10
-    assert not entered.is_set()
-    assert not task.done()
 
-    # Release -> guard acquires, runs its body, and releases cleanly.
-    lock.release()
+    release.set()
     await asyncio.wait_for(task, timeout=2)
-    assert entered.is_set()
-    assert not lock.locked()
+    assert llm_module.litellm.modify_params == getattr(
+        llm_module.litellm, "modify_params", None
+    )
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

A `ClassVar[threading.Lock]` in `openhands/sdk/llm/llm.py` was held for the entire duration of each LLM transport call to guard the process-wide `litellm.modify_params` boolean. Because it was a `ClassVar`, the lock was shared across **all** `LLM` instances in the process, serializing all concurrent sync conversations. With local models (vLLM, Ollama, llama.cpp) where a single call takes 30-120s, 3 parallel conversations took 90-360s instead of 30-120s — the GPU sat idle while other conversations waited on the lock.

`litellm.modify_params` is read by LiteLLM **synchronously during request transformation** (before the HTTP call) — in `prompt_templates/factory.py`, `utils.py`, and provider-specific transformation modules. Once the HTTP request is sent, the flag is no longer consulted. The lock therefore only needs to guard the set/restore of the global, not the full HTTP round-trip.

## Summary

- Replace the hold-for-full-duration lock with a **reference-counted set/restore**: the lock is held only for the brief counter update and global set/restore (microseconds), then released so concurrent sync and async calls overlap. When the last in-flight call finishes, the global is restored to its pre-call value.
- Simplify the async path (`_alitellm_modify_params_ctx`): the previous `run_in_executor` / `asyncio.shield` / cancellation done-callback machinery (added in #4012 to avoid event-loop freezes) is no longer needed because the lock is no longer held across the `await`. A plain blocking `with` is safe when the lock is held for microseconds.
- Remove the now-unused `_litellm_modify_params_lock_executor` `ThreadPoolExecutor`.

**Race note:** if two concurrent calls request *different* `modify_params` values, the last entrant wins the global during transformation. This is inherent to LiteLLM's process-wide global and cannot be solved without an upstream LiteLLM change. In practice, concurrent calls in the same process almost always share the same `modify_params` value, and local models (where the serialization hurts most) use `modify_params=False`.

## Issue Number

Fixes #16459.

## How to Test

```bash
# Run the modify_params context-manager tests
uv run pytest tests/sdk/llm/test_llm_completion.py -k "modify_params" -v

# Run the full LLM test suite
uv run pytest tests/sdk/llm/ -v

# Lint / format / type check
uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py
uv run ruff format --check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py
```

### Verification results

```
$ uv run pytest tests/sdk/llm/test_llm_completion.py -k "modify_params" -v
tests/sdk/llm/test_llm_completion.py::test_litellm_modify_params_ctx_allows_concurrent_threads PASSED
tests/sdk/llm/test_llm_completion.py::test_litellm_modify_params_ctx_restores_original_after_all_done PASSED
tests/sdk/llm/test_llm_completion.py::test_litellm_modify_params_ctx_ref_count_nested PASSED
tests/sdk/llm/test_llm_completion.py::test_litellm_modify_params_ctx_concurrent_overlap PASSED
tests/sdk/llm/test_llm_completion.py::test_alitellm_modify_params_ctx_cleans_up_refs_on_cancel PASSED
tests/sdk/llm/test_llm_completion.py::test_alitellm_modify_params_ctx_does_not_block_event_loop PASSED
6 passed

$ uv run pytest tests/sdk/llm/ -v
949 passed

$ uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py
All checks passed (ruff format, ruff lint, pycodestyle, pyright, import deps, tool registration)
```

### Key new test: `test_litellm_modify_params_ctx_concurrent_overlap`

Two concurrent sync calls each sleep for 0.3s inside the context manager. If serialized (old behavior), total wall time ≈ 0.6s. With the fix, both overlap → total ≈ 0.3s. The test asserts `elapsed < 2 × call_duration` to verify non-serialization.

## Video/Screenshots

N/A — internal concurrency fix, no UI change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `release-note-required` label on the issue is about API breakage detection. This PR does not change any public API — `_litellm_modify_params_ctx` and `_alitellm_modify_params_ctx` are private methods. The ClassVar `_litellm_modify_params_lock_executor` is removed, but it was also private.
- PR #4012 (merged 2026-07-07) fixed the async event-loop freeze by offloading lock acquisition to `run_in_executor`. This PR supersedes that approach by eliminating the long-held lock entirely, making the `run_in_executor` workaround unnecessary.