### PR TITLE
fix(sdk): cap condenser token limit by agent context

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -93,6 +93,17 @@ class LLMSummarizingCondenser(RollingCondenser):
     def handles_condensation_requests(self) -> bool:
         return True
 
+    def _effective_max_tokens(self, agent_llm: LLM | None) -> int | None:
+        limits = [
+            limit
+            for limit in (
+                self.max_tokens,
+                agent_llm.effective_max_input_tokens if agent_llm is not None else None,
+            )
+            if limit is not None
+        ]
+        return min(limits) if limits else None
+
     def get_condensation_reasons(
         self, view: View, agent_llm: LLM | None = None
     ) -> set[Reason]:
@@ -112,15 +123,8 @@ class LLMSummarizingCondenser(RollingCondenser):
         if view.unhandled_condensation_request:
             reasons.add(Reason.REQUEST)
 
-        # Reason 2: Token limit is provided and exceeded. The agent's effective
-        # input limit is authoritative when it is lower than the configured limit.
-        max_tokens = self.max_tokens
-        if agent_llm is not None and agent_llm.effective_max_input_tokens is not None:
-            if max_tokens is None:
-                max_tokens = agent_llm.effective_max_input_tokens
-            else:
-                max_tokens = min(max_tokens, agent_llm.effective_max_input_tokens)
-
+        # Reason 2: Token limit is provided and exceeded.
+        max_tokens = self._effective_max_tokens(agent_llm)
         if max_tokens is not None and agent_llm is not None:
             total_tokens = get_total_token_count(view.events, agent_llm)
             if total_tokens > max_tokens:
@@ -262,13 +266,14 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         if Reason.TOKENS in reasons:
             # Compute the number of tokens we need to eliminate to be under half the
-            # max_tokens value. We know max_tokens and the agent LLM are not None here
-            # because we can't have Reason.TOKENS without them.
-            assert self.max_tokens is not None
+            # effective max_tokens value. We know both are not None here because we
+            # cannot have Reason.TOKENS without them.
+            max_tokens = self._effective_max_tokens(agent_llm)
+            assert max_tokens is not None
             assert agent_llm is not None
 
             total_tokens = get_total_token_count(view.events, agent_llm)
-            tokens_to_reduce = total_tokens - (self.max_tokens // 2)
+            tokens_to_reduce = total_tokens - (max_tokens // 2)
 
             suffix_events_to_keep.add(
                 get_suffix_length_for_token_reduction(

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -112,15 +112,23 @@ class LLMSummarizingCondenser(RollingCondenser):
         if view.unhandled_condensation_request:
             reasons.add(Reason.REQUEST)
 
-        # Reason 2: Token limit is provided and exceeded.
-        if self.max_tokens and agent_llm:
+        # Reason 2: Token limit is provided and exceeded. The agent's effective
+        # input limit is authoritative when it is lower than the configured limit.
+        max_tokens = self.max_tokens
+        if agent_llm is not None and agent_llm.effective_max_input_tokens is not None:
+            if max_tokens is None:
+                max_tokens = agent_llm.effective_max_input_tokens
+            else:
+                max_tokens = min(max_tokens, agent_llm.effective_max_input_tokens)
+
+        if max_tokens is not None and agent_llm is not None:
             total_tokens = get_total_token_count(view.events, agent_llm)
-            if total_tokens > self.max_tokens:
+            if total_tokens > max_tokens:
                 logger.info(
                     "Condenser token limit exceeded: total_tokens=%d max_tokens=%d "
                     "events=%d",
                     total_tokens,
-                    self.max_tokens,
+                    max_tokens,
                     len(view),
                 )
                 reasons.add(Reason.TOKENS)

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -94,13 +94,21 @@ class LLMSummarizingCondenser(RollingCondenser):
         return True
 
     def _effective_max_tokens(self, agent_llm: LLM | None) -> int | None:
+        """Return the effective token cap that triggers token-based condensation.
+
+        Takes the stricter (i.e. smaller) of the condenser's configured
+        ``max_tokens`` and the agent LLM's effective input limit. ``agent_llm``
+        is optional throughout the public API -- callers that only assess
+        request/event-count pressure may pass ``None`` -- in which case only the
+        condenser's own ``max_tokens`` applies.
+
+        Returns ``None`` when no limit is configured.
+        """
+        agent_limit = (
+            agent_llm.effective_max_input_tokens if agent_llm is not None else None
+        )
         limits = [
-            limit
-            for limit in (
-                self.max_tokens,
-                agent_llm.effective_max_input_tokens if agent_llm is not None else None,
-            )
-            if limit is not None
+            limit for limit in (self.max_tokens, agent_limit) if limit is not None
         ]
         return min(limits) if limits else None
 

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -104,11 +104,13 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         Returns ``None`` when no limit is configured.
         """
-        agent_limit = (
-            agent_llm.effective_max_input_tokens if agent_llm is not None else None
-        )
         limits = [
-            limit for limit in (self.max_tokens, agent_limit) if limit is not None
+            limit
+            for limit in (
+                self.max_tokens,
+                agent_llm.effective_max_input_tokens if agent_llm is not None else None,
+            )
+            if limit is not None
         ]
         return min(limits) if limits else None
 

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -387,6 +387,21 @@ def test_token_limit_inherits_agent_effective_input_limit(
     assert Reason.TOKENS in reasons
 
 
+def test_token_reduction_uses_agent_effective_input_limit(mock_llm: LLM) -> None:
+    condenser = LLMSummarizingCondenser(
+        llm=mock_llm, max_size=1000, max_tokens=500, keep_first=2
+    )
+    agent_llm = MagicMock(spec=LLM)
+    agent_llm.effective_max_input_tokens = 100
+    agent_llm.get_token_count.return_value = 200
+
+    view = View.from_events([message_event("event") for _ in range(10)])
+
+    forgotten_events, _ = condenser._get_forgotten_events(view, agent_llm=agent_llm)
+
+    assert forgotten_events
+
+
 def test_condense_with_request_and_events_reasons(mock_llm: LLM) -> None:
     """Test condensation when both REQUEST and EVENTS reasons are true simultaneously.
 

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -277,6 +277,7 @@ def test_condense_with_agent_llm(mock_llm: LLM) -> None:
     # Create a separate mock for the agent's LLM
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
+    agent_llm.effective_max_input_tokens = None
 
     # Prepare a view that triggers condensation
     events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
@@ -307,6 +308,7 @@ def test_condense_with_token_limit_exceeded(mock_llm: LLM) -> None:
     # Create a separate mock for the agent's LLM with token counting
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
+    agent_llm.effective_max_input_tokens = None
 
     # Mock get_token_count to return predictable values based on message content length
     def mock_token_count(messages, **_kwargs):
@@ -343,6 +345,46 @@ def test_condense_with_token_limit_exceeded(mock_llm: LLM) -> None:
 
     # Verify forgotten events were calculated based on token reduction
     assert len(result.forgotten_event_ids) > 0
+
+
+@pytest.mark.parametrize(
+    ("configured_limit", "agent_limit", "token_count", "expected_trigger"),
+    [(500, 100, 200, True), (100, 500, 200, True), (100, 500, 50, False)],
+)
+def test_token_limit_uses_stricter_configured_or_agent_limit(
+    mock_llm: LLM,
+    configured_limit: int,
+    agent_limit: int,
+    token_count: int,
+    expected_trigger: bool,
+) -> None:
+    condenser = LLMSummarizingCondenser(
+        llm=mock_llm, max_size=1000, max_tokens=configured_limit, keep_first=2
+    )
+    agent_llm = MagicMock(spec=LLM)
+    agent_llm.effective_max_input_tokens = agent_limit
+    agent_llm.get_token_count.return_value = token_count
+
+    view = View.from_events([message_event("event") for _ in range(10)])
+
+    reasons = condenser.get_condensation_reasons(view, agent_llm=agent_llm)
+
+    assert (Reason.TOKENS in reasons) is expected_trigger
+
+
+def test_token_limit_inherits_agent_effective_input_limit(
+    mock_llm: LLM,
+) -> None:
+    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=1000, keep_first=2)
+    agent_llm = MagicMock(spec=LLM)
+    agent_llm.effective_max_input_tokens = 100
+    agent_llm.get_token_count.return_value = 200
+
+    view = View.from_events([message_event("event") for _ in range(10)])
+
+    reasons = condenser.get_condensation_reasons(view, agent_llm=agent_llm)
+
+    assert Reason.TOKENS in reasons
 
 
 def test_condense_with_request_and_events_reasons(mock_llm: LLM) -> None:
@@ -405,6 +447,7 @@ def test_condense_with_request_and_tokens_reasons(mock_llm: LLM) -> None:
     # Create a separate mock for the agent's LLM with token counting
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
+    agent_llm.effective_max_input_tokens = None
 
     # Mock get_token_count to return predictable values
     def mock_token_count(messages, **_kwargs):
@@ -453,6 +496,7 @@ def test_condense_with_events_and_tokens_reasons(mock_llm: LLM) -> None:
     # Create a separate mock for the agent's LLM with token counting
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
+    agent_llm.effective_max_input_tokens = None
 
     def mock_token_count(messages, **_kwargs):
         total_chars = 0
@@ -499,6 +543,7 @@ def test_condense_with_all_three_reasons(mock_llm: LLM) -> None:
     # Create a separate mock for the agent's LLM with token counting
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
+    agent_llm.effective_max_input_tokens = None
 
     def mock_token_count(messages, **_kwargs):
         total_chars = 0

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1015,9 +1015,10 @@ def test_llm_summarizing_condenser_max_tokens_none_when_llm_has_no_limit() -> No
     assert agent.condenser.max_tokens is None
 
 
-def test_llm_summarizing_condenser_explicit_none_max_tokens_not_overridden() -> None:
-    """An explicit ``max_tokens=None`` must disable token-based condensation
-    even if the agent LLM has a configured ``max_input_tokens``.
+def test_llm_summarizing_condenser_explicit_none_max_tokens_remains_unset() -> None:
+    """An explicit ``max_tokens=None`` remains unset on the condenser configuration.
+
+    The active agent LLM's effective input limit still governs condensation at runtime.
     """
     llm = LLM(model="test-model", usage_id="agent", max_input_tokens=65536)
     settings = OpenHandsAgentSettings(


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

I have not tested this live, but it is simple enough that I was able to check the code given the tests and reading the code.

---

AGENT:

## Why

When a condenser has a configured token limit larger than the active agent model's effective input limit—or no configured token limit at all—it can wait until the agent request overflows before condensing. The condenser should use the stricter limit from the current agent LLM.

## Summary

- Use the minimum of configured `max_tokens` and `agent_llm.effective_max_input_tokens`.
- Evaluate the effective threshold during condensation so model switches are handled correctly.
- Add regression coverage for configured, inherited, and stricter limits.

## Issue Number

Fixes #4421

## How to Test

Run:

```bash
uv run ruff check openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py
uv run ruff format --check openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py
uv run pytest tests/sdk/context/condenser tests/sdk/agent/test_agent_context_window_condensation.py
```

All 89 focused condenser and context-window tests pass.

## Video/Screenshots

Not applicable: this is an SDK behavior change with automated test coverage.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The threshold preserves explicit condenser configuration as the stricter bound while adapting to the active agent model's effective input capacity.

This pull request description was updated by an AI agent (OpenHands) on behalf of the user.






<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:53231f6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-53231f6-python \
  ghcr.io/openhands/agent-server:53231f6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:53231f6-golang-amd64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-golang-amd64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-golang-amd64
ghcr.io/openhands/agent-server:53231f6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:53231f6-golang-arm64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-golang-arm64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-golang-arm64
ghcr.io/openhands/agent-server:53231f6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:53231f6-java-amd64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-java-amd64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-java-amd64
ghcr.io/openhands/agent-server:53231f6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:53231f6-java-arm64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-java-arm64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-java-arm64
ghcr.io/openhands/agent-server:53231f6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:53231f6-python-amd64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-python-amd64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-python-amd64
ghcr.io/openhands/agent-server:53231f6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:53231f6-python-arm64
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-python-arm64
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-python-arm64
ghcr.io/openhands/agent-server:53231f6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:53231f6-golang
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-golang
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-golang
ghcr.io/openhands/agent-server:53231f6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:53231f6-java
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-java
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-java
ghcr.io/openhands/agent-server:53231f6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:53231f6-python
ghcr.io/openhands/agent-server:53231f68e20b5398a04133cfd3fb851590555f2a-python
ghcr.io/openhands/agent-server:fix-dynamic-condenser-token-limit-python
ghcr.io/openhands/agent-server:53231f6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `53231f6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `53231f6-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

---

## Review progress

- Addressed review feedback and resolved the unresolved review thread (none remain).
- `_effective_max_tokens` now documents why `agent_llm` may be `None`.
- Latest head: `b4d705482`.
