### PR TITLE
Add ready-for-dev issue and PR gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -62,6 +62,16 @@ body:
               5. Error appears
       validations:
           required: false
+    - type: textarea
+      id: acceptance-criteria
+      attributes:
+          label: Acceptance Criteria
+          description: List the testable checklist item(s) that would prove this bug is fixed.
+          placeholder: |
+              - [ ] The reported error no longer occurs
+              - [ ] The fix works with a fresh agent instance
+      validations:
+          required: false
 
     - type: input
       id: installation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -31,12 +31,23 @@ body:
           required: true
 
     - type: textarea
-      id: proposed-solution
+      id: desired-behavior
       attributes:
-          label: Proposed Solution
+          label: Desired Behavior
           description: Describe your ideal solution. What should this feature do? How should it work?
           placeholder: |
               Example - Add a StateManager class that allows saving and loading agent state to/from disk or database. Provide methods like save_state(), load_state(), and clear_state(). Support multiple backend options (JSON files, SQLite, Redis, etc.).
+      validations:
+          required: true
+
+    - type: textarea
+      id: acceptance-criteria
+      attributes:
+          label: Acceptance Criteria
+          description: List the testable checklist item(s) that would prove this feature is complete.
+          placeholder: |
+              - [ ] Saving agent state to disk works end-to-end
+              - [ ] A new Agent restores state from a previously saved snapshot
       validations:
           required: true
 

--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -246,13 +246,17 @@ def main() -> int:
 
     if args.json:
         print(json.dumps({"ready": result.ready, "reasons": result.reasons}))
+        # In --json mode the exit code is not meaningful: the result is consumed
+        # via the printed JSON, and the workflow must run to completion for both
+        # ready and not-ready issues (label add/remove, feedback comment).
+        return 0
+
+    if result.ready:
+        print("Issue meets ready-for-dev criteria.")
     else:
-        if result.ready:
-            print("Issue meets ready-for-dev criteria.")
-        else:
-            print("Issue does not meet ready-for-dev criteria:")
-            for reason in result.reasons:
-                print(f"  - {reason}")
+        print("Issue does not meet ready-for-dev criteria:")
+        for reason in result.reasons:
+            print(f"  - {reason}")
 
     return 0 if result.ready else 1
 

--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -33,6 +33,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+
 BUG_LABEL = "bug"
 ENHANCEMENT_LABEL = "enhancement"
 
@@ -101,22 +102,6 @@ def find_section(sections: dict[str, str], *labels: str) -> str:
     return ""
 
 
-def has_screenshot_or_video(text: str) -> bool:
-    if MARKDOWN_IMAGE_RE.search(text):
-        return True
-    if HTML_IMG_RE.search(text):
-        return True
-    if HTML_VIDEO_RE.search(text):
-        return True
-    if GITHUB_ATTACHMENT_RE.search(text):
-        return True
-    if VIDEO_FILE_RE.search(text):
-        return True
-    if VIDEO_HOST_RE.search(text):
-        return True
-    return False
-
-
 def references_run_method(text: str) -> bool:
     return any(pattern.search(text) for pattern in RUN_METHOD_PATTERNS)
 
@@ -140,9 +125,13 @@ def check_bug(sections: dict[str, str]) -> ReadinessResult:
             "such as `python`, `pytest`, `uv`, or `pip`."
         )
 
-    acceptance = visible_text(find_section(sections, "acceptance criteria", "acceptance"))
+    acceptance = visible_text(
+        find_section(sections, "acceptance criteria", "acceptance")
+    )
     if not acceptance:
-        result.add("Add an `### Acceptance Criteria` section with testable checklist items.")
+        result.add(
+            "Add an `### Acceptance Criteria` section with testable checklist items."
+        )
     elif not has_checklist_item(acceptance):
         result.add(
             "The Acceptance Criteria section must contain at least one checklist item "
@@ -161,9 +150,13 @@ def check_enhancement(sections: dict[str, str]) -> ReadinessResult:
             "Add a `### Desired Behavior` section describing the behavior you want."
         )
 
-    acceptance = visible_text(find_section(sections, "acceptance criteria", "acceptance"))
+    acceptance = visible_text(
+        find_section(sections, "acceptance criteria", "acceptance")
+    )
     if not acceptance:
-        result.add("Add an `### Acceptance Criteria` section with testable checklist items.")
+        result.add(
+            "Add an `### Acceptance Criteria` section with testable checklist items."
+        )
     elif not has_checklist_item(acceptance):
         result.add(
             "The Acceptance Criteria section must contain at least one checklist item "
@@ -204,7 +197,9 @@ def body_and_labels_from_event(event_path: Path) -> tuple[str, list[str]]:
         raise ValueError("GitHub event payload does not contain an issue object")
     body = issue.get("body")
     body = body if isinstance(body, str) else ""
-    labels = [label["name"] for label in issue.get("labels", []) if isinstance(label, dict)]
+    labels = [
+        label["name"] for label in issue.get("labels", []) if isinstance(label, dict)
+    ]
     return body, labels
 
 
@@ -212,7 +207,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Evaluate whether an issue meets the ready-for-dev criteria."
     )
-    parser.add_argument("--body-file", type=Path, help="Read the issue body from a file.")
+    parser.add_argument(
+        "--body-file", type=Path, help="Read the issue body from a file."
+    )
     parser.add_argument(
         "--labels",
         help="Comma-separated issue labels (e.g. 'bug,frontend').",

--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -47,7 +47,7 @@ NO_RESPONSE = "_No response_"
 
 # A reproducible SDK command must appear in the Actual Behavior section.
 RUN_METHOD_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bpython(?:\s|\d|$)", re.IGNORECASE),
+    re.compile(r"\bpython\b", re.IGNORECASE),
     re.compile(r"\bpytest\b", re.IGNORECASE),
     re.compile(r"\buv\b", re.IGNORECASE),
     re.compile(r"\bpip\b", re.IGNORECASE),

--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -1,0 +1,264 @@
+"""Determine whether an issue meets the `ready-for-dev` readiness criteria.
+
+The criteria are type-specific:
+
+- Bug reports (labeled `bug`): the Actual Behavior section must describe a
+  reproducible SDK run and include a supported command (`python`, `pytest`,
+  `uv`, or `pip`), plus a non-empty Acceptance Criteria section with at least
+  one checklist item.
+
+- Enhancements (labeled `enhancement`): the body must contain non-empty
+  Desired Behavior and Acceptance Criteria sections, the latter with at least
+  one checklist item.
+
+GitHub issue forms render each field as an `### <Label>` (h3) heading followed
+by the field text, with empty optional fields rendered as `_No response_`. This
+parser splits the body on those headings so each criterion is checked against
+the right field rather than the whole body.
+
+Local usage:
+
+    python .github/scripts/check_issue_readiness.py --body-file /tmp/issue.md \
+        --labels bug
+    python .github/scripts/check_issue_readiness.py --event-path "$GITHUB_EVENT_PATH"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BUG_LABEL = "bug"
+ENHANCEMENT_LABEL = "enhancement"
+
+# Issue-form fields render as `### Label` h3 headings. Match case-insensitively
+# and tolerate trailing whitespace/colons. `^###\s+` is specific enough because
+# h1/h2 are not produced by issue forms.
+HEADING_RE = re.compile(r"(?m)^###\s+(.+?)\s*$")
+
+# `_No response_` is what GitHub writes for an empty optional form field.
+NO_RESPONSE = "_No response_"
+
+# A reproducible SDK command must appear in the Actual Behavior section.
+RUN_METHOD_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bpython(?:\s|\d|$)", re.IGNORECASE),
+    re.compile(r"\bpytest\b", re.IGNORECASE),
+    re.compile(r"\buv\b", re.IGNORECASE),
+    re.compile(r"\bpip\b", re.IGNORECASE),
+)
+
+# An Acceptance Criteria item is a markdown checklist bullet (`- [ ]` or
+# `- [x]`). We require at least one so the section is verifiable.
+CHECKLIST_ITEM_RE = re.compile(r"(?m)^\s*[-*]\s*\[[ xX]\]")
+
+
+@dataclass
+class ReadinessResult:
+    """Outcome of a readiness check."""
+
+    ready: bool
+    reasons: list[str] = field(default_factory=list)
+
+    def add(self, reason: str) -> None:
+        self.reasons.append(reason)
+        self.ready = False
+
+
+def visible_text(text: str) -> str:
+    """Return field text with HTML comments stripped and emptiness normalized."""
+    cleaned = re.sub(r"<!--[\s\S]*?-->", "", text).strip()
+    if cleaned == NO_RESPONSE:
+        return ""
+    return cleaned
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    """Split the body into a {heading: text} map using `### <heading>` boundaries.
+
+    Issue forms render every field this way. Free-form issues (not created via a
+    form) may still use `###` headings; if they don't, the map is empty and the
+    caller falls back to whole-body checks.
+    """
+    matches = list(HEADING_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[match.group(1).strip().lower()] = body[start:end]
+    return sections
+
+
+def find_section(sections: dict[str, str], *labels: str) -> str:
+    """Return the first matching section text by case-insensitive label."""
+    for label in labels:
+        if label in sections:
+            return sections[label]
+    return ""
+
+
+def has_screenshot_or_video(text: str) -> bool:
+    if MARKDOWN_IMAGE_RE.search(text):
+        return True
+    if HTML_IMG_RE.search(text):
+        return True
+    if HTML_VIDEO_RE.search(text):
+        return True
+    if GITHUB_ATTACHMENT_RE.search(text):
+        return True
+    if VIDEO_FILE_RE.search(text):
+        return True
+    if VIDEO_HOST_RE.search(text):
+        return True
+    return False
+
+
+def references_run_method(text: str) -> bool:
+    return any(pattern.search(text) for pattern in RUN_METHOD_PATTERNS)
+
+
+def has_checklist_item(text: str) -> bool:
+    return bool(CHECKLIST_ITEM_RE.search(text))
+
+
+def check_bug(sections: dict[str, str]) -> ReadinessResult:
+    result = ReadinessResult(ready=True)
+
+    actual = visible_text(find_section(sections, "actual behavior", "actual"))
+    if not actual:
+        result.add(
+            "Fill in the `### Actual Behavior` section with reproducible SDK "
+            "steps and the observed result."
+        )
+    elif not references_run_method(actual):
+        result.add(
+            "The Actual Behavior section must include a reproducible SDK command "
+            "such as `python`, `pytest`, `uv`, or `pip`."
+        )
+
+    acceptance = visible_text(find_section(sections, "acceptance criteria", "acceptance"))
+    if not acceptance:
+        result.add("Add an `### Acceptance Criteria` section with testable checklist items.")
+    elif not has_checklist_item(acceptance):
+        result.add(
+            "The Acceptance Criteria section must contain at least one checklist item "
+            "(`- [ ] …`)."
+        )
+
+    return result
+
+
+def check_enhancement(sections: dict[str, str]) -> ReadinessResult:
+    result = ReadinessResult(ready=True)
+
+    desired = visible_text(find_section(sections, "desired behavior", "desired"))
+    if not desired:
+        result.add(
+            "Add a `### Desired Behavior` section describing the behavior you want."
+        )
+
+    acceptance = visible_text(find_section(sections, "acceptance criteria", "acceptance"))
+    if not acceptance:
+        result.add("Add an `### Acceptance Criteria` section with testable checklist items.")
+    elif not has_checklist_item(acceptance):
+        result.add(
+            "The Acceptance Criteria section must contain at least one checklist item "
+            "(`- [ ] …`)."
+        )
+
+    return result
+
+
+def evaluate_readiness(body: str, labels: list[str]) -> ReadinessResult:
+    """Return the readiness result for an issue body + label set.
+
+    An issue is only a candidate when it carries the `bug` or `enhancement`
+    label. If it has neither, it is treated as not-ready-for-dev (the gate does
+    not apply a label it cannot validate).
+    """
+    label_set = {label.lower() for label in labels}
+    sections = extract_sections(body or "")
+
+    if BUG_LABEL in label_set:
+        return check_bug(sections)
+    if ENHANCEMENT_LABEL in label_set:
+        return check_enhancement(sections)
+
+    return ReadinessResult(
+        ready=False,
+        reasons=[
+            "The issue has neither the `bug` nor `enhancement` label, so its "
+            "readiness criteria cannot be evaluated. Add the appropriate label."
+        ],
+    )
+
+
+def body_and_labels_from_event(event_path: Path) -> tuple[str, list[str]]:
+    payload = json.loads(event_path.read_text())
+    issue = payload.get("issue") or payload.get("pull_request")
+    if not isinstance(issue, dict):
+        raise ValueError("GitHub event payload does not contain an issue object")
+    body = issue.get("body")
+    body = body if isinstance(body, str) else ""
+    labels = [label["name"] for label in issue.get("labels", []) if isinstance(label, dict)]
+    return body, labels
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate whether an issue meets the ready-for-dev criteria."
+    )
+    parser.add_argument("--body-file", type=Path, help="Read the issue body from a file.")
+    parser.add_argument(
+        "--labels",
+        help="Comma-separated issue labels (e.g. 'bug,frontend').",
+        default="",
+    )
+    parser.add_argument(
+        "--event-path",
+        type=Path,
+        default=Path(os.environ["GITHUB_EVENT_PATH"])
+        if "GITHUB_EVENT_PATH" in os.environ
+        else None,
+        help="Read body and labels from a GitHub event payload.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON result instead of human-readable text.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.body_file is not None:
+        body = args.body_file.read_text()
+        labels = [label.strip() for label in args.labels.split(",") if label.strip()]
+    elif args.event_path is not None:
+        body, labels = body_and_labels_from_event(args.event_path)
+    else:
+        raise SystemExit("Pass --body-file or set GITHUB_EVENT_PATH.")
+
+    result = evaluate_readiness(body, labels)
+
+    if args.json:
+        print(json.dumps({"ready": result.ready, "reasons": result.reasons}))
+    else:
+        if result.ready:
+            print("Issue meets ready-for-dev criteria.")
+        else:
+            print("Issue does not meet ready-for-dev criteria:")
+            for reason in result.reasons:
+                print(f"  - {reason}")
+
+    return 0 if result.ready else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -5,6 +5,8 @@ import json
 import os
 import re
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 
@@ -83,8 +85,6 @@ def extract_linked_issue_numbers(body: str) -> list[int]:
 
 
 def fetch_issue_labels(repo: str, issue_number: int, token: str) -> list[str]:
-    import urllib.request
-
     request = urllib.request.Request(
         f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels",
         headers={
@@ -108,8 +108,6 @@ def validate_linked_issue_ready(
         ]
     if not repo or not token:
         return []
-
-    import urllib.error
 
     checked: list[int] = []
     for number in numbers:

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -25,8 +25,11 @@ READY_FOR_DEV_LABEL = "ready-for-dev"
 # Issues created before the `ready-for-dev` rollout are grandfathered: the
 # issue-readiness workflow only labels issues on `issues` events, so long-open
 # issues were never evaluated. Requiring the label retroactively would block
-# existing PRs linked to those issues. Newly created issues must carry it.
-READY_FOR_DEV_ROLLOUT_ISO = "2026-08-12"
+# existing PRs linked to those issues. The cutoff is the UTC day AFTER the
+# rollout/deployment day (2026-08-12), so every issue predating deployment —
+# including ones opened earlier that same day, before the workflow existed —
+# is exempt. Issues created on or after 2026-08-13 must carry the label.
+READY_FOR_DEV_ROLLOUT_ISO = "2026-08-13"
 
 
 def visible_text(text: str) -> str:

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -17,6 +17,9 @@ HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
 HUMAN_HEADING_RE = re.compile(r"(?im)^\s*HUMAN:\s*$")
 AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
+ISSUE_REF_RE = re.compile(r"(?i)(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+#(\d+)")
+BARE_ISSUE_REF_RE = re.compile(r"(?<!\w)#(\d+)")
+READY_FOR_DEV_LABEL = "ready-for-dev"
 
 
 def visible_text(text: str) -> str:
@@ -58,6 +61,72 @@ def extract_human_note(body: str) -> str:
         return ""
 
     return visible_text(body[human_match.end() : agent_match.start()])
+
+
+def extract_linked_issue_numbers(body: str) -> list[int]:
+    numbers: list[int] = []
+    seen: set[int] = set()
+    for match in ISSUE_REF_RE.finditer(body):
+        number = int(match.group(1))
+        if number not in seen:
+            numbers.append(number)
+            seen.add(number)
+
+    sections = extract_sections(body)
+    issue_section = sections.get("Issue Number", "")
+    for match in BARE_ISSUE_REF_RE.finditer(issue_section):
+        number = int(match.group(1))
+        if number not in seen:
+            numbers.append(number)
+            seen.add(number)
+    return numbers
+
+
+def fetch_issue_labels(repo: str, issue_number: int, token: str) -> list[str]:
+    import urllib.request
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(request) as response:  # noqa: S310 - trusted HTTPS API
+        labels = json.loads(response.read().decode())
+    return [label["name"] for label in labels if isinstance(label, dict)]
+
+
+def validate_linked_issue_ready(
+    body: str, repo: str | None = None, token: str | None = None
+) -> list[str]:
+    numbers = extract_linked_issue_numbers(body)
+    if not numbers:
+        return [
+            "Link an issue in the `## Issue Number` section (e.g. `Fixes #123`). "
+            "The issue must carry the `ready-for-dev` label."
+        ]
+    if not repo or not token:
+        return []
+
+    import urllib.error
+
+    checked: list[int] = []
+    for number in numbers:
+        try:
+            labels = fetch_issue_labels(repo, number, token)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                continue
+            raise
+        checked.append(number)
+        if READY_FOR_DEV_LABEL in [label.lower() for label in labels]:
+            return []
+
+    if checked:
+        refs = ", ".join(f"#{number}" for number in checked)
+        return [
+            f"None of the linked issues ({refs}) carry the `ready-for-dev` label. "
+            "The issue must meet the readiness criteria before a PR can be opened."
+        ]
+    return [f"Referenced issue(s) {', '.join(f'#{n}' for n in numbers)} could not be found in this repository."]
 
 
 def validate_pr_body(body: str) -> list[str]:
@@ -123,6 +192,14 @@ def main() -> int:
         raise SystemExit("Pass --body-file or set GITHUB_EVENT_PATH.")
 
     errors = validate_pr_body(body)
+
+    repo = None
+    token = os.environ.get("GITHUB_TOKEN")
+    if args.event_path is not None and args.body_file is None:
+        payload = json.loads(args.event_path.read_text())
+        repo = payload.get("repository", {}).get("full_name")
+    errors.extend(validate_linked_issue_ready(body, repo, token))
+
     for error in errors:
         print(f"::error::{error}")
 

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -17,7 +17,7 @@ HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
 HUMAN_HEADING_RE = re.compile(r"(?im)^\s*HUMAN:\s*$")
 AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
-ISSUE_REF_RE = re.compile(r"(?i)(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+#(\d+)")
+ISSUE_REF_RE = re.compile(r"(?i)\b(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+#(\d+)")
 BARE_ISSUE_REF_RE = re.compile(r"(?<!\w)#(\d+)")
 READY_FOR_DEV_LABEL = "ready-for-dev"
 

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -87,7 +87,10 @@ def fetch_issue_labels(repo: str, issue_number: int, token: str) -> list[str]:
 
     request = urllib.request.Request(
         f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
     )
     with urllib.request.urlopen(request) as response:  # noqa: S310 - trusted HTTPS API
         labels = json.loads(response.read().decode())
@@ -126,7 +129,8 @@ def validate_linked_issue_ready(
             f"None of the linked issues ({refs}) carry the `ready-for-dev` label. "
             "The issue must meet the readiness criteria before a PR can be opened."
         ]
-    return [f"Referenced issue(s) {', '.join(f'#{n}' for n in numbers)} could not be found in this repository."]
+    refs = ", ".join(f"#{number}" for number in numbers)
+    return [f"Referenced issue(s) {refs} could not be found in this repository."]
 
 
 def validate_pr_body(body: str) -> list[str]:

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -22,6 +22,11 @@ AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
 ISSUE_REF_RE = re.compile(r"(?i)\b(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+#(\d+)")
 BARE_ISSUE_REF_RE = re.compile(r"(?<!\w)#(\d+)")
 READY_FOR_DEV_LABEL = "ready-for-dev"
+# Issues created before the `ready-for-dev` rollout are grandfathered: the
+# issue-readiness workflow only labels issues on `issues` events, so long-open
+# issues were never evaluated. Requiring the label retroactively would block
+# existing PRs linked to those issues. Newly created issues must carry it.
+READY_FOR_DEV_ROLLOUT_ISO = "2026-08-12"
 
 
 def visible_text(text: str) -> str:
@@ -84,17 +89,24 @@ def extract_linked_issue_numbers(body: str) -> list[int]:
     return numbers
 
 
-def fetch_issue_labels(repo: str, issue_number: int, token: str) -> list[str]:
+def fetch_issue_details(
+    repo: str, issue_number: int, token: str
+) -> tuple[list[str], str]:
+    """Return an issue's (labels, created_at) from the GitHub API."""
     request = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels",
+        f"https://api.github.com/repos/{repo}/issues/{issue_number}",
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
         },
     )
-    with urllib.request.urlopen(request) as response:  # noqa: S310 - trusted HTTPS API
-        labels = json.loads(response.read().decode())
-    return [label["name"] for label in labels if isinstance(label, dict)]
+    with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310 - trusted HTTPS API
+        issue = json.loads(response.read().decode())
+    labels = [
+        label["name"] for label in issue.get("labels", []) if isinstance(label, dict)
+    ]
+    created_at = issue.get("created_at", "")
+    return labels, created_at
 
 
 def validate_linked_issue_ready(
@@ -104,31 +116,39 @@ def validate_linked_issue_ready(
     if not numbers:
         return [
             "Link an issue in the `## Issue Number` section (e.g. `Fixes #123`). "
-            "The issue must carry the `ready-for-dev` label."
+            "Newly opened issues must carry the `ready-for-dev` label."
         ]
     if not repo or not token:
         return []
 
     checked: list[int] = []
+    not_ready_new: list[int] = []
     for number in numbers:
         try:
-            labels = fetch_issue_labels(repo, number, token)
+            labels, created_at = fetch_issue_details(repo, number, token)
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 continue
             raise
         checked.append(number)
-        if READY_FOR_DEV_LABEL in [label.lower() for label in labels]:
-            return []
+        if READY_FOR_DEV_LABEL in (label.lower() for label in labels):
+            continue
+        if created_at[:10] < READY_FOR_DEV_ROLLOUT_ISO:
+            # Predates the rollout; grandfathered to avoid retroactive blocking.
+            continue
+        not_ready_new.append(number)
 
-    if checked:
-        refs = ", ".join(f"#{number}" for number in checked)
+    if not checked:
+        refs = ", ".join(f"#{number}" for number in numbers)
+        return [f"Referenced issue(s) {refs} could not be found in this repository."]
+    if not_ready_new:
+        refs = ", ".join(f"#{number}" for number in not_ready_new)
         return [
-            f"None of the linked issues ({refs}) carry the `ready-for-dev` label. "
-            "The issue must meet the readiness criteria before a PR can be opened."
+            f"Linked issue(s) ({refs}) carry neither `ready-for-dev` nor a "
+            "pre-rollout creation date. Newly referenced issues must meet the "
+            "readiness criteria before a PR can be opened."
         ]
-    refs = ", ".join(f"#{number}" for number in numbers)
-    return [f"Referenced issue(s) {refs} could not be found in this repository."]
+    return []
 
 
 def validate_pr_body(body: str) -> list[str]:
@@ -154,13 +174,16 @@ def validate_pr_body(body: str) -> list[str]:
     return errors
 
 
-def body_from_event(event_path: Path) -> str:
+def body_from_event(event_path: Path) -> tuple[str, str | None]:
+    """Return the (pull request body, repository full name) from an event payload."""
     payload = json.loads(event_path.read_text())
     pull_request = payload.get("pull_request")
     if not isinstance(pull_request, dict):
         raise ValueError("GitHub event payload does not contain a pull_request object")
     body = pull_request.get("body")
-    return body if isinstance(body, str) else ""
+    body = body if isinstance(body, str) else ""
+    repo = payload.get("repository", {}).get("full_name")
+    return body, repo if isinstance(repo, str) else None
 
 
 def parse_args() -> argparse.Namespace:
@@ -188,18 +211,15 @@ def main() -> int:
     args = parse_args()
     if args.body_file is not None:
         body = args.body_file.read_text()
+        repo = None
     elif args.event_path is not None:
-        body = body_from_event(args.event_path)
+        body, repo = body_from_event(args.event_path)
     else:
         raise SystemExit("Pass --body-file or set GITHUB_EVENT_PATH.")
 
     errors = validate_pr_body(body)
 
-    repo = None
     token = os.environ.get("GITHUB_TOKEN")
-    if args.event_path is not None and args.body_file is None:
-        payload = json.loads(args.event_path.read_text())
-        repo = payload.get("repository", {}).get("full_name")
     errors.extend(validate_linked_issue_ready(body, repo, token))
 
     for error in errors:

--- a/.github/scripts/post-readiness-comment.mjs
+++ b/.github/scripts/post-readiness-comment.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+/**
+ * Post (or update) a `ready-for-dev` readiness comment on an issue.
+ *
+ * Upserts by a hidden HTML marker so repeated runs update the same comment
+ * instead of spamming duplicates. Uses the GITHUB_TOKEN available to the
+ * workflow via the GH_TOKEN env var.
+ *
+ * Usage:
+ *   node post-readiness-comment.mjs \
+ *     --issue-number 123 \
+ *     --repo OpenHands/OpenHands \
+ *     --reasons-file /tmp/reasons.txt \
+ *     --ready           # optional: post a "ready" message instead of "not ready"
+ */
+
+import { readFileSync } from "node:fs";
+
+const MARKER = "<!-- issue-readiness-check -->";
+const API_ROOT = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const [rawKey, inlineValue] = arg.slice(2).split("=", 2);
+    const key = rawKey.replaceAll("-", "_");
+    if (inlineValue !== undefined) {
+      args[key] = inlineValue;
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = "";
+    }
+  }
+  return args;
+}
+
+function requireValue(name, value) {
+  if (!value) throw new Error(`Missing required value: ${name}`);
+  return value;
+}
+
+async function listComments(repo, issueNumber, token) {
+  // Paginate through all comments so the marker is found even on issues
+  // with >100 comments.
+  const all = [];
+  let page = 1;
+  while (true) {
+    const url = `${API_ROOT}/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`;
+    const resp = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!resp.ok) {
+      throw new Error(`Failed to list comments: ${resp.status} ${await resp.text()}`);
+    }
+    const batch = await resp.json();
+    all.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  return all;
+}
+
+async function createComment(repo, issueNumber, body, token) {
+  const url = `${API_ROOT}/repos/${repo}/issues/${issueNumber}/comments`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ body }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to create comment: ${resp.status} ${await resp.text()}`);
+  }
+  return resp.json();
+}
+
+async function updateComment(repo, commentId, body, token) {
+  const url = `${API_ROOT}/repos/${repo}/issues/comments/${commentId}`;
+  const resp = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ body }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to update comment: ${resp.status} ${await resp.text()}`);
+  }
+  return resp.json();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const issueNumber = requireValue("issue-number", args.issue_number);
+  const repo = requireValue("repo", args.repo);
+  const token = process.env.GH_TOKEN;
+  if (!token) throw new Error("GH_TOKEN env var is required");
+
+  const isReady = args.ready === "" || args.ready === "true";
+  const reasonsFile = args.reasons_file || args.reasons;
+  const reasons = reasonsFile
+    ? readFileSync(reasonsFile, "utf8")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+    : [];
+
+  const reasonList = reasons.length
+    ? reasons.map((r) => `- ${r}`).join("\n")
+    : "- The issue does not meet the ready-for-dev criteria.";
+
+  const body = isReady
+    ? [
+        MARKER,
+        "### ✅ `ready-for-dev` label applied",
+        "",
+        "This issue meets the readiness criteria and is ready for contribution.",
+        "A contributor can now open a PR that links this issue (`Fixes #<number>`).",
+        "",
+        "_This is an automated check — no AI was used to generate this comment._",
+      ].join("\n")
+    : [
+        MARKER,
+        "### ⚠️ Not yet `ready-for-dev`",
+        "",
+        "This issue does not yet meet the readiness criteria, so the",
+        "`ready-for-dev` label has not been applied (or has been removed).",
+        "The criteria are type-specific:",
+        "",
+        "**Bug reports** (`bug` label):",
+        "- The `### Actual Behavior` section must describe reproducible SDK steps",
+        "  and include a command such as `python`, `pytest`, `uv`, or `pip`.",
+        "- An `### Acceptance Criteria` section with at least one checklist item (`- [ ] …`).",
+        "",
+        "**Enhancements** (`enhancement` label):",
+        "- A `### Desired Behavior` section.",
+        "- An `### Acceptance Criteria` section with at least one checklist item.",
+        "",
+        "What is missing:",
+        "",
+        reasonList,
+        "",
+        "Edit the issue to address the gaps and the `ready-for-dev` label will be",
+        "applied automatically.",
+        "",
+        "_This is an automated check — no AI was used to generate this comment._",
+      ].join("\n");
+
+  const comments = await listComments(repo, issueNumber, token);
+  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+
+  if (existing) {
+    await updateComment(repo, existing.id, body, token);
+    console.log(`Updated readiness comment ${existing.id} on issue #${issueNumber}`);
+  } else {
+    const created = await createComment(repo, issueNumber, body, token);
+    console.log(`Created readiness comment ${created.id} on issue #${issueNumber}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/refresh_linked_pr_checks.py
+++ b/.github/scripts/refresh_linked_pr_checks.py
@@ -10,9 +10,7 @@ from check_pr_description import extract_linked_issue_numbers
 
 
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args, capture_output=True, text=True, check=False
-    )
+    return subprocess.run(args, capture_output=True, text=True, check=False)
 
 
 def _linked_open_prs(repo: str, issue_number: int) -> list[dict]:

--- a/.github/scripts/refresh_linked_pr_checks.py
+++ b/.github/scripts/refresh_linked_pr_checks.py
@@ -79,6 +79,8 @@ def _rerun_pr_description_check(repo: str, head_sha: str) -> bool:
         [
             "gh",
             "api",
+            "-X",
+            "GET",
             f"repos/{repo}/actions/runs",
             "-f",
             f"head_sha={head_sha}",

--- a/.github/scripts/refresh_linked_pr_checks.py
+++ b/.github/scripts/refresh_linked_pr_checks.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from check_pr_description import extract_linked_issue_numbers
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args, capture_output=True, text=True, check=False
+    )
+
+
+def _linked_open_prs(repo: str, issue_number: int) -> list[dict]:
+    """Return open PRs that cross-reference ``issue_number``."""
+    owner, name = repo.split("/", 1)
+    query = """
+query($owner: String!, $name: String!, $num: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $num) {
+      timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+        nodes {
+          __typename
+          ... on CrossReferencedEvent {
+            source {
+              __typename
+              ... on PullRequest { number headRefOid state }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    result = _run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"num={issue_number}",
+            "--jq",
+            ".data.repository.issue.timelineItems.nodes",
+        ]
+    )
+    if result.returncode != 0:
+        print(f"::warning::Could not query linked PRs: {result.stderr.strip()}")
+        return []
+    try:
+        nodes = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"::warning::Unexpected linked-PR query output: {exc}")
+        return []
+    prs = []
+    for node in nodes:
+        source = node.get("source") if isinstance(node, dict) else None
+        if not isinstance(source, dict):
+            continue
+        if source.get("__typename") != "PullRequest":
+            continue
+        if source.get("state") != "OPEN":
+            continue
+        prs.append(source)
+    return prs
+
+
+def _rerun_pr_description_check(repo: str, head_sha: str) -> bool:
+    """Re-run the latest PR Description Check for the given head SHA."""
+    runs_result = _run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/actions/runs",
+            "-f",
+            f"head_sha={head_sha}",
+            "-f",
+            "per_page=100",
+            "--jq",
+            r'.workflow_runs[] | select(.name=="PR Description Check") | '
+            r'select(.event=="pull_request_target") | "\(.id) \(.created_at)"',
+        ]
+    )
+    if runs_result.returncode != 0:
+        print(f"::warning::Could not list PR checks: {runs_result.stderr.strip()}")
+        return False
+    lines = [line.split() for line in runs_result.stdout.splitlines() if line.strip()]
+    if not lines:
+        return False
+    # Created-at is sortable; pick the most recent run for this commit.
+    latest = sorted(lines, key=lambda item: " ".join(item[1:]))[-1][0]
+    rerun = _run(
+        ["gh", "api", "-X", "POST", f"repos/{repo}/actions/runs/{latest}/rerun"]
+    )
+    if rerun.returncode != 0:
+        print(
+            f"::warning::Could not re-run PR description check ({latest}): "
+            f"{rerun.stderr.strip()}"
+        )
+        return False
+    print(f"Re-ran PR description check (run {latest}) for linked open PR.")
+    return True
+
+
+def main() -> int:
+    payload = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    if {"action", "issue", "label", "repository"} - set(payload):
+        return 0
+    action = payload["action"]
+    raw_label = payload.get("label")
+    label = raw_label.get("name") if isinstance(raw_label, dict) else None
+    if action not in ("labeled", "unlabeled") or label != "ready-for-dev":
+        return 0
+    raw_repo = payload.get("repository")
+    repo = raw_repo.get("full_name") if isinstance(raw_repo, dict) else None
+    raw_issue = payload.get("issue")
+    issue_number = raw_issue.get("number") if isinstance(raw_issue, dict) else None
+    if not repo or not issue_number:
+        return 0
+
+    print(
+        f"ready-for-dev {action}: refreshing PR gates linked to issue #{issue_number}."
+    )
+    refreshed = 0
+    for pr in _linked_open_prs(repo, issue_number):
+        pr_number = pr["number"]
+        body_result = _run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--json",
+                "body",
+                "--jq",
+                ".body",
+            ]
+        )
+        if body_result.returncode != 0:
+            continue
+        if issue_number not in extract_linked_issue_numbers(body_result.stdout):
+            # Cross-referenced but not treated as a linked issue by the gate;
+            # nothing to refresh.
+            continue
+        if _rerun_pr_description_check(repo, pr["headRefOid"]):
+            refreshed += 1
+    print(f"Refreshed PR gates for {refreshed} linked PR(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/issue-readiness-check.yml
+++ b/.github/workflows/issue-readiness-check.yml
@@ -1,0 +1,108 @@
+---
+name: Issue Readiness Check
+
+# Manages the `ready-for-dev` label based on type-specific readiness criteria.
+#
+# Bug reports (label `bug`): the Actual Behavior section must reference a
+# supported run method (`agent-canvas`, `npm run`, or
+# `app.all-hands.dev/canvas`) and embed a screenshot or video, plus an
+# Acceptance Criteria section with at least one checklist item.
+#
+# Enhancements (label `enhancement`): the body must contain Desired Behavior and
+# Acceptance Criteria sections, the latter with at least one checklist item.
+#
+# When criteria are met the label is added (idempotently); when they are not the
+# label is removed. A feedback comment is posted (or updated) in three cases:
+#   1. The issue is first opened or reopened — always comment so the author
+#      knows whether their issue is ready or what is missing.
+#   2. The label is being added (issue became ready) — comment celebrating it.
+#   3. The label is being removed (issue was ready but is no longer) — comment
+#      explaining what changed.
+# Edits that do not change the label state do not produce a new comment. All
+# comments are upserted by a hidden marker so there is at most one per issue.
+
+on:
+    issues:
+        types: [opened, edited, reopened, labeled, unlabeled]
+
+permissions:
+    issues: write
+    contents: read
+
+concurrency:
+    group: issue-readiness-${{ github.event.issue.number }}
+    cancel-in-progress: false
+
+jobs:
+    check:
+        if: github.event.issue.state == 'open' && github.event.issue.pull_request == null
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Checkout trusted workflow scripts
+              uses: actions/checkout@v7
+
+            - name: Evaluate issue readiness
+              id: readiness
+              env:
+                  GITHUB_EVENT_PATH: ${{ github.event_path }}
+              run: |
+                  set -euo pipefail
+                  python .github/scripts/check_issue_readiness.py --json > /tmp/result.json
+                  echo "ready=$(jq -r '.ready' /tmp/result.json)" >> "$GITHUB_OUTPUT"
+                  # Write reasons to a file so the comment step can read them
+                  # without shell-escaping multiline text.
+                  jq -r '.reasons[]?' /tmp/result.json > /tmp/reasons.txt || true
+                  echo "reasons_file=/tmp/reasons.txt" >> "$GITHUB_OUTPUT"
+
+            - name: Add ready-for-dev label
+              if: steps.readiness.outputs.ready == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  # Capture stderr — tolerate "label already present" (exit 0
+                  # from gh) but surface unexpected errors to the step summary.
+                  if ! gh issue edit "${{ github.event.issue.number }}" \
+                      --repo "${{ github.repository }}" \
+                      --add-label "ready-for-dev" 2>/tmp/gh-err.txt; then
+                    echo "::warning::Failed to add ready-for-dev label:" >> "$GITHUB_STEP_SUMMARY"
+                    cat /tmp/gh-err.txt >> "$GITHUB_STEP_SUMMARY"
+                  fi
+
+            - name: Remove ready-for-dev label
+              if: steps.readiness.outputs.ready != 'true' && contains(github.event.issue.labels.*.name, 'ready-for-dev')
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  # Capture stderr — tolerate "label already removed" but
+                  # surface unexpected errors.
+                  if ! gh issue edit "${{ github.event.issue.number }}" \
+                      --repo "${{ github.repository }}" \
+                      --remove-label "ready-for-dev" 2>/tmp/gh-err.txt; then
+                    echo "::warning::Failed to remove ready-for-dev label:" >> "$GITHUB_STEP_SUMMARY"
+                    cat /tmp/gh-err.txt >> "$GITHUB_STEP_SUMMARY"
+                  fi
+
+            - name: Post feedback comment
+              if: >-
+                  github.event.action == 'opened'
+                  || github.event.action == 'reopened'
+                  || (steps.readiness.outputs.ready == 'true' && !contains(github.event.issue.labels.*.name, 'ready-for-dev'))
+                  || (steps.readiness.outputs.ready != 'true' && contains(github.event.issue.labels.*.name, 'ready-for-dev'))
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  if [ "${{ steps.readiness.outputs.ready }}" = "true" ]; then
+                    node .github/scripts/post-readiness-comment.mjs \
+                        --issue-number "${{ github.event.issue.number }}" \
+                        --repo "${{ github.repository }}" \
+                        --ready
+                  else
+                    node .github/scripts/post-readiness-comment.mjs \
+                        --issue-number "${{ github.event.issue.number }}" \
+                        --repo "${{ github.repository }}" \
+                        --reasons-file "${{ steps.readiness.outputs.reasons_file }}"
+                  fi

--- a/.github/workflows/issue-readiness-check.yml
+++ b/.github/workflows/issue-readiness-check.yml
@@ -26,6 +26,8 @@ on:
 
 permissions:
     issues: write
+    pull-requests: read
+    actions: write
     contents: read
 
 concurrency:
@@ -105,3 +107,26 @@ jobs:
                         --repo "${{ github.repository }}" \
                         --reasons-file "${{ steps.readiness.outputs.reasons_file }}"
                   fi
+
+    # When the ready-for-dev label is added or removed, re-run the PR
+    # description check for every open PR that links this issue, so the
+    # `ready-for-dev` gate does not go stale between PR events. Runs after
+    # `check` so the label reflects the settled readiness state.
+    refresh-linked-pr-gates:
+        name: Refresh PR gates for linked issues
+        needs: check
+        if: >-
+            github.event.issue.state == 'open'
+            && github.event.issue.pull_request == null
+            && (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+            && github.event.label.name == 'ready-for-dev'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        steps:
+            - name: Checkout trusted workflow scripts
+              uses: actions/checkout@v7
+
+            - name: Re-run PR description checks for linked open PRs
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: python .github/scripts/refresh_linked_pr_checks.py

--- a/.github/workflows/issue-readiness-check.yml
+++ b/.github/workflows/issue-readiness-check.yml
@@ -4,8 +4,7 @@ name: Issue Readiness Check
 # Manages the `ready-for-dev` label based on type-specific readiness criteria.
 #
 # Bug reports (label `bug`): the Actual Behavior section must reference a
-# supported run method (`agent-canvas`, `npm run`, or
-# `app.all-hands.dev/canvas`) and embed a screenshot or video, plus an
+# reproducible SDK command (`python`, `pytest`, `uv`, or `pip`), plus an
 # Acceptance Criteria section with at least one checklist item.
 #
 # Enhancements (label `enhancement`): the body must contain Desired Behavior and

--- a/.github/workflows/issue-readiness-check.yml
+++ b/.github/workflows/issue-readiness-check.yml
@@ -27,7 +27,6 @@ on:
 permissions:
     issues: write
     pull-requests: read
-    actions: write
     contents: read
 
 concurrency:
@@ -122,6 +121,10 @@ jobs:
             && github.event.label.name == 'ready-for-dev'
         runs-on: ubuntu-24.04
         timeout-minutes: 10
+        permissions:
+            contents: read
+            pull-requests: read
+            actions: write
         steps:
             - name: Checkout trusted workflow scripts
               uses: actions/checkout@v7

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -11,6 +11,7 @@ on:
 permissions:
     contents: read
     pull-requests: read
+    issues: read
 
 jobs:
     validate-pr-description:
@@ -30,5 +31,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.base.sha }}
 
-            - name: Validate HUMAN note and PR template
+            - name: Validate HUMAN note, PR template, and linked-issue readiness
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
               run: python .github/scripts/check_pr_description.py

--- a/tests/cross/test_check_issue_readiness.py
+++ b/tests/cross/test_check_issue_readiness.py
@@ -93,6 +93,16 @@ def test_bug_missing_run_method_fails():
     assert any("reproducible SDK command" in r for r in result.reasons)
 
 
+def test_bug_backticked_python_is_a_valid_run_method():
+    body = BUG_READY.replace(
+        "Running `pip install openhands-sdk` and then `pytest` fails with a TypeError",
+        "Running `python` from a venv fails to start",
+    )
+    result = evaluate_readiness(body, ["bug"])
+    assert result.ready is True
+    assert result.reasons == []
+
+
 def test_bug_acceptance_needs_checklist_item():
     body = BUG_READY.replace("- [ ] No `TypeError`", "Fix the TypeError")
     result = evaluate_readiness(body, ["bug"])

--- a/tests/cross/test_check_issue_readiness.py
+++ b/tests/cross/test_check_issue_readiness.py
@@ -68,7 +68,8 @@ def test_enhancement_missing_acceptance_criteria_fails():
 
 def test_enhancement_missing_desired_behavior_fails():
     body = ENHANCEMENT_READY.replace(
-        "### Desired Behavior\n\n`agent.save_state()` writes session state to a configured backend.\n\n",
+        "### Desired Behavior\n\n"
+        "`agent.save_state()` writes session state to a configured backend.\n\n",
         "",
     )
     result = evaluate_readiness(body, ["enhancement"])

--- a/tests/cross/test_check_issue_readiness.py
+++ b/tests/cross/test_check_issue_readiness.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_prod_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / ".github" / "scripts" / "check_issue_readiness.py"
+    name = "check_issue_readiness"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_prod = _load_prod_module()
+evaluate_readiness = _prod.evaluate_readiness
+extract_sections = _prod.extract_sections
+
+
+ENHANCEMENT_READY = """### Problem or Use Case
+
+I need to persist agent state between sessions.
+
+### Desired Behavior
+
+`agent.save_state()` writes session state to a configured backend.
+
+### Acceptance Criteria
+
+- [ ] `agent.save_state()` writes state to the backend
+- [ ] A new `Agent` restores state from a saved snapshot
+"""
+
+BUG_READY = """### Actual Behavior
+
+Running `pip install openhands-sdk` and then `pytest` fails with a TypeError
+when registering a custom tool.
+
+### Acceptance Criteria
+
+- [ ] No `TypeError` is raised when registering a custom tool
+"""
+
+
+def test_extract_sections_splits_on_headings():
+    sections = extract_sections("### Alpha\n\ntext\n\n### Beta\n\nmore\n")
+    assert sections["alpha"] == "\ntext\n\n"
+    assert sections["beta"] == "\nmore\n"
+
+
+def test_enhancement_ready_passes():
+    result = evaluate_readiness(ENHANCEMENT_READY, ["enhancement"])
+    assert result.ready is True
+    assert result.reasons == []
+
+
+def test_enhancement_missing_acceptance_criteria_fails():
+    body = "### Desired Behavior\n\nSome desired change.\n"
+    result = evaluate_readiness(body, ["enhancement"])
+    assert result.ready is False
+    assert any("Acceptance Criteria" in r for r in result.reasons)
+
+
+def test_enhancement_missing_desired_behavior_fails():
+    body = ENHANCEMENT_READY.replace(
+        "### Desired Behavior\n\n`agent.save_state()` writes session state to a configured backend.\n\n",
+        "",
+    )
+    result = evaluate_readiness(body, ["enhancement"])
+    assert result.ready is False
+    assert any("Desired Behavior" in r for r in result.reasons)
+
+
+def test_bug_ready_passes():
+    result = evaluate_readiness(BUG_READY, ["bug"])
+    assert result.ready is True
+    assert result.reasons == []
+
+
+def test_bug_missing_run_method_fails():
+    body = BUG_READY.replace(
+        "Running `pip install openhands-sdk` and then `pytest` fails",
+        "Running the SDK test harness fails",
+    )
+    result = evaluate_readiness(body, ["bug"])
+    assert result.ready is False
+    assert any("reproducible SDK command" in r for r in result.reasons)
+
+
+def test_bug_acceptance_needs_checklist_item():
+    body = BUG_READY.replace("- [ ] No `TypeError`", "Fix the TypeError")
+    result = evaluate_readiness(body, ["bug"])
+    assert result.ready is False
+    assert any("checklist item" in r for r in result.reasons)
+
+
+def test_no_bug_or_enhancement_label_not_ready():
+    result = evaluate_readiness(ENHANCEMENT_READY, [])
+    assert result.ready is False
+    assert any("bug" in r and "enhancement" in r for r in result.reasons)

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -21,6 +21,9 @@ def _load_prod_module():
 _prod = _load_prod_module()
 validate_pr_body = _prod.validate_pr_body
 body_from_event = _prod.body_from_event
+extract_linked_issue_numbers = _prod.extract_linked_issue_numbers
+validate_linked_issue_ready = _prod.validate_linked_issue_ready
+fetch_issue_labels = _prod.fetch_issue_labels
 
 
 VALID_BODY = """<!-- Keep this PR as draft until it is ready for review. -->
@@ -107,3 +110,66 @@ def test_body_from_event_reads_pull_request_body(tmp_path: Path):
     event_path.write_text(json.dumps({"pull_request": {"body": VALID_BODY}}))
 
     assert body_from_event(event_path) == VALID_BODY
+
+
+def test_extract_linked_issue_numbers_keyword_and_bare_ref():
+    body = (
+        "Fixes #12\n"
+        "Closes #12 again\n"
+        "resolves #34\n"
+        "## Issue Number\n"
+        "Issue: #56, see also #12\n"
+    )
+    assert extract_linked_issue_numbers(body) == [12, 34, 56]
+
+
+def test_extract_linked_issue_numbers_only_bare_ref_in_issue_section():
+    body = "## Summary\n\nSome work.\n\n## Issue Number\n\n#7\n"
+    assert extract_linked_issue_numbers(body) == [7]
+
+
+def test_extract_linked_issue_numbers_no_bare_ref_outside_issue_section():
+    # A bare `#42` in the Summary must not be treated as a linked issue.
+    body = "## Summary\n\nSee #42 for background.\n\n## Issue Number\n\nN/A\n"
+    assert extract_linked_issue_numbers(body) == []
+
+
+def test_validate_linked_issue_ready_requires_a_number():
+    errors = validate_linked_issue_ready("## Issue Number\n\nN/A\n", "org/repo", "token")
+    assert errors and "Link an issue" in errors[0]
+
+
+def test_validate_linked_issue_ready_no_token_skips_network(monkeypatch):
+    def _fail(*args, **kwargs):
+        raise AssertionError("should not call the network without a token")
+
+    monkeypatch.setattr(_prod, "fetch_issue_labels", _fail)
+    assert validate_linked_issue_ready("Fixes #12\n", None, None) == []
+
+
+def test_validate_linked_issue_ready_passes_with_ready_label(monkeypatch):
+    monkeypatch.setattr(
+        _prod, "fetch_issue_labels", lambda repo, num, token: ["ready-for-dev"]
+    )
+    assert validate_linked_issue_ready("Fixes #12\n", "org/repo", "token") == []
+
+
+def test_validate_linked_issue_ready_fails_when_not_ready(monkeypatch):
+    monkeypatch.setattr(
+        _prod, "fetch_issue_labels", lambda repo, num, token: ["bug"]
+    )
+    errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
+    assert errors and "ready-for-dev" in errors[0]
+
+
+def test_validate_linked_issue_ready_skips_missing_issue(monkeypatch):
+    import urllib.error
+
+    def _missing(repo, num, token):
+        raise urllib.error.HTTPError(
+            "https://api.github.com", 404, "Not Found", None, None
+        )
+
+    monkeypatch.setattr(_prod, "fetch_issue_labels", _missing)
+    errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
+    assert errors and "could not be found" in errors[0]

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -135,7 +135,9 @@ def test_extract_linked_issue_numbers_no_bare_ref_outside_issue_section():
 
 
 def test_validate_linked_issue_ready_requires_a_number():
-    errors = validate_linked_issue_ready("## Issue Number\n\nN/A\n", "org/repo", "token")
+    errors = validate_linked_issue_ready(
+        "## Issue Number\n\nN/A\n", "org/repo", "token"
+    )
     assert errors and "Link an issue" in errors[0]
 
 
@@ -155,19 +157,18 @@ def test_validate_linked_issue_ready_passes_with_ready_label(monkeypatch):
 
 
 def test_validate_linked_issue_ready_fails_when_not_ready(monkeypatch):
-    monkeypatch.setattr(
-        _prod, "fetch_issue_labels", lambda repo, num, token: ["bug"]
-    )
+    monkeypatch.setattr(_prod, "fetch_issue_labels", lambda repo, num, token: ["bug"])
     errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
     assert errors and "ready-for-dev" in errors[0]
 
 
 def test_validate_linked_issue_ready_skips_missing_issue(monkeypatch):
     import urllib.error
+    from http.client import HTTPMessage
 
     def _missing(repo, num, token):
         raise urllib.error.HTTPError(
-            "https://api.github.com", 404, "Not Found", None, None
+            "https://api.github.com", 404, "Not Found", HTTPMessage(), None
         )
 
     monkeypatch.setattr(_prod, "fetch_issue_labels", _missing)

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -225,7 +225,9 @@ def test_validate_linked_issue_ready_new_unready_not_masked_by_ready_sibling(
     assert "ready-for-dev" in errors[0]
 
 
-def test_validate_linked_issue_ready_returns_error_when_all_issues_not_found(monkeypatch):
+def test_validate_linked_issue_ready_returns_error_when_all_issues_not_found(
+    monkeypatch,
+):
     import urllib.error
     from http.client import HTTPMessage
 

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -134,6 +134,16 @@ def test_extract_linked_issue_numbers_no_bare_ref_outside_issue_section():
     assert extract_linked_issue_numbers(body) == []
 
 
+def test_extract_linked_issue_numbers_keyword_inside_word_is_ignored():
+    # "fix"/"clos"/"resolv" must not match inside larger words (e.g. "crucifixes").
+    body = (
+        "## Summary\n\n"
+        "crucifixes #12, encloses #34, transfixes #56.\n\n"
+        "## Issue Number\n\nN/A\n"
+    )
+    assert extract_linked_issue_numbers(body) == []
+
+
 def test_validate_linked_issue_ready_requires_a_number():
     errors = validate_linked_issue_ready(
         "## Issue Number\n\nN/A\n", "org/repo", "token"

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -23,7 +23,7 @@ validate_pr_body = _prod.validate_pr_body
 body_from_event = _prod.body_from_event
 extract_linked_issue_numbers = _prod.extract_linked_issue_numbers
 validate_linked_issue_ready = _prod.validate_linked_issue_ready
-fetch_issue_labels = _prod.fetch_issue_labels
+fetch_issue_details = _prod.fetch_issue_details
 
 
 VALID_BODY = """<!-- Keep this PR as draft until it is ready for review. -->
@@ -107,9 +107,18 @@ def test_optional_template_sections_may_be_removed():
 
 def test_body_from_event_reads_pull_request_body(tmp_path: Path):
     event_path = tmp_path / "event.json"
-    event_path.write_text(json.dumps({"pull_request": {"body": VALID_BODY}}))
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {"body": VALID_BODY},
+                "repository": {"full_name": "org/repo"},
+            }
+        )
+    )
 
-    assert body_from_event(event_path) == VALID_BODY
+    body, repo = body_from_event(event_path)
+    assert body == VALID_BODY
+    assert repo == "org/repo"
 
 
 def test_extract_linked_issue_numbers_keyword_and_bare_ref():
@@ -155,21 +164,52 @@ def test_validate_linked_issue_ready_no_token_skips_network(monkeypatch):
     def _fail(*args, **kwargs):
         raise AssertionError("should not call the network without a token")
 
-    monkeypatch.setattr(_prod, "fetch_issue_labels", _fail)
+    monkeypatch.setattr(_prod, "fetch_issue_details", _fail)
     assert validate_linked_issue_ready("Fixes #12\n", None, None) == []
 
 
 def test_validate_linked_issue_ready_passes_with_ready_label(monkeypatch):
     monkeypatch.setattr(
-        _prod, "fetch_issue_labels", lambda repo, num, token: ["ready-for-dev"]
+        _prod,
+        "fetch_issue_details",
+        lambda repo, num, token: (["ready-for-dev"], "2026-08-13T00:00:00Z"),
     )
     assert validate_linked_issue_ready("Fixes #12\n", "org/repo", "token") == []
 
 
-def test_validate_linked_issue_ready_fails_when_not_ready(monkeypatch):
-    monkeypatch.setattr(_prod, "fetch_issue_labels", lambda repo, num, token: ["bug"])
+def test_validate_linked_issue_ready_grandfathers_pre_rollout_issue(monkeypatch):
+    monkeypatch.setattr(
+        _prod,
+        "fetch_issue_details",
+        lambda repo, num, token: (["bug"], "2026-01-15T00:00:00Z"),
+    )
+    assert validate_linked_issue_ready("Fixes #12\n", "org/repo", "token") == []
+
+
+def test_validate_linked_issue_ready_fails_for_new_not_ready_issue(monkeypatch):
+    monkeypatch.setattr(
+        _prod,
+        "fetch_issue_details",
+        lambda repo, num, token: (["bug"], "2026-08-13T00:00:00Z"),
+    )
     errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
     assert errors and "ready-for-dev" in errors[0]
+
+
+def test_validate_linked_issue_ready_new_unready_not_masked_by_ready_sibling(
+    monkeypatch,
+):
+    def _issues(repo, num, token):
+        # #12 carries ready-for-dev; #34 is new and not ready.
+        if num == 34:
+            return ["bug"], "2026-08-13T00:00:00Z"
+        return ["ready-for-dev"], "2026-08-13T00:00:00Z"
+
+    monkeypatch.setattr(_prod, "fetch_issue_details", _issues)
+    body = "Fixes #12 and Closes #34"
+    errors = validate_linked_issue_ready(body, "org/repo", "token")
+    assert "#34" in errors[0]
+    assert "ready-for-dev" in errors[0]
 
 
 def test_validate_linked_issue_ready_skips_missing_issue(monkeypatch):
@@ -181,6 +221,6 @@ def test_validate_linked_issue_ready_skips_missing_issue(monkeypatch):
             "https://api.github.com", 404, "Not Found", HTTPMessage(), None
         )
 
-    monkeypatch.setattr(_prod, "fetch_issue_labels", _missing)
+    monkeypatch.setattr(_prod, "fetch_issue_details", _missing)
     errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
     assert errors and "could not be found" in errors[0]

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -225,7 +225,7 @@ def test_validate_linked_issue_ready_new_unready_not_masked_by_ready_sibling(
     assert "ready-for-dev" in errors[0]
 
 
-def test_validate_linked_issue_ready_skips_missing_issue(monkeypatch):
+def test_validate_linked_issue_ready_returns_error_when_all_issues_not_found(monkeypatch):
     import urllib.error
     from http.client import HTTPMessage
 

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -186,6 +186,19 @@ def test_validate_linked_issue_ready_grandfathers_pre_rollout_issue(monkeypatch)
     assert validate_linked_issue_ready("Fixes #12\n", "org/repo", "token") == []
 
 
+def test_validate_linked_issue_ready_grandfathers_rollout_day_before_deployment(
+    monkeypatch,
+):
+    # Same issue as #4468/#4469: opened on the rollout day (2026-08-12) before
+    # the workflow was deployed, so it was never labeled. It must be exempt.
+    monkeypatch.setattr(
+        _prod,
+        "fetch_issue_details",
+        lambda repo, num, token: (["bug"], "2026-08-12T06:46:00Z"),
+    )
+    assert validate_linked_issue_ready("Fixes #12\n", "org/repo", "token") == []
+
+
 def test_validate_linked_issue_ready_fails_for_new_not_ready_issue(monkeypatch):
     monkeypatch.setattr(
         _prod,

--- a/tests/cross/test_refresh_linked_pr_checks.py
+++ b/tests/cross/test_refresh_linked_pr_checks.py
@@ -49,6 +49,7 @@ class _FakeProc:
 def _fail_on_call(value):
     def _call(*args, **kwargs):
         raise AssertionError(value)
+
     return _call
 
 

--- a/tests/cross/test_refresh_linked_pr_checks.py
+++ b/tests/cross/test_refresh_linked_pr_checks.py
@@ -46,6 +46,17 @@ class _FakeProc:
         self.stderr = ""
 
 
+def _recording_run(calls):
+    def _call(args):
+        calls.append(args)
+        # Listing runs returns one run; rerun is a no-op success.
+        if any("/actions/runs" in a for a in args):
+            return _FakeProc("8675309 2026-08-13T00:00:00Z\n")
+        return _FakeProc()
+
+    return _call
+
+
 def _fail_on_call(value):
     def _call(*args, **kwargs):
         raise AssertionError(value)
@@ -100,3 +111,20 @@ def test_skips_cross_referenced_pr_that_does_not_link_issue(monkeypatch, tmp_pat
     )
     assert _prod.main() == 0
     assert seen == []
+
+
+def test_rerun_pr_description_check_lists_runs_with_get(monkeypatch):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(_prod, "_run", _recording_run(calls))
+    assert _prod._rerun_pr_description_check("org/repo", "abc123") is True
+    # Listing runs must be an explicit GET: `-f` args alone switch `gh api`
+    # to POST, which 404s on the runs collection endpoint (seen in the wild).
+    list_call = next(a for a in calls if "repos/org/repo/actions/runs" in a)
+    assert "-X" in list_call
+    assert list_call[list_call.index("-X") + 1] == "GET"
+    # The selected run is then re-run via an explicit POST.
+    rerun_call = next(a for a in calls if any("/rerun" in arg for arg in a))
+    assert rerun_call[rerun_call.index("api") + 1 : rerun_call.index("api") + 3] == [
+        "-X",
+        "POST",
+    ]

--- a/tests/cross/test_refresh_linked_pr_checks.py
+++ b/tests/cross/test_refresh_linked_pr_checks.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load(name: str, script_name: str):
+    script_path = (
+        Path(__file__).resolve().parents[2] / ".github" / "scripts" / script_name
+    )
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Import check_pr_description first so refresh_linked_pr_checks can resolve its
+# `from check_pr_description import ...` against the module we loaded above.
+_load("check_pr_description", "check_pr_description.py")
+_prod = _load("refresh_linked_pr_checks", "refresh_linked_pr_checks.py")
+
+
+def _event(action="labeled", label="ready-for-dev", number=12):
+    return {
+        "action": action,
+        "issue": {"number": number},
+        "label": {"name": label},
+        "repository": {"full_name": "org/repo"},
+    }
+
+
+def _write_event(monkeypatch, payload, tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(payload))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = ""):
+        self.returncode = 0
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _fail_on_call(value):
+    def _call(*args, **kwargs):
+        raise AssertionError(value)
+    return _call
+
+
+def test_noop_for_unrelated_label(monkeypatch, tmp_path):
+    _write_event(monkeypatch, _event(label="bug"), tmp_path)
+    monkeypatch.setattr(_prod, "_linked_open_prs", _fail_on_call("unexpected"))
+    assert _prod.main() == 0
+
+
+def test_noop_for_unrelated_action(monkeypatch, tmp_path):
+    _write_event(monkeypatch, _event(action="edited"), tmp_path)
+    monkeypatch.setattr(_prod, "_linked_open_prs", _fail_on_call("unexpected"))
+    assert _prod.main() == 0
+
+
+def test_reruns_linked_pr_check_when_readiness_label_changes(monkeypatch, tmp_path):
+    _write_event(monkeypatch, _event(), tmp_path)
+    monkeypatch.setattr(
+        _prod,
+        "_linked_open_prs",
+        lambda repo, num: [{"number": 7, "headRefOid": "abc123"}],
+    )
+    monkeypatch.setattr(_prod, "_run", lambda args: _FakeProc("Fixes #12"))
+    seen = []
+    monkeypatch.setattr(
+        _prod,
+        "_rerun_pr_description_check",
+        lambda repo, sha: (seen.append((repo, sha)) or True),
+    )
+    assert _prod.main() == 0
+    assert seen == [("org/repo", "abc123")]
+
+
+def test_skips_cross_referenced_pr_that_does_not_link_issue(monkeypatch, tmp_path):
+    _write_event(monkeypatch, _event(), tmp_path)
+    monkeypatch.setattr(
+        _prod,
+        "_linked_open_prs",
+        lambda repo, num: [{"number": 7, "headRefOid": "abc123"}],
+    )
+    # Body mentions #99 (the cross-reference) but not the event's issue #12.
+    monkeypatch.setattr(_prod, "_run", lambda args: _FakeProc("Fixes #99"))
+    seen = []
+    monkeypatch.setattr(
+        _prod,
+        "_rerun_pr_description_check",
+        lambda repo, sha: (seen.append((repo, sha)) or True),
+    )
+    assert _prod.main() == 0
+    assert seen == []


### PR DESCRIPTION
HUMAN:

This change ports the readiness gates for SDK issue and PR quality.

---

AGENT:

## Why

The SDK repository had no automated readiness workflow, and PR description validation did not verify that linked issues were ready for development.

## Summary

- Add issue readiness evaluation and ready-for-dev label management for SDK issues.
- Add idempotent readiness feedback comments.
- Require PRs to reference an issue carrying the ready-for-dev label.
- Omit frontend screenshot requirements because software-agent-sdk has no frontend.

## Issue Number

Fixes #4463

## How to Test

- Run `python -m py_compile .github/scripts/check_issue_readiness.py .github/scripts/check_pr_description.py`.
- Run `node --check .github/scripts/post-readiness-comment.mjs`.
- Run `git diff --check`.
- Evaluate an enhancement body with `python .github/scripts/check_issue_readiness.py --json`; complete Desired Behavior and Acceptance Criteria fields return ready=true.

## Video/Screenshots

Not applicable: this repository has no frontend or UI.

## Design Doc

Not included: focused workflow and validation changes.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The linked issue was created with complete enhancement readiness fields and carries the `ready-for-dev` label.

This PR was created by an AI agent (OpenHands) on behalf of the user.












<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c119c1c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c119c1c-python \
  ghcr.io/openhands/agent-server:c119c1c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c119c1c-golang-amd64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-golang-amd64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-golang-amd64
ghcr.io/openhands/agent-server:c119c1c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c119c1c-golang-arm64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-golang-arm64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-golang-arm64
ghcr.io/openhands/agent-server:c119c1c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c119c1c-java-amd64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-java-amd64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-java-amd64
ghcr.io/openhands/agent-server:c119c1c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c119c1c-java-arm64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-java-arm64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-java-arm64
ghcr.io/openhands/agent-server:c119c1c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c119c1c-python-amd64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-python-amd64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-python-amd64
ghcr.io/openhands/agent-server:c119c1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c119c1c-python-arm64
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-python-arm64
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-python-arm64
ghcr.io/openhands/agent-server:c119c1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c119c1c-golang
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-golang
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-golang
ghcr.io/openhands/agent-server:c119c1c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c119c1c-java
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-java
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-java
ghcr.io/openhands/agent-server:c119c1c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c119c1c-python
ghcr.io/openhands/agent-server:c119c1c8dfa904e87139ba72ac741fa22ffe9e0e-python
ghcr.io/openhands/agent-server:add-ready-for-dev-gates-python
ghcr.io/openhands/agent-server:c119c1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c119c1c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c119c1c-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

<!-- review threads resolved in 10cf3b53a; re-triggered edited event -->
_This PR body was updated by an AI agent (OpenHands) on behalf of neubig._

<!-- stdlib imports hoisted in f695d0611; all review threads resolved -->