### PR TITLE
feat: carry ConversationErrorEvent on ConversationRunError for automation callbacks

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/exceptions.py
+++ b/openhands-sdk/openhands/sdk/conversation/exceptions.py
@@ -1,4 +1,5 @@
 from openhands.sdk.conversation.types import ConversationID
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 
 
 ISSUE_URL = "https://github.com/OpenHands/software-agent-sdk/issues/new"
@@ -32,6 +33,7 @@ class ConversationRunError(RuntimeError):
     conversation_id: ConversationID
     persistence_dir: str | None
     original_exception: BaseException
+    conversation_error: ConversationErrorEvent | None
 
     def __init__(
         self,
@@ -39,10 +41,12 @@ class ConversationRunError(RuntimeError):
         original_exception: BaseException,
         persistence_dir: str | None = None,
         message: str | None = None,
+        conversation_error: ConversationErrorEvent | None = None,
     ) -> None:
         self.conversation_id = conversation_id
         self.persistence_dir = persistence_dir
         self.original_exception = original_exception
+        self.conversation_error = conversation_error
         default_msg = self._build_error_message(
             conversation_id, original_exception, persistence_dir
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -143,11 +143,8 @@ def _agent_already_surfaced_error(events: Sequence[Event], since: int = 0) -> bo
     prevents a stale source="agent" event from a prior run from suppressing the error
     event for an unrelated exception in a subsequent run on the same conversation.
     """
-    for i in range(len(events) - 1, since - 1, -1):
-        event = events[i]
-        if isinstance(event, ConversationErrorEvent):
-            return event.source == "agent"
-    return False
+    latest = _latest_conversation_error(events, since)
+    return latest is not None and latest.source == "agent"
 
 
 def _latest_conversation_error(

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -2648,6 +2648,19 @@ class LocalConversation(BaseConversation):
         if first_attempt:
             self._cleanup_initiated = True
 
+            # Hand the existing typed conversation failure to the workspace for
+            # the automation completion callback.
+            try:
+                for event in reversed(self._state.events):
+                    if isinstance(event, ConversationErrorEvent):
+                        if event.classification is not None:
+                            self.workspace.register_failure_kind(
+                                event.classification.kind
+                            )
+                        break
+            except Exception as e:
+                logger.debug(f"Could not register conversation failure: {e}")
+
             # Best-effort: hand the accumulated LLM cost to the workspace so it
             # can be included in the automation completion callback. State is
             # in-process here, so unlike RemoteConversation there is no cache to

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -150,6 +150,17 @@ def _agent_already_surfaced_error(events: Sequence[Event], since: int = 0) -> bo
     return False
 
 
+def _latest_conversation_error(
+    events: Sequence[Event], since: int = 0
+) -> ConversationErrorEvent | None:
+    """Return the latest conversation error emitted during the current run."""
+    for i in range(len(events) - 1, since - 1, -1):
+        event = events[i]
+        if isinstance(event, ConversationErrorEvent):
+            return event
+    return None
+
+
 def _is_acp_prompt_message(event: Event) -> TypeGuard[MessageEvent]:
     if not isinstance(event, MessageEvent):
         return False
@@ -2014,7 +2025,12 @@ class LocalConversation(BaseConversation):
 
             # Re-raise with conversation id and persistence dir for better UX
             raise ConversationRunError(
-                self._state.id, e, persistence_dir=self._state.persistence_dir
+                self._state.id,
+                e,
+                persistence_dir=self._state.persistence_dir,
+                conversation_error=_latest_conversation_error(
+                    self._state.events, _run_start_event_count
+                ),
             ) from e
         finally:
             self._cancel_token = None
@@ -2470,7 +2486,12 @@ class LocalConversation(BaseConversation):
                         )
                     )
             raise ConversationRunError(
-                self._state.id, e, persistence_dir=self._state.persistence_dir
+                self._state.id,
+                e,
+                persistence_dir=self._state.persistence_dir,
+                conversation_error=_latest_conversation_error(
+                    self._state.events, _run_start_event_count
+                ),
             ) from e
         finally:
             # A cancelled token must stay observable: interrupted tool calls run
@@ -2647,19 +2668,6 @@ class LocalConversation(BaseConversation):
         first_attempt = not getattr(self, "_cleanup_initiated", False)
         if first_attempt:
             self._cleanup_initiated = True
-
-            # Hand the existing typed conversation failure to the workspace for
-            # the automation completion callback.
-            try:
-                for event in reversed(self._state.events):
-                    if isinstance(event, ConversationErrorEvent):
-                        if event.classification is not None:
-                            self.workspace.register_failure_kind(
-                                event.classification.kind
-                            )
-                        break
-            except Exception as e:
-                logger.debug(f"Could not register conversation failure: {e}")
 
             # Best-effort: hand the accumulated LLM cost to the workspace so it
             # can be included in the automation completion callback. State is

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1159,6 +1159,7 @@ class RemoteConversation(BaseConversation):
         # subscription snapshot from being mistaken for the post-run snapshot.
         self._run_armed.clear()
         self._drain_terminal_status_queue()
+        run_start_event_count = len(self._state.events)
 
         # Trigger a run on the server using the dedicated run endpoint.
         # Let the server tell us if it's already running (409), avoiding an extra GET.
@@ -1184,7 +1185,9 @@ class RemoteConversation(BaseConversation):
             # after the run was triggered are treated as run-completion signals.
             self._run_armed.set()
             try:
-                self._wait_for_run_completion(poll_interval, timeout)
+                self._wait_for_run_completion(
+                    poll_interval, timeout, run_start_event_count
+                )
             finally:
                 self._run_armed.clear()
 
@@ -1192,6 +1195,7 @@ class RemoteConversation(BaseConversation):
         self,
         poll_interval: float = 1.0,
         timeout: float = 1800.0,
+        since: int = 0,
     ) -> None:
         """Wait for the conversation run to complete.
 
@@ -1246,7 +1250,7 @@ class RemoteConversation(BaseConversation):
             try:
                 ws_status = self._terminal_status_queue.get(timeout=poll_interval)
                 # Raises ConversationRunError on ERROR/STUCK; no-op otherwise.
-                self._handle_conversation_status(ws_status)
+                self._handle_conversation_status(ws_status, since)
                 logger.info(
                     "Run completed via post-run WebSocket state update "
                     "(status: %s, elapsed: %.1fs)",
@@ -1279,7 +1283,7 @@ class RemoteConversation(BaseConversation):
                 terminal_first_seen_at = None
             else:
                 # Raises ConversationRunError for ERROR/STUCK states
-                self._handle_conversation_status(status)
+                self._handle_conversation_status(status, since)
 
                 if status and ConversationExecutionStatus(status).is_terminal():
                     # ERROR/STUCK have already been handled above. FINISHED from
@@ -1340,18 +1344,20 @@ class RemoteConversation(BaseConversation):
         info = resp.json()
         return info.get("execution_status")
 
-    def _handle_conversation_status(self, status: str | None) -> bool:
+    def _handle_conversation_status(self, status: str | None, since: int = 0) -> bool:
         """Handle non-running statuses; return True if the run is complete."""
         if status == ConversationExecutionStatus.RUNNING.value:
             return False
         if status == ConversationExecutionStatus.ERROR.value:
-            error = self._get_last_conversation_error()
+            self._state.events.reconcile()
+            error = self._get_last_conversation_error(since)
+            detail = (
+                f"{error.code}: {error.detail}".strip(": ")
+                if error
+                else "Remote conversation ended with error"
+            )
             raise ConversationRunError(
-                self._id,
-                RuntimeError(
-                    error.detail if error else "Remote conversation ended with error"
-                ),
-                conversation_error=error,
+                self._id, RuntimeError(detail), conversation_error=error
             )
         if status == ConversationExecutionStatus.STUCK.value:
             raise ConversationRunError(
@@ -1389,10 +1395,12 @@ class RemoteConversation(BaseConversation):
             return
         raise ConversationRunError(self._id, exc) from exc
 
-    def _get_last_conversation_error(self) -> ConversationErrorEvent | None:
+    def _get_last_conversation_error(
+        self, since: int = 0
+    ) -> ConversationErrorEvent | None:
         """Return the most recent structured conversation error, if available."""
         events = self._state.events
-        for idx in range(len(events) - 1, -1, -1):
+        for idx in range(len(events) - 1, since - 1, -1):
             event = events[idx]
             if isinstance(event, ConversationErrorEvent):
                 return event

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1688,6 +1688,17 @@ class RemoteConversation(BaseConversation):
             return
         self._cleanup_initiated = True
 
+        # Hand the existing typed conversation failure to the workspace for the
+        # automation completion callback. Do not reclassify the wrapper exception.
+        try:
+            for event in reversed(self._state.events):
+                if isinstance(event, ConversationErrorEvent):
+                    if event.classification is not None:
+                        self.workspace.register_failure_kind(event.classification.kind)
+                    break
+        except Exception as e:
+            logger.debug(f"Could not register conversation failure: {e}")
+
         # Best-effort: hand the accumulated LLM cost to the workspace so it can
         # be included in the automation completion callback. Only read cached
         # state — close() also runs on the failure path, where a live fetch

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1345,10 +1345,13 @@ class RemoteConversation(BaseConversation):
         if status == ConversationExecutionStatus.RUNNING.value:
             return False
         if status == ConversationExecutionStatus.ERROR.value:
-            detail = self._get_last_error_detail()
+            error = self._get_last_conversation_error()
             raise ConversationRunError(
                 self._id,
-                RuntimeError(detail or "Remote conversation ended with error"),
+                RuntimeError(
+                    error.detail if error else "Remote conversation ended with error"
+                ),
+                conversation_error=error,
             )
         if status == ConversationExecutionStatus.STUCK.value:
             raise ConversationRunError(
@@ -1386,17 +1389,14 @@ class RemoteConversation(BaseConversation):
             return
         raise ConversationRunError(self._id, exc) from exc
 
-    def _get_last_error_detail(self) -> str | None:
-        """Return the most recent ConversationErrorEvent detail, if available."""
+    def _get_last_conversation_error(self) -> ConversationErrorEvent | None:
+        """Return the most recent structured conversation error, if available."""
         events = self._state.events
         for idx in range(len(events) - 1, -1, -1):
             event = events[idx]
             if isinstance(event, ConversationErrorEvent):
-                detail = event.detail.strip()
-                code = event.code.strip()
-                if detail and code:
-                    return f"{code}: {detail}"
-                return detail or code or None
+                return event
+        return None
 
     def set_confirmation_policy(self, policy: ConfirmationPolicyBase) -> None:
         payload = {"policy": policy.model_dump()}
@@ -1687,17 +1687,6 @@ class RemoteConversation(BaseConversation):
         if self._cleanup_initiated:
             return
         self._cleanup_initiated = True
-
-        # Hand the existing typed conversation failure to the workspace for the
-        # automation completion callback. Do not reclassify the wrapper exception.
-        try:
-            for event in reversed(self._state.events):
-                if isinstance(event, ConversationErrorEvent):
-                    if event.classification is not None:
-                        self.workspace.register_failure_kind(event.classification.kind)
-                    break
-        except Exception as e:
-            logger.debug(f"Could not register conversation failure: {e}")
 
         # Best-effort: hand the accumulated LLM cost to the workspace so it can
         # be included in the automation completion callback. Only read cached

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -124,10 +124,15 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
                 else None
             )
             if error is None:
+                cause = (
+                    exc_val.original_exception
+                    if isinstance(exc_val, ConversationRunError)
+                    else exc_val
+                )
                 error = ConversationErrorEvent(
                     source="environment",
-                    code=type(exc_val).__name__,
-                    detail=str(exc_val),
+                    code=type(cause).__name__,
+                    detail=str(cause),
                 )
             payload["error"] = error.model_dump(mode="json")
 

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 import httpx
 from pydantic import BeforeValidator, Field, PrivateAttr
 
-from openhands.sdk.event.error_classification import FailureKind, classify_error
+from openhands.sdk.event.error_classification import FailureKind
 from openhands.sdk.git.models import GitChange, GitDiff
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
@@ -52,8 +52,7 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
 
     _conversation_id: str | None = PrivateAttr(default=None)
     _accumulated_cost: float | None = PrivateAttr(default=None)
-    _blocking_kind: FailureKind | None = PrivateAttr(default=None)
-    _blocking_reason: str | None = PrivateAttr(default=None)
+    _failure_kind: FailureKind | None = PrivateAttr(default=None)
 
     def __enter__(self) -> "BaseWorkspace":
         """Enter the workspace context.
@@ -85,33 +84,18 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         """
         return self._accumulated_cost
 
-    def register_blocking_factor(self, kind: FailureKind, reason: str) -> None:
-        """Attach a blocking factor to this workspace's run.
+    def register_failure_kind(self, kind: FailureKind) -> None:
+        """Register the classified failure for this workspace's run.
 
-        Call this when the automation finished but was blocked from fully
-        succeeding — for example, the agent could not reach a configured MCP
-        integration and had to stop early. The blocking factor is included in
-        the completion callback sent to the automation service, which persists
-        it on the run so a "succeeded but blocked" outcome can be surfaced and
-        counted toward auto-disablement.
+        Called by the conversation on close after it has emitted a classified
+        ``ConversationErrorEvent``. The kind is included in the automation
+        completion callback.
 
         Args:
-            kind: FailureKind describing the blocking factor (e.g. ``CONFIG``
-                for an unreachable integration).
-            reason: Human-readable explanation of what blocked the run.
+            kind: The existing conversation error classification.
         """
-        self._blocking_kind = kind
-        self._blocking_reason = reason
-        logger.debug(f"Registered blocking factor {kind.value}: {reason}")
-
-    @property
-    def blocking_reason(self) -> str | None:
-        """Get the blocking reason if one was registered.
-
-        Returns:
-            The blocking reason, or None if none was registered.
-        """
-        return self._blocking_reason
+        self._failure_kind = kind
+        logger.debug(f"Registered failure kind: {kind.value}")
 
     def _send_completion_callback(
         self, exc_type: type | None, exc_val: BaseException | None
@@ -126,11 +110,9 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
           - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
           - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
-        Includes ``conversation_id``, ``cost``, and any registered ``failure_kind`` /
-        ``blocking_reason`` in the payload. On failure, ``failure_kind`` is
-        derived by classifying the exception into the shared SDK failure
-        vocabulary; on a successful-but-blocked exit it is taken from the
-        blocking factor registered via ``register_blocking_factor``.
+        Includes ``conversation_id``, ``cost``, and a registered
+        ``failure_kind`` in the payload. The conversation registers the kind
+        from its existing classified ``ConversationErrorEvent`` on close.
 
         Args:
             exc_type: Exception type if an exception was raised, None otherwise
@@ -149,9 +131,6 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
             payload["run_id"] = run_id
         if exc_val is not None:
             payload["error"] = str(exc_val)
-            failure_kind = classify_error(type(exc_val).__name__, str(exc_val)).kind
-        else:
-            failure_kind = self._blocking_kind
 
         # Include conversation_id if one was registered
         if self._conversation_id is not None:
@@ -161,12 +140,8 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         if self._accumulated_cost is not None:
             payload["cost"] = self._accumulated_cost
 
-        # Include failure metadata so the automation service can attribute the
-        # outcome and count it toward auto-disablement.
-        if failure_kind is not None:
-            payload["failure_kind"] = failure_kind.value
-        if self._blocking_reason is not None:
-            payload["blocking_reason"] = self._blocking_reason
+        if self._failure_kind is not None:
+            payload["failure_kind"] = self._failure_kind.value
 
         try:
             headers: dict[str, str] = {}

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -6,7 +6,8 @@ from typing import Annotated, Any
 import httpx
 from pydantic import BeforeValidator, Field, PrivateAttr
 
-from openhands.sdk.event.error_classification import FailureKind
+from openhands.sdk.conversation.exceptions import ConversationRunError
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.git.models import GitChange, GitDiff
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
@@ -52,7 +53,6 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
 
     _conversation_id: str | None = PrivateAttr(default=None)
     _accumulated_cost: float | None = PrivateAttr(default=None)
-    _failure_kind: FailureKind | None = PrivateAttr(default=None)
 
     def __enter__(self) -> "BaseWorkspace":
         """Enter the workspace context.
@@ -84,19 +84,6 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         """
         return self._accumulated_cost
 
-    def register_failure_kind(self, kind: FailureKind) -> None:
-        """Register the classified failure for this workspace's run.
-
-        Called by the conversation on close after it has emitted a classified
-        ``ConversationErrorEvent``. The kind is included in the automation
-        completion callback.
-
-        Args:
-            kind: The existing conversation error classification.
-        """
-        self._failure_kind = kind
-        logger.debug(f"Registered failure kind: {kind.value}")
-
     def _send_completion_callback(
         self, exc_type: type | None, exc_val: BaseException | None
     ) -> None:
@@ -110,9 +97,10 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
           - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
           - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
-        Includes ``conversation_id``, ``cost``, and a registered
-        ``failure_kind`` in the payload. The conversation registers the kind
-        from its existing classified ``ConversationErrorEvent`` on close.
+        Includes ``conversation_id`` and ``cost`` when registered. On failure,
+        ``error`` is the existing structured ``ConversationErrorEvent`` carried
+        by ``ConversationRunError``, or a classified fallback event for errors
+        outside a conversation.
 
         Args:
             exc_type: Exception type if an exception was raised, None otherwise
@@ -130,7 +118,18 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         if run_id:
             payload["run_id"] = run_id
         if exc_val is not None:
-            payload["error"] = str(exc_val)
+            error = (
+                exc_val.conversation_error
+                if isinstance(exc_val, ConversationRunError)
+                else None
+            )
+            if error is None:
+                error = ConversationErrorEvent(
+                    source="environment",
+                    code=type(exc_val).__name__,
+                    detail=str(exc_val),
+                )
+            payload["error"] = error.model_dump(mode="json")
 
         # Include conversation_id if one was registered
         if self._conversation_id is not None:
@@ -139,9 +138,6 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         # Include accumulated LLM cost if one was registered
         if self._accumulated_cost is not None:
             payload["cost"] = self._accumulated_cost
-
-        if self._failure_kind is not None:
-            payload["failure_kind"] = self._failure_kind.value
 
         try:
             headers: dict[str, str] = {}

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 import httpx
 from pydantic import BeforeValidator, Field, PrivateAttr
 
+from openhands.sdk.event.error_classification import FailureKind, classify_error
 from openhands.sdk.git.models import GitChange, GitDiff
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
@@ -51,6 +52,8 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
 
     _conversation_id: str | None = PrivateAttr(default=None)
     _accumulated_cost: float | None = PrivateAttr(default=None)
+    _blocking_kind: FailureKind | None = PrivateAttr(default=None)
+    _blocking_reason: str | None = PrivateAttr(default=None)
 
     def __enter__(self) -> "BaseWorkspace":
         """Enter the workspace context.
@@ -82,6 +85,34 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         """
         return self._accumulated_cost
 
+    def register_blocking_factor(self, kind: FailureKind, reason: str) -> None:
+        """Attach a blocking factor to this workspace's run.
+
+        Call this when the automation finished but was blocked from fully
+        succeeding — for example, the agent could not reach a configured MCP
+        integration and had to stop early. The blocking factor is included in
+        the completion callback sent to the automation service, which persists
+        it on the run so a "succeeded but blocked" outcome can be surfaced and
+        counted toward auto-disablement.
+
+        Args:
+            kind: FailureKind describing the blocking factor (e.g. ``CONFIG``
+                for an unreachable integration).
+            reason: Human-readable explanation of what blocked the run.
+        """
+        self._blocking_kind = kind
+        self._blocking_reason = reason
+        logger.debug(f"Registered blocking factor {kind.value}: {reason}")
+
+    @property
+    def blocking_reason(self) -> str | None:
+        """Get the blocking reason if one was registered.
+
+        Returns:
+            The blocking reason, or None if none was registered.
+        """
+        return self._blocking_reason
+
     def _send_completion_callback(
         self, exc_type: type | None, exc_val: BaseException | None
     ) -> None:
@@ -95,8 +126,11 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
           - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
           - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
-        Includes ``conversation_id`` in the payload if one was registered, and
-        ``cost`` if one was registered via ``register_cost()``.
+        Includes ``conversation_id``, ``cost``, and any registered ``failure_kind`` /
+        ``blocking_reason`` in the payload. On failure, ``failure_kind`` is
+        derived by classifying the exception into the shared SDK failure
+        vocabulary; on a successful-but-blocked exit it is taken from the
+        blocking factor registered via ``register_blocking_factor``.
 
         Args:
             exc_type: Exception type if an exception was raised, None otherwise
@@ -115,6 +149,9 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
             payload["run_id"] = run_id
         if exc_val is not None:
             payload["error"] = str(exc_val)
+            failure_kind = classify_error(type(exc_val).__name__, str(exc_val)).kind
+        else:
+            failure_kind = self._blocking_kind
 
         # Include conversation_id if one was registered
         if self._conversation_id is not None:
@@ -123,6 +160,13 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
         # Include accumulated LLM cost if one was registered
         if self._accumulated_cost is not None:
             payload["cost"] = self._accumulated_cost
+
+        # Include failure metadata so the automation service can attribute the
+        # outcome and count it toward auto-disablement.
+        if failure_kind is not None:
+            payload["failure_kind"] = failure_kind.value
+        if self._blocking_reason is not None:
+            payload["blocking_reason"] = self._blocking_reason
 
         try:
             headers: dict[str, str] = {}

--- a/tests/sdk/conversation/local/test_conversation_core.py
+++ b/tests/sdk/conversation/local/test_conversation_core.py
@@ -266,6 +266,26 @@ def test_close_reports_accumulated_cost_to_workspace(tmp_path):
     assert conv.workspace.accumulated_cost == 0.75
 
 
+def test_close_registers_existing_error_classification(tmp_path):
+    """close() registers the latest classified conversation failure."""
+    from openhands.sdk.event.conversation_error import ConversationErrorEvent
+    from openhands.sdk.event.error_classification import FailureKind
+
+    agent = create_test_agent()
+    conv = Conversation(agent=agent, persistence_dir=tmp_path, workspace=tmp_path)
+    conv.state.append_event(
+        ConversationErrorEvent(
+            source="environment",
+            code="LLMAuthenticationError",
+            detail="invalid api key",
+        )
+    )
+
+    conv.close()
+
+    assert conv.workspace._failure_kind is FailureKind.AUTH
+
+
 def test_close_reports_zero_cost_when_no_llm_calls(tmp_path):
     """A run that ends before any LLM call — e.g. it errors during setup —
     reports a genuine 0.0, not an omitted cost. Local state is in-process and

--- a/tests/sdk/conversation/local/test_conversation_core.py
+++ b/tests/sdk/conversation/local/test_conversation_core.py
@@ -266,26 +266,6 @@ def test_close_reports_accumulated_cost_to_workspace(tmp_path):
     assert conv.workspace.accumulated_cost == 0.75
 
 
-def test_close_registers_existing_error_classification(tmp_path):
-    """close() registers the latest classified conversation failure."""
-    from openhands.sdk.event.conversation_error import ConversationErrorEvent
-    from openhands.sdk.event.error_classification import FailureKind
-
-    agent = create_test_agent()
-    conv = Conversation(agent=agent, persistence_dir=tmp_path, workspace=tmp_path)
-    conv.state.append_event(
-        ConversationErrorEvent(
-            source="environment",
-            code="LLMAuthenticationError",
-            detail="invalid api key",
-        )
-    )
-
-    conv.close()
-
-    assert conv.workspace._failure_kind is FailureKind.AUTH
-
-
 def test_close_reports_zero_cost_when_no_llm_calls(tmp_path):
     """A run that ends before any LLM call — e.g. it errors during setup —
     reports a genuine 0.0, not an omitted cost. Local state is in-process and

--- a/tests/sdk/conversation/local/test_run_exception_includes_conversation_id.py
+++ b/tests/sdk/conversation/local/test_run_exception_includes_conversation_id.py
@@ -70,6 +70,9 @@ def test_run_raises_conversation_run_error_with_id():
         assert str(conv.id) in str(err)
         # original exception preserved via chaining
         assert isinstance(getattr(err, "original_exception", None), ValueError)
+        assert err.conversation_error is not None
+        assert err.conversation_error.code == "ValueError"
+        assert err.conversation_error.detail == "boom"
 
 
 def test_run_error_includes_persistence_dir_and_issue_url():
@@ -171,7 +174,7 @@ def test_run_does_not_duplicate_agent_emitted_error():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         conv = Conversation(agent=agent, workspace=tmpdir)
-        with pytest.raises(ConversationRunError):
+        with pytest.raises(ConversationRunError) as excinfo:
             conv.run()
 
         errors = [e for e in conv.state.events if isinstance(e, ConversationErrorEvent)]
@@ -179,6 +182,7 @@ def test_run_does_not_duplicate_agent_emitted_error():
         assert errors[0].source == "agent"
         assert errors[0].code == "ACPPromptError"
         assert "model 'x' not found" in errors[0].detail
+        assert excinfo.value.conversation_error is errors[0]
 
 
 def test_run_emits_generic_error_when_agent_did_not():

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -19,6 +19,7 @@ from openhands.sdk.conversation.impl.remote_conversation import RemoteConversati
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.visualizer import DefaultConversationVisualizer
 from openhands.sdk.event import MessageEvent
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.event.conversation_state import (
     FULL_STATE_KEY,
     ConversationStateUpdateEvent,
@@ -1231,7 +1232,12 @@ class TestRemoteConversation:
 
         mock_ws_client.return_value = Mock()
         conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
-        conversation._get_last_error_detail = Mock(return_value="boom")
+        error = ConversationErrorEvent(
+            source="environment",
+            code="LLMAuthenticationError",
+            detail="invalid api key",
+        )
+        conversation.state.events._cached_events.append(error)
         ws_callback = mock_ws_client.call_args.kwargs["callback"]
 
         original_side_effect = mock_client_instance.request.side_effect
@@ -1246,10 +1252,15 @@ class TestRemoteConversation:
 
         mock_client_instance.request.side_effect = post_run_seeds_error
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ConversationRunError) as excinfo:
             conversation.run(blocking=True, poll_interval=10.0)
 
-        assert "boom" in str(excinfo.value) or "error" in str(excinfo.value).lower()
+        attached = excinfo.value.conversation_error
+        assert attached is error
+        assert attached is not None
+        classification = attached.classification
+        assert classification is not None
+        assert classification.kind == "auth"
 
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
@@ -1820,29 +1831,6 @@ class TestRemoteConversation:
         conversation.close()
 
         assert self.workspace.accumulated_cost == 0.75
-
-    @patch(
-        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
-    )
-    def test_close_registers_existing_error_classification(self, mock_ws_client):
-        """Closing registers the latest classified conversation failure."""
-        from openhands.sdk.event.conversation_error import ConversationErrorEvent
-        from openhands.sdk.event.error_classification import FailureKind
-
-        self.setup_mock_client()
-        mock_ws_client.return_value = Mock()
-        conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
-        conversation.state.events._cached_events.append(
-            ConversationErrorEvent(
-                source="environment",
-                code="LLMAuthenticationError",
-                detail="invalid api key",
-            )
-        )
-
-        conversation.close()
-
-        assert self.workspace._failure_kind is FailureKind.AUTH
 
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1237,7 +1237,6 @@ class TestRemoteConversation:
             code="LLMAuthenticationError",
             detail="invalid api key",
         )
-        conversation.state.events._cached_events.append(error)
         ws_callback = mock_ws_client.call_args.kwargs["callback"]
 
         original_side_effect = mock_client_instance.request.side_effect
@@ -1245,6 +1244,7 @@ class TestRemoteConversation:
         def post_run_seeds_error(method, url, **kwargs):
             resp = original_side_effect(method, url, **kwargs)
             if method == "POST" and url.endswith("/run"):
+                conversation.state.events.add_event(error)
                 ws_callback(
                     ConversationStateUpdateEvent(key="execution_status", value="error")
                 )
@@ -1256,8 +1256,8 @@ class TestRemoteConversation:
             conversation.run(blocking=True, poll_interval=10.0)
 
         attached = excinfo.value.conversation_error
-        assert attached is error
         assert attached is not None
+        assert attached is error
         classification = attached.classification
         assert classification is not None
         assert classification.kind == "auth"

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1824,6 +1824,29 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_close_registers_existing_error_classification(self, mock_ws_client):
+        """Closing registers the latest classified conversation failure."""
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.event.error_classification import FailureKind
+
+        self.setup_mock_client()
+        mock_ws_client.return_value = Mock()
+        conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
+        conversation.state.events._cached_events.append(
+            ConversationErrorEvent(
+                source="environment",
+                code="LLMAuthenticationError",
+                detail="invalid api key",
+            )
+        )
+
+        conversation.close()
+
+        assert self.workspace._failure_kind is FailureKind.AUTH
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_close_does_not_fetch_state_to_read_cost(self, mock_ws_client):
         """Closing never fetches state over HTTP — the server may already be gone."""
         mock_client_instance = self.setup_mock_client()

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -1077,7 +1077,8 @@ def test_send_completion_callback_on_failure(monkeypatch):
         payload = mock_client.post.call_args.kwargs["json"]
         assert payload["status"] == "FAILED"
         assert payload["run_id"] == "run-99"
-        assert "script crashed" in payload["error"]
+        assert payload["error"]["detail"] == "script crashed"
+        assert payload["error"]["code"] == "RuntimeError"
 
 
 def test_send_completion_callback_no_op_without_url(monkeypatch):
@@ -1235,28 +1236,26 @@ def test_send_completion_callback_omits_cost_when_not_registered(monkeypatch):
         assert "cost" not in payload
 
 
-def test_register_failure_kind_stores_kind():
-    """register_failure_kind stores an existing conversation classification."""
-    from openhands.sdk.event.error_classification import FailureKind
-
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-
-    workspace.register_failure_kind(FailureKind.AUTH)
-
-    assert workspace._failure_kind is FailureKind.AUTH
-
-
-def test_send_completion_callback_includes_registered_failure_kind(monkeypatch):
-    """The completion callback includes a registered conversation failure kind."""
-    from openhands.sdk.event.error_classification import FailureKind
+def test_send_completion_callback_serializes_conversation_error(monkeypatch):
+    """A ConversationRunError sends its authoritative ConversationErrorEvent."""
+    from openhands.sdk.conversation.exceptions import ConversationRunError
+    from openhands.sdk.event.conversation_error import ConversationErrorEvent
 
     monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace.register_failure_kind(FailureKind.CONFIG)
+    error = ConversationErrorEvent(
+        source="environment",
+        code="LLMAuthenticationError",
+        detail="invalid api key",
+    )
+    import uuid
+
+    exc = ConversationRunError(
+        uuid.uuid4(), RuntimeError("wrapper"), conversation_error=error
+    )
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
-
     with patch("httpx.Client") as MockClient:
         mock_client = MagicMock()
         mock_client.post.return_value = mock_resp
@@ -1264,7 +1263,31 @@ def test_send_completion_callback_includes_registered_failure_kind(monkeypatch):
         mock_client.__exit__ = MagicMock(return_value=False)
         MockClient.return_value = mock_client
 
-        workspace._send_completion_callback(RuntimeError, RuntimeError("failed"))
+        workspace._send_completion_callback(type(exc), exc)
 
         payload = mock_client.post.call_args.kwargs["json"]
-        assert payload["failure_kind"] == "config"
+        assert payload["error"] == error.model_dump(mode="json")
+        assert payload["error"]["classification"]["kind"] == "auth"
+
+
+def test_send_completion_callback_creates_fallback_error(monkeypatch):
+    """A non-conversation exception is converted to a classified error event."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        exc = ValueError("bad configuration")
+        workspace._send_completion_callback(type(exc), exc)
+
+        error = mock_client.post.call_args.kwargs["json"]["error"]
+        assert error["code"] == "ValueError"
+        assert error["detail"] == "bad configuration"
+        assert error["classification"]["kind"] == "unknown"

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -1235,38 +1235,24 @@ def test_send_completion_callback_omits_cost_when_not_registered(monkeypatch):
         assert "cost" not in payload
 
 
-# --- blocking factor tests ---
-
-
-def test_register_blocking_factor_stores_kind_and_reason():
-    """register_blocking_factor stores the kind and reason."""
+def test_register_failure_kind_stores_kind():
+    """register_failure_kind stores an existing conversation classification."""
     from openhands.sdk.event.error_classification import FailureKind
 
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
 
-    workspace.register_blocking_factor(
-        FailureKind.CONFIG, "calendar integration not configured"
-    )
+    workspace.register_failure_kind(FailureKind.AUTH)
 
-    assert workspace._blocking_kind is FailureKind.CONFIG
-    assert workspace.blocking_reason == "calendar integration not configured"
+    assert workspace._failure_kind is FailureKind.AUTH
 
 
-def test_blocking_reason_returns_none_initially():
-    """blocking_reason returns None when nothing was registered."""
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-
-    assert workspace.blocking_reason is None
-
-
-def test_send_completion_callback_classifies_failure(monkeypatch):
-    """A failing exit reports a typed failure_kind derived from the exception."""
-    from openhands.sdk.llm.exceptions import LLMAuthenticationError
+def test_send_completion_callback_includes_registered_failure_kind(monkeypatch):
+    """The completion callback includes a registered conversation failure kind."""
+    from openhands.sdk.event.error_classification import FailureKind
 
     monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
-    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-77")
-
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace.register_failure_kind(FailureKind.CONFIG)
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -1278,63 +1264,7 @@ def test_send_completion_callback_classifies_failure(monkeypatch):
         mock_client.__exit__ = MagicMock(return_value=False)
         MockClient.return_value = mock_client
 
-        exc = LLMAuthenticationError("invalid api key")
-        workspace._send_completion_callback(type(exc), exc)
+        workspace._send_completion_callback(RuntimeError, RuntimeError("failed"))
 
         payload = mock_client.post.call_args.kwargs["json"]
-        assert payload["status"] == "FAILED"
-        assert payload["failure_kind"] == "auth"
-
-
-def test_send_completion_callback_reports_blocked_completion(monkeypatch):
-    """A completed-but-blocked run reports the registered blocking factor."""
-    from openhands.sdk.event.error_classification import FailureKind
-
-    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
-    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-88")
-
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace.register_blocking_factor(
-        FailureKind.CONFIG, "calendar integration not configured"
-    )
-
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-
-    with patch("httpx.Client") as MockClient:
-        mock_client = MagicMock()
-        mock_client.post.return_value = mock_resp
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        MockClient.return_value = mock_client
-
-        workspace._send_completion_callback(None, None)
-
-        payload = mock_client.post.call_args.kwargs["json"]
-        assert payload["status"] == "COMPLETED"
         assert payload["failure_kind"] == "config"
-        assert payload["blocking_reason"] == "calendar integration not configured"
-
-
-def test_send_completion_callback_omits_metadata_when_unset(monkeypatch):
-    """No failure_kind/blocking_reason when there is no failure or block."""
-    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
-
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-
-    with patch("httpx.Client") as MockClient:
-        mock_client = MagicMock()
-        mock_client.post.return_value = mock_resp
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        MockClient.return_value = mock_client
-
-        workspace._send_completion_callback(None, None)
-
-        payload = mock_client.post.call_args.kwargs["json"]
-        assert payload["status"] == "COMPLETED"
-        assert "failure_kind" not in payload
-        assert "blocking_reason" not in payload

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -1233,3 +1233,108 @@ def test_send_completion_callback_omits_cost_when_not_registered(monkeypatch):
 
         payload = mock_client.post.call_args.kwargs["json"]
         assert "cost" not in payload
+
+
+# --- blocking factor tests ---
+
+
+def test_register_blocking_factor_stores_kind_and_reason():
+    """register_blocking_factor stores the kind and reason."""
+    from openhands.sdk.event.error_classification import FailureKind
+
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    workspace.register_blocking_factor(
+        FailureKind.CONFIG, "calendar integration not configured"
+    )
+
+    assert workspace._blocking_kind is FailureKind.CONFIG
+    assert workspace.blocking_reason == "calendar integration not configured"
+
+
+def test_blocking_reason_returns_none_initially():
+    """blocking_reason returns None when nothing was registered."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    assert workspace.blocking_reason is None
+
+
+def test_send_completion_callback_classifies_failure(monkeypatch):
+    """A failing exit reports a typed failure_kind derived from the exception."""
+    from openhands.sdk.llm.exceptions import LLMAuthenticationError
+
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-77")
+
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        exc = LLMAuthenticationError("invalid api key")
+        workspace._send_completion_callback(type(exc), exc)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "FAILED"
+        assert payload["failure_kind"] == "auth"
+
+
+def test_send_completion_callback_reports_blocked_completion(monkeypatch):
+    """A completed-but-blocked run reports the registered blocking factor."""
+    from openhands.sdk.event.error_classification import FailureKind
+
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-88")
+
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace.register_blocking_factor(
+        FailureKind.CONFIG, "calendar integration not configured"
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"
+        assert payload["failure_kind"] == "config"
+        assert payload["blocking_reason"] == "calendar integration not configured"
+
+
+def test_send_completion_callback_omits_metadata_when_unset(monkeypatch):
+    """No failure_kind/blocking_reason when there is no failure or block."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"
+        assert "failure_kind" not in payload
+        assert "blocking_reason" not in payload


### PR DESCRIPTION
HUMAN:

This is a simple enough change and test coverage is good.

AGENT: 

## Summary

Carries the SDK's existing typed `ConversationErrorEvent` on `ConversationRunError` so the workspace automation completion callback can serialize it directly. This is the SDK side of `OpenHands/automation` #325 / issue #323.

## Changes

- **`ConversationRunError.conversation_error`**: New optional field carrying the authoritative `ConversationErrorEvent` emitted during the failed run.
- **Local conversation**: Both `run()` and `arun()` attach the latest `ConversationErrorEvent` emitted during the current run (scoped by `_run_start_event_count`).
- **Remote conversation**: `_handle_conversation_status` retrieves the latest structured error from cached events and attaches it.
- **Workspace callback**: `_send_completion_callback` serializes `ConversationRunError.conversation_error` directly as the callback `error` field. For exceptions outside a conversation (e.g. setup failures), it constructs a fallback `ConversationErrorEvent` that self-classifies via the existing `classify_error`.

## Why

- The conversation already owns the authoritative classified error event.
- `ConversationRunError` already travels from `conversation.run()` through `workspace.__exit__`.
- No mutable workspace registration, no callback-side reclassification, no new Pydantic models.
- SDK users can inspect `exc.conversation_error` directly.
- The callback `error` is now a structured `ConversationErrorEvent` (or a legacy string for older SDKs).

## Issue Number

Fixes #323

## How to Test

- Focused tests: local/remote authoritative event attachment, fallback event creation, workspace callback serialization, existing cost/conversation_id callback behavior.
- Changed-file pre-commit passes (ruff, pycodestyle, pyright, import rules).

This PR was created by an AI agent (OpenHands) on behalf of neubig.

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e3bba47-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e3bba47-python \
  ghcr.io/openhands/agent-server:e3bba47-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e3bba47-golang-amd64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-golang-amd64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-golang-amd64
ghcr.io/openhands/agent-server:e3bba47-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e3bba47-golang-arm64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-golang-arm64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-golang-arm64
ghcr.io/openhands/agent-server:e3bba47-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e3bba47-java-amd64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-java-amd64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-java-amd64
ghcr.io/openhands/agent-server:e3bba47-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e3bba47-java-arm64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-java-arm64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-java-arm64
ghcr.io/openhands/agent-server:e3bba47-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e3bba47-python-amd64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-python-amd64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-python-amd64
ghcr.io/openhands/agent-server:e3bba47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e3bba47-python-arm64
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-python-arm64
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-python-arm64
ghcr.io/openhands/agent-server:e3bba47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e3bba47-golang
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-golang
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-golang
ghcr.io/openhands/agent-server:e3bba47-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e3bba47-java
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-java
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-java
ghcr.io/openhands/agent-server:e3bba47-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e3bba47-python
ghcr.io/openhands/agent-server:e3bba47376e750e926a18de069e092b95ee39588-python
ghcr.io/openhands/agent-server:feat-report-automation-blocking-factor-python
ghcr.io/openhands/agent-server:e3bba47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e3bba47-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e3bba47-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
