### PR TITLE
fix(llm): refresh MiniMax model metadata

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -14,6 +14,31 @@ from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
 
 logger = getLogger(__name__)
 
+_MODEL_METADATA_OVERRIDES: dict[str, dict[str, Any]] = {
+    "MiniMax-M3": {
+        "max_input_tokens": 1_000_000,
+        "input_cost_per_token": 0.0000006,
+        "output_cost_per_token": 0.0000024,
+        "cache_read_input_token_cost": 0.00000012,
+    },
+    "MiniMax-M2.7": {
+        "max_input_tokens": 204_800,
+        "input_cost_per_token": 0.0000003,
+        "output_cost_per_token": 0.0000012,
+        "cache_read_input_token_cost": 0.00000006,
+        "cache_creation_input_token_cost": 0.000000375,
+    },
+}
+
+
+def _apply_model_metadata_overrides(
+    model: str, model_info: Mapping[str, Any] | None
+) -> dict[str, Any] | None:
+    overrides = _MODEL_METADATA_OVERRIDES.get(model.split("/")[-1])
+    if overrides is None:
+        return dict(model_info) if model_info is not None else None
+    return {**(model_info or {}), **overrides}
+
 
 def _merge_raw_model_metadata(model_info: Mapping[str, Any]) -> dict[str, Any]:
     """Preserve raw LiteLLM capability fields."""
@@ -97,20 +122,24 @@ def get_litellm_model_info(
             cache_key=cache_key,
         )
         if model_info:
-            return model_info
+            return _apply_model_metadata_overrides(model, model_info)
 
     # Fallbacks: try base name variants
     try:
         model_info = get_model_info(model.split(":")[0])
         if model_info:
-            return _merge_raw_model_metadata(model_info)
+            return _apply_model_metadata_overrides(
+                model, _merge_raw_model_metadata(model_info)
+            )
     except Exception:
         pass
     try:
         model_info = get_model_info(model.split("/")[-1])
         if model_info:
-            return _merge_raw_model_metadata(model_info)
+            return _apply_model_metadata_overrides(
+                model, _merge_raw_model_metadata(model_info)
+            )
     except Exception:
         pass
 
-    return None
+    return _apply_model_metadata_overrides(model, None)

--- a/tests/sdk/llm/test_model_info_proxy_lookup.py
+++ b/tests/sdk/llm/test_model_info_proxy_lookup.py
@@ -14,6 +14,7 @@ aliases (claude-opus-4-8 vision still off).
 from unittest.mock import patch
 
 from openhands.sdk.llm.utils.model_info import (
+    _apply_model_metadata_overrides,
     _get_model_info_from_litellm_proxy,
     _merge_raw_model_metadata,
     get_litellm_model_info,
@@ -138,3 +139,19 @@ def test_raw_registry_capabilities_survive_typed_model_info_projection():
     assert info["supports_reasoning"] is True
     assert info["supports_adaptive_thinking"] is True
     assert info["supports_sampling_params"] is False
+
+
+def test_minimax_model_metadata_overrides():
+    assert _apply_model_metadata_overrides("minimax/MiniMax-M3", {}) == {
+        "max_input_tokens": 1_000_000,
+        "input_cost_per_token": 0.0000006,
+        "output_cost_per_token": 0.0000024,
+        "cache_read_input_token_cost": 0.00000012,
+    }
+    assert _apply_model_metadata_overrides("minimax/MiniMax-M2.7", {}) == {
+        "max_input_tokens": 204_800,
+        "input_cost_per_token": 0.0000003,
+        "output_cost_per_token": 0.0000012,
+        "cache_read_input_token_cost": 0.00000006,
+        "cache_creation_input_token_cost": 0.000000375,
+    }


### PR DESCRIPTION
<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The pinned LiteLLM metadata for MiniMax models is stale and incomplete:

- `MiniMax-M3` is priced at half the published rates, so token accounting and
  cost reporting are understated by 2x.
- `MiniMax-M2.7` has no native context-window or pricing metadata at all, so
  lookups fall through and the SDK has no context limit or cost basis for it.

## Summary

- Add a small `_MODEL_METADATA_OVERRIDES` table in
  `openhands-sdk/openhands/sdk/llm/utils/model_info.py` pinning the correct
  context window and per-token costs for `MiniMax-M3` (1,000,000 context;
  $0.60 in / $2.40 out / $0.12 cache-read per million tokens) and
  `MiniMax-M2.7` (204,800 context; $0.30 in / $1.20 out / $0.06 cache-read /
  $0.375 cache-write per million tokens).
- Apply the overrides through `_apply_model_metadata_overrides()` on every
  return path of `get_litellm_model_info()`, including the proxy lookup, both
  base-name fallbacks, and the previously-`None` path so `MiniMax-M2.7`
  resolves even with no upstream registry entry.
- Match on the last `/`-separated segment so both bare and provider-prefixed
  model ids (e.g. `minimax/MiniMax-M3`) are covered.
- Add `test_minimax_model_metadata_overrides` to
  `tests/sdk/llm/test_model_info_proxy_lookup.py`.

## Issue Number

## How to Test

The change is confined to model-metadata resolution, so it is exercised through
the public `get_litellm_model_info()` lookup path rather than a live API call.

Run the lookup directly and confirm the resolved metadata:

```
uv sync --frozen
OPENHANDS_SUPPRESS_BANNER=1 uv run python -c "
from openhands.sdk.llm.utils.model_info import get_litellm_model_info
for m in ('minimax/MiniMax-M3', 'minimax/MiniMax-M2.7'):
    i = get_litellm_model_info(None, None, m) or {}
    print(m, i.get('max_input_tokens'), i.get('input_cost_per_token'),
          i.get('output_cost_per_token'), i.get('cache_read_input_token_cost'),
          i.get('cache_creation_input_token_cost'))
"
```

Observed output:

```
minimax/MiniMax-M3 1000000 6e-07 2.4e-06 1.2e-07 None
minimax/MiniMax-M2.7 204800 3e-07 1.2e-06 6e-08 3.75e-07
```

Both rows match the published context windows and rates, and `MiniMax-M2.7`
now resolves where it previously returned no metadata.

Checks run on this branch:

```
uv run pytest tests/sdk/llm/test_model_info_proxy_lookup.py -q   # 7 passed
uv run ruff check openhands-sdk/openhands/sdk/llm/utils/model_info.py tests/sdk/llm/test_model_info_proxy_lookup.py
uv run ruff format --check openhands-sdk/openhands/sdk/llm/utils/model_info.py tests/sdk/llm/test_model_info_proxy_lookup.py
uv run pyright openhands-sdk/openhands/sdk/llm/utils/model_info.py   # 0 errors
```

## Video/Screenshots

Not applicable - this change has no UI surface. The console output above is the
end-to-end evidence for the metadata lookup.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The overrides are a stopgap pin until the upstream LiteLLM registry ships
correct MiniMax entries; once it does, the corresponding entry can be dropped
from `_MODEL_METADATA_OVERRIDES` with no other change.
