### PR TITLE
feat(prompt): mention local conversation history

### DIFF
--- a/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
@@ -108,7 +108,7 @@ class MemorySection(_StaticTextSection):
     _AGENTS_MD_GUIDANCE = """\
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills"""
 

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
@@ -108,7 +108,7 @@ class MemorySection(_StaticTextSection):
     _AGENTS_MD_GUIDANCE = """\
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills"""
 

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
@@ -108,6 +108,7 @@ class MemorySection(_StaticTextSection):
     _AGENTS_MD_GUIDANCE = """\
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills"""
 

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/static.py
@@ -108,7 +108,7 @@ class MemorySection(_StaticTextSection):
     _AGENTS_MD_GUIDANCE = """\
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills"""
 

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
+++ b/tests/sdk/context/prompts/snapshots/anthropic__browser-on__secana-on__cli-on__win32.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/gemini__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/openai__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-off__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-off__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-off.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
+++ b/tests/sdk/context/prompts/snapshots/other__browser-on__secana-on__cli-on.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__custom.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__custom.txt
@@ -10,7 +10,7 @@ You are a tiny cat agent with toe beans.
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__custom.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__custom.txt
@@ -10,7 +10,7 @@ You are a tiny cat agent with toe beans.
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__custom.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__custom.txt
@@ -10,7 +10,7 @@ You are a tiny cat agent with toe beans.
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__custom.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__custom.txt
@@ -10,6 +10,7 @@ You are a tiny cat agent with toe beans.
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__default.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__default.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__default.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__default.txt
@@ -10,6 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
+* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__default.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__default.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history; for Agent Canvas, also check `$HOME/.openhands/agent-canvas/conversations/`, or `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>

--- a/tests/sdk/context/prompts/snapshots/soul__default.txt
+++ b/tests/sdk/context/prompts/snapshots/soul__default.txt
@@ -10,7 +10,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 <MEMORY>
 * Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
-* When asked to find a previous local OpenHands conversation, search `$HOME/.openhands/conversations/` for its event history; in Agent Canvas, also check `$OH_CANVAS_SAFE_STATE_DIR/conversations/` when that variable is set.
+* When asked to find a previous local OpenHands conversation, search the workspace's `workspace/conversations/` directory for its event history.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills
 </MEMORY>


### PR DESCRIPTION
HUMAN:

Tested and it works. Before

<img width="776" height="365" alt="Screenshot 2026-08-18 at 1 36 13 PM" src="https://github.com/user-attachments/assets/29f97973-8bee-4706-b681-1ce9b2b2ed47" />

After

<img width="768" height="267" alt="Screenshot 2026-08-18 at 1 35 54 PM" src="https://github.com/user-attachments/assets/2476465b-c18b-455f-99d7-01dbd7b8d08f" />


AGENT:

## Why

Agents need a reliable place to look when users ask about previous local OpenHands conversations. The persisted event history is stored outside the workspace, so the default prompt should identify the local OpenHands and Agent Canvas locations without encouraging unrelated history scans.

## Summary

- Use `workspace/conversations/`, the SDK's actual default `persistence_dir`, as the agent guidance for locating persisted local conversation history.
- Update the prompt golden snapshots.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `98338ff37aea` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -2437,0 +2438 @@
+schema TelemetrySpec property deployment_kind optional schema=type="string" enum=["local","remote"] default="local"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Fixes #4528

## How to Test

Run the focused prompt tests:

```bash
uv run pytest tests/sdk/context/prompts/test_prompt_snapshot.py tests/sdk/context/prompts/test_default_registry.py
```

Result: 100 passed.

Repository pre-commit checks also passed: Ruff format, Ruff lint, pycodestyle, Pyright, import dependency, and tool-registration checks.

The rendered prompt includes both storage-location references in the default `<MEMORY>` guidance, while static prompt tests confirm no host-specific path is expanded.

## Video/Screenshots

Not applicable: this is an SDK prompt-only change with no visual UI behavior.

## Design Doc

Not applicable: this is a one-line prompt guidance change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This pull request was created by an AI agent (OpenHands) on behalf of the user.





<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:58c9a14-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-58c9a14-python \
  ghcr.io/openhands/agent-server:58c9a14-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:58c9a14-golang-amd64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-golang-amd64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-golang-amd64
ghcr.io/openhands/agent-server:58c9a14-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:58c9a14-golang-arm64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-golang-arm64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-golang-arm64
ghcr.io/openhands/agent-server:58c9a14-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:58c9a14-java-amd64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-java-amd64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-java-amd64
ghcr.io/openhands/agent-server:58c9a14-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:58c9a14-java-arm64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-java-arm64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-java-arm64
ghcr.io/openhands/agent-server:58c9a14-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:58c9a14-python-amd64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-python-amd64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-python-amd64
ghcr.io/openhands/agent-server:58c9a14-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:58c9a14-python-arm64
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-python-arm64
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-python-arm64
ghcr.io/openhands/agent-server:58c9a14-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:58c9a14-golang
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-golang
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-golang
ghcr.io/openhands/agent-server:58c9a14-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:58c9a14-java
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-java
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-java
ghcr.io/openhands/agent-server:58c9a14-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:58c9a14-python
ghcr.io/openhands/agent-server:58c9a14a843b0fcdbd39304121a1d3494965e4f6-python
ghcr.io/openhands/agent-server:feat-mention-local-conversation-history-python
ghcr.io/openhands/agent-server:58c9a14-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `58c9a14-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `58c9a14-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

