### PR TITLE
fix(message): prevent cache_control emission when cache is disabled

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/message.py
+++ b/openhands-sdk/openhands/sdk/llm/message.py
@@ -300,7 +300,8 @@ class Message(BaseModel):
         if not force_string_serializer and (
             cache_enabled or vision_enabled or function_calling_enabled
         ):
-            message_dict = self._list_serializer(vision_enabled=vision_enabled)
+            message_dict = self._list_serializer(vision_enabled=vision_enabled, 
+                                                 cache_enabled=cache_enabled)
         else:
             # some providers, like HF and Groq/llama, don't support a list here, but a
             # single string
@@ -339,7 +340,7 @@ class Message(BaseModel):
         # tool call keys are added in to_chat_dict to centralize behavior
         return message_dict
 
-    def _list_serializer(self, *, vision_enabled: bool) -> dict[str, Any]:
+    def _list_serializer(self, *, vision_enabled: bool, cache_enabled: bool) -> dict[str, Any]:
         content: list[dict[str, Any]] = []
         role_tool_with_prompt_caching = False
 
@@ -357,6 +358,10 @@ class Message(BaseModel):
         for item in self.content:
             # All content types now return list[dict[str, Any]]
             item_dicts = item.to_llm_dict()
+            
+            if not cache_enabled:
+                for d in item_dicts:
+                    d.pop("cache_control", None)
 
             if self.role == "tool" and item_dicts:
                 for d in item_dicts:
@@ -367,7 +372,7 @@ class Message(BaseModel):
             # We have to remove cache_prompt for tool content and move it up to the
             # message level
             # See discussion here for details: https://github.com/BerriAI/litellm/issues/6422#issuecomment-2438765472
-            if self.role == "tool" and item.cache_prompt:
+            if cache_enabled and self.role == "tool" and item.cache_prompt:
                 role_tool_with_prompt_caching = True
                 for d in item_dicts:
                     d.pop("cache_control", None)

--- a/tests/sdk/llm/test_message_serialization.py
+++ b/tests/sdk/llm/test_message_serialization.py
@@ -277,6 +277,27 @@ class TestLLMAPISerialization:
         assert len(llm_data["content"]) == 2
         assert llm_data["content"][0]["type"] == "text"
         assert llm_data["content"][1]["type"] == "image_url"
+        
+    def test_tool_message_omits_cache_when_cache_disabled_with_function_calling(self):
+        message = Message(
+        role="tool",
+        content=[TextContent(text="Tool response", cache_prompt=True)],
+        tool_call_id="call_123",
+        name="test_tool",
+        )
+        llm_data = message.to_chat_dict(
+        **{
+            **DEFAULT_SERIALIZATION_OPTS,
+            "cache_enabled": False,
+            "function_calling_enabled": True,
+            }
+        )
+
+        assert "cache_control" not in llm_data
+        assert "cache_control" not in llm_data["content"][0]
+        
+        
+
 
 
 class TestSerializationPathSelection:

--- a/tests/sdk/llm/test_thinking_blocks.py
+++ b/tests/sdk/llm/test_thinking_blocks.py
@@ -259,7 +259,7 @@ def test_message_list_serializer_with_thinking_blocks():
         thinking_blocks=[thinking_block],
     )
 
-    serialized = message._list_serializer(vision_enabled=False)
+    serialized = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Thinking blocks should be in a separate field, not in content
     assert "thinking_blocks" in serialized
@@ -340,7 +340,7 @@ def test_multiple_thinking_blocks():
     assert message.thinking_blocks[1].signature is not None
 
     # Test serialization - thinking blocks should be in separate field
-    serialized = message._list_serializer(vision_enabled=False)
+    serialized = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Verify thinking_blocks field
     assert "thinking_blocks" in serialized
@@ -402,7 +402,7 @@ def test_thinking_blocks_in_message_dict():
     )
 
     # Test via _list_serializer
-    message_dict = message._list_serializer(vision_enabled=False)
+    message_dict = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Verify thinking_blocks is a top-level field in message_dict
     assert "thinking_blocks" in message_dict
@@ -457,7 +457,7 @@ def test_no_thinking_blocks_field_when_empty():
         content=[TextContent(text="Simple response.")],
     )
 
-    message_dict = message._list_serializer(vision_enabled=False)
+    message_dict = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # When there are no thinking blocks, the field should not be present
     assert "thinking_blocks" not in message_dict
@@ -478,7 +478,7 @@ def test_thinking_blocks_only_for_assistant_role():
         thinking_blocks=[thinking_block],
     )
 
-    user_dict = user_message._list_serializer(vision_enabled=False)
+    user_dict = user_message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Thinking blocks should not be added for non-assistant roles
     assert "thinking_blocks" not in user_dict
@@ -490,7 +490,7 @@ def test_thinking_blocks_only_for_assistant_role():
         thinking_blocks=[thinking_block],
     )
 
-    assistant_dict = assistant_message._list_serializer(vision_enabled=False)
+    assistant_dict = assistant_message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Thinking blocks should be added for assistant role
     assert "thinking_blocks" in assistant_dict
@@ -511,7 +511,7 @@ def test_redacted_thinking_block_in_message_dict():
         thinking_blocks=[redacted_block],
     )
 
-    message_dict = message._list_serializer(vision_enabled=False)
+    message_dict = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Verify redacted thinking block is in message_dict
     assert "thinking_blocks" in message_dict
@@ -536,7 +536,7 @@ def test_mixed_thinking_and_redacted_blocks():
         thinking_blocks=[thinking_block, redacted_block],
     )
 
-    message_dict = message._list_serializer(vision_enabled=False)
+    message_dict = message._list_serializer(vision_enabled=False, cache_enabled=False)
 
     # Verify both types are in message_dict
     assert "thinking_blocks" in message_dict


### PR DESCRIPTION
HUMAN:

Fixes an issue where disabled caching could still emit cache_control markers during message serialization.

AGENT:

## Why

`Message.to_chat_dict` could emit `cache_control` fields even when caching was explicitly disabled with `cache_enabled=False`.

cache_prompt=True on individual content blocks indicates that the content is eligible for caching, but it should not result in cache markers being emitted when the overall message serialization has cache_enabled=False.

When list serialization was selected due to other features such as function calling, `_list_serializer` did not receive or check the cache setting. This allowed content with `cache_prompt=True` to add cache markers even though caching was disabled.

## Summary

- Pass `cache_enabled` from `Message.to_chat_dict` into `_list_serializer`.
- Ensure _list_serializer respects the global cache_enabled setting and suppresses content-level and message-level cache_control fields when caching is disabled.
- Added regression coverage for tool messages using `cache_prompt=True` with `cache_enabled=False` and `function_calling_enabled=True`.

## Issue Number

Fixes #4511

## How to Test

Ran the following tests:

```bash
uv run pytest tests/sdk/llm/test_message.py -q
uv run pytest tests/sdk/llm/test_message_serialization.py -q
uv run pytest tests/sdk/llm/test_thinking_blocks.py -q
uv run pytest tests/sdk/llm -q
```
Result:

973 passed

The regression scenario covers the case where a content item requests caching (TextContent(cache_prompt=True)), but caching is disabled globally during serialization:
```
content=[TextContent(text="Tool response", cache_prompt=True)]


message.to_chat_dict(
    cache_enabled=False,
    function_calling_enabled=True,
)
```
Expected behavior:

- No cache_control fields should be emitted because caching is disabled globally.

Previous behavior:

- The content-level cache_prompt=True flag could still produce cache_control markers.

The expected behavior is that the returned message does not contain any cache_control fields.

## Video/Screenshots

Not applicable. This change affects SDK serialization behavior and does not introduce a user-facing UI change.

## Design Doc

Not required. This is a small bug fix that preserves existing behavior when caching is enabled.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change is backward compatible. Existing `cache_enabled=True` behavior is unchanged; the fix only prevents cache markers from being emitted when caching has been explicitly disabled.
Added regression tests covering the disabled-caching scenario, including tool messages with `cache_prompt=True` and `function_calling_enabled=True`.