### PR TITLE
feat(task-tracker): add stable task identifiers

### DIFF
--- a/openhands-tools/openhands/tools/task_tracker/definition.py
+++ b/openhands-tools/openhands/tools/task_tracker/definition.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
+from uuid import uuid4
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -30,6 +31,13 @@ TaskTrackerStatusType = Literal["todo", "in_progress", "done"]
 
 
 class TaskItem(BaseModel):
+    id: str = Field(
+        default_factory=lambda: str(uuid4()),
+        description=(
+            "A stable identifier for the task. Preserve it when updating an "
+            "existing task; omit it only when creating a new task."
+        ),
+    )
     title: str = Field(..., description="A brief title for the task.")
     notes: str = Field("", description="Additional details or notes about the task.")
     status: TaskTrackerStatusType = Field(
@@ -48,7 +56,11 @@ class TaskTrackerAction(Action):
     )
     task_list: list[TaskItem] = Field(
         default_factory=list,
-        description="The full task list. Required parameter of `plan` command.",
+        description=(
+            "The full task list. Required parameter of `plan` command. When "
+            "updating tasks, preserve the IDs returned by `view`; omit IDs only "
+            "for new tasks."
+        ),
     )
 
     @property
@@ -130,7 +142,7 @@ class TaskTrackerObservation(Observation):
                     text.append("⏳ ", style="blue")
 
                 # Task title
-                text.append(f"{i}. {task.title}", style="white")
+                text.append(f"{i}. [{task.id}] {task.title}", style="white")
 
                 # NEW: show notes under the title if present
                 if task.notes:
@@ -155,7 +167,7 @@ class TaskTrackerExecutor(ToolExecutor[TaskTrackerAction, TaskTrackerObservation
 
         Args:
             save_dir: Optional directory to save tasks to. If provided, tasks will be
-                     persisted to save_dir/TASKS.md
+                     persisted to save_dir/TASKS.json
         """
         self.save_dir = Path(save_dir) if save_dir else None
         logger.info(f"TaskTrackerExecutor initialized with save_dir: {self.save_dir}")
@@ -223,7 +235,7 @@ class TaskTrackerExecutor(ToolExecutor[TaskTrackerAction, TaskTrackerObservation
             title = task.title
             notes = task.notes
 
-            content += f"{i}. {status_icon} {title}\n"
+            content += f"{i}. {status_icon} [{task.id}] {title}\n"
             if notes:
                 content += f"   {notes}\n"
             content += "\n"
@@ -291,6 +303,8 @@ Utilize this tool in the following situations:
    implementation. Maintain focus by limiting active work to one task
 7. Task completion - Update status to done and identify any additional work
    that emerged during implementation
+8. Task identity - Before updating a task list, view the current list and
+   preserve the IDs of existing tasks. Omit an ID only for a newly created task.
 
 ## Situations Where Tool Usage Is Unnecessary
 

--- a/tests/tools/task_tracker/test_task_tracker.py
+++ b/tests/tools/task_tracker/test_task_tracker.py
@@ -1,0 +1,79 @@
+"""Tests for TaskTracker persistence and stable task identifiers."""
+
+import json
+from uuid import UUID
+
+from openhands.tools.task_tracker import TaskTrackerAction, TaskTrackerExecutor
+from openhands.tools.task_tracker.definition import TaskItem
+
+
+def test_task_items_receive_unique_ids() -> None:
+    tasks = [
+        TaskItem(title="Inspect the repository", notes="", status="todo")
+        for _ in range(2)
+    ]
+
+    assert UUID(tasks[0].id)
+    assert UUID(tasks[1].id)
+    assert tasks[0].id != tasks[1].id
+
+
+def test_task_tracker_persists_task_ids_and_statuses(tmp_path) -> None:
+    tasks = [
+        TaskItem(
+            title="Inspect the repository",
+            notes="Read the project instructions first.",
+            status="done",
+        ),
+        TaskItem(title="Implement the change", notes="", status="in_progress"),
+    ]
+
+    executor = TaskTrackerExecutor(save_dir=str(tmp_path))
+    executor(TaskTrackerAction(command="plan", task_list=tasks))
+
+    restored_executor = TaskTrackerExecutor(save_dir=str(tmp_path))
+    observation = restored_executor(TaskTrackerAction(command="view"))
+
+    assert observation.task_list == tasks
+    assert all(f"[{task.id}]" in observation.text for task in tasks)
+
+
+def test_task_tracker_preserves_ids_supplied_during_updates() -> None:
+    task = TaskItem(title="Implement the change", notes="", status="todo")
+    executor = TaskTrackerExecutor()
+    executor(TaskTrackerAction(command="plan", task_list=[task]))
+
+    updated_task = TaskItem(
+        id=task.id,
+        title=task.title,
+        notes="Implemented and verified.",
+        status="done",
+    )
+    observation = executor(TaskTrackerAction(command="plan", task_list=[updated_task]))
+
+    assert observation.task_list[0].id == task.id
+    assert observation.task_list[0].status == "done"
+
+
+def test_task_tracker_loads_legacy_tasks_without_ids(tmp_path) -> None:
+    (tmp_path / "TASKS.json").write_text(
+        json.dumps([{"title": "Existing task", "notes": "", "status": "todo"}])
+    )
+
+    executor = TaskTrackerExecutor(save_dir=str(tmp_path))
+    observation = executor(TaskTrackerAction(command="view"))
+
+    assert len(observation.task_list) == 1
+    assert UUID(observation.task_list[0].id)
+    assert "[" + observation.task_list[0].id + "]" in observation.text
+
+
+def test_task_tracker_action_loads_legacy_payload_without_ids() -> None:
+    action = TaskTrackerAction.model_validate(
+        {
+            "command": "plan",
+            "task_list": [{"title": "Existing task", "notes": "", "status": "todo"}],
+        }
+    )
+
+    assert UUID(action.task_list[0].id)


### PR DESCRIPTION
HUMAN:

I ran the tests locally and manually checked that task IDs are generated, persisted, and remain stable after reloading, including with legacy TASKS.json files that do not contain IDs.

---

AGENT:
- Added stable IDs to TaskTracker items.
- Preserved IDs through TASKS.json persistence and legacy payload loading.
- Added regression coverage for IDs, persistence, updates, and legacy data.

## Why

The condenser asks agents to preserve task IDs and statuses, but TaskTracker did
not previously provide stable task identifiers. This makes task references
reliable across updates, persistence, and context condensation.

## Summary

- Generate a stable UUID for every TaskTracker item.
- Show IDs in task-list output and persist them in TASKS.json.
- Keep legacy task files and action payloads without IDs compatible.

## Issue Number

None.

## How to Test

1. Run `uv run pytest tests/tools/task_tracker -q`.
2. Create tasks with the `plan` command, then use `view` and confirm each task
   has an ID.
3. Recreate the executor using the same persistence directory and confirm the
   IDs remain unchanged.
4. Load a legacy TASKS.json file without IDs and confirm it remains readable.

## Video/Screenshots

Not applicable: this is a backend task-tracking change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Related planning and condenser regression tests passed locally.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.47s · commit 03532eb  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 8/8 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 5.0% | No direct hunk selected |
| Contract regression | 24.0% | No direct hunk selected |
| Data loss | 12.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 7.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 78.0% | No primary concern to locate |

</details>


<!-- jev-input-signature e32a6fa76386c505a7d5b817fd01b14de098c095527c8f992b45b104f80425fa -->
<!-- jev-fast-audit:end -->
