### PR TITLE
fix(agent-server): backfill redacted LLM api_key on agent_settings la…

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1480,6 +1480,35 @@ class ConversationService:
                 load_memory=bool(stored_context and stored_context.load_memory),
             )
             request = request.model_copy(update={"agent": resolved_agent})
+        elif request.agent_settings is not None:
+            # The client-supplied ``agent_settings`` payload may have had its
+            # LLM secrets redacted to ``"**********"`` (e.g. fetched via
+            # ``GET /api/settings`` without ``X-Expose-Secrets``), which
+            # ``validate_secret`` turns into ``None`` during request
+            # validation. Backfill any still-missing LLM secret fields from
+            # the server's persisted agent settings, mirroring how the
+            # ``agent_profile_id`` path above always resolves credentials
+            # server-side rather than trusting client-supplied secret values.
+            from openhands.agent_server.persistence import (
+                PersistedSettings,
+                get_settings_store,
+            )
+            from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
+
+            settings = get_settings_store().load() or PersistedSettings()
+            persisted_llm = settings.agent_settings.llm
+            updates: dict[str, Any] = {}
+            for field in LLM_SECRET_FIELDS:
+                if getattr(request.agent.llm, field, None) is not None:
+                    continue
+                persisted_value = getattr(persisted_llm, field, None)
+                if persisted_value is not None:
+                    updates[field] = persisted_value
+            if updates:
+                new_llm = request.agent.llm.model_copy(update=updates)
+                request = request.model_copy(
+                    update={"agent": request.agent.model_copy(update={"llm": new_llm})}
+                )
 
         additions = request.agent_launch_additions
         suffix = (

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -34,6 +34,7 @@ from openhands.agent_server.models import (
     StoredConversation,
     UpdateConversationRequest,
 )
+from openhands.agent_server.persistence import PersistedSettings
 from openhands.agent_server.utils import safe_rmtree as _safe_rmtree
 from openhands.sdk import LLM, Agent, AgentBase, Message
 from openhands.sdk.agent.acp_agent import ACPAgent
@@ -340,6 +341,167 @@ async def test_start_conversation_decrypts_encrypted_agent_settings_mcp_env(
         ]
         == "ghp-plaintext"
     )
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_backfills_redacted_llm_api_key_from_agent_settings(
+    conversation_service, tmp_path
+):
+    """Regression test for #4533.
+
+    When a client launches via the ``agent_settings`` fallback (the seeded
+    default agent profile path) using a settings payload it fetched from
+    ``GET /api/settings`` without ``X-Expose-Secrets``, the LLM ``api_key``
+    arrives redacted (``"**********"``) and ``validate_secret`` turns it
+    into ``None`` during request validation. The launched agent must still
+    carry the real, server-persisted API key rather than launching with a
+    ``None`` key.
+    """
+    from openhands.sdk.settings.model import default_agent_settings
+    from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
+
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    persisted_settings = PersistedSettings(
+        agent_settings=default_agent_settings().model_copy(
+            update={
+                "llm": LLM(
+                    model="gpt-4o",
+                    usage_id="test-llm",
+                    api_key=SecretStr("sk-real-persisted-key"),
+                )
+            }
+        )
+    )
+
+    request = StartConversationRequest(
+        agent_settings={
+            "schema_version": 1,
+            "agent_kind": "llm",
+            "llm": {
+                "model": "gpt-4o",
+                "usage_id": "test-llm",
+                # As sent back by a client that fetched settings without
+                # X-Expose-Secrets: the real key redacted to this marker.
+                "api_key": REDACTED_SECRET_VALUE,
+            },
+            "tools": [],
+        },
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+    # Sanity check: validation already dropped the redacted key to None,
+    # same as the reported bug's base_state.json before any fix.
+    assert request.agent.llm.api_key is None
+
+    captured: dict[str, Any] = {}
+
+    async def fake_start_event_service(stored: StoredConversation, **kwargs):
+        agent = cast(AgentBase, kwargs.get("agent"))
+        captured["agent"] = agent
+        service = AsyncMock(spec=EventService)
+        service.stored = stored
+        service.get_state.return_value = ConversationState(
+            id=stored.id,
+            agent=agent,
+            workspace=stored.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=stored.confirmation_policy,
+        )
+        return service
+
+    with (
+        patch(
+            "openhands.agent_server.persistence.get_settings_store"
+        ) as mock_get_store,
+        patch.object(
+            conversation_service,
+            "_start_event_service",
+            side_effect=fake_start_event_service,
+        ),
+    ):
+        mock_get_store.return_value.load.return_value = persisted_settings
+        await conversation_service.start_conversation(request)
+
+    agent = captured["agent"]
+    assert isinstance(agent.llm.api_key, SecretStr)
+    assert agent.llm.api_key.get_secret_value() == "sk-real-persisted-key"
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_agent_settings_does_not_override_explicit_llm_api_key(
+    conversation_service, tmp_path
+):
+    """A client-supplied (non-redacted) api_key must never be clobbered by
+    the persisted server value — the backfill only fills in what's missing.
+    """
+    from openhands.sdk.settings.model import default_agent_settings
+
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    persisted_settings = PersistedSettings(
+        agent_settings=default_agent_settings().model_copy(
+            update={
+                "llm": LLM(
+                    model="gpt-4o",
+                    usage_id="test-llm",
+                    api_key=SecretStr("sk-persisted-should-not-be-used"),
+                )
+            }
+        )
+    )
+
+    request = StartConversationRequest(
+        agent_settings={
+            "schema_version": 1,
+            "agent_kind": "llm",
+            "llm": {
+                "model": "gpt-4o",
+                "usage_id": "test-llm",
+                "api_key": "sk-explicit-client-key",
+            },
+            "tools": [],
+        },
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+    assert isinstance(request.agent.llm.api_key, SecretStr)
+    assert request.agent.llm.api_key.get_secret_value() == "sk-explicit-client-key"
+
+    captured: dict[str, Any] = {}
+
+    async def fake_start_event_service(stored: StoredConversation, **kwargs):
+        agent = cast(AgentBase, kwargs.get("agent"))
+        captured["agent"] = agent
+        service = AsyncMock(spec=EventService)
+        service.stored = stored
+        service.get_state.return_value = ConversationState(
+            id=stored.id,
+            agent=agent,
+            workspace=stored.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=stored.confirmation_policy,
+        )
+        return service
+
+    with (
+        patch(
+            "openhands.agent_server.persistence.get_settings_store"
+        ) as mock_get_store,
+        patch.object(
+            conversation_service,
+            "_start_event_service",
+            side_effect=fake_start_event_service,
+        ),
+    ):
+        mock_get_store.return_value.load.return_value = persisted_settings
+        await conversation_service.start_conversation(request)
+
+    agent = captured["agent"]
+    assert isinstance(agent.llm.api_key, SecretStr)
+    assert agent.llm.api_key.get_secret_value() == "sk-explicit-client-key"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN: 

Resolves [#4533](https://github.com/OpenHands/software-agent-sdk/issues/4533). When a conversation launches via a raw settings payload, the frontend sends that payload to the backend with the API key masked as a string of asterisks — which is expected, since the backend never returns real secrets to the client. What was actually missing was a step to fetch the real API key back from the server once that masked payload reached the backend. Fixed it, added tests, and verified everything locally.

---

AGENT:

## Why

Starting a conversation via the seeded default agent profile (the `agent_settings` fallback path, as opposed to `agent_profile_id`) fails with `litellm.AuthenticationError` even when the LLM is fully configured and its API key is saved server-side. The named-agent-profile launch path already works correctly for the same LLM config, so this is a regression specific to one of the two launch paths, not a key/model/cipher problem.

## Summary

**Root cause:**
When a client fetches settings via `GET /api/settings` without `X-Expose-Secrets`, secret fields come back redacted
(`"**********"`). If that redacted `agent_settings` payload is later sent to `POST /api/conversations`, `StartConversationRequest`'s
`_populate_agent_from_settings` validator converts it into an `Agent` via `validate_agent_settings(...).create_agent()`. During that construction, `validate_secret()` sees the redaction marker and converts it to `None` (by design, so redacted round-trips never leak `"**********"` as a literal credential). Unlike the `agent_profile_id` launch path — which always re-resolves credentials fresh from the server's persisted settings — the `agent_settings` fallback path had no equivalent recovery step, so the agent launched with `llm.api_key = None` and the first LLM call failed authentication.

**Fix:**
In `ConversationService._start_conversation`, when the request came in via `agent_settings` (not `agent_profile_id`), backfill any still-`None` LLM secret field (`api_key`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`) from the server's
persisted `agent_settings.llm`, but only for fields the client didn't already supply a real value for — an explicit client-supplied key is never overridden. This mirrors the existing `agent_profile_id` path's behavior of trusting server-persisted credentials over a
possibly-redacted client payload.

**Note**:
 `Agent` and `LLM` are frozen Pydantic models, so the fix builds the updated `LLM` and `Agent` via `model_copy(update=...)` rather than direct attribute assignment, consistent with how the adjacent `agent_profile_id` branch already rebuilds `request` in this function.

## Issue Number

Fixes #4533

## How to Test

1. Tests
```
uv run pytest tests/agent_server/test_conversation_service.py -q -k "backfill or explicit_llm_api_key or decrypts_encrypted_agent_settings"
```

Result: all passing (3 tests: the 2 new regression tests plus the existing encrypted-agent-settings test, confirming no interference).
```
uv run pytest tests/agent_server/test_conversation_service.py -q
```

Result: 110 passed.

2. Repository checks
```
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/conversation_service.py tests/agent_server/test_conversation_service.py
```

Result: Ruff format, Ruff lint, pycodestyle, pyright, import rules, and Tool subclass registration checks all passed.

3. Two new regression tests were added:
- `test_start_conversation_backfills_redacted_llm_api_key_from_agent_settings` —
  reproduces the reported bug (redacted `api_key` in the `agent_settings` payload) and asserts the launched agent carries the   real, server-persisted key instead of `None`.
- `test_start_conversation_agent_settings_does_not_override_explicit_llm_api_key` — 
  asserts a client-supplied real key is never clobbered by the persisted server value.

4. Known environment quirk (not related to this change)

`test_restart_resumes_conversations_after_non_graceful_shutdown` fails locally on Windows due to a platform difference in `os.kill(pid, 0)` liveness detection inside `conversation_lease.py` (Windows raises a generic `OSError` for an invalid/synthetic PID rather than POSIX's `ProcessLookupError`, so the conservative fallback reports the forged lease as still alive). This test doesn't touch `agent_settings` at all, and passes on Linux both with and without this change; expected to pass on the repo's Linux CI.

## Video/Screenshots

N/A — backend fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Verified against the real reported failure mode: I traced the redaction → `validate_secret()` → `None` path in
`pydantic_secrets.py` and `request.py`, and confirmed empirically that the two agent classes involved (`Agent`, `ACPAgent`) are frozen Pydantic models — direct attribute mutation on `.llm` raises `ValidationError: Instance is frozen`, which shaped the
`model_copy`-based approach used here.
