### PR TITLE
fix(agent-server): page bash events after filtering

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -216,21 +216,26 @@ class BashEventService:
                     start_index = i
                     break
 
-        page_slice = matched[start_index : start_index + limit]
-        next_page_id = None
-        if start_index + limit < len(matched):
-            next_page_id = matched[start_index + limit]
-
+        # Collect matching events for this page. Apply the order filter before
+        # counting toward the page limit so the cursor does not skip matches.
         page_events: list[BashEventBase] = []
-        for name in page_slice:
-            event = self._load_event_from_file(self.bash_events_dir / name)
+        next_page_id = None
+        for i in range(start_index, len(matched)):
+            if len(page_events) >= limit:
+                # Set next_page_id to the current file for the next page.
+                next_page_id = matched[i]
+                break
+
+            event = self._load_event_from_file(self.bash_events_dir / matched[i])
             if event is None:
                 continue
+
             # Filter by order if specified (only applies to BashOutput events)
             if order__gt is not None:
                 event_order = getattr(event, "order", None)
                 if event_order is not None and event_order <= order__gt:
                     continue
+
             page_events.append(event)
 
         return BashEventPage(items=page_events, next_page_id=next_page_id)

--- a/tests/agent_server/test_terminal_service.py
+++ b/tests/agent_server/test_terminal_service.py
@@ -3,8 +3,10 @@
 import asyncio
 import sys
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import pytest
 
@@ -495,6 +497,64 @@ async def test_search_pagination(bash_service):
     page1_ids = {event.id for event in page1.items}
     page2_ids = {event.id for event in page2.items}
     assert len(page1_ids.intersection(page2_ids)) == 0  # No overlap
+
+
+@pytest.mark.asyncio
+async def test_search_pagination_applies_order_filter_before_limit(bash_service):
+    """Pagination should count only events that pass the order filter."""
+    command_id = UUID("00000000-0000-0000-0000-000000000001")
+    events = [
+        BashOutput(
+            command_id=command_id,
+            order=0,
+            timestamp=datetime(2024, 1, 1, 0, 0, 0, 1, tzinfo=UTC),
+        ),
+        BashOutput(
+            command_id=command_id,
+            order=1,
+            timestamp=datetime(2024, 1, 1, 0, 0, 0, 2, tzinfo=UTC),
+        ),
+        BashOutput(
+            command_id=command_id,
+            order=2,
+            timestamp=datetime(2024, 1, 1, 0, 0, 0, 3, tzinfo=UTC),
+        ),
+        BashOutput(
+            command_id=command_id,
+            order=3,
+            timestamp=datetime(2024, 1, 1, 0, 0, 0, 4, tzinfo=UTC),
+        ),
+    ]
+    for event in events:
+        bash_service._save_event_to_file(event)
+
+    page = await bash_service.search_bash_events(
+        kind__eq="BashOutput",
+        order__gt=1,
+        limit=1,
+    )
+
+    assert [event.order for event in page.items] == [2]
+    assert page.next_page_id is not None
+
+    next_page = await bash_service.search_bash_events(
+        kind__eq="BashOutput",
+        order__gt=1,
+        limit=1,
+        page_id=page.next_page_id,
+    )
+
+    assert [event.order for event in next_page.items] == [3]
+    assert next_page.next_page_id is None
+
+    empty_page = await bash_service.search_bash_events(
+        kind__eq="BashOutput",
+        order__gt=3,
+        limit=1,
+    )
+
+    assert empty_page.items == []
+    assert empty_page.next_page_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN:

I reproduced the pagination gap from #4388 locally with persisted bash events and confirmed the fix pages past filtered output correctly. The branch is rebased onto the latest main (which refactored bash event search into a worker-thread sync path), and I re-verified the fix and its regression on top of that refactor.

---

AGENT:

## Why

`BashEventService.search_bash_events` applied the `order__gt` filter only after taking a raw filename page. When the first files were older than the requested order, a page could be empty or undersized and its cursor could skip matching bash output events. This breaks incremental polling when enough older output files exist.

## Summary

- Apply `order__gt` before counting events toward the page limit.
- Preserve filename ordering, timestamp filters, and cursor semantics.
- Add a regression covering filtered-out files before two matching pages.
- Rebase onto current main and re-apply the fix inside the refactored `_search_bash_events_sync` worker-thread path.

## Issue Number

Fixes #4388

## How to Test

Focused regression:

```text
uv run pytest tests/agent_server/test_terminal_service.py::test_search_pagination_applies_order_filter_before_limit -q
1 passed
```

Related terminal-service coverage:

```text
uv run pytest tests/agent_server/test_terminal_service.py -q
18 passed
```

Changed-path checks:

```text
uv run pytest tests/agent_server/test_bash_service.py tests/agent_server/test_terminal_router.py tests/agent_server/test_sockets_service_getters.py -q
20 passed
```

Repository checks:

```text
make build
completed successfully

.venv/bin/pre-commit run --files openhands-agent-server/openhands/agent_server/bash_service.py tests/agent_server/test_terminal_service.py
all hooks passed

uv run pyright
0 errors, 4 existing warnings
```

The full `tests/agent_server` run completed with 1,979 passed, 13 deselected, and one unrelated baseline failure in `tests/agent_server/test_docker_build.py::test_build_with_telemetry_preserves_telemetry_on_failure`. That failure exhausts the test's `time.monotonic` mock during its failure-cleanup assertion and does not touch the changed files.

After the rebase onto current main, the pagination behavior was re-verified directly against the refactored `_search_bash_events_sync`: filtered pages return orders 2 then 3 across two pages, an all-filtered query returns an empty page with no cursor, and unfiltered pagination is unchanged.

## Video/Screenshots

This is a backend pagination fix with no visual surface. The regression test exercises the persisted event files, filtered page collection, and cursor-following behavior directly.

## Design Doc

Not included: the root cause and the filter-before-limit approach are described in the `Why`/`Summary` sections and are exercised by the regression test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change was developed with AI assistance during analysis, implementation, and testing. The `HUMAN` section above is intentionally left for the human contributor, as required by the repository template.