### PR TITLE
fix(agent): keep terminal prefix aliases from doubling an existing executable

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -484,19 +484,6 @@ def _maybe_rewrite_as_terminal_command(
     return tool_name
 
 
-def _starts_with_executable(command: Any, executable: str) -> bool:
-    """Whether ``command``'s first whitespace-delimited token is ``executable``.
-
-    Comparing whole tokens keeps ``github status`` from looking like it already
-    carries a ``git`` prefix.
-    """
-    if not isinstance(command, str):
-        return False
-
-    tokens = command.split(maxsplit=1)
-    return bool(tokens) and tokens[0] == executable
-
-
 def normalize_tool_call(
     tool_name: str,
     arguments: dict[str, Any],
@@ -537,7 +524,9 @@ def normalize_tool_call(
                 }
                 if not original_command:
                     normalized_arguments["command"] = base_name
-                elif _starts_with_executable(original_command, base_name):
+                elif str(original_command).split(maxsplit=1)[:1] == [base_name]:
+                    # Already carries the executable, e.g. git(command="git status").
+                    # Comparing whole tokens keeps "github status" prefixed.
                     normalized_arguments["command"] = original_command
                 else:
                     normalized_arguments["command"] = f"{base_name} {original_command}"

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -484,6 +484,19 @@ def _maybe_rewrite_as_terminal_command(
     return tool_name
 
 
+def _starts_with_executable(command: Any, executable: str) -> bool:
+    """Whether ``command``'s first whitespace-delimited token is ``executable``.
+
+    Comparing whole tokens keeps ``github status`` from looking like it already
+    carries a ``git`` prefix.
+    """
+    if not isinstance(command, str):
+        return False
+
+    tokens = command.split(maxsplit=1)
+    return bool(tokens) and tokens[0] == executable
+
+
 def normalize_tool_call(
     tool_name: str,
     arguments: dict[str, Any],
@@ -522,10 +535,12 @@ def normalize_tool_call(
                     for key, value in arguments.items()
                     if key in {"security_risk", "summary"}
                 }
-                if original_command:
-                    normalized_arguments["command"] = f"{base_name} {original_command}"
-                else:
+                if not original_command:
                     normalized_arguments["command"] = base_name
+                elif _starts_with_executable(original_command, base_name):
+                    normalized_arguments["command"] = original_command
+                else:
+                    normalized_arguments["command"] = f"{base_name} {original_command}"
         elif "terminal" in available_tools:
             terminal_command = _maybe_rewrite_as_terminal_command(
                 tool_name,

--- a/tests/sdk/agent/test_tool_call_compatibility.py
+++ b/tests/sdk/agent/test_tool_call_compatibility.py
@@ -704,6 +704,48 @@ def test_reset_alias_executes_terminal_tool(tmp_path):
     assert getattr(action_event.action, "command") == "reset clear"
 
 
+def test_git_alias_keeps_an_already_complete_command(tmp_path):
+    """Regression: a command that already names the executable is left alone."""
+    events = _run_tool_call(
+        tmp_path,
+        tool_name="git",
+        arguments={"command": "git status"},
+        tool_names=(TERMINAL_TOOL_SPEC,),
+    )
+
+    action_event = next(e for e in events if isinstance(e, ActionEvent))
+    errors = [e for e in events if isinstance(e, AgentErrorEvent)]
+
+    assert not errors
+    assert action_event.tool_name == TERMINAL_TOOL_NAME
+    assert action_event.action is not None
+    assert getattr(action_event.action, "command") == "git status"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "command", "expected"),
+    [
+        ("git", "status", "git status"),
+        ("git", "git status", "git status"),
+        ("git", "git", "git"),
+        ("git", "\tgit\tstatus", "\tgit\tstatus"),
+        ("git", "github status", "git github status"),
+        ("git", "gitk", "git gitk"),
+        ("reset", "clear", "reset clear"),
+        ("reset", "reset clear", "reset clear"),
+    ],
+)
+def test_terminal_prefix_alias_only_adds_a_missing_executable(
+    tool_name, command, expected
+):
+    normalized_tool_name, arguments = agent_utils.normalize_tool_call(
+        tool_name, {"command": command}, {TERMINAL_TOOL_NAME}
+    )
+
+    assert normalized_tool_name == TERMINAL_TOOL_NAME
+    assert arguments["command"] == expected
+
+
 def test_shell_tool_name_git_falls_back_to_terminal(tmp_path):
     """Test that 'git' without arguments falls back to terminal."""
     events = _run_tool_call(

--- a/tests/sdk/agent/test_tool_call_compatibility.py
+++ b/tests/sdk/agent/test_tool_call_compatibility.py
@@ -704,24 +704,6 @@ def test_reset_alias_executes_terminal_tool(tmp_path):
     assert getattr(action_event.action, "command") == "reset clear"
 
 
-def test_git_alias_keeps_an_already_complete_command(tmp_path):
-    """Regression: a command that already names the executable is left alone."""
-    events = _run_tool_call(
-        tmp_path,
-        tool_name="git",
-        arguments={"command": "git status"},
-        tool_names=(TERMINAL_TOOL_SPEC,),
-    )
-
-    action_event = next(e for e in events if isinstance(e, ActionEvent))
-    errors = [e for e in events if isinstance(e, AgentErrorEvent)]
-
-    assert not errors
-    assert action_event.tool_name == TERMINAL_TOOL_NAME
-    assert action_event.action is not None
-    assert getattr(action_event.action, "command") == "git status"
-
-
 @pytest.mark.parametrize(
     ("tool_name", "command", "expected"),
     [


### PR DESCRIPTION
HUMAN:

I reproduced the issue for both `git` and `reset`. The fix avoids adding the alias twice while still keeping commands like `github status` and `gitk` working correctly.

---

AGENT:

## Why

When a tool call arrives under the `git` or `reset` alias, `normalize_tool_call` prepends
the alias name to the command. That assumes the model always splits the executable out of
the command, but `git(command="git status")` is just as common a shape as
`git(command="status")`. The first one turned into `git git status`, where the second `git`
sits in the subcommand slot, so the turn burns a tool call and comes back with
`git: 'git' is not a git command`.

The duplicated prefix is not confined to the helper. `normalize_tool_call` runs while a
model tool call is converted into an `ActionEvent`, so the broken command is what the
terminal actually executes.

## Summary

- Prepend the alias only when the command's first token is not already that executable
- Compare whole tokens, so `git(command="github status")` still gets its prefix

## Issue Number

Fixes #4468

## How to Test

The script below drives a real `Conversation` with the real `TerminalTool`; only the LLM
response is mocked, so the tool call travels the production normalization path and the
command is really executed.

```python
import json
from unittest.mock import patch

from litellm import ChatCompletionMessageToolCall
from litellm.types.utils import Choices, Function, Message as LiteLLMMessage, ModelResponse
from pydantic import SecretStr

from openhands.sdk import LLM, Agent, Conversation, Message, TextContent, Tool
from openhands.sdk.event import ActionEvent, ObservationEvent
from openhands.sdk.tool import register_tool
from openhands.tools.terminal import TerminalTool

register_tool("TerminalTool", TerminalTool)


def model_response(tool_name, arguments):
    return ModelResponse(
        id="mock-1",
        choices=[Choices(index=0, message=LiteLLMMessage(
            role="assistant", content="Checking the repository state.",
            tool_calls=[ChatCompletionMessageToolCall(
                id="call_1", type="function",
                function=Function(name=tool_name, arguments=json.dumps(arguments)))]),
            finish_reason="tool_calls")],
        created=0, model="mock-model", object="chat.completion",
    )


def run(tool_name, arguments, workspace):
    agent = Agent(
        llm=LLM(model="mock-model", usage_id="proof", api_key=SecretStr("mock"),
                base_url="http://mock"),
        tools=[Tool(name="TerminalTool")],
    )
    conversation = Conversation(agent=agent, workspace=workspace)
    events = []
    with patch("openhands.sdk.llm.llm.litellm_completion",
               return_value=model_response(tool_name, arguments)):
        conversation.send_message(
            Message(role="user", content=[TextContent(text="Check git status.")]))
        agent.step(conversation, on_event=events.append)

    print(f"\n=== model emitted: {tool_name}({arguments}) ===")
    for event in events:
        if isinstance(event, ActionEvent) and event.action is not None:
            print("  executed command :", repr(getattr(event.action, "command", None)))
        if isinstance(event, ObservationEvent):
            text = str(event.observation.to_llm_content[0].text)
            print("  observation      :", "\n".join(text.strip().splitlines()[:2]))
    conversation.close()


if __name__ == "__main__":
    import sys
    run("git", {"command": "git status"}, sys.argv[1])
    run("git", {"command": "status"}, sys.argv[1])
```

Point it at any git repository, for example `python proof.py /tmp/demo-repo`.

On `main` at `5bfa7fc`:

```
=== model emitted: git({'command': 'git status'}) ===
  executed command : 'git git status'
  observation      : git: 'git' is not a git command. See 'git --help'.
=== model emitted: git({'command': 'status'}) ===
  executed command : 'git status'
  observation      : On branch master
```

On this branch:

```
=== model emitted: git({'command': 'git status'}) ===
  executed command : 'git status'
  observation      : On branch master
=== model emitted: git({'command': 'status'}) ===
  executed command : 'git status'
  observation      : On branch master
```

Unit coverage on top of that:

```
uv run pytest tests/sdk/agent/test_tool_call_compatibility.py
```

The new parametrized case pins both directions, including `github status` and `gitk`, which
must keep their prefix. Reverting the source change while keeping the tests fails exactly
the five already-prefixed cases and leaves the rest green.

## Video/Screenshots

Not applicable: the change is in tool-call normalization, and the console transcript above
is the user-visible effect.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`reset` is in the same alias set and had the same problem, so it is covered too.

One pre-existing Windows failure in that test file,
`test_malformed_tool_name_bash_xml_tag`, also fails on a clean `main` checkout here and is
unrelated.
