### PR TITLE
fix(agent-server): move bash event search off event loop and replace glob with scandir

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -83,15 +83,23 @@ class BashEventService:
 
     async def get_bash_event(self, event_id: str) -> BashEventBase | None:
         """Get the event with the id given, or None if there was no such event."""
-        # Use glob pattern to find files ending with the event_id
-        pattern = f"*_{event_id}"
-        files = self._get_event_files_by_pattern(pattern)
+        # The directory scan is blocking I/O; run it off the asyncio event loop.
+        return await asyncio.to_thread(self._get_bash_event_sync, event_id)
 
-        if not files:
-            return None
+    def _get_bash_event_sync(self, event_id: str) -> BashEventBase | None:
+        """Sync: find the event file whose name ends with ``_<event_id>``.
 
-        # Load and return the first matching event
-        return self._load_event_from_file(files[0])
+        Uses a single ``os.scandir`` pass (one readdir, no per-entry stat or
+        fnmatch regex) instead of ``glob.glob("*_<event_id>")``, which compiles
+        a regex and matches every entry in an unbounded events directory.
+        """
+        self._ensure_bash_events_dir()
+        suffix = f"_{event_id}"
+        with os.scandir(self.bash_events_dir) as it:
+            for entry in it:
+                if entry.name.endswith(suffix):
+                    return self._load_event_from_file(Path(entry.path))
+        return None
 
     async def batch_get_bash_events(
         self, event_ids: list[str]
@@ -114,72 +122,104 @@ class BashEventService:
         page_id: str | None = None,
         limit: int = 100,
     ) -> BashEventPage:
-        """Search for events. If an command_id is given, only the observations for the
-        action are returned."""
+        """Search for events. If a command_id is given, only the observations for
+        the action are returned.
 
-        # Build the search pattern based on filename format:
-        # - BashCommand: <timestamp>_<kind>_<event_id>
-        # - BashOutput: <timestamp>_<kind>_<command_id>_<event_id>
-        search_parts = ["*"]  # Start with wildcard for timestamp
-
-        if kind__eq:
-            search_parts.append(kind__eq)
-        else:
-            search_parts.append("*")  # Wildcard for kind if not specified
-
-        if command_id__eq:
-            search_parts.append(command_id__eq.hex)
-
-        # Always end with wildcard for event_id
-        search_parts.append("*")
-
-        search_pattern = "_".join(search_parts)
-        files = self._get_event_files_by_pattern(search_pattern)
-        files.sort(
-            key=lambda f: f.name,
-            reverse=(sort_order == BashEventSortOrder.TIMESTAMP_DESC),
+        The directory scan, sort, filter and file reads are all blocking I/O,
+        so the whole search runs off the asyncio event loop in a worker thread
+        (``asyncio.to_thread``) to avoid stalling concurrent requests.
+        """
+        return await asyncio.to_thread(
+            self._search_bash_events_sync,
+            kind__eq,
+            command_id__eq,
+            timestamp__gte,
+            timestamp__lt,
+            order__gt,
+            sort_order,
+            page_id,
+            limit,
         )
 
-        # Timestamp filtering.
-        if timestamp__gte:
-            timestamp_gte_str = self._timestamp_to_str(timestamp__gte)
-            files = [file for file in files if file.name >= timestamp_gte_str]
-        if timestamp__lt:
-            timestamp_lt_str = self._timestamp_to_str(timestamp__lt)
-            files = [file for file in files if file.name < timestamp_lt_str]
+    def _search_bash_events_sync(
+        self,
+        kind__eq: str | None,
+        command_id__eq: UUID | None,
+        timestamp__gte: datetime | None,
+        timestamp__lt: datetime | None,
+        order__gt: int | None,
+        sort_order: BashEventSortOrder,
+        page_id: str | None,
+        limit: int,
+    ) -> BashEventPage:
+        """Sync search: one ``os.scandir`` pass + cheap segment filter.
 
-        # Handle pagination
-        page_files = []
+        Replaces ``glob.glob`` (which compiles a fnmatch regex and matches every
+        entry in an unbounded events directory) with a single ``os.scandir`` pass
+        that splits each filename on ``_`` and compares the fixed segments
+        (kind, command_id) directly. Filenames are
+        ``<timestamp>_<kind>[_<command_id>]_<event_id>`` with a 20-digit
+        timestamp prefix, so a lexicographic name comparison is a timestamp
+        comparison and is used both to pre-filter by the time window and to sort.
+        """
+        self._ensure_bash_events_dir()
+        gte_str = self._timestamp_to_str(timestamp__gte) if timestamp__gte else None
+        lt_str = self._timestamp_to_str(timestamp__lt) if timestamp__lt else None
+        kind_filter = kind__eq
+        cmd_filter = command_id__eq.hex if command_id__eq else None
+        reverse = sort_order == BashEventSortOrder.TIMESTAMP_DESC
+
+        matched: list[str] = []
+        with os.scandir(self.bash_events_dir) as it:
+            for entry in it:
+                name = entry.name
+                # Timestamp-prefix pre-filter: filenames sort lexicographically
+                # by timestamp, so a string compare on the whole name bounds
+                # the time window without parsing the timestamp.
+                if gte_str is not None and name < gte_str:
+                    continue
+                if lt_str is not None and name >= lt_str:
+                    continue
+                # Segment filter: [timestamp, kind, (command_id), event_id].
+                # Cheaper than fnmatch and avoids matching unrelated files.
+                if kind_filter is not None or cmd_filter is not None:
+                    parts = name.split("_")
+                    if kind_filter is not None:
+                        if len(parts) < 2 or parts[1] != kind_filter:
+                            continue
+                    if cmd_filter is not None:
+                        # Only BashOutput (4 segments) carries a command_id.
+                        if len(parts) < 4 or parts[2] != cmd_filter:
+                            continue
+                matched.append(name)
+
+        matched.sort(reverse=reverse)
+
+        # Resolve page_id to a starting index.
         start_index = 0
-
-        # Find the starting point if page_id is provided
         if page_id:
-            for i, file in enumerate(files):
-                if str(file.name) == page_id:
+            for i, name in enumerate(matched):
+                if name == page_id:
                     start_index = i
                     break
 
-        # Collect items for this page
+        # Collect only the page slice; load just those files.
+        page_slice = matched[start_index : start_index + limit]
         next_page_id = None
-        for i in range(start_index, len(files)):
-            if len(page_files) >= limit:
-                # We have collected enough items for this page
-                # Set next_page_id to the current file for next page
-                next_page_id = str(files[i].name)
-                break
-            page_files.append(files[i])
+        if start_index + limit < len(matched):
+            next_page_id = matched[start_index + limit]
 
-        # Load only the page files (not all files)
-        page_events = []
-        for file_path in page_files:
-            event = self._load_event_from_file(file_path)
-            if event is not None:
-                # Filter by order if specified (only applies to BashOutput events)
-                if order__gt is not None:
-                    event_order = getattr(event, "order", None)
-                    if event_order is not None and event_order <= order__gt:
-                        continue
-                page_events.append(event)
+        page_events: list[BashEventBase] = []
+        for name in page_slice:
+            event = self._load_event_from_file(self.bash_events_dir / name)
+            if event is None:
+                continue
+            # Filter by order if specified (only applies to BashOutput events)
+            if order__gt is not None:
+                event_order = getattr(event, "order", None)
+                if event_order is not None and event_order <= order__gt:
+                    continue
+            page_events.append(event)
 
         return BashEventPage(items=page_events, next_page_id=next_page_id)
 

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -98,7 +98,6 @@ class BashEventService:
 
     async def get_bash_event(self, event_id: str) -> BashEventBase | None:
         """Get the event with the id given, or None if there was no such event."""
-        # Blocking I/O — dispatched off the event loop.
         async with self._filesystem_search_semaphore:
             return await asyncio.to_thread(self._get_bash_event_sync, event_id)
 
@@ -144,7 +143,6 @@ class BashEventService:
         so the whole search runs off the asyncio event loop in a worker thread
         (``asyncio.to_thread``) to avoid stalling concurrent requests.
         """
-        # Blocking I/O — dispatched off the event loop.
         async with self._filesystem_search_semaphore:
             return await asyncio.to_thread(
                 self._search_bash_events_sync,

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -103,9 +103,8 @@ class BashEventService:
     def _get_bash_event_sync(self, event_id: str) -> BashEventBase | None:
         """Sync: find the event file whose name ends with ``_<event_id>``.
 
-        Uses a single ``os.scandir`` pass (one readdir, no per-entry stat or
-        fnmatch regex) instead of ``glob.glob("*_<event_id>")``, which compiles
-        a regex and matches every entry in an unbounded events directory.
+        Scans the events directory in a single ``os.scandir`` pass (one readdir,
+        no per-entry stat or regex) and returns the first matching file.
         """
         self._ensure_bash_events_dir()
         suffix = f"_{event_id}"
@@ -172,11 +171,9 @@ class BashEventService:
     ) -> BashEventPage:
         """Sync search: one ``os.scandir`` pass + cheap segment filter.
 
-        Replaces ``glob.glob`` (which compiles a fnmatch regex and matches every
-        entry in an unbounded events directory) with a single ``os.scandir`` pass
-        that splits each filename on ``_`` and compares the fixed segments
-        (kind, command_id) directly. Filenames are
-        ``<timestamp>_<kind>[_<command_id>]_<event_id>`` with a 20-digit
+        Splits each filename on ``_`` and compares the fixed segments
+        (kind, command_id) directly rather than matching with regexes. Filenames
+        are ``<timestamp>_<kind>[_<command_id>]_<event_id>`` with a 20-digit
         timestamp prefix, so a lexicographic name comparison is a timestamp
         comparison and is used both to pre-filter by the time window and to sort.
         """

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -98,9 +98,7 @@ class BashEventService:
 
     async def get_bash_event(self, event_id: str) -> BashEventBase | None:
         """Get the event with the id given, or None if there was no such event."""
-        # The directory scan is blocking I/O; run it off the asyncio event loop.
-        # Serialize scans so concurrent get/search polls cannot exhaust the
-        # process-wide default thread pool.
+        # Blocking I/O — dispatched off the event loop.
         async with self._filesystem_search_semaphore:
             return await asyncio.to_thread(self._get_bash_event_sync, event_id)
 
@@ -146,9 +144,7 @@ class BashEventService:
         so the whole search runs off the asyncio event loop in a worker thread
         (``asyncio.to_thread``) to avoid stalling concurrent requests.
         """
-        # Keep at most one full shared-directory scan in the default thread
-        # pool. Without this bound, many open terminal tabs can move the same
-        # original event-loop starvation into thread-pool starvation.
+        # Blocking I/O — dispatched off the event loop.
         async with self._filesystem_search_semaphore:
             return await asyncio.to_thread(
                 self._search_bash_events_sync,
@@ -222,7 +218,6 @@ class BashEventService:
                     start_index = i
                     break
 
-        # Collect only the page slice; load just those files.
         page_slice = matched[start_index : start_index + limit]
         next_page_id = None
         if start_index + limit < len(matched):

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -41,6 +41,10 @@ class BashEventService:
     # endpoints that use asyncio.to_thread (notably conversations/search).
     # Serialize only the expensive bash-event filesystem work: queued callers
     # remain asynchronous while one worker performs the shared-directory scan.
+    # 1 (full serialization) is an intentional strict bound: a single scan is
+    # cheap (~0.2s on 100k files), so overlapping even a few scans saves little
+    # wall time but, at scale, risks monopolizing the shared worker pool for the
+    # sake of marginal poll latency; queued callers still proceed asynchronously.
     _filesystem_search_semaphore: asyncio.Semaphore = field(
         default_factory=lambda: asyncio.Semaphore(1),
         init=False,

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -35,6 +35,17 @@ class BashEventService:
         default_factory=lambda: PubSub[BashEventBase](max_subscribers=50),
         init=False,
     )
+    # Multiple open terminal tabs poll bash events concurrently. Moving each
+    # directory scan to the default thread pool keeps it off the event loop, but
+    # unbounded concurrent scans can still occupy every worker and starve other
+    # endpoints that use asyncio.to_thread (notably conversations/search).
+    # Serialize only the expensive bash-event filesystem work: queued callers
+    # remain asynchronous while one worker performs the shared-directory scan.
+    _filesystem_search_semaphore: asyncio.Semaphore = field(
+        default_factory=lambda: asyncio.Semaphore(1),
+        init=False,
+        repr=False,
+    )
 
     def _ensure_bash_events_dir(self) -> None:
         """Ensure the bash events directory exists."""
@@ -84,7 +95,10 @@ class BashEventService:
     async def get_bash_event(self, event_id: str) -> BashEventBase | None:
         """Get the event with the id given, or None if there was no such event."""
         # The directory scan is blocking I/O; run it off the asyncio event loop.
-        return await asyncio.to_thread(self._get_bash_event_sync, event_id)
+        # Serialize scans so concurrent get/search polls cannot exhaust the
+        # process-wide default thread pool.
+        async with self._filesystem_search_semaphore:
+            return await asyncio.to_thread(self._get_bash_event_sync, event_id)
 
     def _get_bash_event_sync(self, event_id: str) -> BashEventBase | None:
         """Sync: find the event file whose name ends with ``_<event_id>``.
@@ -129,17 +143,21 @@ class BashEventService:
         so the whole search runs off the asyncio event loop in a worker thread
         (``asyncio.to_thread``) to avoid stalling concurrent requests.
         """
-        return await asyncio.to_thread(
-            self._search_bash_events_sync,
-            kind__eq,
-            command_id__eq,
-            timestamp__gte,
-            timestamp__lt,
-            order__gt,
-            sort_order,
-            page_id,
-            limit,
-        )
+        # Keep at most one full shared-directory scan in the default thread
+        # pool. Without this bound, many open terminal tabs can move the same
+        # original event-loop starvation into thread-pool starvation.
+        async with self._filesystem_search_semaphore:
+            return await asyncio.to_thread(
+                self._search_bash_events_sync,
+                kind__eq,
+                command_id__eq,
+                timestamp__gte,
+                timestamp__lt,
+                order__gt,
+                sort_order,
+                page_id,
+                limit,
+            )
 
     def _search_bash_events_sync(
         self,

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from openhands.agent_server import bash_router as bash_router_module
 from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
-from openhands.agent_server.models import BashCommand
+from openhands.agent_server.models import BashCommand, BashEventSortOrder, BashOutput
 from openhands.agent_server.server_details_router import (
     mark_initialization_complete,
     server_details_router,
@@ -108,6 +108,92 @@ async def test_bash_execution_error_log_omits_command(
 
     assert "Error executing bash command" in caplog.text
     assert secret not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# search_bash_events
+# ---------------------------------------------------------------------------
+
+
+async def test_search_bash_events_filters_and_paginates(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    command_id = uuid4()
+    other_command_id = uuid4()
+
+    command = BashCommand(command="echo target", id=command_id, timestamp=_OLD)
+    output_0 = BashOutput(
+        command_id=command_id,
+        order=0,
+        stdout="first",
+        timestamp=_OLD.replace(microsecond=1),
+    )
+    output_1 = BashOutput(
+        command_id=command_id,
+        order=1,
+        stdout="second",
+        timestamp=_OLD.replace(microsecond=2),
+    )
+    other_output = BashOutput(
+        command_id=other_command_id,
+        order=0,
+        stdout="other",
+        timestamp=_OLD.replace(microsecond=3),
+    )
+    for event in (command, output_0, output_1, other_output):
+        service._save_event_to_file(event)
+
+    first_page = await service.search_bash_events(
+        kind__eq="BashOutput",
+        command_id__eq=command_id,
+        sort_order=BashEventSortOrder.TIMESTAMP,
+        limit=1,
+    )
+    assert [event.id for event in first_page.items] == [output_0.id]
+    assert first_page.next_page_id is not None
+
+    second_page = await service.search_bash_events(
+        kind__eq="BashOutput",
+        command_id__eq=command_id,
+        sort_order=BashEventSortOrder.TIMESTAMP,
+        page_id=first_page.next_page_id,
+        limit=10,
+    )
+    assert [event.id for event in second_page.items] == [output_1.id]
+    assert second_page.next_page_id is None
+
+
+async def test_search_bash_events_runs_blocking_scan_off_event_loop(
+    tmp_path: Path,
+):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    service._save_event_to_file(BashCommand(command="echo ok"))
+
+    with patch(
+        "openhands.agent_server.bash_service.asyncio.to_thread",
+        wraps=asyncio.to_thread,
+    ) as to_thread:
+        page = await service.search_bash_events(limit=10)
+
+    assert len(page.items) == 1
+    assert to_thread.call_count == 1
+    assert to_thread.call_args.args[0] == service._search_bash_events_sync
+
+
+async def test_get_bash_event_runs_blocking_scan_off_event_loop(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    command = BashCommand(command="echo ok")
+    service._save_event_to_file(command)
+
+    with patch(
+        "openhands.agent_server.bash_service.asyncio.to_thread",
+        wraps=asyncio.to_thread,
+    ) as to_thread:
+        event = await service.get_bash_event(command.id.hex)
+
+    assert event is not None
+    assert event.id == command.id
+    assert to_thread.call_count == 1
+    assert to_thread.call_args.args[0] == service._get_bash_event_sync
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -196,6 +196,35 @@ async def test_get_bash_event_runs_blocking_scan_off_event_loop(tmp_path: Path):
     assert to_thread.call_args.args[0] == service._get_bash_event_sync
 
 
+async def test_concurrent_searches_serialize_filesystem_scans(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    service._save_event_to_file(BashCommand(command="echo ok"))
+
+    active = 0
+    max_active = 0
+    original_search = service._search_bash_events_sync
+
+    def tracked_search(*args):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            # Keep the worker occupied long enough for all concurrent callers
+            # to queue on the async semaphore.
+            time.sleep(0.02)
+            return original_search(*args)
+        finally:
+            active -= 1
+
+    with patch.object(service, "_search_bash_events_sync", tracked_search):
+        pages = await asyncio.gather(
+            *(service.search_bash_events(limit=10) for _ in range(8))
+        )
+
+    assert all(len(page.items) == 1 for page in pages)
+    assert max_active == 1
+
+
 # ---------------------------------------------------------------------------
 # delete_events_older_than
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:

This fixes a production slowdown I reproduced on a long-running Agent Canvas install without deleting historical bash data.

---

AGENT:

## Why

Fixes #4480.

`BashEventService.search_bash_events` and `get_bash_event` synchronously ran `glob.glob()` over the entire shared, unbounded `OH_BASH_EVENTS_DIR` on the uvicorn/asyncio event loop. On a long-running install with **105,631 files / 655 MB**, each search matched every historic entry across every conversation, blocking unrelated requests.

OpenHands/OpenHands#16437 profiles the production failure: ~95% of GIL samples in `glob`/`fnmatch` beneath `search_bash_events`, with the main event loop pinned.

## Summary

- Move the complete bash-event search/get filesystem path off the event loop via `asyncio.to_thread`.
- Replace `glob.glob` + `fnmatch` with one `os.scandir` pass and direct filename-segment filtering.
- Serialize full shared-directory scans with an async semaphore so many callers queue asynchronously instead of exhausting the default worker pool.
- Preserve the existing API, pagination behavior, file format, and all historical data.

## Issue Number

Fixes #4480. Related: OpenHands/OpenHands#16437 and OpenHands/OpenHands#16438.

## How to Test

Automated:

```bash
pytest -q tests/agent_server/test_bash_service.py
# 11 passed
```

The tests cover filtering, order, pagination, delegation to `asyncio.to_thread`, and serialization of concurrent filesystem scans.

Live end-to-end test:

1. Started the editable agent-server branch against the existing Agent Canvas store with 105,631 bash event files.
2. Exercised `/api/bash/bash_events/search`, `/api/conversations/search`, and `/health` every 10 seconds for 10 minutes while agents and automations were active.
3. Stress-tested 12 simultaneous bash-event searches together with conversation search and health.

Before/after on the same data:

| Endpoint | Before | After |
|---|---:|---:|
| `bash_events/search?limit=20&sort_order=TIMESTAMP_DESC` | 7.31s | 0.23–0.33s monitored |
| `conversations/search?limit=20` while bash scans contend | >120s timeout | 0.35–0.96s monitored |
| `/health` | ~0.002s | ~0.002s |

Stress result with 12 simultaneous bash polls:

- conversation search: 1.31s
- health: 0.02s
- bash polls: asynchronously queued; all completed in 1.5–4.9s

This is a possible **non-destructive replacement** for rbren's OpenHands/OpenHands#16438. That PR mitigates the same failure by deleting bash events older than two days; this PR fixes scan cost and event-loop/thread-pool starvation in the agent-server without deleting history. Retention remains available as an independent policy.

## Video/Screenshots

No GUI behavior changed. The live benchmark and 10-minute monitor output are included above; all requests were run through the live Agent Canvas agent-server on the 105k-file data set.

## Design Doc

Not included. This is a localized implementation change with no API or storage-format migration.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Python's built-in SQLite is available and an index could eliminate the O(n) directory scan entirely. This PR deliberately avoids index migration/reconciliation complexity and delivers a measured ~30× improvement with no data migration or deletion.






<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cfd7c35-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cfd7c35-python \
  ghcr.io/openhands/agent-server:cfd7c35-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cfd7c35-golang-amd64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-golang-amd64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-golang-amd64
ghcr.io/openhands/agent-server:cfd7c35-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cfd7c35-golang-arm64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-golang-arm64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-golang-arm64
ghcr.io/openhands/agent-server:cfd7c35-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cfd7c35-java-amd64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-java-amd64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-java-amd64
ghcr.io/openhands/agent-server:cfd7c35-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cfd7c35-java-arm64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-java-arm64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-java-arm64
ghcr.io/openhands/agent-server:cfd7c35-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cfd7c35-python-amd64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-python-amd64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-python-amd64
ghcr.io/openhands/agent-server:cfd7c35-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cfd7c35-python-arm64
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-python-arm64
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-python-arm64
ghcr.io/openhands/agent-server:cfd7c35-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cfd7c35-golang
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-golang
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-golang
ghcr.io/openhands/agent-server:cfd7c35-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:cfd7c35-java
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-java
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-java
ghcr.io/openhands/agent-server:cfd7c35-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:cfd7c35-python
ghcr.io/openhands/agent-server:cfd7c3543c97a7ee4977a0a9d804ff828013a21b-python
ghcr.io/openhands/agent-server:fix-bash-events-search-off-event-loop-python
ghcr.io/openhands/agent-server:cfd7c35-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cfd7c35-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cfd7c35-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

<!-- iterate-watchdog: re-trigger review-thread gate (threads resolved) -->
