### PR TITLE
fix(sdk): Track DeepSeek prompt cache hits in telemetry

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -21,6 +21,68 @@ from openhands.sdk.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _usage_int(value: Any) -> int:
+    return int(value or 0)
+
+
+def _usage_attr(usage: Any, name: str) -> int:
+    try:
+        return _usage_int(getattr(usage, name, 0))
+    except (AttributeError, TypeError):
+        return 0
+
+
+def _prompt_token_details(usage: Any) -> Any:
+    return getattr(usage, "prompt_tokens_details", None) or getattr(
+        usage, "input_tokens_details", None
+    )
+
+
+def _completion_token_details(usage: Any) -> Any:
+    return getattr(usage, "completion_tokens_details", None) or getattr(
+        usage, "output_tokens_details", None
+    )
+
+
+def _cache_read_tokens(usage: Any) -> int:
+    details = _prompt_token_details(usage)
+    if details is not None:
+        cached_tokens = _usage_attr(details, "cached_tokens")
+        if cached_tokens:
+            return cached_tokens
+
+    for field_name in (
+        "prompt_cache_hit_tokens",
+        "cache_read_input_tokens",
+        "cached_tokens",
+    ):
+        cached_tokens = _usage_attr(usage, field_name)
+        if cached_tokens:
+            return cached_tokens
+
+    return 0
+
+
+def _cache_write_tokens(usage: Any) -> int:
+    for field_name in (
+        "_cache_creation_input_tokens",
+        "cache_creation_input_tokens",
+    ):
+        cache_write = _usage_attr(usage, field_name)
+        if cache_write:
+            return cache_write
+
+    details = _prompt_token_details(usage)
+    if details is None:
+        return 0
+
+    return (
+        _usage_attr(details, "cache_write_tokens")
+        or _usage_attr(details, "cache_creation_tokens")
+        or _usage_attr(details, "cache_creation_input_tokens")
+    )
+
+
 class Telemetry(BaseModel):
     """
     Handles latency, token/cost accounting, and optional logging.
@@ -183,8 +245,13 @@ class Telemetry(BaseModel):
             if completion_tokens is None:
                 completion_tokens = getattr(usage, "output_tokens", 0)
 
-            pt = int(prompt_tokens or 0)
-            ct = int(completion_tokens or 0)
+            if prompt_tokens is None:
+                prompt_tokens = _usage_attr(usage, "prompt_cache_hit_tokens") + (
+                    _usage_attr(usage, "prompt_cache_miss_tokens")
+                )
+
+            pt = _usage_int(prompt_tokens)
+            ct = _usage_int(completion_tokens)
             return pt > 0 or ct > 0
         except Exception:
             return False
@@ -206,37 +273,30 @@ class Telemetry(BaseModel):
           - input_tokens_details.cached_tokens
           - output_tokens_details.reasoning_tokens
         """
-        prompt_tokens = int(
+        prompt_tokens = _usage_int(
             getattr(usage, "prompt_tokens", None)
             or getattr(usage, "input_tokens", 0)
             or 0
         )
-        completion_tokens = int(
+        if not prompt_tokens:
+            prompt_tokens = _usage_attr(usage, "prompt_cache_hit_tokens") + (
+                _usage_attr(usage, "prompt_cache_miss_tokens")
+            )
+
+        completion_tokens = _usage_int(
             getattr(usage, "completion_tokens", None)
             or getattr(usage, "output_tokens", 0)
             or 0
         )
 
-        cache_read = 0
-        p_details = getattr(usage, "prompt_tokens_details", None) or getattr(
-            usage, "input_tokens_details", None
-        )
-        if p_details is not None:
-            cache_read = int(getattr(p_details, "cached_tokens", 0) or 0)
-
-        # Kimi-K2-thinking populate usage.cached_tokens field
-        if not cache_read and hasattr(usage, "cached_tokens"):
-            cache_read = int(getattr(usage, "cached_tokens", 0) or 0)
+        cache_read = _cache_read_tokens(usage)
 
         reasoning_tokens = 0
-        c_details = getattr(usage, "completion_tokens_details", None) or getattr(
-            usage, "output_tokens_details", None
-        )
+        c_details = _completion_token_details(usage)
         if c_details is not None:
-            reasoning_tokens = int(getattr(c_details, "reasoning_tokens", 0) or 0)
+            reasoning_tokens = _usage_attr(c_details, "reasoning_tokens")
 
-        # Chat-specific: litellm may set a hidden cache write field
-        cache_write = int(getattr(usage, "_cache_creation_input_tokens", 0) or 0)
+        cache_write = _cache_write_tokens(usage)
 
         self.metrics.add_token_usage(
             prompt_tokens=prompt_tokens,
@@ -321,38 +381,32 @@ class Telemetry(BaseModel):
             try:
                 usage = getattr(resp, "usage", None)
                 if usage:
-                    prompt_tokens = int(
+                    prompt_tokens = _usage_int(
                         getattr(usage, "prompt_tokens", None)
                         or getattr(usage, "input_tokens", 0)
                         or 0
                     )
-                    completion_tokens = int(
+                    if not prompt_tokens:
+                        prompt_tokens = _usage_attr(
+                            usage, "prompt_cache_hit_tokens"
+                        ) + _usage_attr(usage, "prompt_cache_miss_tokens")
+
+                    completion_tokens = _usage_int(
                         getattr(usage, "completion_tokens", None)
                         or getattr(usage, "output_tokens", 0)
                         or 0
                     )
-                    details = getattr(
-                        usage, "completion_tokens_details", None
-                    ) or getattr(usage, "output_tokens_details", None)
+                    details = _completion_token_details(usage)
                     reasoning_tokens = (
-                        int(getattr(details, "reasoning_tokens", 0) or 0)
-                        if details
-                        else 0
-                    )
-                    p_details = getattr(
-                        usage, "prompt_tokens_details", None
-                    ) or getattr(usage, "input_tokens_details", None)
-                    cache_read_tokens = (
-                        int(getattr(p_details, "cached_tokens", 0) or 0)
-                        if p_details
-                        else 0
+                        _usage_attr(details, "reasoning_tokens") if details else 0
                     )
 
                     data["usage_summary"] = {
                         "prompt_tokens": prompt_tokens,
                         "completion_tokens": completion_tokens,
                         "reasoning_tokens": reasoning_tokens,
-                        "cache_read_tokens": cache_read_tokens,
+                        "cache_read_tokens": _cache_read_tokens(usage),
+                        "cache_write_tokens": _cache_write_tokens(usage),
                     }
             except Exception:
                 # Best-effort only; don't fail logging

--- a/tests/sdk/llm/test_llm_telemetry.py
+++ b/tests/sdk/llm/test_llm_telemetry.py
@@ -197,6 +197,51 @@ class TestTelemetryTokenUsage:
         token_usage = basic_telemetry.metrics.token_usages[0]
         assert token_usage.cache_write_tokens == 30
 
+    def test_record_usage_with_deepseek_cache_hit_tokens(self, basic_telemetry):
+        """Test token usage recording with DeepSeek cache hit tokens."""
+        usage = Usage.model_construct(
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            prompt_cache_hit_tokens=75,
+            prompt_cache_miss_tokens=25,
+        )
+
+        basic_telemetry._record_usage(usage, "test-id", 4096)
+
+        token_usage = basic_telemetry.metrics.token_usages[0]
+        assert token_usage.prompt_tokens == 100
+        assert token_usage.cache_read_tokens == 75
+
+    def test_record_usage_derives_deepseek_prompt_tokens(self, basic_telemetry):
+        """Test token usage recording when only DeepSeek cache buckets exist."""
+        usage = Usage.model_construct(
+            completion_tokens=50,
+            total_tokens=150,
+            prompt_cache_hit_tokens=75,
+            prompt_cache_miss_tokens=25,
+        )
+
+        basic_telemetry._record_usage(usage, "test-id", 4096)
+
+        token_usage = basic_telemetry.metrics.token_usages[0]
+        assert token_usage.prompt_tokens == 100
+        assert token_usage.cache_read_tokens == 75
+
+    def test_record_usage_with_top_level_cache_creation(self, basic_telemetry):
+        """Test token usage recording with public cache creation tokens."""
+        usage = Usage.model_construct(
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            cache_creation_input_tokens=30,
+        )
+
+        basic_telemetry._record_usage(usage, "test-id", 4096)
+
+        token_usage = basic_telemetry.metrics.token_usages[0]
+        assert token_usage.cache_write_tokens == 30
+
     def test_record_usage_missing_tokens(self, basic_telemetry):
         """Test token usage recording with missing token counts."""
         usage = Usage()  # Empty usage


### PR DESCRIPTION
HUMAN:

I reviewed this telemetry fix and want DeepSeek cache-hit token accounting preserved correctly.

---

AGENT:

## Why

DeepSeek-compatible usage payloads can report cache hits as top-level `prompt_cache_hit_tokens`, with `prompt_tokens` equal to cache hits plus misses. OpenHands telemetry already tracks cache read/write buckets, but the current normalization only reads nested `prompt_tokens_details.cached_tokens`, `input_tokens_details.cached_tokens`, or `usage.cached_tokens`, so DeepSeek cache hits can be recorded as zero cache-read tokens.

That makes cache-heavy DeepSeek runs look like ordinary input-token usage in SDK metrics, downstream agent-server stats, and UI consumers.

## Summary

- Normalize cache-read tokens from DeepSeek-style `prompt_cache_hit_tokens` and top-level `cache_read_input_tokens`.
- Normalize cache-write tokens from public top-level `cache_creation_input_tokens` and prompt detail write fields, while preserving the existing LiteLLM private-field path.
- Reuse the same normalization in optional LLM call logs so `usage_summary` matches recorded metrics.
- Add regression coverage for DeepSeek cache hits, hit+miss prompt-token fallback, and public cache-creation fields.

## Issue Number

Fixes #4491

## How to Test

```
uv run pytest tests/sdk/llm/test_llm_telemetry.py -q
```

Result: 45 passed.

```
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/telemetry.py tests/sdk/llm/test_llm_telemetry.py
```

Result: YAML skipped; Ruff format, Ruff lint, pycodestyle, pyright, import rules, and tool registration checks passed.

## Video/Screenshots

No UI surface. This is telemetry normalization covered by unit tests.

## Design Doc

Not added. This is a narrow telemetry bug fix with no public API change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.36s · commit 8be0c90  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 14.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 88.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 589942e6474f6456950b134d35a4a9247aca4051cbb6e54f53ee93704d29671a -->
<!-- jev-fast-audit:end -->
