### PR TITLE
fix(sdk): preserve pinned requested_ref in InstallationManager.update()

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/installation/manager.py
+++ b/openhands-sdk/openhands/sdk/extensions/installation/manager.py
@@ -291,12 +291,17 @@ class InstallationManager[T: ExtensionProtocol]:
         return info
 
     def update(self, name: str) -> InstallationInfo | None:
-        """Update an installed extension to the latest version.
+        """Reconcile an installed extension with its tracked source.
 
-        Re-fetches the extension from its original source with ``ref=None``
-        (i.e. the latest available) and force-reinstalls it.  The previous
-        ``enabled`` state is preserved because ``install(force=True)``
-        carries it over.
+        Re-fetches the extension from its original source at the same
+        ``requested_ref`` recorded at install time and force-reinstalls it.
+        A pinned install (tag or commit) is re-resolved to that ref, so
+        ``update()`` catches drift (e.g. a moved tag) without un-pinning it.
+        A floating install (``requested_ref`` is ``None``) resolves to the
+        source's current default-branch HEAD, same as before.  Re-pinning to
+        a different ref is a separate, explicit ``install(source, ref=new_ref,
+        force=True)`` call.  The previous ``enabled`` state is preserved
+        because ``install(force=True)`` carries it over.
 
         Args:
             name: Name of the extension to update.
@@ -320,7 +325,7 @@ class InstallationManager[T: ExtensionProtocol]:
         logger.info(f"Updating extension {name} from {redacted}")
         return self.install(
             source=current_info.source,
-            ref=None,
+            ref=current_info.requested_ref,
             repo_path=current_info.repo_path,
             force=True,
         )

--- a/tests/sdk/extensions/installation/test_installation_manager.py
+++ b/tests/sdk/extensions/installation/test_installation_manager.py
@@ -513,12 +513,13 @@ def test_update_nonexistent_extension(
     assert info is None
 
 
-def test_update_clears_requested_ref_to_track_latest(
+def test_update_preserves_pinned_requested_ref(
     manager: InstallationManager[MockExtension],
     mock_extension_dir: Path,
 ):
-    """update() re-fetches with ref=None, so a previously pinned requested_ref
-    is cleared to reflect that the extension now tracks the latest version."""
+    """update() re-fetches at the recorded requested_ref instead of ref=None,
+    so a pinned install stays pinned (only its resolved SHA may move, e.g.
+    a moved tag). Regression guard for issue #4363."""
     with patch(
         "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
         return_value=(mock_extension_dir, "abc123"),
@@ -530,5 +531,31 @@ def test_update_clears_requested_ref_to_track_latest(
         updated = manager.update("mock-extension")
 
     assert updated is not None
+    assert updated.requested_ref == "v1.0.0"
+    assert updated.resolved_ref == "def456"
+    # update() must re-fetch at the pinned ref, not the default branch.
+    assert mock_fetch.call_count == 2
+    assert mock_fetch.call_args.kwargs["ref"] == "v1.0.0"
+
+
+def test_update_floating_install_resolves_latest(
+    manager: InstallationManager[MockExtension],
+    mock_extension_dir: Path,
+):
+    """update() on a floating install (requested_ref is None) still resolves
+    to the source's current default-branch HEAD, same as before."""
+    with patch(
+        "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
+        return_value=(mock_extension_dir, "abc123"),
+    ) as mock_fetch:
+        info = manager.install(source="github:org/repo")
+        assert info.requested_ref is None
+
+        mock_fetch.return_value = (mock_extension_dir, "def456")
+        updated = manager.update("mock-extension")
+
+    assert updated is not None
     assert updated.requested_ref is None
     assert updated.resolved_ref == "def456"
+    assert mock_fetch.call_count == 2
+    assert mock_fetch.call_args.kwargs["ref"] is None


### PR DESCRIPTION
HUMAN:

Santhi Prakash — small correctness fix for the extension update path; see AGENT section for evidence.

---

AGENT:

## Why

`InstallationManager.update()` always re-fetched with `ref=None`, ignoring the `requested_ref` recorded at install time (added in #4349 / #4375). Calling `update()` on an extension pinned to a tag or commit silently un-pinned it and jumped to the source's current default-branch HEAD instead of just re-syncing to the pinned ref. This is reachable today via the public API for both Plugins and Skills:

- `plugins_router.py` `POST /installed/{plugin_name}/refresh` → `service_update_plugin` → `InstallationManager.update()`
- `skills_router.py` `POST /installed/{skill_name}/refresh` → `service_update_skill` → `InstallationManager.update()`

Reported in #4363.

## Summary

- `update()` now re-fetches at `current_info.requested_ref` instead of hardcoding `ref=None`. A pinned install (tag/commit) stays pinned (only its resolved SHA may move, e.g. a moved tag); a floating install (`requested_ref` is `None`) still resolves to latest, same as before.
- Re-pinning to a different ref remains an explicit `install(source, ref=new_ref, force=True)` call — `update()` needs no new parameter.
- This mirrors the reconcile-vs-repin split already used by the Canvas Extensions staged refresh (`check_canvas_extension_update` fetches with `ref=current_info.requested_ref`), so the shared `InstallationManager` now matches that established pattern.
- Replaced `test_update_clears_requested_ref_to_track_latest` (which encoded the old un-pinning behavior) with `test_update_preserves_pinned_requested_ref`, and added `test_update_floating_install_resolves_latest` to guard the floating case.

## Issue Number

Fixes #4363

## How to Test

```
uv run pytest tests/sdk/extensions/installation/test_installation_manager.py -q
uv run pytest tests/sdk/extensions/ tests/agent_server/canvas_extensions/ tests/agent_server/test_skills_router.py tests/agent_server/test_plugins_router.py -q
uv run ruff check openhands-sdk/openhands/sdk/extensions/installation/manager.py tests/sdk/extensions/installation/test_installation_manager.py
uv run pre-commit run --files openhands-sdk/openhands/sdk/extensions/installation/manager.py tests/sdk/extensions/installation/test_installation_manager.py
```

## Video/Screenshots

Not applicable — pure logic change with no UI/visual surface; behavior is covered by the unit tests above.

## Design Doc

Not added — this is a small one-line correctness fix (a trivial PR per CONTRIBUTING.md), not a new API or behavior-change in the agent loop.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This changes the (previously undocumented) behavior of `update()` and the `/refresh` endpoints for Plugins and Skills: a pinned extension now stays pinned on refresh instead of jumping to latest. The issue calls this out explicitly and the new behavior matches the reconcile-vs-repin distinction already shipped for Canvas Extensions in #4374. No persisted settings shape or REST contract changes — `InstallationInfo.requested_ref` is unchanged.