### PR TITLE
feat(tracing): enhance observability by recording ACP turn usage and …

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -72,7 +72,7 @@ from openhands.sdk.agent.acp_file_credentials import (
     write_secret_file,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
-from openhands.sdk.agent.acp_tracing import ACPTurnTrace
+from openhands.sdk.agent.acp_tracing import ACPTurnTrace, ACPTurnUsage
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context import AgentContext
 from openhands.sdk.conversation.state import ConversationExecutionStatus
@@ -1844,13 +1844,24 @@ class ACPAgent(AgentBase):
             atexit.unregister(callback)
             self._atexit_callback = None
 
+    def _observability_server_key(self) -> str | None:
+        """Which ACP CLI is running, for span labelling.
+
+        Prefers the provider detected from the live server's ``agent_name`` over
+        the configured :attr:`acp_server`, which is ``None`` whenever the agent
+        was built directly rather than through ``ACPAgentSettings`` — the case
+        the standalone SDK examples take.
+        """
+        provider = detect_acp_provider_by_agent_name(self._agent_name)
+        return provider.key if provider is not None else self.acp_server
+
     def _record_usage(
         self,
         response: PromptResponse | None,
         session_id: str,
         elapsed: float | None = None,
         usage_update: UsageUpdate | None = None,
-    ) -> None:
+    ) -> ACPTurnUsage:
         """Record cost, token usage, latency, and notify stats callback once.
 
         Args:
@@ -1858,16 +1869,23 @@ class ACPAgent(AgentBase):
             session_id: Session identifier used as the response_id for metrics.
             elapsed: Wall-clock seconds for this prompt round-trip (optional).
             usage_update: The synchronized ACP UsageUpdate for this turn, if any.
+
+        Returns:
+            What this turn consumed, so the caller can also put it on the
+            turn's observability span. Metrics remain the source of truth;
+            this only surfaces the numbers already derived here.
         """
         # -- Cost recording ---------------------------------------------------
         # claude-agent-acp, codex-acp: report cost via UsageUpdate notification
         # gemini-cli: does not send UsageUpdate (cost derived from tokens below)
         cost_recorded = False
+        turn_cost = 0.0
         if usage_update is not None and usage_update.cost is not None:
             last_cost = self._client._last_cost_by_session.get(session_id, 0.0)
             delta = usage_update.cost.amount - last_cost
             if delta > 0:
                 self.llm.metrics.add_cost(delta)
+                turn_cost = delta
                 cost_recorded = True
             self._client._last_cost_by_session[session_id] = usage_update.cost.amount
             self._client._last_cost = usage_update.cost.amount
@@ -1899,6 +1917,7 @@ class ACPAgent(AgentBase):
             )
             if cost > 0:
                 self.llm.metrics.add_cost(cost)
+                turn_cost = cost
 
         if not cost_recorded and not input_tokens and not output_tokens:
             # gemini-cli currently returns response.usage=None and
@@ -1917,6 +1936,15 @@ class ACPAgent(AgentBase):
                 self.llm.telemetry._stats_update_callback()
             except Exception:
                 logger.debug("Stats update callback failed", exc_info=True)
+
+        return ACPTurnUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            reasoning_tokens=reasoning,
+            cost=turn_cost,
+        )
 
     # -- Capability helpers ------------------------------------------------
 
@@ -3007,7 +3035,7 @@ class ACPAgent(AgentBase):
         self._client.trace.abandon()
         self._client.reset()
         self._client.trace = ACPTurnTrace(
-            acp_server=self.acp_server,
+            acp_server=self._observability_server_key(),
             model_id=self._current_model_id,
             mask=mask,
         )
@@ -3382,7 +3410,7 @@ class ACPAgent(AgentBase):
 
         session_id = self._session_id or ""
         usage_update = self._client.pop_turn_usage_update(session_id)
-        self._record_usage(
+        turn_usage = self._record_usage(
             response,
             session_id,
             elapsed=elapsed,
@@ -3408,7 +3436,10 @@ class ACPAgent(AgentBase):
             response_text = "(No response from ACP server)"
 
         self._client.trace.finish_turn(
-            response_text, thought_text, self._client.accumulated_tool_calls
+            response_text,
+            thought_text,
+            self._client.accumulated_tool_calls,
+            usage=turn_usage,
         )
 
         # ACP step() boundaries are full remote assistant turns, not

--- a/openhands-sdk/openhands/sdk/agent/acp_tracing.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_tracing.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import should_enable_observability
@@ -31,6 +31,101 @@ ACP_SERVER_METADATA_KEY = "acp_server"
 ACP_MODEL_METADATA_KEY = "acp_model"
 
 TURN_SPAN_NAME = "acp.completion"
+
+# Span attribute names, spelled as literals rather than taken from lmnr's
+# ``Attributes`` enum: that enum has no member for the cache or reasoning keys,
+# and hardcoding keeps this module importable without lmnr. They mirror what
+# lmnr's LiteLLM instrumentation writes on the native path, which is what lets a
+# consumer read an ACP turn's usage without an ACP-specific branch.
+_PROVIDER_ATTR = "gen_ai.system"
+_REQUEST_MODEL_ATTR = "gen_ai.request.model"
+_RESPONSE_MODEL_ATTR = "gen_ai.response.model"
+_INPUT_TOKENS_ATTR = "gen_ai.usage.input_tokens"
+_OUTPUT_TOKENS_ATTR = "gen_ai.usage.output_tokens"
+_CACHE_READ_TOKENS_ATTR = "gen_ai.usage.cache_read_input_tokens"
+_CACHE_WRITE_TOKENS_ATTR = "gen_ai.usage.cache_creation_input_tokens"
+_REASONING_TOKENS_ATTR = "gen_ai.usage.reasoning_tokens"
+_TOTAL_TOKENS_ATTR = "llm.usage.total_tokens"
+_COST_ATTR = "gen_ai.usage.cost"
+
+# Deliberately absent: ``gen_ai.response.id``. The only per-turn identifier ACP
+# offers is the session id, which is effectively a bearer token (see
+# ``_fingerprint_session_id``) — it must not reach the backend even fingerprinted.
+
+#: ``gen_ai.system`` per ACP provider, in the vocabulary lmnr's LiteLLM
+#: instrumentation produces natively, so ACP spans aggregate with native ones
+#: rather than forming a second cohort. Keyed off the provider rather than
+#: inferred from the model, because ACP model ids are CLI aliases (``opus[1m]``,
+#: ``sonnet``, ``auto``) that name no provider. An unrecognised server is left
+#: unlabelled: a wrong provider sends a consumer to the wrong price table.
+_PROVIDER_BY_SERVER = {
+    "claude-code": "anthropic",
+    "codex": "openai",
+    "gemini-cli": "gemini",
+}
+
+
+class ACPTurnUsage(NamedTuple):
+    """What one ACP turn consumed, as the server reported it.
+
+    ``ACPAgent._record_usage`` already derives every field to feed the
+    in-process ``Metrics``, which stays the source of truth; this carries the
+    same numbers to the turn's span, which would otherwise report it as free.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
+    cost: float = 0.0
+
+    @property
+    def total_tokens(self) -> int:
+        """Every token the turn was billed for.
+
+        Cache counts are added rather than assumed to be inside the input
+        count: ACP reports them *outside* ``input_tokens``, where litellm and
+        OpenAI count them inside it (the same split ``MetricsSnapshot``
+        already handles). Reasoning tokens are *not* added — providers bill
+        thinking as output, so they are already in ``output_tokens``.
+
+        ACP's own ``Usage.total_tokens`` is not used: its schema describes it
+        as a sum "across session", so a server that reads that literally would
+        report a running total no single turn can detect.
+        """
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+        )
+
+
+def _usage_attributes(usage: ACPTurnUsage) -> dict[str, int | float]:
+    """The span attributes for a turn's usage, omitting what wasn't reported.
+
+    A count the server never sent is left off rather than written as ``0``: a
+    present zero asserts the turn was free, which would hide the real cases
+    where usage is simply unavailable (gemini-cli sends none today), and
+    forecloses the backend pricing the turn itself.
+    """
+    return {
+        key: value
+        for key, value in (
+            (_INPUT_TOKENS_ATTR, usage.input_tokens),
+            (_OUTPUT_TOKENS_ATTR, usage.output_tokens),
+            (_CACHE_READ_TOKENS_ATTR, usage.cache_read_tokens),
+            (_CACHE_WRITE_TOKENS_ATTR, usage.cache_write_tokens),
+            (_REASONING_TOKENS_ATTR, usage.reasoning_tokens),
+            (_TOTAL_TOKENS_ATTR, usage.total_tokens),
+            # Set explicitly rather than left to the backend: an ACP model id
+            # is a CLI alias no pricing table resolves, and the CLI's own
+            # figure is the authoritative one anyway.
+            (_COST_ATTR, usage.cost),
+        )
+        if value
+    }
 
 
 def _truncate(value: Any, limit: int = 100_000) -> Any:
@@ -53,6 +148,10 @@ def _truncate(value: Any, limit: int = 100_000) -> Any:
 
 class ACPTurnTrace:
     """Emits one ``LLM`` span per ACP turn plus a ``TOOL`` span per tool call.
+
+    The turn span also carries the model, provider and usage as ``gen_ai.*``
+    attributes, so an ACP conversation reports its real tokens and cost instead
+    of reading as a free session.
 
     Every method is a no-op when observability is disabled, and no method may
     raise: a tracing failure must not take down the turn it is describing.
@@ -78,6 +177,19 @@ class ACPTurnTrace:
             self._metadata[ACP_SERVER_METADATA_KEY] = acp_server
         if model_id:
             self._metadata[ACP_MODEL_METADATA_KEY] = model_id
+        # Stamped at turn start, so model identity survives a turn that times
+        # out and never reports usage. Request and response model are the same
+        # value: ACP reports no per-turn model, and while ``set_acp_model`` can
+        # land mid-turn, the cost is booked against the model the turn started
+        # on — re-reading it at the end would disagree with this span's own
+        # metadata and with its TOOL children.
+        self._attributes: dict[str, Any] = {}
+        if model_id:
+            self._attributes[_REQUEST_MODEL_ATTR] = model_id
+            self._attributes[_RESPONSE_MODEL_ATTR] = model_id
+        provider = _PROVIDER_BY_SERVER.get(acp_server or "")
+        if provider:
+            self._attributes[_PROVIDER_ATTR] = provider
         self._turn_span: Any = None
         self._turn_context: LaminarSpanContext | None = None
         self._tool_spans: dict[str, Any] = {}
@@ -101,6 +213,9 @@ class ACPTurnTrace:
                     span_type="LLM",
                     metadata=dict(self._metadata),
                 )
+                # Stamped before the span is published to the other thread, so
+                # it is still private here and no lock contention is added.
+                self._set_attributes(span, self._attributes)
                 self._turn_span = span
                 self._turn_context = Laminar.get_laminar_span_context(span)
         except Exception:
@@ -147,8 +262,14 @@ class ACPTurnTrace:
         text: str,
         thoughts: str,
         tool_calls: list[dict[str, Any]],
+        usage: ACPTurnUsage | None = None,
     ) -> None:
-        """Set the turn's assistant message and close every span it opened."""
+        """Set the turn's assistant message and usage, and close every span.
+
+        ``usage`` is a parameter rather than a separate call so it cannot be
+        written after ``end()``, which would drop it silently and log an OTel
+        warning.
+        """
         with self._lock:
             open_spans = list(self._tool_spans.items())
             self._tool_spans.clear()
@@ -161,6 +282,8 @@ class ACPTurnTrace:
 
         if span is None:
             return
+        if usage is not None:
+            self._set_attributes(span, _usage_attributes(usage))
         try:
             span.set_output([_assistant_message(text, thoughts, tool_calls)])
         except Exception:
@@ -184,6 +307,20 @@ class ACPTurnTrace:
             span.end()
         except Exception:
             logger.debug("ACP turn span could not be ended", exc_info=True)
+
+    @staticmethod
+    def _set_attributes(span: Any, attributes: dict[str, Any]) -> None:
+        """Best-effort: a rejected attribute must not cost us the whole span.
+
+        One ``set_attributes`` call rather than one per key, so the OTel span
+        lock is taken once and a violated ordering warns once.
+        """
+        if not attributes:
+            return
+        try:
+            span.set_attributes(attributes)
+        except Exception:
+            logger.debug("ACP span attributes could not be set", exc_info=True)
 
     @staticmethod
     def _close_tool_span(span: Any, entry: dict[str, Any]) -> None:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -56,6 +56,7 @@ from openhands.sdk.agent.acp_file_credentials import (
     codex_auth_file,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
+from openhands.sdk.agent.acp_tracing import ACPTurnTrace, ACPTurnUsage
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context import AgentContext
 from openhands.sdk.conversation.secret_registry import SecretRegistry
@@ -3664,6 +3665,136 @@ class TestACPAgentTelemetry:
         assert agent.llm.metrics.accumulated_cost == 0.0
         assert len(agent.llm.metrics.costs) == 0
         assert len(agent.llm.metrics.token_usages) == 1
+
+    # -- The usage a turn hands to its observability span ------------------
+    #
+    # ``_record_usage`` returns what it wrote into ``Metrics`` so the turn can
+    # mirror it onto its LLM span (#4368). ``Metrics`` stays the source of
+    # truth; these pin that the returned copy agrees with it.
+
+    def _finish_turn_usages(self, monkeypatch) -> list:
+        """Capture the ``usage`` each finished turn hands its span.
+
+        Patches the module-level name so the trace the agent builds per turn in
+        ``_reset_client_for_attempt`` is the recording one; it still subclasses
+        the real trace, so nothing about span behaviour is faked away.
+        """
+        captured: list[ACPTurnUsage | None] = []
+
+        class RecordingTrace(ACPTurnTrace):
+            def finish_turn(self, text, thoughts, tool_calls, usage=None):
+                captured.append(usage)
+                super().finish_turn(text, thoughts, tool_calls, usage=usage)
+
+        monkeypatch.setattr(acp_agent_module, "ACPTurnTrace", RecordingTrace)
+        return captured
+
+    def test_a_finished_turn_hands_the_span_the_usage_it_recorded(
+        self, tmp_path, monkeypatch
+    ):
+        """Catches a reordering that would close the span before usage lands."""
+        captured = self._finish_turn_usages(monkeypatch)
+        agent, conversation = self._make_step_fixtures(
+            tmp_path,
+            usage={
+                "input": 100,
+                "output": 50,
+                "cache_read": 10,
+                "cache_write": 5,
+                "thought": 20,
+            },
+            cost=(0.05, 200000),
+        )
+
+        agent.step(conversation, on_event=lambda _: None)
+
+        (usage,) = captured
+        recorded = agent.llm.metrics.token_usages[-1]
+        assert usage == ACPTurnUsage(
+            input_tokens=recorded.prompt_tokens,
+            output_tokens=recorded.completion_tokens,
+            cache_read_tokens=recorded.cache_read_tokens,
+            cache_write_tokens=recorded.cache_write_tokens,
+            reasoning_tokens=recorded.reasoning_tokens,
+            cost=agent.llm.metrics.costs[-1].cost,
+        )
+
+    def test_a_turn_reports_the_cost_delta_not_the_cumulative_total(
+        self, tmp_path, monkeypatch
+    ):
+        """ACP reports cost cumulatively per session; the span wants this turn's."""
+        captured = self._finish_turn_usages(monkeypatch)
+        agent = _make_agent()
+
+        for cumulative in (0.05, 0.12):
+            _, conversation = self._make_step_fixtures(
+                tmp_path,
+                agent=agent,
+                usage={"input": 100, "output": 50},
+                cost=(cumulative, 128000),
+            )
+            agent.step(conversation, on_event=lambda _: None)
+
+        first, second = captured
+        assert first is not None and second is not None
+        assert first.cost == pytest.approx(0.05)
+        assert second.cost == pytest.approx(0.07)
+
+    def test_a_turn_reports_the_estimated_cost_when_the_cli_sends_none(
+        self, tmp_path, monkeypatch
+    ):
+        """The gemini-cli path: cost is derived from tokens, and the span gets
+        the derived figure rather than nothing."""
+        captured = self._finish_turn_usages(monkeypatch)
+        agent, conversation = self._make_step_fixtures(
+            tmp_path,
+            agent=_make_agent(acp_model="claude-opus-5"),
+            usage={"input": 100, "output": 50},
+            cost=None,
+        )
+
+        agent.step(conversation, on_event=lambda _: None)
+
+        estimated = _estimate_cost_from_tokens("claude-opus-5", 100, 50)
+        assert estimated > 0, "pick a model litellm can price"
+        (usage,) = captured
+        assert usage is not None
+        assert usage.cost == pytest.approx(estimated)
+
+    def test_a_turn_reports_no_usage_when_the_server_sends_none(
+        self, tmp_path, monkeypatch
+    ):
+        """An all-zero record, which the span then omits rather than
+        reporting as a genuinely free turn."""
+        captured = self._finish_turn_usages(monkeypatch)
+        agent, conversation = self._make_step_fixtures(tmp_path)
+
+        agent.step(conversation, on_event=lambda _: None)
+
+        assert captured == [ACPTurnUsage()]
+        assert agent.llm.metrics.token_usages == []
+
+    def test_a_directly_built_agent_still_labels_spans_with_the_running_cli(
+        self, tmp_path, monkeypatch
+    ):
+        """``acp_server`` is only set by ``ACPAgentSettings.create_agent()``, so a
+        directly-built agent — what the standalone SDK examples do — would leave
+        its spans with no provider. The running server's name supplies it."""
+        built: list[dict] = []
+
+        class RecordingTrace(ACPTurnTrace):
+            def __init__(self, **kwargs):
+                built.append(kwargs)
+                super().__init__(**kwargs)
+
+        monkeypatch.setattr(acp_agent_module, "ACPTurnTrace", RecordingTrace)
+        agent, conversation = self._make_step_fixtures(tmp_path)
+        assert agent.acp_server is None
+        agent._agent_name = "claude-agent-acp"
+
+        agent.step(conversation, on_event=lambda _: None)
+
+        assert built[-1]["acp_server"] == "claude-code"
 
     def test_step_records_partial_metrics_on_usage_timeout(self, tmp_path, caplog):
         """Timeout waiting for UsageUpdate logs warning but records token metrics."""

--- a/tests/sdk/agent/test_acp_tracing.py
+++ b/tests/sdk/agent/test_acp_tracing.py
@@ -16,10 +16,24 @@ from openhands.sdk.agent.acp_tracing import (
     AGENT_KIND_METADATA_KEY,
     TURN_SPAN_NAME,
     ACPTurnTrace,
+    ACPTurnUsage,
 )
 
 
 METADATA_PREFIX = "lmnr.association.properties.metadata."
+
+# Spelled out rather than imported: these are a wire contract with Laminar, so a
+# rename in the SDK must fail here rather than silently follow along.
+INPUT_TOKENS = "gen_ai.usage.input_tokens"
+OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+CACHE_READ_TOKENS = "gen_ai.usage.cache_read_input_tokens"
+CACHE_WRITE_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
+REASONING_TOKENS = "gen_ai.usage.reasoning_tokens"
+TOTAL_TOKENS = "llm.usage.total_tokens"
+COST = "gen_ai.usage.cost"
+REQUEST_MODEL = "gen_ai.request.model"
+RESPONSE_MODEL = "gen_ai.response.model"
+PROVIDER = "gen_ai.system"
 
 
 @pytest.fixture
@@ -104,6 +118,10 @@ def _by_type(spans, span_type: str):
 
 def _meta(span, key: str):
     return (span.attributes or {}).get(METADATA_PREFIX + key)
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes or {})
 
 
 def _tool_text(span) -> str:
@@ -230,12 +248,12 @@ def test_tracing_is_inert_when_observability_is_disabled(monkeypatch, exported):
         "openhands.sdk.agent.acp_tracing.should_enable_observability",
         lambda: False,
     )
-    trace = ACPTurnTrace(acp_server="codex", model_id=None)
+    trace = ACPTurnTrace(acp_server="codex", model_id="gpt-5.5")
     trace.start_turn("go")
     entry = _tool_entry("call_1")
     trace.tool_started(entry)
     trace.tool_finished(entry)
-    trace.finish_turn("done", "", [entry])
+    trace.finish_turn("done", "", [entry], usage=ACPTurnUsage(100, 50, cost=0.05))
 
     assert exported() == ()
 
@@ -405,3 +423,158 @@ def test_the_prompt_is_dropped_rather_than_recorded_raw_if_masking_fails(exporte
 
     (llm,) = _by_type(exported(), "LLM")
     assert "ghp_secret" not in str((llm.attributes or {}).get("lmnr.span.input"))
+
+
+def _finished_turn(exported, usage: ACPTurnUsage | None, **kwargs):
+    """Run one bare turn and return the exported LLM span's attributes."""
+    trace = ACPTurnTrace(acp_server=kwargs.pop("acp_server", "claude-code"), **kwargs)
+    trace.start_turn("go")
+    trace.finish_turn("done", "", [], usage=usage)
+    (llm,) = _by_type(exported(), "LLM")
+    return _attrs(llm)
+
+
+def test_turn_span_carries_the_token_counts_the_acp_server_reported(exported):
+    attrs = _finished_turn(
+        exported,
+        ACPTurnUsage(input_tokens=100, output_tokens=50),
+        model_id="claude-opus-5",
+    )
+
+    assert attrs[INPUT_TOKENS] == 100
+    assert attrs[OUTPUT_TOKENS] == 50
+
+
+def test_turn_span_counts_cache_tokens_outside_the_input_count(exported):
+    """ACP reports cache reads outside ``input_tokens``, where litellm counts
+    them inside it — so the total is a sum of all four, not input+output. A
+    claude-code turn is mostly cache reads, so getting this wrong understates
+    the billed work by orders of magnitude."""
+    attrs = _finished_turn(
+        exported,
+        ACPTurnUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=50_000,
+            cache_write_tokens=2_000,
+        ),
+        model_id="claude-opus-5",
+    )
+
+    assert attrs[CACHE_READ_TOKENS] == 50_000
+    assert attrs[CACHE_WRITE_TOKENS] == 2_000
+    assert attrs[TOTAL_TOKENS] == 52_150
+
+
+def test_turn_span_omits_reasoning_tokens_from_the_total_it_reports(exported):
+    """Providers bill thinking as output, so reasoning is already counted."""
+    attrs = _finished_turn(
+        exported,
+        ACPTurnUsage(input_tokens=100, output_tokens=50, reasoning_tokens=20),
+        model_id="claude-opus-5",
+    )
+
+    assert attrs[REASONING_TOKENS] == 20
+    assert attrs[TOTAL_TOKENS] == 150
+
+
+def test_turn_span_omits_token_attributes_when_the_server_reported_none(exported):
+    """gemini-cli reports no usage today. A present ``0`` would assert the turn
+    was free, hiding that the number is simply unknown."""
+    attrs = _finished_turn(exported, ACPTurnUsage(), model_id="auto")
+
+    for key in (INPUT_TOKENS, OUTPUT_TOKENS, TOTAL_TOKENS, REASONING_TOKENS):
+        assert key not in attrs
+
+
+def test_turn_span_carries_the_cost_the_agent_recorded_for_the_turn(exported):
+    attrs = _finished_turn(
+        exported,
+        ACPTurnUsage(input_tokens=100, output_tokens=50, cost=0.07),
+        model_id="claude-opus-5",
+    )
+
+    assert attrs[COST] == pytest.approx(0.07)
+
+
+def test_turn_span_omits_cost_when_the_cli_reports_none(exported):
+    """Absent means unknown, not free — and leaves the backend free to price it."""
+    attrs = _finished_turn(
+        exported,
+        ACPTurnUsage(input_tokens=100, output_tokens=50),
+        model_id="claude-opus-5",
+    )
+
+    assert COST not in attrs
+
+
+def test_turn_span_names_the_model_before_the_turn_produces_any_usage(exported):
+    """Model identity is stamped at turn start, so a turn that times out and is
+    abandoned still says which model it ran on."""
+    trace = ACPTurnTrace(acp_server="claude-code", model_id="opus[1m]")
+    trace.start_turn("go")
+    trace.abandon()
+
+    (llm,) = _by_type(exported(), "LLM")
+    assert _attrs(llm)[REQUEST_MODEL] == "opus[1m]"
+    assert _attrs(llm)[RESPONSE_MODEL] == "opus[1m]"
+
+
+@pytest.mark.parametrize(
+    "acp_server,provider",
+    [("claude-code", "anthropic"), ("codex", "openai"), ("gemini-cli", "gemini")],
+)
+def test_turn_span_names_the_provider_the_acp_cli_fronts(
+    exported, acp_server, provider
+):
+    """These exact strings are what lmnr's LiteLLM instrumentation infers for the
+    native path, so ACP spans aggregate with native ones."""
+    attrs = _finished_turn(exported, None, acp_server=acp_server, model_id=None)
+
+    assert attrs[PROVIDER] == provider
+
+
+def test_a_custom_acp_server_leaves_the_provider_unset(exported):
+    """A guessed provider would send a consumer to the wrong price table."""
+    attrs = _finished_turn(exported, None, acp_server="custom", model_id=None)
+
+    assert PROVIDER not in attrs
+
+
+def test_the_turn_span_records_no_response_id(exported):
+    """The only per-turn id ACP offers is the session id, which is effectively a
+    bearer token. Completing lmnr's 'minimum LLM attribute set' with it would
+    ship a credential to the tracing backend."""
+    attrs = _finished_turn(
+        exported, ACPTurnUsage(input_tokens=1, output_tokens=1), model_id="sonnet"
+    )
+
+    assert "gen_ai.response.id" not in attrs
+
+
+def test_usage_attributes_the_span_rejects_never_break_the_turn(exported):
+    trace = ACPTurnTrace(acp_server="codex", model_id="gpt-5.5")
+    trace.start_turn("go")
+    span = trace._turn_span
+    with patch.object(
+        type(span),
+        "set_attributes",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("rejected")),
+    ):
+        trace.finish_turn("done", "", [], usage=ACPTurnUsage(100, 50, cost=0.05))
+
+    # The turn still lands: output set, span ended and therefore exported.
+    (llm,) = _by_type(exported(), "LLM")
+    assert json.loads(_attrs(llm)["lmnr.span.output"])[0]["content"] == "done"
+    assert INPUT_TOKENS not in _attrs(llm), "the patch did not take effect"
+
+
+def test_usage_reported_for_a_turn_that_never_started_is_dropped(exported):
+    """``finish_turn`` after an abandoned turn must not resurrect a span."""
+    trace = ACPTurnTrace(acp_server="codex", model_id="gpt-5.5")
+    trace.start_turn("go")
+    trace.abandon()
+    trace.finish_turn("done", "", [], usage=ACPTurnUsage(100, 50, cost=0.05))
+
+    (llm,) = _by_type(exported(), "LLM")
+    assert INPUT_TOKENS not in _attrs(llm)


### PR DESCRIPTION
HUMAN:

in the listed 4 issues -
1. LLM-equivalent spans per assistant turn, carrying messages and tool calls
2. TOOL spans for ACP tool calls, parented to step spans
3. Token/cost attributes on spans
4. Model identity as span attributes

items 1 and 2 were already fixed by another PR #4376 

my PR->
 the `_record_usage` was returning `none`
Now it hands back the numbers it just recorded, as `ACPTurnUsage`, and the caller passes them into 
`finish_turn(usage=...)`
which writes them onto the span under standard gen_ai.* keys. 

---

AGENT:

## Why

ACP turn spans carried no usage. Cost and tokens for an ACP turn were recorded into
the in-process `Metrics` by `ACPAgent._record_usage`, but nothing carried them onto the
span that describes the turn — so in Laminar (or any OTLP backend) every ACP
conversation read as a free session, and dashboards built on trace data reported ACP
spend as zero.

Model and provider identity had the same gap: they were attached as span *metadata*
only, not as `gen_ai.*` attributes, so backends could not group, filter, or price ACP
turns alongside turns from a direct-LLM `Agent`.

## Summary

- Add `ACPTurnUsage` (a `NamedTuple`) to `acp_tracing.py` holding one turn's tokens and
  cost. `ACPAgent._record_usage` now returns it instead of `None`, so the figures it
  already derives reach the turn's span. `Metrics` remains the source of truth; this
  adds no new derivation.
- Stamp `gen_ai.*` attributes on the turn span: request/response model and
  `gen_ai.system` at turn start (so model identity survives a turn that times out and
  never reports usage), and usage plus `gen_ai.usage.cost` via
  `ACPTurnTrace.finish_turn(usage=...)`. Counts the server never reported are omitted
  rather than written as `0`, so "usage unavailable" (gemini-cli sends none today) stays
  distinguishable from "this turn was free".
- Add `ACPAgent._observability_server_key()`, which falls back to the provider detected
  from the live server's `agent_name` when `acp_server` is `None` — the case for an
  `ACPAgent` built directly rather than through `ACPAgentSettings`, as the standalone
  SDK examples do. Those spans previously carried no provider label at all.

Compatibility: additive. `finish_turn`'s `usage` is an optional keyword argument, and
`_record_usage` is private — a caller ignoring the new return value is unaffected. No
change to the agent loop or to any REST/WebSocket shape.

## Issue Number

Fixes #4368 

## How to Test

**1. Unit tests** — on top of `main` at 20f7f5f8f:

​```
$ uv run pytest tests/sdk/agent/test_acp_agent.py tests/sdk/agent/test_acp_tracing.py -q
475 passed, 10 warnings in 10.22s
​```

**2. Attributes verified leaving the process over a real OTLP exporter.** Unit tests assert
what is set on the span object; this checks the attributes actually survive serialization
and export, which is where a rejected attribute type or a write-after-`end()` would
silently drop them. `ACPTurnTrace` is driven the way `ACPAgent` drives it, with hand-fed
usage, against a local OTLP endpoint:

​```python
from openhands.sdk.agent.acp_tracing import ACPTurnTrace, ACPTurnUsage
from openhands.sdk.observability.laminar import maybe_init_laminar

maybe_init_laminar()
usage = ACPTurnUsage(
    input_tokens=1234, output_tokens=567, cache_read_tokens=8901,
    cache_write_tokens=234, reasoning_tokens=45, cost=0.0321,
)
trace = ACPTurnTrace(acp_server="claude-code", model_id="claude-sonnet-4-5")
trace.start_turn("List the Python files under openhands-sdk/openhands/sdk/agent/.")
trace.finish_turn("Here are the agent modules.", "thoughts", [], usage=usage)

from lmnr import Laminar
Laminar.flush()
print("total_tokens:", usage.total_tokens)
​```

​```
$ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces \
  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf \
  LMNR_FORCE_HTTP=true uv run python verify_acp_span.py
observability enabled: True
total_tokens: 10936
​```

Decoding the exported (gzipped) OTLP payload at the receiving end, all ten attributes are
present on the turn span:

​```
=== OTLP export received: 1064 bytes (gzip) -> 2347 bytes decompressed ===
  gen_ai.request.model                gen_ai.usage.cache_read_input_tokens
  gen_ai.response.model               gen_ai.usage.cache_creation_input_tokens
  gen_ai.system                       gen_ai.usage.reasoning_tokens
  gen_ai.usage.input_tokens           llm.usage.total_tokens
  gen_ai.usage.output_tokens          gen_ai.usage.cost
​```

`total_tokens` = 10936 = 1234 + 567 + 8901 + 234 — the 45 reasoning tokens correctly
excluded, since providers already bill thinking as output.

**Not done, stated plainly:** I have not run this against a live claude-agent-acp server
with real credentials, so the usage numbers above are hand-fed rather than server-reported.
The one remaining untested link is `_record_usage`'s return value reaching `finish_turn`
during a real turn; unit tests cover that call path, and everything downstream of it is
covered by the export check above. To reproduce the full path:

​```
export ANTHROPIC_API_KEY=<key>          # or ANTHROPIC_BASE_URL for a LiteLLM proxy
export LMNR_PROJECT_API_KEY=<laminar key>
uv run python examples/01_standalone_sdk/40_acp_agent_example.py
​```

Happy to run that and post the trace if a reviewer wants it before merge.

## Video/Screenshots

No screenshot: the verification above used a local OTLP endpoint rather than the Laminar
UI, and its output is quoted inline as text instead.


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `_PROVIDER_BY_SERVER` in `acp_tracing.py` maps the `acp_server` discriminator to a
  `gen_ai.system` value. That mapping arguably belongs on `ACPProviderInfo` in
  `settings/acp_providers.py` alongside the other per-provider metadata, so a newly
  registered provider cannot silently end up with no `gen_ai.system`. Happy to move it
  there in this PR if reviewers prefer.
- Unrelated pre-existing failure on `main`:
  `tests/sdk/conversation/test_local_conversation_mcp.py::test_reconciliation_targets_replaced_agent`
  fails at 20f7f5f8f without any of this branch's changes (`tools_map` contains
  `inspect_image_with_vision` alongside `replacement`). Not touched by this PR.
