### PR TITLE
fix(extensions): avoid duplicate .git suffix in GitHub shorthand

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/fetch.py
+++ b/openhands-sdk/openhands/sdk/extensions/fetch.py
@@ -66,7 +66,7 @@ def parse_extension_source(source: str) -> tuple[SourceType, str]:
                 f"Invalid GitHub shorthand format: {source}. "
                 f"Expected format: github:owner/repo"
             )
-        url = f"https://github.com/{repo_path}.git"
+        url = normalize_git_url(f"https://github.com/{repo_path}")
         return (SourceType.GITHUB, url)
 
     # Git URLs: detect by protocol/scheme rather than enumerating providers

--- a/tests/sdk/extensions/test_fetch.py
+++ b/tests/sdk/extensions/test_fetch.py
@@ -26,6 +26,12 @@ def test_parse_github_shorthand():
     assert url == "https://github.com/owner/repo.git"
 
 
+def test_parse_github_shorthand_with_git_suffix():
+    source_type, url = parse_extension_source("github:owner/repo.git")
+    assert source_type == SourceType.GITHUB
+    assert url == "https://github.com/owner/repo.git"
+
+
 def test_parse_github_shorthand_with_whitespace():
     source_type, url = parse_extension_source("  github:owner/repo  ")
     assert source_type == SourceType.GITHUB


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I fixed the GitHub shorthand parsing so URLs that already end in .git no longer get an extra .git appended.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

`github:owner/repo.git` currently becomes `https://github.com/owner/repo.git.git`, so extension fetching tries the wrong clone URL.

## Summary

- Pass the expanded GitHub shorthand through `normalize_git_url` instead of appending `.git` directly.
- Cover an already-suffixed shorthand while keeping the existing shorthand and full URL behavior unchanged.

## Issue Number

Fixes #4520

## How to Test

Invoked the parser directly with this checkout on `PYTHONPATH`:

```text
main:   https://github.com/owner/repo.git.git
branch: https://github.com/owner/repo.git
```

Then ran:

```text
python -m pytest tests/sdk/extensions/test_fetch.py -q
42 passed
```

Ruff format, Ruff lint, pycodestyle, import rules, tool registration, and `git diff --check` also pass for the changed files.

## Video/Screenshots

Not applicable for this parser-only change.

## Design Doc

Not needed for this small bug fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The existing shorthand format checks are unchanged.
