### PR TITLE
fix: make dict-entry secret redaction case-insensitive

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -302,16 +302,18 @@ def redact_text_secrets(text: str) -> str:
     text = re.sub(r"api_key='[^']*'", "api_key='<redacted>'", text)
     text = re.sub(r'api_key="[^"]*"', 'api_key="<redacted>"', text)
 
-    # Dict entries with sensitive key names
+    # Dict entries with sensitive key names (case-insensitive, like is_secret_key)
     text = re.sub(
         r"('[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD)[A-Z_]*':\s*')[^']*(')",
         r"\g<1><redacted>\2",
         text,
+        flags=re.IGNORECASE,
     )
     text = re.sub(
         r'("[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD)[A-Z_]*":\s*")[^"]*(")',
         r"\g<1><redacted>\2",
         text,
+        flags=re.IGNORECASE,
     )
 
     # URL query params

--- a/tests/sdk/utils/test_redact.py
+++ b/tests/sdk/utils/test_redact.py
@@ -2,6 +2,7 @@
 
 from openhands.sdk.utils.redact import (
     SENSITIVE_URL_PARAMS,
+    redact_text_secrets,
     redact_url_credentials,
     redact_url_credentials_in_text,
     redact_url_params,
@@ -251,3 +252,35 @@ class TestRedactUrlCredentialsInText:
         """For a bare whole-URL string both helpers agree."""
         url = "https://oauth2:SECRET@gitlab.com/org/repo.git"
         assert redact_url_credentials_in_text(url) == redact_url_credentials(url)
+
+
+# ---------------------------------------------------------------------------
+# redact_text_secrets
+# ---------------------------------------------------------------------------
+
+
+class TestRedactTextSecretsDictKeys:
+    """Dict-entry redaction is case-insensitive, like is_secret_key.
+
+    Regression tests for https://github.com/OpenHands/software-agent-sdk/issues/4505
+    """
+
+    def test_redacts_lowercase_and_mixed_case_dict_keys(self):
+        text = (
+            "{'api_key': 's3cr3t', \"token\": \"tok-XYZ\", "
+            "'UserPassword': 'p@ssw0rd', 'normal': 'keep-me'}"
+        )
+        assert redact_text_secrets(text) == (
+            "{'api_key': '<redacted>', \"token\": \"<redacted>\", "
+            "'UserPassword': '<redacted>', 'normal': 'keep-me'}"
+        )
+
+    def test_uppercase_dict_keys_still_redacted(self):
+        text = "{'API_KEY': 'abc', \"MY_SECRET\": \"def\"}"
+        assert redact_text_secrets(text) == (
+            "{'API_KEY': '<redacted>', \"MY_SECRET\": \"<redacted>\"}"
+        )
+
+    def test_non_sensitive_entries_unchanged(self):
+        text = "{'name': 'alice', 'path': '/tmp/x'}"
+        assert redact_text_secrets(text) == text


### PR DESCRIPTION
HUMAN:

I reviewed the two-flag regex diff and the failing-then-passing pytest output for the new regression tests before submitting.

---

AGENT:

## Why

The two dictionary-entry substitutions in `redact_text_secrets` (`openhands-sdk/openhands/sdk/utils/redact.py`) only matched uppercase key names (`[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD)[A-Z_]*`), so text like `{'api_key': 's3cr3t'}` or `'UserPassword': 'p@ssw0rd'` passed through unredacted. The same module's `is_secret_key` matches case-insensitively, and the function's docstring does not restrict the key categories to uppercase. `redact_text_secrets` runs on ACP stdout/stderr lines and error details before they reach logs, so lowercase secret keys in process output leaked.

## Summary

- Add `flags=re.IGNORECASE` to both dict-entry substitutions in `redact_text_secrets`; quote handling, value boundaries, URL/header/API-key-literal behavior, and uppercase matching are untouched
- Add `TestRedactTextSecretsDictKeys` regression tests: the issue's exact reproduction (verified failing before the fix, passing after), uppercase keys still redacted, non-sensitive entries unchanged

## Issue Number

Fixes #4505

## How to Test

```bash
uv run pytest tests/sdk/utils/test_redact.py -q
```

38 tests pass on this branch. Before the fix, `test_redacts_lowercase_and_mixed_case_dict_keys` fails with the secrets left in the output, reproducing the issue exactly.

End-to-end check through the ACP logging path (`acp_agent.py` passes raw output lines through `redact_text_secrets` before logging). Running the same line through the public API on `main` vs this branch:

```
$ python -c "from openhands.sdk.utils.redact import redact_text_secrets; print(redact_text_secrets(\"auth failed for {'api_key': 's3cr3t-value', \\\"token\\\": \\\"tok-XYZ\\\", 'normal': 'keep-me'}\"))"

# on main:
auth failed for {'api_key': 's3cr3t-value', "token": "tok-XYZ", 'normal': 'keep-me'}

# on this branch:
auth failed for {'api_key': '<redacted>', "token": "<redacted>", 'normal': 'keep-me'}
```

Also ran `tests/sdk/utils/test_command.py` (a `redact_text_secrets` caller): 12 passed. `ruff check` and `ruff format --check` clean on both changed files.

## Video/Screenshots

Not a GUI change; the before/after log output above shows the behavior change.

## Design Doc

Not needed for a two-flag fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The module docstring lists `OpenHands/runtime-api` as carrying a partial copy of this file; that copy may want the same flag if it shares these patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
