### PR TITLE
fix(file_editor): give str_replace snippets the full leading context window

### DIFF
--- a/openhands-tools/openhands/tools/file_editor/editor.py
+++ b/openhands-tools/openhands/tools/file_editor/editor.py
@@ -255,16 +255,16 @@ class FileEditor:
         self._history_manager.add_history(path, file_content)
 
         # Create a snippet of the edited section
-        start_line = max(0, replacement_line - SNIPPET_CONTEXT_WINDOW)
+        start_line = max(1, replacement_line - SNIPPET_CONTEXT_WINDOW)
         end_line = replacement_line + SNIPPET_CONTEXT_WINDOW + new_str.count("\n")
 
         # Read just the snippet range
-        snippet = self.read_file(path, start_line=start_line + 1, end_line=end_line)
+        snippet = self.read_file(path, start_line=start_line, end_line=end_line)
 
         # Prepare the success message
         success_message = f"The file {path} has been edited. "
         success_message += self._make_output(
-            snippet, f"a snippet of {path}", start_line + 1
+            snippet, f"a snippet of {path}", start_line
         )
 
         success_message += (

--- a/tests/tools/file_editor/test_basic_operations.py
+++ b/tests/tools/file_editor/test_basic_operations.py
@@ -378,6 +378,39 @@ Review the changes and make sure they are as expected. Edit the file again if ne
     assert "This is a sample file." in test_file.read_text()
 
 
+@pytest.mark.parametrize(
+    ("replaced_line", "first_line", "last_line"),
+    [
+        (10, 6, 14),
+        # Near the top of the file the window is clamped instead of shifted.
+        (2, 1, 6),
+    ],
+)
+def test_str_replace_snippet_keeps_the_context_window_on_both_sides(
+    tmp_path, replaced_line, first_line, last_line
+):
+    editor = FileEditor()
+    test_file = tmp_path / "context.txt"
+    test_file.write_text("\n".join(f"line {number:02d}" for number in range(1, 22)))
+
+    result = editor(
+        command="str_replace",
+        path=str(test_file),
+        old_str=f"line {replaced_line:02d}",
+        new_str="replacement line",
+    )
+
+    assert result.text is not None
+    for number in range(first_line, last_line + 1):
+        expected = (
+            "replacement line" if number == replaced_line else f"line {number:02d}"
+        )
+        assert f"{number:6}\t{expected}" in result.text
+    if first_line > 1:
+        assert f"{first_line - 1:6}\tline {first_line - 1:02d}" not in result.text
+    assert f"{last_line + 1:6}\tline {last_line + 1:02d}" not in result.text
+
+
 def test_str_replace_multi_line_no_linting(editor):
     editor, test_file = editor
     result = editor(


### PR DESCRIPTION
HUMAN:

I reproduced the `str_replace` snippet issue and confirmed the leading context was one line short. The fix makes the context window symmetric without changing `insert`, which already behaves correctly.

---

AGENT:

## Why

After a `str_replace`, the editor hands the model a verification snippet around the edit.
`replacement_line` is one-based and `read_file` takes one-based inclusive bounds, but the
lower bound was computed as `max(0, replacement_line - SNIPPET_CONTEXT_WINDOW)` and then
passed as `start_line + 1`. The upper bound has no such offset, so with
`SNIPPET_CONTEXT_WINDOW = 4` the model got three lines of leading context and four trailing
ones.

## Summary

- Compute the snippet's lower bound as a one-based line and pass it to `read_file` unchanged
- Number the snippet from that same line

## Issue Number

Fixes #4469

## How to Test

```python
from pathlib import Path
from tempfile import TemporaryDirectory

from openhands.tools.file_editor.editor import FileEditor

with TemporaryDirectory() as directory:
    path = Path(directory) / "context.txt"
    path.write_text("\n".join(f"line {n:02d}" for n in range(1, 22)))

    result = FileEditor()(
        command="str_replace",
        path=str(path),
        old_str="line 10",
        new_str="replacement line",
    )
    print(result.text)
```

On `main` at `5bfa7fc` the snippet starts at line 7:

```
The file context.txt has been edited. Here's the result of running `cat -n` on a snippet of context.txt:
     7	line 07
     8	line 08
     9	line 09
    10	replacement line
    11	line 11
    12	line 12
    13	line 13
    14	line 14
```

On this branch it starts at line 6, so the window is symmetric:

```
The file context.txt has been edited. Here's the result of running `cat -n` on a snippet of context.txt:
     6	line 06
     7	line 07
     8	line 08
     9	line 09
    10	replacement line
    11	line 11
    12	line 12
    13	line 13
    14	line 14
```

Unit coverage:

```
uv run pytest tests/tools/file_editor
```

155 passed, 2 skipped. The new parametrized test checks an edit away from both file
boundaries and an edit near the top, where the window is clamped rather than shifted.
Reverting the source change while keeping the tests fails only the first case.

## Video/Screenshots

Not applicable: the snippet output above is the user-visible effect.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

I checked `insert` before touching anything, expecting the same arithmetic there. It is
fine: `insert_line` is the line the new content goes *after*, so the inserted block starts
at `insert_line + 1` and the existing `max(1, insert_line - SNIPPET_CONTEXT_WINDOW + 1)`
already yields four lines on each side. Only `str_replace` is off, so this leaves `insert`
alone.

Unrelated cosmetic detail I noticed while measuring, not touched here: the snippet ends with
a newline, so `_make_output` numbers one trailing empty line (the bare `15` in the output
above). Happy to send that separately if it is worth fixing.
