### PR TITLE
fix(sdk): resolve workspace default from active LLM profile

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -339,8 +339,10 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         """Return the validated agent settings from ``GET /api/settings``.
 
         Uses ``X-Expose-Secrets: plaintext`` so secret fields (e.g. LLM
-        api_key) are returned as plain strings. The persisted settings migration
-        entry point selects the correct discriminated-union variant.
+        api_key) are returned as plain strings. The validated
+        ``SettingsResponse`` is narrowed through
+        :meth:`SettingsResponse.get_agent_settings`, which selects the correct
+        discriminated-union variant.
         """
         return self._fetch_settings_response().get_agent_settings()
 
@@ -405,7 +407,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if profile_name is None:
             settings_response = self._fetch_settings_response(expose_secrets=False)
             resolved_profile_name = settings_response.active_profile
-            if not resolved_profile_name:
+            if resolved_profile_name in (None, ""):
                 settings_response = self._fetch_settings_response()
                 agent_settings = settings_response.get_agent_settings()
                 if not llm_kwargs:

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -321,15 +321,11 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     # settings endpoints. Subclasses like OpenHandsCloudWorkspace may override
     # to use alternative endpoints (e.g., Cloud API).
 
-    def _fetch_settings_response(self) -> SettingsResponse:
-        """Call ``GET /api/settings`` with plaintext secret exposure.
-
-        Keep the outer response available so default LLM resolution can honor
-        ``active_profile`` rather than discarding the pointer and silently using
-        a stale ``agent_settings.llm`` payload.
-        """
+    def _fetch_settings_response(self, *, expose_secrets: bool = True) -> SettingsResponse:
+        """Call ``GET /api/settings`` and return the validated response."""
         headers = dict(self._headers)
-        headers["X-Expose-Secrets"] = "plaintext"
+        if expose_secrets:
+            headers["X-Expose-Secrets"] = "plaintext"
 
         response = self.client.get("/api/settings", headers=headers)
         response.raise_for_status()
@@ -378,7 +374,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         If no ``active_profile`` is configured, the legacy
         ``agent_settings.llm`` payload is used as a fallback (preserving
         backward compatibility for servers that have not adopted named
-        profiles), with a warning.
+        profiles).
 
         Args:
             profile_name: Optional LLM profile name. When provided, loads that
@@ -405,9 +401,10 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             raise RuntimeError("Workspace host is not set")
 
         if profile_name is None:
-            settings_response = self._fetch_settings_response()
+            settings_response = self._fetch_settings_response(expose_secrets=False)
             resolved_profile_name = settings_response.active_profile
             if resolved_profile_name is None:
+                settings_response = self._fetch_settings_response()
                 agent_settings = settings_response.get_agent_settings()
                 if not llm_kwargs:
                     return agent_settings.llm

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -371,16 +371,16 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         reraise=True,
     )
     def get_llm(self, profile_name: str | None = None, **llm_kwargs: Any) -> "LLM":
-        """Fetch LLM settings from persisted settings or a named profile.
+        """Fetch the active LLM profile or fall back to persisted settings.
 
         Args:
             profile_name: Optional LLM profile name. When provided, loads that
-                named profile instead of the active persisted LLM settings.
+                named profile instead of resolving the active profile.
             **llm_kwargs: Additional keyword arguments that override persisted
                 or profile values (e.g., ``model``, ``temperature``).
 
         Returns:
-            An LLM instance configured with the persisted settings or profile.
+            An LLM instance configured with the active profile or persisted settings.
 
         Raises:
             FileNotFoundError: If ``profile_name`` does not exist.
@@ -417,7 +417,8 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
                 "falling back to agent_settings.llm. Configure a named "
                 "profile and activate it to ensure credentials are preserved."
             )
-            settings = settings_response.get_agent_settings()  # type: ignore[union-attr]
+            assert settings_response is not None
+            settings = settings_response.get_agent_settings()
             if not llm_kwargs:
                 return settings.llm
             llm_data = settings.llm.model_dump(context={"expose_secrets": "plaintext"})

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -373,6 +373,13 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     def get_llm(self, profile_name: str | None = None, **llm_kwargs: Any) -> "LLM":
         """Fetch the active or explicitly named LLM profile.
 
+        When no ``profile_name`` is given, the persisted ``active_profile``
+        pointer is resolved first (so the UI-advertised default is honored).
+        If no ``active_profile`` is configured, the legacy
+        ``agent_settings.llm`` payload is used as a fallback (preserving
+        backward compatibility for servers that have not adopted named
+        profiles), with a warning.
+
         Args:
             profile_name: Optional LLM profile name. When provided, loads that
                 named profile instead of resolving the active profile.
@@ -397,7 +404,6 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if not self.host or self.host == "undefined":
             raise RuntimeError("Workspace host is not set")
 
-        llm_data: dict[str, Any] = {}
         resolved_profile_name = profile_name
         settings_response: SettingsResponse | None = None
         if resolved_profile_name is None:
@@ -405,10 +411,21 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             resolved_profile_name = settings_response.active_profile
 
         if resolved_profile_name is None:
-            raise RuntimeError("No active LLM profile is configured")
+            assert settings_response is not None  # reachable only via the fetch above
+            logger.warning(
+                "No active LLM profile is configured; falling back to legacy "
+                "agent_settings.llm. Set an active profile to avoid stale settings."
+            )
+            agent_settings = settings_response.get_agent_settings()
+            if not llm_kwargs:
+                return agent_settings.llm
+            llm_data = agent_settings.llm.model_dump(
+                context={"expose_secrets": "plaintext"}
+            )
+        else:
+            llm_data = self._fetch_llm_profile_config(resolved_profile_name)
+            llm_data["usage_id"] = f"profile:{resolved_profile_name}"
 
-        llm_data = self._fetch_llm_profile_config(resolved_profile_name)
-        llm_data["usage_id"] = f"profile:{resolved_profile_name}"
         llm_data.update(llm_kwargs)
         return LLM(**llm_data)
 

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -321,27 +321,30 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     # settings endpoints. Subclasses like OpenHandsCloudWorkspace may override
     # to use alternative endpoints (e.g., Cloud API).
 
-    def _fetch_agent_settings(
-        self,
-    ) -> "OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings":
-        """Call ``GET /api/settings`` and return a validated settings model.
+    def _fetch_settings_response(self) -> SettingsResponse:
+        """Call ``GET /api/settings`` with plaintext secret exposure.
 
-        Uses ``X-Expose-Secrets: plaintext`` so secret fields (e.g. LLM
-        api_key) are returned as plain strings.  The outer response is
-        validated via :class:`SettingsResponse`, then the ``agent_settings``
-        dict is validated through :meth:`SettingsResponse.get_agent_settings`,
-        which applies the persisted settings migration entry point before
-        picking the correct discriminated-union variant
-        (``OpenHandsAgentSettings`` or ``ACPAgentSettings``).
+        Keep the outer response available so default LLM resolution can honor
+        ``active_profile`` rather than discarding the pointer and silently using
+        a stale ``agent_settings.llm`` payload.
         """
         headers = dict(self._headers)
         headers["X-Expose-Secrets"] = "plaintext"
 
         response = self.client.get("/api/settings", headers=headers)
         response.raise_for_status()
+        return SettingsResponse.model_validate(response.json())
 
-        data = SettingsResponse.model_validate(response.json())
-        return data.get_agent_settings()
+    def _fetch_agent_settings(
+        self,
+    ) -> "OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings":
+        """Return the validated agent settings from ``GET /api/settings``.
+
+        Uses ``X-Expose-Secrets: plaintext`` so secret fields (e.g. LLM
+        api_key) are returned as plain strings. The persisted settings migration
+        entry point selects the correct discriminated-union variant.
+        """
+        return self._fetch_settings_response().get_agent_settings()
 
     def _fetch_llm_profile_config(self, profile_name: str) -> dict[str, Any]:
         """Call ``GET /api/profiles/{name}`` and return plaintext LLM config."""
@@ -394,11 +397,27 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if not self.host or self.host == "undefined":
             raise RuntimeError("Workspace host is not set")
 
-        if profile_name:
-            llm_data = self._fetch_llm_profile_config(profile_name)
-            llm_data["usage_id"] = f"profile:{profile_name}"
+        llm_data: dict[str, Any] = {}
+        resolved_profile_name = profile_name
+        settings_response: SettingsResponse | None = None
+        if resolved_profile_name is None:
+            settings_response = self._fetch_settings_response()
+            resolved_profile_name = settings_response.active_profile
+
+        if resolved_profile_name is not None:
+            llm_data = self._fetch_llm_profile_config(resolved_profile_name)
+            llm_data["usage_id"] = f"profile:{resolved_profile_name}"
         else:
-            settings = self._fetch_agent_settings()
+            # No active_profile is set on the server. Fall back to the legacy
+            # agent_settings.llm payload, but log a warning so the caller knows
+            # they are not using a named profile and may be using stale or
+            # keyless configuration.
+            logger.warning(
+                "No active LLM profile is set on the agent-server; "
+                "falling back to agent_settings.llm. Configure a named "
+                "profile and activate it to ensure credentials are preserved."
+            )
+            settings = settings_response.get_agent_settings()  # type: ignore[union-attr]
             if not llm_kwargs:
                 return settings.llm
             llm_data = settings.llm.model_dump(context={"expose_secrets": "plaintext"})

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -404,22 +404,22 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if not self.host or self.host == "undefined":
             raise RuntimeError("Workspace host is not set")
 
-        resolved_profile_name = profile_name
-        settings_response: SettingsResponse | None = None
-        if resolved_profile_name is None:
+        if profile_name is None:
             settings_response = self._fetch_settings_response()
             resolved_profile_name = settings_response.active_profile
-
-        if resolved_profile_name is None:
-            agent_settings = settings_response.get_agent_settings()
-            if not llm_kwargs:
-                return agent_settings.llm
-            llm_data = agent_settings.llm.model_dump(
-                context={"expose_secrets": "plaintext"}
-            )
+            if resolved_profile_name is None:
+                agent_settings = settings_response.get_agent_settings()
+                if not llm_kwargs:
+                    return agent_settings.llm
+                llm_data = agent_settings.llm.model_dump(
+                    context={"expose_secrets": "plaintext"}
+                )
+            else:
+                llm_data = self._fetch_llm_profile_config(resolved_profile_name)
+                llm_data["usage_id"] = f"profile:{resolved_profile_name}"
         else:
-            llm_data = self._fetch_llm_profile_config(resolved_profile_name)
-            llm_data["usage_id"] = f"profile:{resolved_profile_name}"
+            llm_data = self._fetch_llm_profile_config(profile_name)
+            llm_data["usage_id"] = f"profile:{profile_name}"
 
         llm_data.update(llm_kwargs)
         return LLM(**llm_data)

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -405,7 +405,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if profile_name is None:
             settings_response = self._fetch_settings_response(expose_secrets=False)
             resolved_profile_name = settings_response.active_profile
-            if resolved_profile_name is None:
+            if not resolved_profile_name:
                 settings_response = self._fetch_settings_response()
                 agent_settings = settings_response.get_agent_settings()
                 if not llm_kwargs:

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -411,11 +411,6 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             resolved_profile_name = settings_response.active_profile
 
         if resolved_profile_name is None:
-            assert settings_response is not None  # reachable only via the fetch above
-            logger.warning(
-                "No active LLM profile is configured; falling back to legacy "
-                "agent_settings.llm. Set an active profile to avoid stale settings."
-            )
             agent_settings = settings_response.get_agent_settings()
             if not llm_kwargs:
                 return agent_settings.llm

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -321,7 +321,9 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     # settings endpoints. Subclasses like OpenHandsCloudWorkspace may override
     # to use alternative endpoints (e.g., Cloud API).
 
-    def _fetch_settings_response(self, *, expose_secrets: bool = True) -> SettingsResponse:
+    def _fetch_settings_response(
+        self, *, expose_secrets: bool = True
+    ) -> SettingsResponse:
         """Call ``GET /api/settings`` and return the validated response."""
         headers = dict(self._headers)
         if expose_secrets:

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -371,16 +371,16 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         reraise=True,
     )
     def get_llm(self, profile_name: str | None = None, **llm_kwargs: Any) -> "LLM":
-        """Fetch the active LLM profile or fall back to persisted settings.
+        """Fetch the active or explicitly named LLM profile.
 
         Args:
             profile_name: Optional LLM profile name. When provided, loads that
                 named profile instead of resolving the active profile.
-            **llm_kwargs: Additional keyword arguments that override persisted
-                or profile values (e.g., ``model``, ``temperature``).
+            **llm_kwargs: Additional keyword arguments that override profile
+                values (e.g., ``model``, ``temperature``).
 
         Returns:
-            An LLM instance configured with the active profile or persisted settings.
+            An LLM instance configured with the active or named profile.
 
         Raises:
             FileNotFoundError: If ``profile_name`` does not exist.
@@ -404,25 +404,11 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             settings_response = self._fetch_settings_response()
             resolved_profile_name = settings_response.active_profile
 
-        if resolved_profile_name is not None:
-            llm_data = self._fetch_llm_profile_config(resolved_profile_name)
-            llm_data["usage_id"] = f"profile:{resolved_profile_name}"
-        else:
-            # No active_profile is set on the server. Fall back to the legacy
-            # agent_settings.llm payload, but log a warning so the caller knows
-            # they are not using a named profile and may be using stale or
-            # keyless configuration.
-            logger.warning(
-                "No active LLM profile is set on the agent-server; "
-                "falling back to agent_settings.llm. Configure a named "
-                "profile and activate it to ensure credentials are preserved."
-            )
-            assert settings_response is not None
-            settings = settings_response.get_agent_settings()
-            if not llm_kwargs:
-                return settings.llm
-            llm_data = settings.llm.model_dump(context={"expose_secrets": "plaintext"})
+        if resolved_profile_name is None:
+            raise RuntimeError("No active LLM profile is configured")
 
+        llm_data = self._fetch_llm_profile_config(resolved_profile_name)
+        llm_data["usage_id"] = f"profile:{resolved_profile_name}"
         llm_data.update(llm_kwargs)
         return LLM(**llm_data)
 

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -164,6 +164,14 @@ def live_server_env(
             shutil.rmtree(cwd_conversations)
 
 
+def _assert_secret(value: "str | SecretStr", expected: str) -> None:
+    """Assert a SecretStr-or-str api_key matches the expected plaintext."""
+    if isinstance(value, SecretStr):
+        assert value.get_secret_value() == expected
+    else:
+        assert value == expected
+
+
 def test_health_endpoints_return_ok_json(server_env):
     with httpx.Client() as client:
         for endpoint in ("/alive", "/health"):
@@ -2131,6 +2139,77 @@ def test_remote_state_exposes_invoked_skills(
     assert obs_text.rstrip().endswith("relative to that directory.")
 
     conv.close()
+
+
+def test_workspace_default_llm_resolves_active_profile_despite_settings_drift(
+    tmp_path, monkeypatch
+):
+    """An unpinned automation gets the UI-advertised active named profile.
+
+    Reproduces the production drift through real HTTP endpoints: activate GLM,
+    then patch only legacy agent_settings.llm to keyless GPT while leaving the
+    active pointer untouched. RemoteWorkspace.get_llm() must resolve GLM and its
+    named-profile credential. Explicit profile selection remains an override.
+    """
+    with live_server_env(tmp_path, monkeypatch) as env:
+        with httpx.Client(base_url=env["host"], timeout=10.0) as client:
+            save_glm = client.post(
+                "/api/profiles/glm-default",
+                json={
+                    "llm": {
+                        "model": "openhands/glm-5.2",
+                        "api_key": "sk-glm-key",
+                    },
+                    "include_secrets": True,
+                },
+            )
+            assert save_glm.status_code == 201
+            assert client.post("/api/profiles/glm-default/activate").status_code == 200
+
+            save_explicit = client.post(
+                "/api/profiles/explicit-model",
+                json={
+                    "llm": {
+                        "model": "openrouter/explicit-model",
+                        "api_key": "sk-explicit-key",
+                    },
+                    "include_secrets": True,
+                },
+            )
+            assert save_explicit.status_code == 201
+
+            drift = client.patch(
+                "/api/settings",
+                json={
+                    "agent_settings_diff": {
+                        "llm": {"model": "gpt-5.5", "api_key": None}
+                    }
+                },
+            )
+            assert drift.status_code == 200
+
+            profiles = client.get("/api/profiles").json()
+            settings = client.get("/api/settings").json()
+            assert profiles["active_profile"] == "glm-default"
+            assert settings["active_profile"] == "glm-default"
+            assert settings["agent_settings"]["llm"]["model"] == "gpt-5.5"
+
+        workspace = RemoteWorkspace(
+            host=env["host"],
+            working_dir=str(env["workspace_path"]),
+        )
+        default_llm = workspace.get_llm()
+        assert default_llm.model == "openhands/glm-5.2"
+        assert default_llm.api_key is not None
+        _assert_secret(default_llm.api_key, "sk-glm-key")
+        assert default_llm.usage_id == "profile:glm-default"
+
+        # Mirrors an explicit AUTOMATION_MODEL/profile_name override.
+        explicit_llm = workspace.get_llm(profile_name="explicit-model")
+        assert explicit_llm.model == "openrouter/explicit-model"
+        assert explicit_llm.api_key is not None
+        _assert_secret(explicit_llm.api_key, "sk-explicit-key")
+        assert explicit_llm.usage_id == "profile:explicit-model"
 
 
 def test_settings_and_secrets_api_with_live_server(server_env):

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -431,10 +431,21 @@ def test_get_llm_returns_configured_llm(monkeypatch):
         },
         "conversation_settings": {},
         "llm_api_key_is_set": True,
-        "active_profile": None,
+        "active_profile": "default",
     }
     mock_response.raise_for_status = Mock()
-    mock_client.get.return_value = mock_response
+    profile_response = Mock()
+    profile_response.status_code = 200
+    profile_response.raise_for_status = Mock()
+    profile_response.json.return_value = {
+        "name": "default",
+        "config": {
+            "model": "gpt-4",
+            "api_key": "sk-test-key",
+            "base_url": "https://api.openai.com/v1",
+        },
+    }
+    mock_client.get.side_effect = [mock_response, profile_response]
     workspace._client = mock_client
 
     llm = workspace.get_llm()
@@ -449,12 +460,10 @@ def test_get_llm_returns_configured_llm(monkeypatch):
         assert llm.api_key == "sk-test-key"
     assert llm.base_url == "https://api.openai.com/v1"
 
-    # Verify API was called with correct headers
-    mock_client.get.assert_called_once()
-    call_args = mock_client.get.call_args
-    assert call_args[0][0] == "/api/settings"
-    assert call_args[1]["headers"]["X-Expose-Secrets"] == "plaintext"
-    assert call_args[1]["headers"]["X-Session-API-Key"] == "test-key"
+    assert [call.args[0] for call in mock_client.get.call_args_list] == [
+        "/api/settings",
+        "/api/profiles/default",
+    ]
 
 
 def test_get_llm_without_name_resolves_active_profile(monkeypatch):
@@ -505,10 +514,8 @@ def test_get_llm_without_name_resolves_active_profile(monkeypatch):
     ]
 
 
-def test_get_llm_without_active_profile_warns_and_falls_back(monkeypatch, caplog):
-    """When no active_profile is set, fall back to agent_settings.llm with a warning."""
-    import logging
-
+def test_get_llm_without_active_profile_fails(monkeypatch):
+    """When no active_profile is set, fail instead of using stale settings."""
     monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
     workspace = RemoteWorkspace(
         host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
@@ -529,11 +536,13 @@ def test_get_llm_without_active_profile_warns_and_falls_back(monkeypatch, caplog
     client.get.return_value = settings_response
     workspace._client = client
 
-    with caplog.at_level(logging.WARNING, logger="openhands.sdk.workspace.remote.base"):
-        llm = workspace.get_llm()
+    with pytest.raises(RuntimeError, match="No active LLM profile is configured"):
+        workspace.get_llm()
 
-    assert llm.model == "gpt-4"
-    assert "No active LLM profile" in caplog.text
+    client.get.assert_called_once_with(
+        "/api/settings",
+        headers={"X-Session-API-Key": "test-key", "X-Expose-Secrets": "plaintext"},
+    )
 
 
 def test_get_llm_with_kwargs_override(monkeypatch):
@@ -558,12 +567,23 @@ def test_get_llm_with_kwargs_override(monkeypatch):
         },
         "conversation_settings": {},
         "llm_api_key_is_set": True,
+        "active_profile": "default",
     }
     mock_response.raise_for_status = Mock()
-    mock_client.get.return_value = mock_response
+    profile_response = Mock()
+    profile_response.status_code = 200
+    profile_response.raise_for_status = Mock()
+    profile_response.json.return_value = {
+        "name": "default",
+        "config": {
+            "model": "gpt-3.5-turbo",
+            "api_key": "sk-persisted-key",
+        },
+    }
+    mock_client.get.side_effect = [mock_response, profile_response]
     workspace._client = mock_client
 
-    # Override model but use persisted API key
+    # Override model but use the active profile API key
     llm = workspace.get_llm(model="gpt-4o")
 
     assert llm.model == "gpt-4o"  # Overridden

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -559,6 +559,31 @@ def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
     }
 
 
+def test_get_llm_with_empty_active_profile_falls_back_to_legacy(monkeypatch):
+    """Malformed empty active_profile values use the legacy fallback."""
+    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/tmp")
+
+    settings_response = Mock()
+    settings_response.json.return_value = {
+        "agent_settings": {"llm": {"model": "gpt-4", "api_key": "sk-legacy"}},
+        "conversation_settings": {},
+        "llm_api_key_is_set": True,
+        "active_profile": "",
+    }
+    settings_response.raise_for_status = Mock()
+
+    client = MagicMock()
+    client.get.return_value = settings_response
+    workspace._client = client
+
+    assert workspace.get_llm().model == "gpt-4"
+    assert [call.args[0] for call in client.get.call_args_list] == [
+        "/api/settings",
+        "/api/settings",
+    ]
+
+
 def test_get_llm_with_kwargs_override(monkeypatch):
     """Test get_llm allows kwargs to override persisted settings."""
     from pydantic import SecretStr

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -514,8 +514,10 @@ def test_get_llm_without_name_resolves_active_profile(monkeypatch):
     ]
 
 
-def test_get_llm_without_active_profile_fails(monkeypatch):
-    """When no active_profile is set, fail instead of using stale settings."""
+def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
+    """When no active_profile is set, fall back to legacy agent_settings.llm."""
+    from pydantic import SecretStr
+
     monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
     workspace = RemoteWorkspace(
         host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
@@ -536,9 +538,13 @@ def test_get_llm_without_active_profile_fails(monkeypatch):
     client.get.return_value = settings_response
     workspace._client = client
 
-    with pytest.raises(RuntimeError, match="No active LLM profile is configured"):
-        workspace.get_llm()
+    llm = workspace.get_llm()
 
+    assert llm.model == "gpt-4"
+    assert isinstance(llm.api_key, SecretStr)
+    assert llm.api_key.get_secret_value() == "sk-legacy"
+
+    # Only /api/settings is fetched; no profile lookup since active_profile is None.
     client.get.assert_called_once_with(
         "/api/settings",
         headers={"X-Session-API-Key": "test-key", "X-Expose-Secrets": "plaintext"},

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -514,8 +514,11 @@ def test_get_llm_without_name_resolves_active_profile(monkeypatch):
     ]
 
 
-def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
-    """When no active_profile is set, fall back to legacy agent_settings.llm."""
+@pytest.mark.parametrize("active_profile", [None, ""])
+def test_get_llm_without_active_profile_falls_back_to_legacy(
+    monkeypatch, active_profile
+):
+    """Falsy active_profile values use the legacy agent_settings.llm fallback."""
     from pydantic import SecretStr
 
     monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
@@ -530,7 +533,7 @@ def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
         },
         "conversation_settings": {},
         "llm_api_key_is_set": True,
-        "active_profile": None,
+        "active_profile": active_profile,
     }
     settings_response.raise_for_status = Mock()
 
@@ -557,31 +560,6 @@ def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
         "X-Session-API-Key": "test-key",
         "X-Expose-Secrets": "plaintext",
     }
-
-
-def test_get_llm_with_empty_active_profile_falls_back_to_legacy(monkeypatch):
-    """Malformed empty active_profile values use the legacy fallback."""
-    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/tmp")
-
-    settings_response = Mock()
-    settings_response.json.return_value = {
-        "agent_settings": {"llm": {"model": "gpt-4", "api_key": "sk-legacy"}},
-        "conversation_settings": {},
-        "llm_api_key_is_set": True,
-        "active_profile": "",
-    }
-    settings_response.raise_for_status = Mock()
-
-    client = MagicMock()
-    client.get.return_value = settings_response
-    workspace._client = client
-
-    assert workspace.get_llm().model == "gpt-4"
-    assert [call.args[0] for call in client.get.call_args_list] == [
-        "/api/settings",
-        "/api/settings",
-    ]
 
 
 def test_get_llm_with_kwargs_override(monkeypatch):

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -431,6 +431,7 @@ def test_get_llm_returns_configured_llm(monkeypatch):
         },
         "conversation_settings": {},
         "llm_api_key_is_set": True,
+        "active_profile": None,
     }
     mock_response.raise_for_status = Mock()
     mock_client.get.return_value = mock_response
@@ -454,6 +455,85 @@ def test_get_llm_returns_configured_llm(monkeypatch):
     assert call_args[0][0] == "/api/settings"
     assert call_args[1]["headers"]["X-Expose-Secrets"] == "plaintext"
     assert call_args[1]["headers"]["X-Session-API-Key"] == "test-key"
+
+
+def test_get_llm_without_name_resolves_active_profile(monkeypatch):
+    """Default resolution honors active_profile, not stale agent settings."""
+    from pydantic import SecretStr
+
+    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
+    workspace = RemoteWorkspace(
+        host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
+    )
+
+    settings_response = Mock()
+    settings_response.json.return_value = {
+        "agent_settings": {
+            "llm": {"model": "gpt-5.5", "api_key": None},
+        },
+        "conversation_settings": {},
+        "llm_api_key_is_set": False,
+        "active_profile": "glm-default",
+    }
+    settings_response.raise_for_status = Mock()
+    profile_response = Mock()
+    profile_response.status_code = 200
+    profile_response.json.return_value = {
+        "name": "glm-default",
+        "config": {
+            "model": "openhands/glm-5.2",
+            "api_key": "sk-glm-key",
+            "usage_id": "default",
+        },
+        "api_key_set": True,
+    }
+    profile_response.raise_for_status = Mock()
+
+    client = MagicMock()
+    client.get.side_effect = [settings_response, profile_response]
+    workspace._client = client
+
+    llm = workspace.get_llm()
+
+    assert llm.model == "openhands/glm-5.2"
+    assert isinstance(llm.api_key, SecretStr)
+    assert llm.api_key.get_secret_value() == "sk-glm-key"
+    assert llm.usage_id == "profile:glm-default"
+    assert [call.args[0] for call in client.get.call_args_list] == [
+        "/api/settings",
+        "/api/profiles/glm-default",
+    ]
+
+
+def test_get_llm_without_active_profile_warns_and_falls_back(monkeypatch, caplog):
+    """When no active_profile is set, fall back to agent_settings.llm with a warning."""
+    import logging
+
+    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
+    workspace = RemoteWorkspace(
+        host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
+    )
+
+    settings_response = Mock()
+    settings_response.json.return_value = {
+        "agent_settings": {
+            "llm": {"model": "gpt-4", "api_key": "sk-legacy"},
+        },
+        "conversation_settings": {},
+        "llm_api_key_is_set": True,
+        "active_profile": None,
+    }
+    settings_response.raise_for_status = Mock()
+
+    client = MagicMock()
+    client.get.return_value = settings_response
+    workspace._client = client
+
+    with caplog.at_level(logging.WARNING, logger="openhands.sdk.workspace.remote.base"):
+        llm = workspace.get_llm()
+
+    assert llm.model == "gpt-4"
+    assert "No active LLM profile" in caplog.text
 
 
 def test_get_llm_with_kwargs_override(monkeypatch):

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -544,11 +544,19 @@ def test_get_llm_without_active_profile_falls_back_to_legacy(monkeypatch):
     assert isinstance(llm.api_key, SecretStr)
     assert llm.api_key.get_secret_value() == "sk-legacy"
 
-    # Only /api/settings is fetched; no profile lookup since active_profile is None.
-    client.get.assert_called_once_with(
+    # Discovery avoids exposing legacy credentials; the fallback fetches them only
+    # when active_profile is absent.
+    assert [call.args[0] for call in client.get.call_args_list] == [
         "/api/settings",
-        headers={"X-Session-API-Key": "test-key", "X-Expose-Secrets": "plaintext"},
-    )
+        "/api/settings",
+    ]
+    assert client.get.call_args_list[0].kwargs["headers"] == {
+        "X-Session-API-Key": "test-key"
+    }
+    assert client.get.call_args_list[1].kwargs["headers"] == {
+        "X-Session-API-Key": "test-key",
+        "X-Expose-Secrets": "plaintext",
+    }
 
 
 def test_get_llm_with_kwargs_override(monkeypatch):


### PR DESCRIPTION
HUMAN:

This fixes a silent model/credential drift where unpinned automations launched with a stale keyless LLM instead of the UI-advertised default.

---

AGENT:

## Why

Fixes #4494.

`RemoteWorkspace.get_llm()` with no `profile_name` fetched `/api/settings` and returned `agent_settings.llm` directly, ignoring the `active_profile` pointer. A subsequent `PATCH /api/settings` containing an explicit `agent_settings_diff.llm` can update the legacy LLM payload while leaving `active_profile` unchanged, so the server advertises one default while SDK callers consume a different, potentially keyless model.

Two production automation conversations launched with keyless `gpt-5.5` and failed authentication, even though the UI showed `glm-5.2` as the active default LLM profile.

## Summary

- `RemoteWorkspace.get_llm(None)` now resolves the persisted `active_profile` pointer from `/api/settings` and loads that named profile via `/api/profiles/{name}`, preserving its credentials.
- When no `active_profile` is set, the previous fallback to `agent_settings.llm` is preserved.
- Explicit `profile_name` and `llm_kwargs` overrides remain unchanged.
- Added a unit test proving the active profile is resolved (mocked HTTP).
- Added a live-server integration test that activates GLM, drifts `agent_settings.llm` to keyless GPT via `PATCH /api/settings`, and proves `workspace.get_llm()` returns GLM with its key.
- The live test also proves explicit `profile_name` selection still overrides the default.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `4e9940e96caa` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -4,0 +5 @@
+operation DELETE /api/llm/provider-connections/{connection_id} operationId=delete_provider_connection_api_llm_provider_connections__connection_id__delete
@@ -40,0 +42 @@
+operation GET /api/llm/provider-connections operationId=list_provider_connections_api_llm_provider_connections_get
@@ -62,0 +65 @@
+operation PATCH /api/llm/provider-connections/{connection_id} operationId=update_provider_connection_api_llm_provider_connections__connection_id__patch
@@ -97,0 +101 @@
+operation POST /api/llm/provider-connections operationId=create_provider_connection_api_llm_provider_connections_post
@@ -121,0 +126 @@
+parameter DELETE /api/llm/provider-connections/{connection_id} path:connection_id required=true schema=type="string"
@@ -201,0 +207 @@
+parameter PATCH /api/llm/provider-connections/{connection_id} path:connection_id required=true schema=type="string"
@@ -243,0 +250 @@
+requestBody PATCH /api/llm/provider-connections/{connection_id} application/json required=true schema=ProviderConnectionUpdateRequest
@@ -268,0 +276 @@
+requestBody POST /api/llm/provider-connections application/json required=true schema=ProviderConnectionCreateRequest
@@ -291,0 +300,2 @@
+response DELETE /api/llm/provider-connections/{connection_id} 200 application/json schema=ProviderConnectionResponse
+response DELETE /api/llm/provider-connections/{connection_id} 422 application/json schema=HTTPValidationError
@@ -370,0 +381 @@
+response GET /api/llm/provider-connections 200 application/json schema=type="array" items=ProviderConnectionResponse
@@ -402,0 +414,2 @@
+response PATCH /api/llm/provider-connections/{connection_id} 200 application/json schema=ProviderConnectionResponse
+response PATCH /api/llm/provider-connections/{connection_id} 422 application/json schema=HTTPValidationError
@@ -500,0 +514,2 @@
+response POST /api/llm/provider-connections 201 application/json schema=ProviderConnectionResponse
+response POST /api/llm/provider-connections 422 application/json schema=HTTPValidationError
@@ -1568,0 +1584 @@
+schema LLM-Input property provider_connection_id optional schema=anyOf=[type="string",type="null"]
@@ -1624,0 +1641 @@
+schema LLM-Output property provider_connection_id optional schema=anyOf=[type="string",type="null"]
@@ -2066,0 +2084,2 @@
+schema ProfileInfo property provider_connection_broken optional schema=type="boolean" default=false
+schema ProfileInfo property provider_connection_id optional schema=anyOf=[type="string",type="null"]
@@ -2073,0 +2093,18 @@
+schema ProviderConnectionCreateRequest property api_key required schema=type="string" format="password" minLength=1
+schema ProviderConnectionCreateRequest property base_url optional schema=anyOf=[type="string" maxLength=2048,type="null"]
+schema ProviderConnectionCreateRequest property display_name required schema=type="string" minLength=1 maxLength=128
+schema ProviderConnectionCreateRequest property provider optional schema=type="string" default="custom" minLength=1 maxLength=128
+schema ProviderConnectionCreateRequest type="object" additionalProperties=false
+schema ProviderConnectionResponse property api_key_set optional schema=type="boolean" default=false
+schema ProviderConnectionResponse property base_url optional schema=anyOf=[type="string",type="null"]
+schema ProviderConnectionResponse property created_at required schema=type="integer"
+schema ProviderConnectionResponse property display_name required schema=type="string"
+schema ProviderConnectionResponse property id required schema=type="string"
+schema ProviderConnectionResponse property provider required schema=type="string"
+schema ProviderConnectionResponse property updated_at required schema=type="integer"
+schema ProviderConnectionResponse type="object"
+schema ProviderConnectionUpdateRequest property api_key optional schema=anyOf=[type="string" format="password",type="null"]
+schema ProviderConnectionUpdateRequest property base_url optional schema=anyOf=[type="string" maxLength=2048,type="null"]
+schema ProviderConnectionUpdateRequest property display_name optional schema=anyOf=[type="string" minLength=1 maxLength=128,type="null"]
+schema ProviderConnectionUpdateRequest property provider optional schema=anyOf=[type="string" minLength=1 maxLength=128,type="null"]
+schema ProviderConnectionUpdateRequest type="object" additionalProperties=false
@@ -2437,0 +2475 @@
+schema TelemetrySpec property deployment_kind optional schema=type="string" enum=["local","remote"] default="local"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Fixes #4494.

## How to Test

```bash
uv run pytest -q tests/sdk/workspace/remote/test_remote_workspace.py \
  -k get_llm --disable-warnings
# 6 passed

uv run pytest -q tests/cross/test_remote_conversation_live_server.py \
  -k workspace_default_llm_resolves_active_profile_despite_settings_drift -vv
# 1 passed (11.25s)
```

Before (on `origin/main`, same test):

```text
assert default_llm.model == "openhands/glm-5.2"
AssertionError: assert 'gpt-5.5' == 'openhands/glm-5.2'
```

After:

```text
test_workspace_default_llm_resolves_active_profile_despite_settings_drift PASSED
```

## Video/Screenshots

Before terminal capture:

```text
default_llm.model = gpt-5.5 (stale agent_settings.llm)
default_llm.api_key = None
```

After terminal capture:

```text
default_llm.model = openhands/glm-5.2 (active profile)
default_llm.api_key = sk-glm-key (named profile credential preserved)
default_llm.usage_id = profile:glm-default
explicit_llm.model = openrouter/explicit-model (override preserved)
```

## Design Doc

Not included. The change is localized to `RemoteWorkspace.get_llm()` default resolution.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The acceptance criteria from issue #4494 are addressed as follows:

- [x] Integration test activates named profile A, patches `agent_settings.llm` to B without changing the pointer, and proves the default path resolves A. (`test_workspace_default_llm_resolves_active_profile_despite_settings_drift`)
- [x] `RemoteWorkspace.get_llm()` with no `profile_name` returns the named active LLM profile. (same test + `test_get_llm_without_name_resolves_active_profile`)
- [x] An automation with `model = null` uses the same default LLM profile shown in Agent Canvas settings. (the live test reproduces the exact automation code path: `workspace.get_llm()` with no profile name)
- [x] Named-profile credentials are preserved; the default path does not silently downgrade to `api_key=None`. (the live test asserts `api_key` is not None and matches the profile's key)
- [x] Explicit `workspace.get_llm(profile_name="...")` behavior remains unchanged. (the live test also calls `get_llm(profile_name="explicit-model")` and asserts it returns that profile)
- [x] Explicit per-automation `AUTOMATION_MODEL` selection continues to override the default. (`AUTOMATION_MODEL` sets `profile_name`, which takes precedence over the new active-profile resolution)
- [x] Agent Profile model resolution remains unchanged and is clearly distinguished from workspace default-LLM resolution. (Agent Profile resolution happens in `useCreateConversation`; this PR only changes `RemoteWorkspace.get_llm()`)
- [x] Before/after test output included: before shows active profile GLM but resolves GPT; after shows both resolving GLM.

The `test_settings_and_secrets_api_with_live_server` failure is pre-existing on `origin/main` (environment secrets leak into the test server) and is not caused by this PR.













<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5c6cffb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5c6cffb-python \
  ghcr.io/openhands/agent-server:5c6cffb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5c6cffb-golang-amd64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-golang-amd64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-golang-amd64
ghcr.io/openhands/agent-server:5c6cffb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5c6cffb-golang-arm64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-golang-arm64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-golang-arm64
ghcr.io/openhands/agent-server:5c6cffb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5c6cffb-java-amd64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-java-amd64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-java-amd64
ghcr.io/openhands/agent-server:5c6cffb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5c6cffb-java-arm64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-java-arm64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-java-arm64
ghcr.io/openhands/agent-server:5c6cffb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5c6cffb-python-amd64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-python-amd64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-python-amd64
ghcr.io/openhands/agent-server:5c6cffb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5c6cffb-python-arm64
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-python-arm64
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-python-arm64
ghcr.io/openhands/agent-server:5c6cffb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5c6cffb-golang
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-golang
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-golang
ghcr.io/openhands/agent-server:5c6cffb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5c6cffb-java
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-java
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-java
ghcr.io/openhands/agent-server:5c6cffb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5c6cffb-python
ghcr.io/openhands/agent-server:5c6cffb385cd66259d5a160f411a3c88aa174f2d-python
ghcr.io/openhands/agent-server:fix-workspace-default-active-llm-python
ghcr.io/openhands/agent-server:5c6cffb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5c6cffb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5c6cffb-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
