### PR TITLE
perf(agent-server): cache unchanged conversation summaries

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -553,6 +553,32 @@ def _state_signature(base_state_path: str) -> tuple[int, int] | None:
     return None
 
 
+def _stored_metadata_signature(stored: StoredConversation) -> int:
+    """Change-detection fingerprint for ``stored`` metadata on a cached row.
+
+    ``cached_info`` is keyed by ``base_state.json``, but also embeds
+    ``StoredConversation`` metadata that can change independently via
+    ``meta.json`` (notably auto-title). Fingerprint exactly the fields
+    ``_compose_conversation_info`` lifts from ``stored`` so a metadata-only
+    update invalidates the cache. Keep the set in sync with that function.
+    """
+    metadata = stored.model_dump(
+        mode="json",
+        include={
+            "title",
+            "metrics",
+            "created_at",
+            "updated_at",
+            "forked_from_conversation_id",
+            "forked_from_event_id",
+            "parent_conversation_id",
+            "client_tools",
+            "launched_agent_profile",
+        },
+    )
+    return hash(json.dumps(metadata, sort_keys=True, default=str))
+
+
 def _read_execution_status_sync(
     base_state_path: str,
 ) -> ConversationExecutionStatus | None:
@@ -583,6 +609,11 @@ class _ConversationRecord:
     # keep the validated object until base_state.json changes rather than
     # reparsing a large nested ConversationState on every request.
     cached_info: ConversationInfo | None = None
+    # Fingerprint of ``stored`` metadata (title, metrics, …) as of the last
+    # composition. ``cached_info`` is keyed by ``state_signature`` alone, so
+    # metadata-only updates (``meta.json``, e.g. auto-title) must also
+    # invalidate it.
+    stored_signature: int | None = None
 
 
 @dataclass
@@ -829,8 +860,17 @@ class ConversationService:
             record.execution_status = conversation_info.execution_status
             return conversation_info
 
+        # ``record.stored`` is refreshed above for live conversations; idle rows
+        # keep the catalog copy. Fingerprint it so metadata-only updates (e.g.
+        # auto-title, which writes meta.json without touching base_state.json)
+        # invalidate the cached ConversationInfo rather than serving stale rows.
+        stored_signature = _stored_metadata_signature(record.stored)
         cached = record.cached_info
-        if cached is not None and signature == record.state_signature:
+        if (
+            cached is not None
+            and signature == record.state_signature
+            and stored_signature == record.stored_signature
+        ):
             # Parent/child relationships are catalog-derived and can change
             # without touching this conversation's base_state.json.
             if cached.sub_conversation_ids != children:
@@ -847,6 +887,7 @@ class ConversationService:
             _compose_conversation_info, record.stored, state, children
         )
         record.state_signature = signature
+        record.stored_signature = stored_signature
         record.cached_info = conversation_info
         record.execution_status = conversation_info.execution_status
         return conversation_info

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -578,6 +578,11 @@ class _ConversationRecord:
     state_signature: tuple[int, int] | None = None
     # Memoised by _base_state_path.
     base_state_path: str | None = None
+    # Full ConversationInfo composed from the persisted state at
+    # ``state_signature``. Sidebar polling repeatedly asks for the same rows;
+    # keep the validated object until base_state.json changes rather than
+    # reparsing a large nested ConversationState on every request.
+    cached_info: ConversationInfo | None = None
 
 
 @dataclass
@@ -714,6 +719,7 @@ class ConversationService:
                 record = self._conversation_records.get(conversation_id)
                 if record is not None:
                     record.stored = event_service.stored
+                    record.cached_info = None
                 return
             self._credential_bindings.setdefault(conversation_id, {})[secret_name] = (
                 binding
@@ -743,6 +749,7 @@ class ConversationService:
                 record = self._conversation_records.get(conversation_id)
                 if record is not None:
                     record.stored = event_service.stored
+                    record.cached_info = None
                 event_services.pop(conversation_id, None)
             if first_error is not None:
                 raise first_error
@@ -809,15 +816,25 @@ class ConversationService:
             return conversation_info
 
         signature = _state_signature(self._base_state_path(conversation_id, record))
+        cached = record.cached_info
+        if cached is not None and signature == record.state_signature:
+            # Parent/child relationships are catalog-derived and can change
+            # without touching this conversation's base_state.json.
+            if cached.sub_conversation_ids != children:
+                cached = cached.model_copy(update={"sub_conversation_ids": children})
+                record.cached_info = cached
+            return cached
+
         state = await asyncio.to_thread(
             self._load_persisted_state_sync, conversation_id
         )
         if state is None:
             return None
-        record.state_signature = signature
         conversation_info = await asyncio.to_thread(
             _compose_conversation_info, record.stored, state, children
         )
+        record.state_signature = signature
+        record.cached_info = conversation_info
         record.execution_status = conversation_info.execution_status
         return conversation_info
 
@@ -1628,6 +1645,10 @@ class ConversationService:
                 None, _update_state_tags_sync, state, request.tags
             )
         event_service.stored.updated_at = utc_now()
+        record = self._conversation_records.get(conversation_id)
+        if record is not None:
+            record.stored = event_service.stored
+            record.cached_info = None
         # Save the updated metadata to disk
         await event_service.save_meta()
 
@@ -1915,6 +1936,7 @@ class ConversationService:
                 record = self._conversation_records.get(conversation_id)
                 if record is not None:
                     record.stored = event_service.stored
+                    record.cached_info = None
                 bindings = dict(event_service.credential_bindings)
                 try:
                     await event_service.__aexit__(None, None, None)

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -838,6 +838,7 @@ class ConversationService:
 
         event_service = event_services.get(conversation_id)
         if event_service is not None and event_service.is_open():
+            live = True
             # Do not acquire the live ConversationState's FIFOLock just to list
             # a sidebar row. Native OpenHands arun() intentionally holds that
             # lock across an entire LLM/tool step, which can last minutes; with
@@ -847,6 +848,8 @@ class ConversationService:
             # keyed cache as idle conversations. Live detail/event endpoints
             # remain authoritative for an individual open conversation.
             record.stored = event_service.stored
+        else:
+            live = False
 
         signature = _state_signature(self._base_state_path(conversation_id, record))
         if signature is None and event_service is not None and event_service.is_open():
@@ -861,15 +864,17 @@ class ConversationService:
             return conversation_info
 
         # ``record.stored`` is refreshed above for live conversations; idle rows
-        # keep the catalog copy. Fingerprint it so metadata-only updates (e.g.
-        # auto-title, which writes meta.json without touching base_state.json)
-        # invalidate the cached ConversationInfo rather than serving stale rows.
-        stored_signature = _stored_metadata_signature(record.stored)
+        # keep the catalog copy. Only live conversations can mutate that in-memory
+        # object via metadata-only updates (e.g. auto-title, which writes
+        # ``meta.json`` without touching ``base_state.json``), so fingerprint it
+        # only when the live refresh actually ran — keeps the hot persisted-row
+        # sidebar path free of a per-request dump+hash.
+        stored_signature = _stored_metadata_signature(record.stored) if live else None
         cached = record.cached_info
         if (
             cached is not None
             and signature == record.state_signature
-            and stored_signature == record.stored_signature
+            and (not live or stored_signature == record.stored_signature)
         ):
             # Parent/child relationships are catalog-derived and can change
             # without touching this conversation's base_state.json.

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -807,15 +807,28 @@ class ConversationService:
 
         event_service = event_services.get(conversation_id)
         if event_service is not None and event_service.is_open():
+            # Do not acquire the live ConversationState's FIFOLock just to list
+            # a sidebar row. Native OpenHands arun() intentionally holds that
+            # lock across an entire LLM/tool step, which can last minutes; with
+            # several parallel runs, composing every live row waits behind each
+            # active step and serializes conversation search. The autosaved
+            # base_state.json is the listing snapshot and has the same signature-
+            # keyed cache as idle conversations. Live detail/event endpoints
+            # remain authoritative for an individual open conversation.
+            record.stored = event_service.stored
+
+        signature = _state_signature(self._base_state_path(conversation_id, record))
+        if signature is None and event_service is not None and event_service.is_open():
+            # Direct embedders/tests can inject a live EventService without a
+            # persisted state file. There is no disk snapshot to list in that
+            # case, so retain the live-state fallback.
             state = await event_service.get_state()
-            record.state_signature = None
             conversation_info = await asyncio.to_thread(
                 _compose_conversation_info_sync, event_service.stored, state, children
             )
             record.execution_status = conversation_info.execution_status
             return conversation_info
 
-        signature = _state_signature(self._base_state_path(conversation_id, record))
         cached = record.cached_info
         if cached is not None and signature == record.state_signature:
             # Parent/child relationships are catalog-derived and can change

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -899,8 +899,9 @@ class ConversationService:
                 # Authoritative: we own it, so disk can only be staler.
                 state = await event_service.get_state()
                 record.execution_status = state.execution_status
-                # Autosave will invalidate any signature we hold.
+                # Autosave will invalidate any signature and cached info we hold.
                 record.state_signature = None
+                record.cached_info = None
                 continue
             targets.append(
                 (
@@ -927,6 +928,9 @@ class ConversationService:
                 continue
             if status is not None:
                 record.execution_status = status
+            # A persisted change (or a move to an unreadable state) invalidates
+            # any cached ConversationInfo derived from the previous snapshot.
+            record.cached_info = None
             record.state_signature = signature
 
     async def _reconcile_active_records(self) -> None:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -823,6 +823,40 @@ async def test_finished_status_refresh_invalidates_cached_info(persisted_convers
 
 
 @pytest.mark.asyncio
+async def test_search_refreshes_cached_info_on_metadata_only_update(
+    persisted_conversation,
+):
+    """Metadata-only updates (meta.json) invalidate the cached row.
+
+    ``cached_info`` embeds ``StoredConversation`` metadata (title, metrics) but
+    is keyed by ``base_state.json`` alone. A live conversation changing only
+    ``stored`` metadata — e.g. auto-title — must not be served the stale row.
+    """
+    conversations_dir, conversation_id = persisted_conversation
+
+    async with ConversationService(conversations_dir=conversations_dir) as service:
+        runtime = await service.get_event_service(conversation_id)
+        assert runtime is not None
+
+        # Populate the cached ConversationInfo from the untitled snapshot.
+        initial = await service.search_conversations()
+        assert [item.id for item in initial.items] == [conversation_id]
+        assert initial.items[0].title is None
+        record = service._conversation_records[conversation_id]
+        assert record.cached_info is not None
+
+        # Change only stored metadata; base_state.json is untouched.
+        runtime.stored = runtime.stored.model_copy(update={"title": "Generated Title"})
+        await runtime.save_meta()
+
+        page = await service.search_conversations()
+        assert [item.id for item in page.items] == [conversation_id]
+        assert page.items[0].title == "Generated Title"
+        assert service._event_services is not None
+        assert set(service._event_services) == {conversation_id}
+
+
+@pytest.mark.asyncio
 async def test_waiting_hydration_cannot_restore_deleted_conversation(
     persisted_conversation,
 ):

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -3798,6 +3798,45 @@ async def test_search_composes_conversation_info_off_event_loop(persisted_conver
 
 
 @pytest.mark.asyncio
+async def test_search_reuses_persisted_conversation_info_until_state_changes(
+    persisted_conversation,
+):
+    """Repeated sidebar polls should not reparse unchanged base_state.json."""
+    conversations_dir, conversation_id = persisted_conversation
+    async with ConversationService(conversations_dir=conversations_dir) as service:
+        real_load = service._load_persisted_state_sync
+        with patch.object(
+            service, "_load_persisted_state_sync", wraps=real_load
+        ) as load:
+            first = await service.search_conversations()
+            second = await service.search_conversations()
+
+        assert [item.id for item in first.items] == [conversation_id]
+        assert [item.id for item in second.items] == [conversation_id]
+        assert load.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_invalidates_cached_info_when_state_file_changes(
+    persisted_conversation,
+):
+    conversations_dir, conversation_id = persisted_conversation
+    async with ConversationService(conversations_dir=conversations_dir) as service:
+        first = await service.search_conversations()
+        base_state = conversations_dir / conversation_id.hex / "base_state.json"
+        payload = json.loads(base_state.read_text())
+        payload["execution_status"] = ConversationExecutionStatus.FINISHED.value
+        # Change size as well as mtime so the signature changes on every FS.
+        payload["max_iterations"] = 1234567
+        base_state.write_text(json.dumps(payload))
+
+        second = await service.search_conversations()
+
+    assert first.items[0].execution_status != ConversationExecutionStatus.FINISHED
+    assert second.items[0].execution_status == ConversationExecutionStatus.FINISHED
+
+
+@pytest.mark.asyncio
 async def test_search_composes_live_conversation_info_with_state_lock(tmp_path):
     """Live list/search composition must lock state in the worker thread."""
     conversations_dir = tmp_path / "conversations"

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -3837,8 +3837,8 @@ async def test_search_invalidates_cached_info_when_state_file_changes(
 
 
 @pytest.mark.asyncio
-async def test_search_composes_live_conversation_info_with_state_lock(tmp_path):
-    """Live list/search composition must lock state in the worker thread."""
+async def test_search_live_conversation_does_not_wait_for_state_lock(tmp_path):
+    """Sidebar listing must not block behind a live agent's long step lock."""
     conversations_dir = tmp_path / "conversations"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -3848,32 +3848,30 @@ async def test_search_composes_live_conversation_info_with_state_lock(tmp_path):
         confirmation_policy=NeverConfirm(),
     )
 
-    original_compose = _compose_conversation_info
-    loop_ident = threading.get_ident()
-    found = {}
-
     async with ConversationService(conversations_dir=conversations_dir) as service:
         conversation_info, _ = await service.start_conversation(request)
         event_services = service._event_services
         assert event_services is not None
-        event_service = event_services[conversation_info.id]
-        live_state = await event_service.get_state()
+        live_state = await event_services[conversation_info.id].get_state()
 
-        def spy(stored, state, children):
-            found["thread_ident"] = threading.get_ident()
-            found["state_owned"] = state.owned()
-            found["state_is_live"] = state is live_state
-            return original_compose(stored, state, children)
+        # Hold the same FIFOLock that LocalConversation.arun() holds across a
+        # native OpenHands agent step. The old listing path composed from the
+        # live state and blocked until this lock was released.
+        acquired = threading.Event()
+        release = threading.Event()
 
-        with patch(
-            "openhands.agent_server.conversation_service._compose_conversation_info",
-            side_effect=spy,
-        ) as comp:
-            page = await service.search_conversations()
-            assert [item.id for item in page.items] == [conversation_info.id]
-            assert comp.call_count >= 1
+        def hold_state_lock():
+            with live_state:
+                acquired.set()
+                assert release.wait(timeout=5)
 
-    assert found.get("thread_ident") is not None
-    assert found["thread_ident"] != loop_ident
-    assert found["state_is_live"] is True
-    assert found["state_owned"] is True
+        holder = threading.Thread(target=hold_state_lock)
+        holder.start()
+        assert acquired.wait(timeout=2)
+        try:
+            page = await asyncio.wait_for(service.search_conversations(), timeout=1)
+        finally:
+            release.set()
+            holder.join(timeout=2)
+
+    assert [item.id for item in page.items] == [conversation_info.id]

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -774,6 +774,55 @@ async def test_status_filters_refresh_unloaded_shared_state(persisted_conversati
 
 
 @pytest.mark.asyncio
+async def test_finished_status_refresh_invalidates_cached_info(persisted_conversation):
+    """A persisted status change invalidates the observer's cached row.
+
+    The observer caches a ``ConversationInfo`` for an IDLE snapshot. After the
+    owner finishes the conversation, a filtered search must serve the refreshed
+    ``FINISHED`` status rather than the stale cached ``IDLE`` row.
+    """
+    conversations_dir, conversation_id = persisted_conversation
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        primary_runtime = await primary.get_event_service(conversation_id)
+        assert primary_runtime is not None
+
+        async with ConversationService(conversations_dir=conversations_dir) as observer:
+            # Populate the observer's catalog entry + cached_info from the IDLE
+            # snapshot (unfiltered search does not refresh statuses).
+            initial = await observer.search_conversations()
+            assert [item.id for item in initial.items] == [conversation_id]
+            record = observer._conversation_records[conversation_id]
+            assert record.cached_info is not None
+            assert record.execution_status == ConversationExecutionStatus.IDLE
+
+            # Primary finishes the conversation behind the observer's back.
+            primary_state = await primary_runtime.get_state()
+            primary_state.execution_status = ConversationExecutionStatus.FINISHED
+
+            # The observer's filtered search refreshes statuses; it must not
+            # serve the stale cached IDLE ConversationInfo.
+            page = await observer.search_conversations(
+                execution_status=ConversationExecutionStatus.FINISHED
+            )
+            assert [item.id for item in page.items] == [conversation_id]
+            assert (
+                page.items[0].execution_status == ConversationExecutionStatus.FINISHED
+            )
+
+            # An unfiltered search must also surface the refreshed status rather
+            # than the stale cached IDLE row (which would otherwise persist
+            # forever for a finished conversation).
+            unfiltered = await observer.search_conversations()
+            assert [item.id for item in unfiltered.items] == [conversation_id]
+            assert (
+                unfiltered.items[0].execution_status
+                == ConversationExecutionStatus.FINISHED
+            )
+            assert observer._event_services == {}
+
+
+@pytest.mark.asyncio
 async def test_waiting_hydration_cannot_restore_deleted_conversation(
     persisted_conversation,
 ):


### PR DESCRIPTION
HUMAN:

This fixes the remaining production conversation-sidebar slowdown after isolating it from the separate bash-event glob issue.

---

AGENT:

## Why

`GET /api/conversations/search` loads and validates each page item's full `base_state.json` into a deeply nested `ConversationState`, then composes a full `ConversationInfo`, on every sidebar poll. Agent Canvas polls the first 20 rows every 10 seconds; automations may request larger pages. Unchanged rows are repeatedly reparsed even though the catalog already tracks a `(mtime_ns, size)` state signature.

On the affected store (487 conversations), an hourly automation's five-page full catalog walk took **12.486s** and overlapped the browser sidebar. During contention, even `limit=1` took **25.55s** and larger page requests timed out at **40–120s**, while `/health` stayed ~0.002s and direct single-conversation GETs remained ~0.02s. This identifies full list composition/shared-worker contention as a distinct bottleneck from bash-event search (tracked separately in #4480 / #4481).

## Summary

- Cache the composed `ConversationInfo` on each in-memory catalog record.
- Reuse it while `base_state.json`'s existing `(mtime_ns, size)` signature is unchanged.
- Invalidate when state changes and when live metadata (`stored`) changes.
- Refresh catalog-derived child IDs without reparsing the conversation state.
- No API, wire-format, or on-disk storage changes.

## Issue Number

No pre-existing issue found. Related production evidence: #4480 (separate bash-event search bottleneck), and neubig/droplet-automations#2 (removes the exhaustive full-catalog caller).

## How to Test

Automated:

```bash
uv run pytest -q tests/agent_server/test_conversation_service.py
# 105 passed
```

New regression tests prove:

1. Two unchanged searches load/parse persisted state only once.
2. Updating `base_state.json` invalidates the cache and returns the new execution status.
3. Existing off-event-loop composition behavior remains covered.

Live benchmark baseline, same store and server before this cache:

```text
12 consecutive unchanged first-page polls (limit=20):
median 0.506s, min 0.416s, max 1.188s, total 6.576s
```

After deploying this branch together with #4481 on the same store, 12 consecutive first-page polls measured:

```text
cold first request: 0.072s
warm median:        0.063s
warm range:         0.056–0.076s
total (12 polls):   0.781s
```

Compared with the pre-cache median of 0.506s and total of 6.576s, warm polling is **8.0× faster** and 12-poll aggregate time is **8.4× lower**. The first request is also low because startup's catalog initialization has already validated enough state to populate signatures; any uncached page item is cached on first composition.

Contention evidence before the fix:

| Scenario | Before |
|---|---:|
| Full catalog, 487 records / 5 pages | 12.486s |
| `limit=1` with queued concurrent listings | 25.55s |
| `limit=20` with queued concurrent listings | >40s timeout |
| `/health` during slowdown | ~0.002s |


### Parallel-run isolation

A further live reproduction with 6 active OpenHands conversations revealed that the prior cache still composed **live** rows from each in-memory `ConversationState`. `LocalConversation.arun()` intentionally holds that state's `FIFOLock` across an entire `agent.astep()` (LLM + tool work), so sidebar listing waited behind each active step. This is why high parallelism slowed listing even though conversation runs use a dedicated 10-worker run executor.

This PR now lists persisted live conversations from their autosaved `base_state.json` snapshot and signature-keyed cache, rather than acquiring live step locks. Individual conversation detail/event endpoints remain authoritative. A regression test holds a live state lock in another thread and asserts listing completes within one second.

Live result after deploying with 6 previously-running conversations:

```text
first/cold page: 0.409s
warm pages:      0.032–0.050s
```

Before this change the same endpoint timed out repeatedly at 10–30 seconds while `/health` stayed fast.

## Video/Screenshots

No visual UI change. API timings and the live request-log correlation are included above.

## Design Doc

Not included. This adds a catalog-local cache keyed by the state signature that already exists for status refresh.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The response remains the existing full `ConversationInfo` for compatibility. A future lightweight summary endpoint could further reduce the ~1 MB first-page response, but is not required for this cache improvement.







<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:749eec2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-749eec2-python \
  ghcr.io/openhands/agent-server:749eec2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:749eec2-golang-amd64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-golang-amd64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-golang-amd64
ghcr.io/openhands/agent-server:749eec2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:749eec2-golang-arm64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-golang-arm64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-golang-arm64
ghcr.io/openhands/agent-server:749eec2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:749eec2-java-amd64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-java-amd64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-java-amd64
ghcr.io/openhands/agent-server:749eec2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:749eec2-java-arm64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-java-arm64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-java-arm64
ghcr.io/openhands/agent-server:749eec2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:749eec2-python-amd64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-python-amd64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-python-amd64
ghcr.io/openhands/agent-server:749eec2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:749eec2-python-arm64
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-python-arm64
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-python-arm64
ghcr.io/openhands/agent-server:749eec2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:749eec2-golang
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-golang
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-golang
ghcr.io/openhands/agent-server:749eec2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:749eec2-java
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-java
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-java
ghcr.io/openhands/agent-server:749eec2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:749eec2-python
ghcr.io/openhands/agent-server:749eec27d88f6c5bf6a65874ea927ac4d41d432c-python
ghcr.io/openhands/agent-server:fix-conversation-search-summary-cache-python
ghcr.io/openhands/agent-server:749eec2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `749eec2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `749eec2-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->