### PR TITLE
fix(agent-server): keep crash recovery result on interrupted action branch

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1109,7 +1109,14 @@ class EventService:
                     for e in state.events
                 )
                 if not already_observed:
+                    # The persisted HEAD can lag this action when the process
+                    # dies after writing the event file but before autosaving
+                    # leaf_event_id. Parent the recovery result to the action
+                    # explicitly; otherwise normal tree stamping attaches it to
+                    # the stale HEAD, making the action and result siblings and
+                    # leaving an orphan tool result on the active branch.
                     error_event = AgentErrorEvent(
+                        parent_id=first_action.id,
                         tool_name=first_action.tool_name,
                         tool_call_id=first_action.tool_call_id,
                         error=(

--- a/tests/cross/test_conversation_lease_behavior.py
+++ b/tests/cross/test_conversation_lease_behavior.py
@@ -14,8 +14,15 @@ from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.models import StartConversationRequest
 from openhands.sdk import LLM, Agent
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event import ActionEvent, AgentErrorEvent, Event, ObservationEvent
-from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.event import (
+    ActionEvent,
+    AgentErrorEvent,
+    Event,
+    MessageEvent,
+    ObservationEvent,
+    SystemPromptEvent,
+)
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
 from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.workspace import LocalWorkspace
@@ -151,3 +158,91 @@ async def test_expired_lease_takeover_fences_stale_writer_with_disk_events(tmp_p
 
             with pytest.raises(ConversationOwnershipLostError):
                 primary_state.execution_status = ConversationExecutionStatus.ERROR
+
+
+@pytest.mark.asyncio
+async def test_crash_recovery_error_is_on_active_branch_for_next_turn(tmp_path):
+    """A restart between event-file append and persisted HEAD must remain resumable.
+
+    This reproduces the production ordering with real ConversationService,
+    LocalConversation, EventLog, and filesystem persistence:
+
+    1. Persist an action while the conversation is RUNNING.
+    2. Simulate process death after the action file lands but before
+       ``leaf_event_id`` is saved by rewinding only the persisted HEAD.
+    3. Let a second service take over the expired lease and synthesize the
+       crash-recovery AgentErrorEvent.
+    4. Append a real follow-up user message, like the Iterate watchdog does.
+    5. Build the view's manipulation indices, the same operation the
+       summarizing condenser performs before the next LLM turn.
+
+    The current implementation writes the recovery error as a sibling of the
+    action (both parented to the stale HEAD), so the active branch contains a
+    tool result without its tool call and manipulation_indices raises KeyError.
+    """
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(_request(workspace_dir))
+        assert primary._event_services is not None
+        event_service = primary._event_services[conversation_info.id]
+        state = await event_service.get_state()
+        conversation = event_service._conversation
+        assert conversation is not None
+        conversation_dir = conversations_dir / conversation_info.id.hex
+
+        # Establish a realistic active branch before the in-flight action.
+        system_prompt = SystemPromptEvent(
+            system_prompt=TextContent(text="You are a coding agent."), tools=[]
+        )
+        conversation._on_event(system_prompt)
+        user_message = MessageEvent(
+            source="user",
+            llm_message=Message(
+                role="user", content=[TextContent(text="run the command")]
+            ),
+        )
+        conversation._on_event(user_message)
+        stale_leaf = state.leaf_event_id
+        assert stale_leaf == user_message.id
+
+        running_action = _create_running_terminal_action("chatcmpl-tool-crash-recovery")
+        conversation._on_event(running_action)
+        state.execution_status = ConversationExecutionStatus.RUNNING
+        assert state.leaf_event_id == running_action.id
+
+        # Reproduce the crash window: the action event file exists, while the
+        # base snapshot still points at the preceding user message.
+        base_state_path = conversation_dir / "base_state.json"
+        base_state = json.loads(base_state_path.read_text())
+        base_state["leaf_event_id"] = stale_leaf
+        base_state_path.write_text(json.dumps(base_state))
+        _expire_lease(conversation_dir)
+
+        async with ConversationService(
+            conversations_dir=conversations_dir
+        ) as secondary:
+            assert secondary._event_services is not None
+            recovered = secondary._event_services[conversation_info.id]
+            recovered_state = await recovered.get_state()
+
+            disk_events = _load_disk_events(conversation_dir)
+            recovery_error = next(
+                event for event in disk_events if isinstance(event, AgentErrorEvent)
+            )
+            assert recovery_error.tool_call_id == running_action.tool_call_id
+
+            # Resume exactly as a follow-up automation does.
+            await recovered.send_message(
+                Message(
+                    role="user",
+                    content=[TextContent(text="continue after the restart")],
+                ),
+                run=False,
+            )
+
+            # Must not raise: the next turn/condenser needs a valid tool-call
+            # boundary in the active branch.
+            recovered_state.view.manipulation_indices


### PR DESCRIPTION
HUMAN:

This reproduces and fixes a restart-corruption bug seen in three real Agent Canvas conversations, using a file-backed lease-takeover test with no mocks in the failure path.

---

AGENT:

## Why

Fixes #4487.

If the agent-server dies after an `ActionEvent` file is persisted but before `base_state.json` saves the advanced `leaf_event_id`, crash recovery correctly finds the interrupted action in the full event log but emits its synthetic `AgentErrorEvent` at the stale active HEAD. The action and result become siblings; the active branch contains a result without its tool call. The next context-preparation/condensation pass raises `KeyError` in `ToolCallMatchingProperty.manipulation_indices`, permanently breaking follow-up turns.

Three production conversations failed with this exact stack and distinct `chatcmpl-tool-*` IDs after one server restart.

## Summary

- Add an integration-style reproducer using real `ConversationService`, `EventService`, `LocalConversation`, file-backed `EventLog`, persisted HEAD, lease expiration/takeover, recovery emission, and follow-up handling.
- Explicitly set crash recovery's synthetic `AgentErrorEvent.parent_id` to the interrupted `ActionEvent.id`.
- Keep strict tool-call matching unchanged; repair event-tree lineage instead of suppressing invariant failures.

## Issue Number

Fixes #4487.

## How to Test

The test commit was run on current main before the fix commit and failed faithfully:

```bash
uv run pytest -q tests/cross/test_conversation_lease_behavior.py \
  -k crash_recovery_error_is_on_active_branch_for_next_turn -vv
```

Before:

```text
recovered_state.view.manipulation_indices
.../tool_call_matching.py:93
    pending_tool_call_ids.remove(event.tool_call_id)
KeyError: 'chatcmpl-tool-crash-recovery'
```

After, on this PR with the same test unchanged:

```text
test_live_lease_blocks_split_brain_resume_with_disk_events PASSED
test_expired_lease_takeover_fences_stale_writer_with_disk_events PASSED
test_crash_recovery_error_is_on_active_branch_for_next_turn PASSED
3 passed in 1.83s
```

Related strict invariant suite:

```bash
uv run pytest -q \
  tests/sdk/context/view/properties/test_tool_call_matching.py \
  tests/sdk/context/view/test_view_manipulation_indices.py \
  tests/cross/test_conversation_lease_behavior.py
# 33 passed in 3.81s
```

## Video/Screenshots

Before terminal capture:

```text
FAILED ...test_crash_recovery_error_is_on_active_branch_for_next_turn
KeyError: 'chatcmpl-tool-crash-recovery'
```

After terminal capture:

```text
3 passed
```

## Design Doc

Not included. The production change is one explicit `parent_id` assignment at the existing crash-recovery emission point.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The failure path uses no mocks. Only the unavoidable process-crash atomicity window is simulated: after a real action append, persisted `leaf_event_id` is rewound to the preceding user message before a real lease takeover. The fix is a separate commit after the red test commit, preserving the before/after history in one PR.



<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6604560-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6604560-python \
  ghcr.io/openhands/agent-server:6604560-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6604560-golang-amd64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-golang-amd64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-golang-amd64
ghcr.io/openhands/agent-server:6604560-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6604560-golang-arm64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-golang-arm64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-golang-arm64
ghcr.io/openhands/agent-server:6604560-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6604560-java-amd64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-java-amd64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-java-amd64
ghcr.io/openhands/agent-server:6604560-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6604560-java-arm64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-java-arm64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-java-arm64
ghcr.io/openhands/agent-server:6604560-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6604560-python-amd64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-python-amd64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-python-amd64
ghcr.io/openhands/agent-server:6604560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6604560-python-arm64
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-python-arm64
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-python-arm64
ghcr.io/openhands/agent-server:6604560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6604560-golang
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-golang
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-golang
ghcr.io/openhands/agent-server:6604560-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6604560-java
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-java
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-java
ghcr.io/openhands/agent-server:6604560-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6604560-python
ghcr.io/openhands/agent-server:660456096d8ffba5404d45287d10901c6e588f56-python
ghcr.io/openhands/agent-server:test-crash-recovery-orphan-result-python
ghcr.io/openhands/agent-server:6604560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6604560-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6604560-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->