### PR TITLE
feat(file-router): add POST /file/create_directory

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -663,6 +663,52 @@ async def download_file_query(
     return await _download_file(path)
 
 
+@file_router.post("/create_directory")
+async def create_directory(
+    path: Annotated[str, Query(description="Absolute directory path to create")],
+) -> Success:
+    """Create a directory in the workspace, including any missing parents.
+
+    Idempotent: an existing directory succeeds and its contents are left
+    untouched. Creating over an existing file, or under a path whose parent is
+    a file, is a client error (400) rather than a server fault.
+    """
+    update_last_execution_time()
+    logger.info(f"Creating directory: {path}")
+
+    target_path = Path(path)
+    if not target_path.is_absolute():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path must be absolute",
+        )
+
+    try:
+        await asyncio.to_thread(lambda: target_path.mkdir(parents=True, exist_ok=True))
+    except (FileExistsError, NotADirectoryError):
+        # mkdir(exist_ok=True) still raises when the final component exists as a
+        # non-directory; NotADirectoryError covers a parent component being a
+        # file. Both are the caller's path being wrong, not a server fault.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path exists and is not a directory",
+        )
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: {e}",
+        )
+    except Exception as e:
+        logger.error(f"Failed to create directory {path}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create directory: {str(e)}",
+        )
+
+    logger.info(f"Created directory {target_path}")
+    return Success()
+
+
 def _list_home_favorites(
     home: Path, limit: int = 50, include_hidden: bool = False
 ) -> list[FileBrowserEntry]:

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -245,7 +245,8 @@ def test_create_directory_existing_file_fails(client, tmp_path):
 
 
 @pytest.mark.skipif(
-    os.geteuid() == 0, reason="root bypasses directory write permissions"
+    getattr(os, "geteuid", lambda: -1)() == 0,
+    reason="root bypasses directory write permissions",
 )
 def test_create_directory_permission_denied(client, tmp_path):
     """Test that an unwritable parent returns 403."""

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import json
+import os
 import subprocess
 import tarfile
 import tempfile
@@ -165,6 +166,107 @@ def test_download_file_query_param_directory_fails(client, tmp_path):
 def test_download_file_query_param_missing_path(client):
     """Test that download without path parameter returns 422."""
     response = client.get("/api/file/download")
+
+    assert response.status_code == 422
+
+
+# =============================================================================
+# Create Directory Tests - POST /api/file/create_directory
+# =============================================================================
+
+
+def test_create_directory_success(client, tmp_path):
+    """Test successful directory creation."""
+    target_path = tmp_path / "new_directory"
+
+    response = client.post(
+        "/api/file/create_directory",
+        params={"path": str(target_path)},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+    assert target_path.is_dir()
+
+
+def test_create_directory_creates_missing_parents(client, tmp_path):
+    """Test that intermediate directories are created."""
+    target_path = tmp_path / "parent" / "child" / "grandchild"
+
+    response = client.post(
+        "/api/file/create_directory",
+        params={"path": str(target_path)},
+    )
+
+    assert response.status_code == 200
+    assert target_path.is_dir()
+
+
+def test_create_directory_existing_directory_succeeds(client, tmp_path):
+    """Test that creating an existing directory is idempotent."""
+    target_path = tmp_path / "already_here"
+    target_path.mkdir()
+    (target_path / "keep.txt").write_text("untouched")
+
+    response = client.post(
+        "/api/file/create_directory",
+        params={"path": str(target_path)},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+    assert (target_path / "keep.txt").read_text() == "untouched"
+
+
+def test_create_directory_relative_path_fails(client):
+    """Test that creating with a relative path returns 400."""
+    response = client.post(
+        "/api/file/create_directory",
+        params={"path": "relative/path/dir"},
+    )
+
+    assert response.status_code == 400
+    assert "must be absolute" in response.json()["detail"]
+
+
+def test_create_directory_existing_file_fails(client, tmp_path):
+    """Test that creating over an existing file returns 400, not 500."""
+    target_path = tmp_path / "a_file.txt"
+    target_path.write_text("do not clobber me")
+
+    response = client.post(
+        "/api/file/create_directory",
+        params={"path": str(target_path)},
+    )
+
+    assert response.status_code == 400
+    assert "not a directory" in response.json()["detail"].lower()
+    assert target_path.read_text() == "do not clobber me"
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root bypasses directory write permissions"
+)
+def test_create_directory_permission_denied(client, tmp_path):
+    """Test that an unwritable parent returns 403."""
+    parent = tmp_path / "readonly"
+    parent.mkdir()
+    parent.chmod(0o500)
+    try:
+        response = client.post(
+            "/api/file/create_directory",
+            params={"path": str(parent / "child")},
+        )
+
+        assert response.status_code == 403
+        assert "permission denied" in response.json()["detail"].lower()
+    finally:
+        parent.chmod(0o700)
+
+
+def test_create_directory_missing_path(client):
+    """Test that creating without a path parameter returns 422."""
+    response = client.post("/api/file/create_directory")
 
     assert response.status_code == 422
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fully tested and working for me

---

AGENT:

End-to-end evidence (not just unit tests): the agent-server was started from this branch on `:18923` and driven over real HTTP through a locally built `@openhands/typescript-client` with a hand-written `createDirectory` caller. Verified live: creating a nested directory with a space in the name (confirmed on disk), a repeat call against the same path (idempotent, contents untouched), the new directory immediately visible to `GET /api/file/search_subdirs` (the folder picker's own listing endpoint), create-over-existing-file → 400, and relative path → 400. Unit: `tests/agent_server/test_file_router.py` 85/85 (7 new), `ruff` clean, `make test-server-schema` passes (OpenAPI determinism + quality + swagger validate).

## Why

The OpenHands frontend's workspace folder picker cannot create a directory — there is no directory-creation endpoint anywhere in the file API, so a "New Folder" button has nothing to call (OpenHands/OpenHands#16561). The only stock mechanism that materializes a directory is `_upload_file`'s incidental `mkdir` of the target's parent, which collapses all failures to 500 and can't clean up after itself (no file-delete endpoint exists).

## Summary

- Add `POST /api/file/create_directory?path=<abs>`: `mkdir(parents=True, exist_ok=True)` via `asyncio.to_thread` (same offload pattern as `_upload_file`), idempotent on repeat calls.
- Typed errors instead of the upload path's bare 500: 400 for a non-absolute path, a path that collides with an existing file, or a path under a file; 403 for permission denied (matching `search_subdirs`).
- 7 new tests (success, creates missing parents, existing-dir idempotent, relative-path 400, existing-file 400, permission-denied 403 via a real `chmod 0o500` with root skip, missing path param).

## Issue Number

OpenHands/OpenHands#16561

## How to Test

Run the agent-server from this branch, then:

```
curl -X POST 'http://localhost:8000/api/file/create_directory?path=/tmp/oh-test/new-dir'
curl -X POST 'http://localhost:8000/api/file/create_directory?path=/tmp/oh-test/new-dir'   # idempotent
curl 'http://localhost:8000/api/file/search_subdirs?path=/tmp/oh-test'                       # new-dir listed
curl -X POST 'http://localhost:8000/api/file/create_directory?path=relative/dir'             # 400
```

Or just `uv run pytest tests/agent_server/test_file_router.py` (85 tests).

## Video/Screenshots

<img width="1264" height="774" alt="image" src="https://github.com/user-attachments/assets/4492d4f0-9325-43e8-ac77-ed1d0bc6eb0d" />

<img width="1259" height="457" alt="image" src="https://github.com/user-attachments/assets/9022381c-ddb5-4b23-8816-730820537ca2" />


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Purely additive endpoint; no existing contract changes, so no deprecation runway is engaged. Companion typescript-client change (`FileClient.createDirectory`) is ready and will follow once this lands in an agent-server release, per the release-train dependency. Design alternatives considered and rejected are documented on the linked issue (upload-`.keep` shim, bash `mkdir`).
