### PR TITLE
ci: look for the docs feature branch in the contributor's fork

### DIFF
--- a/.github/workflows/check-documented-examples.yml
+++ b/.github/workflows/check-documented-examples.yml
@@ -20,6 +20,8 @@ permissions:
 jobs:
     check-examples:
         runs-on: ubuntu-latest
+        env:
+            FORK_DOCS_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         steps:
             - name: Checkout agent-sdk repository
               uses: actions/checkout@v7
@@ -36,8 +38,20 @@ jobs:
                   fetch-depth: 0
                   ref: ${{ github.head_ref || github.ref_name }}
 
+            # Fork contributors cannot push their docs branch to OpenHands/docs.
+            - name: Checkout docs repository (try fork feature branch)
+              if: steps.checkout-feature.outcome == 'failure' && env.FORK_DOCS_OWNER != '' && env.FORK_DOCS_OWNER != github.repository_owner
+              uses: actions/checkout@v7
+              continue-on-error: true
+              id: checkout-fork
+              with:
+                  repository: ${{ env.FORK_DOCS_OWNER }}/docs
+                  path: docs
+                  fetch-depth: 0
+                  ref: ${{ github.head_ref }}
+
             - name: Checkout docs repository (fallback to main)
-              if: steps.checkout-feature.outcome == 'failure'
+              if: steps.checkout-feature.outcome == 'failure' && steps.checkout-fork.outcome != 'success'
               uses: actions/checkout@v7
               with:
                   repository: OpenHands/docs


### PR DESCRIPTION
<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I checked that fork PRs were falling back to docs main even when the contributor had the matching docs branch. This just checks that fork branch first, then falls back like before.

AGENT:

## Why

The docs example check looks for a branch in `OpenHands/docs` named after the PR head ref. Fork contributors can't push a branch there, so that step always fails, the run falls back to docs `main`, and any example added in the same PR gets reported as undocumented until the docs PR merges.

I went through the fork branches whose `check-examples` never went green. All 8 of them have a branch with the same name sitting in the contributor's own `docs` fork, so the convention the workflow already relies on is being followed, the workflow just never looks there.

## Summary

- For PRs from a fork, try `<fork-owner>/docs` at the head ref before falling back to docs `main`.

## Issue Number

None.

## How to Test

The `check-examples` run on this PR exercises the new step. I pushed `onatozmenn/docs@ci/docs-example-check-fork-docs`, a plain copy of docs `main`, so it has something to resolve here. From the job log:

```
Syncing repository: OpenHands/docs      <- try feature branch, no such branch
Syncing repository: onatozmenn/docs     <- new step, resolves
   Found 86 documented example(s)
All examples are documented!
```

The step list shows "fallback to main" as `skipped`, and that is the part that matters, since it only skips when the fork checkout succeeded. Both attempts report `success` as their conclusion because of `continue-on-error`, so the skipped fallback is the honest signal.

For the content half, using the checker's own `find_documented_examples` against a checkout of `onatozmenn/docs@feat/prompt-hooks` (the docs branch for #4160, which adds `57_prompt_hooks`):

```
fork branch: documented count 85, 'examples/01_standalone_sdk/57_prompt_hooks/main.py' in set -> True
docs main:   documented count 86, same path in set                                       -> False
```

That False is exactly why #4160 sits red today, and it flips with this change.

`actionlint` is clean on the file (and reports the expression error if I typo `steps.checkout-fork.outcome`, so it really is checking it).

## Video/Screenshots

CI only, see the job logs on this PR.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The step is skipped for same repo PRs, and a missing, renamed or private `docs` fork just fails it and falls back to `main` like before.

One thing worth saying out loud: this lets a fork owned markdown file decide the outcome of the check. The job runs on `pull_request` with a read only token and already executes the fork's own copy of `check_documented_examples.py`, so it isn't new exposure, but someone could turn the check green by writing the code block in their own docs fork and never opening a docs PR. Docs review is the real gate either way, and the check is optional. Happy to drop this if you'd rather keep the check tied to `OpenHands/docs` only.
