### PR TITLE
feat: Add deployment kind to agent-server telemetry

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -14,6 +14,7 @@ from openhands.agent_server.env_parser import (
     get_env_parser,
     merge,
 )
+from openhands.agent_server.telemetry_types import DeploymentKind
 from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.utils.cipher import Cipher
 
@@ -135,13 +136,19 @@ TelemetryExporterKind = Literal["none", "posthog", "http"]
 class TelemetrySpec(BaseModel):
     """Deployment-supplied product-analytics transport settings.
 
-    This carries *transport* only. Whether telemetry may be delivered is
-    resolved from consent (``misc_settings.telemetry.consent``, optionally
-    seeded or overridden by ``OH_TELEMETRY_CONSENT``) — there is no deployment
-    "mode" here, and nothing in the agent-server special-cases a hosted
-    deployment.
+    This carries transport plus the non-identifying deployment tag. Whether
+    telemetry may be delivered is resolved from consent
+    (``misc_settings.telemetry.consent``, optionally seeded or overridden by
+    ``OH_TELEMETRY_CONSENT``).
     """
 
+    deployment_kind: DeploymentKind = Field(
+        default="local",
+        description=(
+            "Deployment kind attached to diagnostic events. Use 'saas' for "
+            "hosted OpenHands and 'local' for self-hosted or developer runs."
+        ),
+    )
     exporter: TelemetryExporterKind = Field(
         default="none",
         description=(

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -145,7 +145,7 @@ class TelemetrySpec(BaseModel):
     deployment_kind: DeploymentKind = Field(
         default="local",
         description=(
-            "Deployment kind attached to diagnostic events. Use 'saas' for "
+            "Deployment kind attached to diagnostic events. Use 'remote' for "
             "hosted OpenHands and 'local' for self-hosted or developer runs."
         ),
     )

--- a/openhands-agent-server/openhands/agent_server/telemetry/__init__.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/__init__.py
@@ -26,6 +26,7 @@ from openhands.agent_server.telemetry.factory import (
 )
 from openhands.agent_server.telemetry.models import (
     TELEMETRY_SCHEMA_VERSION,
+    DeploymentKind,
     DiagnosticEvent,
     RuntimeProperties,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "TELEMETRY_SCHEMA_VERSION",
     "BufferedTelemetrySink",
     "ConversationTelemetryContext",
+    "DeploymentKind",
     "DiagnosticEvent",
     "DISTINCT_ID_HEADER",
     "DiagnosticEventFactory",

--- a/openhands-agent-server/openhands/agent_server/telemetry/factory.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/factory.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from openhands.agent_server.server_details_router import ServerInfo
 from openhands.agent_server.telemetry.models import (
     TELEMETRY_SCHEMA_VERSION,
+    DeploymentKind,
     DiagnosticEvent,
     DiagnosticProperties,
     EventName,
@@ -64,7 +65,11 @@ def _python_version() -> str:
     return f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
-def build_runtime_properties(*, deferred_init: bool) -> RuntimeProperties:
+def build_runtime_properties(
+    *,
+    deferred_init: bool,
+    deployment_kind: DeploymentKind = "local",
+) -> RuntimeProperties:
     """Snapshot the coarse runtime facts shared by every event."""
     # Versions and build metadata come from ServerInfo's own field defaults, so
     # /server_info and telemetry can never disagree about what is running.
@@ -78,6 +83,7 @@ def build_runtime_properties(*, deferred_init: bool) -> RuntimeProperties:
         python_version=_python_version(),
         platform=_platform_token(),
         deferred_init=deferred_init,
+        deployment_kind=deployment_kind,
     )
 
 

--- a/openhands-agent-server/openhands/agent_server/telemetry/models.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/models.py
@@ -22,6 +22,8 @@ from typing import Annotated, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
+from openhands.agent_server.telemetry_types import DeploymentKind
+
 
 TELEMETRY_SCHEMA_VERSION: Final[int] = 1
 
@@ -144,6 +146,7 @@ class RuntimeProperties(BaseModel):
     python_version: SafeToken
     platform: SafeToken
     deferred_init: bool
+    deployment_kind: DeploymentKind = "local"
     source: Literal["openhands-agent-server"] = "openhands-agent-server"
 
 
@@ -290,6 +293,7 @@ EXPECTED_PROPERTY_NAMES: Final[frozenset[str]] = frozenset(
         "python_version",
         "platform",
         "deferred_init",
+        "deployment_kind",
         "source",
         "$insert_id",
         "conversation_ref",

--- a/openhands-agent-server/openhands/agent_server/telemetry/service.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry/service.py
@@ -104,7 +104,10 @@ async def build_telemetry_sink(config: Config) -> TelemetrySink:
 
     spec = config.telemetry
     _event_factory = DiagnosticEventFactory(
-        runtime=build_runtime_properties(deferred_init=config.deferred_init),
+        runtime=build_runtime_properties(
+            deferred_init=config.deferred_init,
+            deployment_kind=spec.deployment_kind,
+        ),
         salt=(
             spec.salt.get_secret_value()
             if spec.salt is not None

--- a/openhands-agent-server/openhands/agent_server/telemetry_types.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry_types.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
 
-DeploymentKind = Literal["local", "saas"]
+DeploymentKind = Literal["local", "remote"]

--- a/openhands-agent-server/openhands/agent_server/telemetry_types.py
+++ b/openhands-agent-server/openhands/agent_server/telemetry_types.py
@@ -1,0 +1,4 @@
+from typing import Literal
+
+
+DeploymentKind = Literal["local", "saas"]

--- a/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
+++ b/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
@@ -6,10 +6,11 @@ import sys
 from fastapi.testclient import TestClient
 
 from openhands.agent_server.api import create_app
-from openhands.agent_server.config import Config
+from openhands.agent_server.config import Config, TelemetrySpec
 from openhands.agent_server.telemetry import (
     NoOpTelemetrySink,
     build_telemetry_sink,
+    get_event_factory,
     get_telemetry_sink,
 )
 
@@ -23,6 +24,20 @@ async def test_building_from_a_default_config_stays_a_noop(temp_persistence_dir)
     sink = await build_telemetry_sink(Config(static_files_path=None))
     assert isinstance(sink, NoOpTelemetrySink)
     assert sink.enabled is False
+
+
+async def test_building_sink_carries_configured_deployment_kind(
+    temp_persistence_dir,
+):
+    sink = await build_telemetry_sink(
+        Config(static_files_path=None, telemetry=TelemetrySpec(deployment_kind="saas"))
+    )
+    try:
+        factory = get_event_factory()
+        assert factory is not None
+        assert factory.runtime.deployment_kind == "saas"
+    finally:
+        await sink.aclose()
 
 
 async def test_opt_in_without_an_api_key_stays_inactive(config_factory):
@@ -57,7 +72,7 @@ def test_importing_the_telemetry_package_does_not_import_posthog():
 import sys
 
 import openhands.agent_server.telemetry as t
-from openhands.agent_server.config import Config
+from openhands.agent_server.config import Config, TelemetrySpec
 from openhands.agent_server.api import create_app
 
 assert "posthog" not in sys.modules, "importing telemetry pulled in posthog"

--- a/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
+++ b/tests/agent_server/telemetry/test_telemetry_disabled_by_default.py
@@ -30,12 +30,14 @@ async def test_building_sink_carries_configured_deployment_kind(
     temp_persistence_dir,
 ):
     sink = await build_telemetry_sink(
-        Config(static_files_path=None, telemetry=TelemetrySpec(deployment_kind="saas"))
+        Config(
+            static_files_path=None, telemetry=TelemetrySpec(deployment_kind="remote")
+        )
     )
     try:
         factory = get_event_factory()
         assert factory is not None
-        assert factory.runtime.deployment_kind == "saas"
+        assert factory.runtime.deployment_kind == "remote"
     finally:
         await sink.aclose()
 

--- a/tests/agent_server/telemetry/test_telemetry_no_duplication.py
+++ b/tests/agent_server/telemetry/test_telemetry_no_duplication.py
@@ -77,13 +77,15 @@ def test_no_deployment_mode_concept_remains():
 def test_deployment_kind_is_a_runtime_property_not_a_mode():
     import openhands.agent_server.config as config_mod
 
-    assert config_mod.TelemetrySpec(deployment_kind="saas").deployment_kind == "saas"
+    assert (
+        config_mod.TelemetrySpec(deployment_kind="remote").deployment_kind == "remote"
+    )
     assert m.RuntimeProperties.model_fields["deployment_kind"].default == "local"
     assert (
         build_runtime_properties(
-            deferred_init=False, deployment_kind="saas"
+            deferred_init=False, deployment_kind="remote"
         ).deployment_kind
-        == "saas"
+        == "remote"
     )
 
 

--- a/tests/agent_server/telemetry/test_telemetry_no_duplication.py
+++ b/tests/agent_server/telemetry/test_telemetry_no_duplication.py
@@ -74,6 +74,19 @@ def test_no_deployment_mode_concept_remains():
     assert "deployment_mode" not in m.RuntimeProperties.model_fields
 
 
+def test_deployment_kind_is_a_runtime_property_not_a_mode():
+    import openhands.agent_server.config as config_mod
+
+    assert config_mod.TelemetrySpec(deployment_kind="saas").deployment_kind == "saas"
+    assert m.RuntimeProperties.model_fields["deployment_kind"].default == "local"
+    assert (
+        build_runtime_properties(
+            deferred_init=False, deployment_kind="saas"
+        ).deployment_kind
+        == "saas"
+    )
+
+
 def test_versions_match_server_info():
     """Telemetry and /server_info must never disagree about what is running."""
     from openhands.agent_server.server_details_router import ServerInfo

--- a/tests/agent_server/telemetry/test_telemetry_schema.py
+++ b/tests/agent_server/telemetry/test_telemetry_schema.py
@@ -161,4 +161,5 @@ def test_payload_carries_schema_version_and_excludes_distinct_id():
     # distinct_id is the transport's addressing field, not a property.
     assert "distinct_id" not in payload
     assert "kind" not in payload
+    assert payload["deployment_kind"] == "local"
     assert set(payload) <= set(m.EXPECTED_PROPERTY_NAMES)

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -40,6 +40,14 @@ def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_pat
     assert registration.auto_load is True
 
 
+def test_load_config_reads_telemetry_deployment_kind_from_env(monkeypatch, tmp_path):
+    config_path = tmp_path / "missing.json"
+    monkeypatch.setenv(CONFIG_PATH_ENV, str(config_path))
+    monkeypatch.setenv("OH_TELEMETRY_DEPLOYMENT_KIND", "saas")
+
+    assert load_config().telemetry.deployment_kind == "saas"
+
+
 def test_conversation_idle_ttl_defaults_to_twenty_minutes():
     assert DEFAULT_CONVERSATION_IDLE_TTL_SECONDS == 1200.0
     assert Config().conversation_idle_ttl_seconds == 1200.0

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -43,9 +43,9 @@ def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_pat
 def test_load_config_reads_telemetry_deployment_kind_from_env(monkeypatch, tmp_path):
     config_path = tmp_path / "missing.json"
     monkeypatch.setenv(CONFIG_PATH_ENV, str(config_path))
-    monkeypatch.setenv("OH_TELEMETRY_DEPLOYMENT_KIND", "saas")
+    monkeypatch.setenv("OH_TELEMETRY_DEPLOYMENT_KIND", "remote")
 
-    assert load_config().telemetry.deployment_kind == "saas"
+    assert load_config().telemetry.deployment_kind == "remote"
 
 
 def test_conversation_idle_ttl_defaults_to_twenty_minutes():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I've tested that the deployment kind tag shows up as expected

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

OSS-9943 identifies that SaaS and local deployments currently rely on different analytics event names and property sets, which makes unified conversation tracking unreliable. This SDK-side change adds a safe `deployment_kind` runtime property so hosted OpenHands can tag SDK telemetry as `remote` while local/self-hosted runs continue to default to `local`.

## Summary

- Adds `deployment_kind` (`local` | `remote`) to agent-server telemetry config and runtime properties.
- Threads `config.telemetry.deployment_kind` into the process-wide telemetry event factory so emitted payloads include the deployment tag.
- Adds schema/config/service tests for defaults, env loading, and payload propagation.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `98338ff37aea` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -2437,0 +2438 @@
+schema TelemetrySpec property deployment_kind optional schema=type="string" enum=["local","remote"] default="local"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Related to #4427

Linear: OSS-9943: https://linear.app/all-hands-ai/issue/OSS-9943/enable-sdk-telemetry-on-saas-for-unified-conversation-tracking

## How to Test

Unit and static validation run:

```bash
uv run pytest tests/agent_server/telemetry/test_telemetry_schema.py tests/agent_server/telemetry/test_telemetry_no_duplication.py tests/agent_server/test_config.py
```

Result: `50 passed, 5 warnings in 0.11s`.

Additional targeted service-path test:

```bash
uv run pytest tests/agent_server/telemetry/test_telemetry_disabled_by_default.py::test_building_sink_carries_configured_deployment_kind -vv
```

Result: `1 passed, 6 warnings in 0.70s`.

Pre-commit validation run:

```bash
uv run pre-commit run --files \
  openhands-agent-server/openhands/agent_server/telemetry_types.py \
  openhands-agent-server/openhands/agent_server/telemetry/models.py \
  openhands-agent-server/openhands/agent_server/telemetry/factory.py \
  openhands-agent-server/openhands/agent_server/config.py \
  openhands-agent-server/openhands/agent_server/telemetry/service.py \
  openhands-agent-server/openhands/agent_server/telemetry/__init__.py \
  tests/agent_server/telemetry/test_telemetry_schema.py \
  tests/agent_server/telemetry/test_telemetry_no_duplication.py \
  tests/agent_server/telemetry/test_telemetry_disabled_by_default.py \
  tests/agent_server/test_config.py
```

Result: all hooks passed (`Ruff format`, `Ruff lint`, `pycodestyle`, `pyright`, import dependency rules, and tool subclass registration).

End-to-end smoke check run against the real config loader, telemetry sink builder, event factory, and payload serialization path:

```bash
OPENHANDS_SUPPRESS_BANNER=1 \
OPENHANDS_AGENT_SERVER_CONFIG_PATH=/tmp/missing-oh-config.json \
OH_TELEMETRY_DEPLOYMENT_KIND=remote \
uv run python - <<'PY'
import asyncio

from openhands.agent_server.config import load_config
from openhands.agent_server.telemetry import build_telemetry_sink, get_event_factory
from openhands.agent_server.telemetry.models import EventName, ServerLifecycleProperties

async def main():
    config = load_config()
    sink = await build_telemetry_sink(config)
    try:
        factory = get_event_factory()
        assert factory is not None
        event = factory.build(EventName.SERVER_STARTED, ServerLifecycleProperties())
        payload = event.to_payload()
        print(f"config.telemetry.deployment_kind={config.telemetry.deployment_kind}")
        print(f"factory.runtime.deployment_kind={factory.runtime.deployment_kind}")
        print(f"payload.deployment_kind={payload['deployment_kind']}")
        print(f"sink.enabled={sink.enabled}")
    finally:
        await sink.aclose()

asyncio.run(main())
PY
```

Observed output:

```text
config.telemetry.deployment_kind=remote
factory.runtime.deployment_kind=remote
payload.deployment_kind=remote
sink.enabled=False
```

`sink.enabled=False` is expected for this smoke check because the exporter remains unset; the check verifies the config → sink builder → factory → serialized payload path without sending telemetry externally.

## Video/Screenshots

Not applicable; this is a backend telemetry metadata/config change. The smoke-test output above is the functional evidence.

## Design Doc

Not added. This is a small additive telemetry metadata change following the existing `TelemetrySpec` and `RuntimeProperties` design.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally only covers the SDK prerequisite. The SaaS/deploy-side config change to set the exporter, PostHog key, user identity, and `deployment_kind=remote` should stay coordinated with the existing SaaS deploy PR.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fde9bd44-7ec1-4801-a334-3971301bac15)


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:29e1078-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-29e1078-python \
  ghcr.io/openhands/agent-server:29e1078-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:29e1078-golang-amd64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-golang-amd64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-golang-amd64
ghcr.io/openhands/agent-server:29e1078-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:29e1078-golang-arm64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-golang-arm64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-golang-arm64
ghcr.io/openhands/agent-server:29e1078-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:29e1078-java-amd64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-java-amd64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-java-amd64
ghcr.io/openhands/agent-server:29e1078-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:29e1078-java-arm64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-java-arm64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-java-arm64
ghcr.io/openhands/agent-server:29e1078-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:29e1078-python-amd64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-python-amd64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-python-amd64
ghcr.io/openhands/agent-server:29e1078-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:29e1078-python-arm64
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-python-arm64
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-python-arm64
ghcr.io/openhands/agent-server:29e1078-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:29e1078-golang
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-golang
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-golang
ghcr.io/openhands/agent-server:29e1078-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:29e1078-java
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-java
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-java
ghcr.io/openhands/agent-server:29e1078-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:29e1078-python
ghcr.io/openhands/agent-server:29e10783ac467861853a46e5716f3e322049c751-python
ghcr.io/openhands/agent-server:oss-9943-sdk-telemetry-deployment-kind-python
ghcr.io/openhands/agent-server:29e1078-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `29e1078-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `29e1078-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->