### PR TITLE
feat: emit canonical conversation telemetry from agent server

### DIFF
--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -194,7 +194,7 @@ repository.
 
 #### What is sent
 
-Events: `conversation_started`, `conversation_finished`, `conversation_failed`,
+Events: `conversation_created`, `conversation_finished`, `conversation_failed`,
 `conversation_error`, `request_failed`, `server_started`, `server_stopped` — all
 prefixed `agent_server.`.
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -2127,10 +2127,10 @@ class ConversationService:
 
         The subscriber is attached on *every* path, including rehydration, so
         errors and terminal outcomes are always captured. But
-        ``conversation_started`` is emitted only for a genuinely new
+        ``conversation_created`` is emitted only for a genuinely new
         conversation: ``_start_event_service`` also runs when an idle
         conversation is lazily reloaded and when RUNNING conversations are
-        recovered after a restart, and counting those as starts would inflate
+        recovered after a restart, and counting those as creations would inflate
         the metric on every server bounce.
 
         Deliberately total: telemetry must never be able to fail conversation

--- a/openhands-agent-server/openhands/agent_server/telemetry/factory.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/factory.py
@@ -137,11 +137,13 @@ class DiagnosticEventFactory:
         *,
         user_id: str | None = None,
         occurred_at: datetime | None = None,
+        insert_id: str | None = None,
     ) -> DiagnosticEvent:
         return DiagnosticEvent(
             event_name=event_name,
             schema_version=TELEMETRY_SCHEMA_VERSION,
             occurred_at=occurred_at or utc_now(),
+            insert_id=insert_id,
             distinct_id=self.distinct_id(user_id),
             runtime=self._runtime,
             properties=properties,

--- a/openhands-agent-server/openhands/agent_server/telemetry/models.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/models.py
@@ -67,7 +67,7 @@ class EventName(StrEnum):
     SERVER_STARTED = "agent_server.server_started"
     SERVER_STOPPED = "agent_server.server_stopped"
     CONVERSATION_STARTED = "agent_server.conversation_started"
-    CONVERSATION_CREATED = "conversation_created"
+    CONVERSATION_CREATED = "agent_server.conversation_created"
     CONVERSATION_FINISHED = "agent_server.conversation_finished"
     CONVERSATION_FAILED = "agent_server.conversation_failed"
     CONVERSATION_ERROR = "agent_server.conversation_error"

--- a/openhands-agent-server/openhands/agent_server/telemetry/models.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/models.py
@@ -67,6 +67,7 @@ class EventName(StrEnum):
     SERVER_STARTED = "agent_server.server_started"
     SERVER_STOPPED = "agent_server.server_stopped"
     CONVERSATION_STARTED = "agent_server.conversation_started"
+    CONVERSATION_CREATED = "conversation_created"
     CONVERSATION_FINISHED = "agent_server.conversation_finished"
     CONVERSATION_FAILED = "agent_server.conversation_failed"
     CONVERSATION_ERROR = "agent_server.conversation_error"
@@ -245,6 +246,7 @@ class DiagnosticEvent(BaseModel):
     event_name: EventName
     schema_version: int = TELEMETRY_SCHEMA_VERSION
     occurred_at: datetime
+    insert_id: SafeToken | None = None
 
     distinct_id: Annotated[str, StringConstraints(min_length=1, max_length=256)]
     """Correlation identity, passed through verbatim.
@@ -271,6 +273,8 @@ class DiagnosticEvent(BaseModel):
             **self.runtime.model_dump(mode="json"),
             **self.properties.model_dump(mode="json", exclude={"kind"}),
         }
+        if self.insert_id is not None:
+            payload["$insert_id"] = self.insert_id
         return payload
 
 
@@ -287,6 +291,7 @@ EXPECTED_PROPERTY_NAMES: Final[frozenset[str]] = frozenset(
         "platform",
         "deferred_init",
         "source",
+        "$insert_id",
         "conversation_ref",
         "llm_model_family",
         "agent_kind",

--- a/openhands-agent-server/openhands/agent_server/telemetry/subscriber.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/subscriber.py
@@ -135,7 +135,7 @@ class TelemetrySubscriber(Subscriber[Event]):
             self._emit_terminal(status)
 
     def emit_started(self) -> None:
-        """Emit ``conversation_started``. Called once, at registration."""
+        """Emit canonical ``conversation_created`` once at registration."""
         try:
             properties = m.ConversationStartedProperties(
                 conversation_ref=self.context.conversation_ref,
@@ -149,13 +149,14 @@ class TelemetrySubscriber(Subscriber[Event]):
             )
             self.sink.emit(
                 self.factory.build(
-                    m.EventName.CONVERSATION_STARTED,
+                    m.EventName.CONVERSATION_CREATED,
                     properties,
                     user_id=self.context.user_id,
+                    insert_id=(f"conversation_created:{self.context.conversation_ref}"),
                 )
             )
         except Exception:
-            logger.debug("Telemetry failed to emit conversation_started", exc_info=True)
+            logger.debug("Telemetry failed to emit conversation_created", exc_info=True)
 
     def _emit_terminal(self, status: str) -> None:
         if self._terminal_emitted:
@@ -287,7 +288,7 @@ class TelemetrySubscriber(Subscriber[Event]):
         conversation. Emitting unconditionally here produced a
         ``conversation_finished`` — carrying a non-terminal
         ``terminal_status`` like ``paused`` — for a conversation that did
-        nothing this session, with no matching ``conversation_started``, and
+        nothing this session, with no matching ``conversation_created``, and
         again on every view-then-restart cycle for the same
         ``conversation_ref``.
 

--- a/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
+++ b/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
@@ -106,7 +106,7 @@ async def test_conversation_service_reads_the_live_sink_not_a_captured_one(
     captured at construction, every conversation would see the pre-init NoOp and
     emit nothing regardless of consent. Build the service while the sink is still a
     NoOp, enable telemetry afterwards, and assert a new conversation still attaches
-    the subscriber and emits ``conversation_started``.
+    the subscriber and emits ``conversation_created``.
     """
     from uuid import uuid4
 
@@ -178,7 +178,7 @@ async def test_conversation_service_reads_the_live_sink_not_a_captured_one(
     )
 
     assert len(event_service.subscribers) == 1
-    assert m.EventName.CONVERSATION_STARTED in sink.events
+    assert m.EventName.CONVERSATION_CREATED in sink.events
 
 
 def test_app_exposes_a_sink_on_state_after_startup(temp_persistence_dir):

--- a/tests/agent_server/telemetry/test_telemetry_end_to_end.py
+++ b/tests/agent_server/telemetry/test_telemetry_end_to_end.py
@@ -131,7 +131,7 @@ async def test_opted_in_session_emits_sanitized_lifecycle_and_error_events():
     await asyncio.wait_for(sink.aclose(), timeout=10)
 
     names = [p["event"] for p in exporter.payloads]
-    assert m.EventName.CONVERSATION_STARTED in names
+    assert m.EventName.CONVERSATION_CREATED in names
     assert m.EventName.CONVERSATION_ERROR in names
     assert m.EventName.CONVERSATION_FINISHED in names
 
@@ -173,7 +173,10 @@ async def test_opted_in_session_reports_useful_diagnostics():
 
     by_name = {p["event"]: p["properties"] for p in exporter.payloads}
 
-    started = by_name[m.EventName.CONVERSATION_STARTED]
+    started = by_name[m.EventName.CONVERSATION_CREATED]
+    assert (
+        started["$insert_id"] == f"conversation_created:{started['conversation_ref']}"
+    )
     assert started["llm_model_family"] == "anthropic"
     assert started["tool_count"] == 4
 

--- a/tests/agent_server/telemetry/test_telemetry_schema.py
+++ b/tests/agent_server/telemetry/test_telemetry_schema.py
@@ -76,6 +76,7 @@ def test_property_names_match_the_declared_allowlist():
     actual: set[str] = {"schema_version"}
     for model in PROPERTY_MODELS:
         actual.update(n for n in model.model_fields if n != "kind")
+    actual.add("$insert_id")
 
     assert actual == set(m.EXPECTED_PROPERTY_NAMES), (
         "Diagnostic property set changed. Update EXPECTED_PROPERTY_NAMES "

--- a/tests/agent_server/telemetry/test_telemetry_subscriber.py
+++ b/tests/agent_server/telemetry/test_telemetry_subscriber.py
@@ -79,12 +79,12 @@ def make_subscriber(sink, factory, user_id: str | None = "user-1"):
 # ── lifecycle ─────────────────────────────────────────────────────────────
 
 
-async def test_emits_exactly_one_started_event(factory):
+async def test_emits_exactly_one_created_event(factory):
     sink = CollectingSink()
     sub = make_subscriber(sink, factory)
 
     sub.emit_started()
-    assert sink.names == [m.EventName.CONVERSATION_STARTED]
+    assert sink.names == [m.EventName.CONVERSATION_CREATED]
 
 
 def test_started_is_only_emitted_for_genuinely_new_conversations():
@@ -92,7 +92,7 @@ def test_started_is_only_emitted_for_genuinely_new_conversations():
 
     It is called when an idle conversation is lazily reloaded and when RUNNING
     conversations are recovered after a restart. Emitting
-    ``conversation_started`` from all of those would inflate the metric on
+    ``conversation_created`` from all of those would inflate the metric on
     every server bounce, so the flag must default to *not* emitting.
     """
     import inspect
@@ -103,7 +103,7 @@ def test_started_is_only_emitted_for_genuinely_new_conversations():
     param = sig.parameters["is_new_conversation"]
 
     assert param.default is False, (
-        "_start_event_service must default to NOT emitting conversation_started; "
+        "_start_event_service must default to NOT emitting conversation_created; "
         "the hydration path relies on that default"
     )
     assert param.kind is inspect.Parameter.KEYWORD_ONLY
@@ -156,7 +156,7 @@ async def test_close_is_silent_when_no_run_was_observed(factory):
 
     The subscriber attaches on every _start_event_service path, including the
     lazy attach when a user merely views an old conversation. Emitting on close
-    produced a conversation_finished with no matching conversation_started,
+    produced a conversation_finished with no matching conversation_created,
     repeated on every view-then-restart cycle for the same conversation_ref.
     """
     sink = CollectingSink()
@@ -397,7 +397,7 @@ async def test_disabled_sink_short_circuits_before_building_events(factory):
 
     sub.emit_started()
     # emit() itself is a no-op on a disabled sink; nothing is recorded.
-    assert sink.events == [] or sink.names == [m.EventName.CONVERSATION_STARTED]
+    assert sink.events == [] or sink.names == [m.EventName.CONVERSATION_CREATED]
 
 
 # ── identity ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
HUMAN:
Canonicalize conversation creation telemetry around the agent-server source of truth.

AGENT:
## Why
- The conversation KPI should count only real agent-server conversations, not browser or request-level milestones.
- PostHog retries need a deterministic `$insert_id` to avoid duplicate KPI counts.

## How to Test
- `uv run pytest tests/agent_server/telemetry/test_telemetry_subscriber.py tests/agent_server/telemetry/test_telemetry_end_to_end.py tests/agent_server/telemetry/test_telemetry_schema.py -q`
- `uv run pytest tests/agent_server/telemetry/test_telemetry_exporter_posthog.py -q`

## Summary
- Emits canonical `agent_server.conversation_created` telemetry from agent-server for genuinely new conversations.
- Adds deterministic `$insert_id` values based on the sanitized conversation reference.
- Updates telemetry tests/docs from the old started milestone to the canonical created milestone.

This PR description was updated by an AI agent (OpenHands) on behalf of the user.



<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c96c16a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c96c16a-python \
  ghcr.io/openhands/agent-server:c96c16a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c96c16a-golang-amd64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-golang-amd64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-golang-amd64
ghcr.io/openhands/agent-server:c96c16a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c96c16a-golang-arm64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-golang-arm64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-golang-arm64
ghcr.io/openhands/agent-server:c96c16a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c96c16a-java-amd64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-java-amd64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-java-amd64
ghcr.io/openhands/agent-server:c96c16a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c96c16a-java-arm64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-java-arm64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-java-arm64
ghcr.io/openhands/agent-server:c96c16a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c96c16a-python-amd64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-python-amd64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-python-amd64
ghcr.io/openhands/agent-server:c96c16a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c96c16a-python-arm64
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-python-arm64
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-python-arm64
ghcr.io/openhands/agent-server:c96c16a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c96c16a-golang
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-golang
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-golang
ghcr.io/openhands/agent-server:c96c16a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c96c16a-java
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-java
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-java
ghcr.io/openhands/agent-server:c96c16a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c96c16a-python
ghcr.io/openhands/agent-server:c96c16a9ac1969effd40aff80d7f7db5222ebbd5-python
ghcr.io/openhands/agent-server:oss-8687-canonical-conversation-telemetry-python
ghcr.io/openhands/agent-server:c96c16a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c96c16a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c96c16a-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
