### PR TITLE
Azure API version update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,11 @@ jobs:
               run: |
                   # Allowed top-level directories under tests/
                   # Each must have a corresponding CI job or workflow that runs them.
-                  #   tests.yml:             sdk, tools, workspace, agent_server, cross
+                  #   tests.yml:             sdk, tools, workspace, agent_server, cross, agent_flight_recorder
                   #   run-examples.yml:      examples
                   #   integration-runner.yml: integration
                   #   (data-only):           fixtures
-                  ALLOWED="sdk tools workspace agent_server cross examples integration fixtures"
+                  ALLOWED="sdk tools workspace agent_server cross agent_flight_recorder examples integration fixtures"
 
                   violations=""
                   for entry in tests/*/; do
@@ -65,6 +65,41 @@ jobs:
                     exit 1
                   fi
                   echo "✓ All test directories are in the allowlist"
+
+    agent-flight-recorder-tests:
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+              with: {fetch-depth: 0}
+
+            - name: Detect flight recorder changes
+              id: changed
+              uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+              with:
+                  files: |
+                      agent-flight-recorder/**
+                      tests/agent_flight_recorder/**
+                      pyproject.toml
+                      uv.lock
+                      .github/workflows/tests.yml
+
+            - name: Install uv
+              if: steps.changed.outputs.any_changed == 'true'
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  enable-cache: true
+                  python-version: '3.13'
+
+            - name: Install dependencies
+              if: steps.changed.outputs.any_changed == 'true'
+              run: uv sync --frozen --group dev
+
+            - name: Run package and headless GUI tests
+              if: steps.changed.outputs.any_changed == 'true'
+              env:
+                  QT_QPA_PLATFORM: offscreen
+              run: uv run pytest tests/agent_flight_recorder
 
     sdk-tests:
         runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/agent-flight-recorder/AGENTS.md
+++ b/agent-flight-recorder/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Flight Recorder Guidance
+
+- Preserve the recorder constitution in `.specify/memory/constitution.md`.
+- Callback paths must remain bounded, non-blocking, and exception-contained.
+- Treat `.afr` records as authoritative; SQLite is a rebuildable index.
+- Keep capture, diagnostics, services, and Qt presentation separate.
+- Derived data and findings must retain resolvable evidence identifiers.
+- Put tests under `tests/agent_flight_recorder/` and use `pytest-qt` for GUI behavior.
+- Run pre-commit on every changed file and focused tests after each logical change.

--- a/agent-flight-recorder/AGENT_FLIGHT_RECORDER_DESIGN.md
+++ b/agent-flight-recorder/AGENT_FLIGHT_RECORDER_DESIGN.md
@@ -1,0 +1,1149 @@
+# Agent Flight Recorder
+
+Status: Proposed
+Date: 2026-09-01
+Target: OpenHands Software Agent SDK and Python desktop GUI
+
+## 1. Summary
+
+Agent Flight Recorder is a local-first observability and diagnostics system for
+OpenHands agent runs. It records conversation events, agent and subagent
+relationships, LLM requests and responses, tool activity, context condensation,
+workspace changes, token usage, cost, latency, retries, errors, and termination
+reasons.
+
+The system presents this data in a standalone Python desktop GUI built with
+PySide6. Its primary view is an interactive swimlane timeline linked to a trace
+tree and detail inspector. A separate diagnostic layer detects unproductive
+loops, poor context selection, failed handoffs, expensive prompts, lost
+requirements, and premature completion.
+
+Collection is deterministic. LLM-based analysis never participates in the
+observed run and cannot modify its workspace.
+
+## 2. Problem
+
+Agent failures are difficult to understand from terminal logs alone. Important
+evidence is distributed across conversation events, model calls, tool results,
+subagent runs, test output, context summaries, and file changes.
+
+Developers need to answer questions such as:
+
+- What information did the model receive before this decision?
+- Which agent or tool caused a change?
+- Why did the system repeat an action?
+- Which facts were removed or distorted during context condensation?
+- Did a subagent return useful evidence to its parent?
+- Why did the run stop?
+- Where were tokens, time, and money spent?
+- What is the smallest change that would improve the next run?
+
+## 3. Goals
+
+1. Reconstruct the visible execution history of an OpenHands run.
+2. Show exact model-visible input and visible model output when LLM logging is
+   enabled.
+3. Correlate agents, LLM calls, tools, files, tests, and condensation events.
+4. Stream new activity to a UI while a run is executing.
+5. Detect common context and loop failures with evidence-backed findings.
+6. Measure recorder overhead and diagnostic accuracy.
+7. Support local SDK conversations first and remote Agent Server runs second.
+8. Deliver all visible application components as a native Python GUI without a
+  browser or JavaScript runtime.
+
+## 4. Non-goals
+
+- Replacing OpenHands conversation persistence.
+- Allowing the diagnostic agent to edit code or control the observed run.
+- Building a general log management platform.
+- Supporting distributed production deployment in the first milestone.
+- Inferring causality when the trace contains no supporting evidence.
+
+## 5. Design Principles
+
+### 5.1 Observe without controlling
+
+Recorder failure must not fail the observed agent run. Instrumentation writes to
+a bounded queue, and callback exceptions are contained and reported separately.
+
+### 5.2 Preserve facts before interpretation
+
+Raw OpenHands event identities and ordering metadata are retained. Derived spans
+and findings refer back to those immutable records.
+
+### 5.3 Separate capture from diagnosis
+
+Capture uses code and structured SDK callbacks. Rules and diagnostic models read
+stored traces after or alongside collection.
+
+### 5.4 Every diagnosis needs evidence
+
+A finding must cite event, LLM call, artifact, or test-result identifiers.
+Unsupported explanations are not displayed as facts.
+
+## 6. User Stories
+
+### Run investigator
+
+As a developer, I can open a failed run, select an iteration, inspect the exact
+context sent to the model, and compare it with the preceding iteration.
+
+### Orchestration designer
+
+As an agent developer, I can see parent-child agent relationships, handoff
+payloads, parallel execution, wait time, and reducer output.
+
+### Context engineer
+
+As a context engineer, I can see which events entered each LLM call, which were
+removed by condensation, and whether important requirements survived.
+
+### Loop engineer
+
+As a loop engineer, I can identify repeated tool calls, recurring failures,
+iterations without workspace progress, and the final stopping condition.
+
+### Cost investigator
+
+As a developer, I can attribute tokens, latency, and cost to a model call,
+agent, iteration, and complete run.
+
+## 7. System Context
+
+```mermaid
+flowchart LR
+    OH[OpenHands SDK or Agent Server] --> A[Recorder Adapter]
+    A --> Q[Bounded Event Queue]
+    Q --> C[Collector]
+  C --> T[AFR Trace Bundle]
+    C --> DB[(SQLite)]
+    C --> B[(Content Blob Store)]
+  T --> S[Python Application Services]
+  DB --> S
+  B --> S
+  S --> UI[PySide6 Desktop GUI]
+    DB --> R[Rule Engine]
+    R --> F[(Findings)]
+    DB --> DA[Diagnostic Agent]
+    DA --> F
+  F --> S
+```
+
+## 8. OpenHands Integration Points
+
+### 8.1 Conversation events
+
+Attach a callback through `Conversation(callbacks=[...])`. Each OpenHands
+`Event` provides an ID, timestamp, source, and `parent_id`. The adapter stores
+the event's discriminated type and serialized payload.
+
+OpenHands invokes user callbacks before its default state-persistence callback.
+The recorder therefore treats callback data as observed events and does not read
+conversation state from inside the callback.
+
+### 8.2 Streaming output
+
+Attach `Conversation(token_callbacks=[...])` when live token display is enabled.
+Chunks are streamed to connected clients but are not persisted individually by
+default. The completed response is the durable record.
+
+### 8.3 Exact LLM calls
+
+Enable OpenHands completion logging and register
+`llm.telemetry.set_log_completions_callback(...)`. The callback receives a
+filename and JSON log payload containing request context, response, cost,
+timestamp, latency, and usage information.
+
+For remote conversations, consume `LLMCompletionLogEvent`, whose `log_data`
+contains the JSON-encoded completion record and whose fields include model and
+usage identifiers.
+
+Conversation events alone are not considered an exact reconstruction of a model
+request. Context condensation, message merging, tool schemas, and provider
+options can make the final request differ from a projection of the event log.
+
+### 8.4 Metrics
+
+Read snapshots from conversation statistics or LLM metrics. OpenHands exposes
+per-call and accumulated values for:
+
+- Prompt and completion tokens
+- Cache read and write tokens
+- Reasoning tokens
+- Context-window size
+- Cost
+- Response latency
+- Response ID
+
+The response ID is used to correlate metrics with LLM output and action events.
+
+### 8.5 Context condensation
+
+Record every `Condensation` event. It identifies forgotten event IDs, the
+generated summary, summary insertion offset, and the LLM response that produced
+it. The UI can therefore show a before-and-after context view without guessing
+which events were removed.
+
+### 8.6 Agent and subagent lineage
+
+Within a conversation, OpenHands `parent_id` values define the event tree.
+Cross-conversation delegation needs explicit trace propagation. The orchestration
+adapter assigns one `trace_id` to the complete run and passes a
+`parent_agent_span_id` when creating each delegated conversation or workflow
+agent.
+
+Until cross-conversation propagation is implemented, the UI labels inferred
+relationships as unverified rather than presenting them as authoritative.
+
+## 9. Proposed Architecture
+
+### 9.1 Recorder Adapter
+
+A small Python package embedded in the process running the OpenHands SDK.
+
+Responsibilities:
+
+- Create run and agent span identifiers.
+- Convert callbacks into versioned recorder envelopes.
+- Correlate OpenHands event and response IDs.
+- Propagate trace context into delegated work.
+- Send records to an in-process bounded queue.
+- Drop or truncate content according to configured size limits.
+- Never block on database or network I/O in an OpenHands callback.
+
+### 9.2 Collector
+
+A background worker that validates, normalizes, and persists batches.
+
+Responsibilities:
+
+- Assign a monotonically increasing sequence number per run.
+- Deduplicate records by producer ID and source event ID.
+- Store searchable metadata in SQLite.
+- Store optional large content as compressed blobs.
+- Publish committed records to live UI subscribers.
+- Expose queue pressure and dropped-record counters.
+
+### 9.3 Trace Store
+
+SQLite in write-ahead logging mode is sufficient for the local MVP. Structured
+metadata remains queryable while potentially large prompt, response, and tool
+payloads live in compressed content blobs.
+
+The portable `.afr` trace bundle is the canonical record. SQLite is a local
+query index built from that bundle and can be deleted and regenerated without
+losing trace information. The bundle and database schemas are
+migration-controlled. Recorder envelopes retain a `schema_version` so imported
+traces can be upgraded.
+
+### 9.4 Rule Engine
+
+Deterministic detectors run on committed trace records. Rules are inexpensive,
+repeatable, testable, and suitable for live warnings.
+
+### 9.5 Diagnostic Agent
+
+An optional read-only agent analyzes a bounded evidence packet after deterministic
+rules run. It receives excerpts and identifiers, not database access or workspace
+tools. Its output must satisfy a strict finding schema.
+
+### 9.6 Python Application Services
+
+Python service classes provide trace queries, bundle import and export,
+diagnostic execution, and live subscriptions. They are independent of Qt so the
+same behavior can be tested headlessly and reused by the command-line tools.
+
+When the recorder and GUI share a process, the collector publishes committed
+record batches through a Qt signal adapter. When an observed OpenHands run is in
+another process, the GUI tails its active `.afr/records.jsonl` file and refreshes
+from the last committed sequence. `QFileSystemWatcher` provides notifications
+with a short polling fallback because filesystem notification coalescing differs
+by platform.
+
+The MVP does not start an HTTP server or require a browser. A remote API may be
+added later as an optional adapter without changing the application services or
+trace format.
+
+### 9.7 Trace UI
+
+A standalone PySide6 desktop application uses a swimlane timeline as the primary
+run overview. `QMainWindow`, `QSplitter`, `QTreeView`, `QTabWidget`, and a custom
+`QGraphicsView` timeline provide synchronized drill-down into agent lineage, LLM
+context, tool activity, artifacts, metrics, and findings.
+
+Database access, bundle parsing, diagnostics, and other blocking work run outside
+the GUI thread. Worker objects communicate immutable view models to widgets with
+Qt signals and slots. The GUI remains read-only with respect to the observed
+agent workspace.
+
+## 10. Trace Model
+
+The model follows OpenTelemetry concepts while preserving OpenHands-specific
+data. A future OTLP exporter should not require replacing the internal schema.
+
+### 10.1 Hierarchy
+
+```text
+Trace: one user task or orchestration run
+  Run span
+    Agent span
+      Iteration span
+        LLM span
+        Tool span
+        Condensation span
+      Delegated agent span
+    Evaluation span
+```
+
+### 10.2 Event envelope
+
+```json
+{
+  "schema_version": 1,
+  "record_id": "uuid",
+  "producer_id": "sdk-process-uuid",
+  "trace_id": "uuid",
+  "span_id": "uuid",
+  "parent_span_id": "uuid-or-null",
+  "agent_span_id": "uuid-or-null",
+  "sequence": 42,
+  "observed_at": "2026-09-01T12:00:00.000Z",
+  "source_timestamp": "2026-09-01T11:59:59.950Z",
+  "monotonic_ns": 8273649123000,
+  "kind": "llm.response",
+  "openhands_event_id": "uuid-or-null",
+  "llm_response_id": "provider-response-id-or-null",
+  "payload": {},
+  "content_ref": "sha256-or-null"
+}
+```
+
+Timestamps are descriptive. `sequence` is the authoritative display order for
+records committed by one collector. `monotonic_ns` is optional and is used only
+to calculate durations between records from the same producer. It must not be
+compared across processes. `agent_span_id` is a denormalized reference to the
+owning swimlane and avoids repeatedly walking the span tree during live updates.
+
+### 10.3 Core record kinds
+
+```text
+run.started                 run.finished
+agent.started               agent.finished
+iteration.started           iteration.finished
+conversation.event          conversation.status_changed
+llm.request                 llm.stream_delta
+llm.response                llm.error
+llm.retry                   llm.metrics
+tool.request                tool.result
+tool.error                  context.condensed
+delegation.started          delegation.finished
+workspace.snapshot          workspace.diff
+test.started                test.finished
+budget.warning              recorder.warning
+finding.created
+```
+
+### 10.4 SQLite tables
+
+#### `runs`
+
+`trace_id`, task label, status, start and end time, stop reason, repository
+identity, recorder version, total tokens, cost, and latency.
+
+#### `spans`
+
+`span_id`, `trace_id`, `parent_span_id`, type, name, agent identity, model,
+status, start and end sequence, start and end time, and attributes JSON.
+
+#### `records`
+
+Envelope fields, record kind, correlation identifiers, searchable summary,
+payload JSON, and content reference.
+
+#### `llm_calls`
+
+Call and response IDs, model, usage ID, request and response references, finish
+reason, token counts, cache counts, cost, latency, retry count, context hash,
+and status.
+
+#### `artifacts`
+
+Artifact ID, trace and span IDs, kind, path, content hash, MIME type, size,
+created sequence, and optional content reference.
+
+#### `findings`
+
+Finding ID, trace ID, rule or analyzer ID, category, severity, confidence,
+title, explanation, recommendation, evidence references, status, and creation
+time.
+
+#### `content_blobs`
+
+SHA-256 hash, compression, byte length, media type, and content. Identical content
+is stored once.
+
+### 10.5 Portable Trace File Format
+
+The canonical portable output is an Agent Flight Recorder trace bundle. An
+active trace is a directory named `<trace_id>.afr`. A finalized trace may remain
+a directory or be packaged as `<trace_id>.afr.zip` without changing its internal
+layout.
+
+```text
+<trace_id>.afr/
+  manifest.json
+  records.jsonl
+  findings.jsonl
+  content/
+    <sha256>.json.zst
+    <sha256>.txt.zst
+  checksums.sha256
+```
+
+#### `manifest.json`
+
+The manifest describes the bundle and the final run state:
+
+```json
+{
+  "format": "agent-flight-recorder",
+  "format_version": 1,
+  "trace_id": "uuid",
+  "created_at": "2026-09-01T12:00:00.000Z",
+  "completed_at": "2026-09-01T12:04:32.000Z",
+  "status": "completed",
+  "stop_reason": "agent_finished",
+  "recorder_version": "0.1.0",
+  "record_count": 142,
+  "finding_count": 3,
+  "content_encoding": "zstd"
+}
+```
+
+During an active run, `completed_at`, `stop_reason`, counts, and checksums may be
+absent. Finalization writes the completed manifest atomically and then writes
+`checksums.sha256`. Adding findings after a run completes returns the directory
+to an unfinalized state; the recorder updates the manifest and checksums before
+exporting a new immutable `.afr.zip`.
+
+#### `records.jsonl`
+
+`records.jsonl` is the append-only source of truth for observed activity. Each
+UTF-8 line is one event envelope from section 10.2. Requirements:
+
+- Lines are ordered by strictly increasing `sequence` within the trace.
+- Every `record_id` is unique within the bundle.
+- Re-ingesting the same `record_id` is idempotent.
+- Each line is independently valid JSON and ends with a newline.
+- A span's starting record carries its name, type, lane label, and attributes.
+- Its matching terminal record uses the same `span_id` and carries status, stop
+  reason when applicable, and `duration_ms`.
+- `parent_span_id` must resolve to another span in the bundle or be explicitly
+  marked unresolved in the payload.
+- Large content uses `content_ref`; it is not duplicated in the envelope.
+
+Timeline span lifecycles use these record-kind pairs:
+
+| Span type | Starting kind | Terminal kind |
+| --- | --- | --- |
+| Run | `run.started` | `run.finished` |
+| Agent | `agent.started` | `agent.finished` |
+| Iteration | `iteration.started` | `iteration.finished` |
+| Delegation | `delegation.started` | `delegation.finished` |
+| LLM | `llm.request` | `llm.response` or `llm.error` |
+| Tool | `tool.request` | `tool.result` or `tool.error` |
+| Test | `test.started` | `test.finished` |
+
+`conversation.event`, `context.condensed`, warnings, workspace snapshots,
+workspace diffs, and findings are instantaneous records unless their payload
+explicitly references a containing span.
+
+Example span pair:
+
+```json
+{"schema_version":1,"record_id":"rec-10","producer_id":"proc-1","trace_id":"trace-1","span_id":"llm-3","parent_span_id":"iteration-2","agent_span_id":"agent-1","sequence":10,"observed_at":"2026-09-01T12:00:02.000Z","source_timestamp":"2026-09-01T12:00:02.000Z","monotonic_ns":2000000000,"kind":"llm.request","openhands_event_id":null,"llm_response_id":null,"payload":{"span_type":"llm","name":"Planning completion","lane_label":"Main agent","model":"gpt-5.5","status":"running"},"content_ref":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
+{"schema_version":1,"record_id":"rec-11","producer_id":"proc-1","trace_id":"trace-1","span_id":"llm-3","parent_span_id":"iteration-2","agent_span_id":"agent-1","sequence":11,"observed_at":"2026-09-01T12:00:03.250Z","source_timestamp":"2026-09-01T12:00:03.250Z","monotonic_ns":3250000000,"kind":"llm.response","openhands_event_id":"event-7","llm_response_id":"response-9","payload":{"status":"completed","duration_ms":1250,"prompt_tokens":1240,"completion_tokens":183,"cost":0.014},"content_ref":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}
+```
+
+#### `findings.jsonl`
+
+Each UTF-8 line is one diagnostic finding using the schema in section 13.2.
+Findings are separate because analysis may run after trace finalization. Every
+evidence ID must resolve to a record or span in `records.jsonl`.
+
+#### `content/`
+
+Optional content is addressed by SHA-256 of the exact uncompressed bytes. A
+reference has the form `sha256:<64 lowercase hexadecimal characters>`. The
+filename is the hash without the prefix, followed by a media suffix and optional
+`.zst` compression suffix. Importers verify the hash after decompression and
+reject path traversal or unsupported content types.
+
+#### `checksums.sha256`
+
+The finalized bundle contains SHA-256 checksums for the manifest, JSONL files,
+and every content blob. The checksum file itself is not included in its own
+checksum list. Active traces may omit this file.
+
+#### Compatibility rules
+
+- Readers must reject unsupported major `format_version` values.
+- Readers must ignore unknown envelope fields and preserve unknown record kinds.
+- Import builds a fresh SQLite index; database files are never included in the
+  portable bundle.
+- A truncated final JSONL line after a crash is ignored and reported as a
+  recorder warning; all preceding complete lines remain valid.
+
+### 10.6 Timeline Projection
+
+The swimlane timeline is a deterministic projection of `records.jsonl`, not a
+separate source of truth:
+
+1. Group records by `agent_span_id` to create agent swimlanes.
+2. Order lanes by the `sequence` of their `agent.started` record, nesting child
+   agents immediately below their parent.
+3. Pair start and finish records by `span_id` to create timeline bars.
+4. Use `observed_at` for cross-process placement and same-producer
+   `monotonic_ns` or recorded `duration_ms` for bar width.
+5. Render unfinished spans from their start time to the latest observed record
+   and mark them incomplete.
+6. Place instantaneous events such as warnings and condensation at their
+   observed timestamp.
+7. Break timestamp ties with `sequence`.
+
+This projection guarantees that the CLI, desktop GUI, and imported trace show
+the same lane ordering and span relationships.
+
+## 11. Run and Span State
+
+Run states are:
+
+```text
+CREATED -> RUNNING -> COMPLETED
+                   -> FAILED
+                   -> PAUSED -> RUNNING
+                   -> INTERRUPTED
+```
+
+Every terminal run state requires a `stop_reason`, such as:
+
+```text
+agent_finished
+acceptance_tests_passed
+iteration_limit
+budget_exceeded
+stuck_detected
+user_interrupt
+uncaught_error
+recorder_import
+unknown
+```
+
+Recorder warnings do not change the observed run state.
+
+## 12. Context Reconstruction
+
+For each LLM call, the recorder stores:
+
+- Final messages sent to the provider after condensation and projection
+- System prompt and activated skills
+- Tool definitions visible to the model
+- Model and request options
+- Visible response text and tool calls
+- Token usage, cost, latency, and finish reason
+- IDs of contributing conversation events when known
+- A stable hash of the context
+
+The context view supports:
+
+1. **Exact view:** the captured final request.
+2. **Source view:** contributing OpenHands events.
+3. **Diff view:** additions and removals since the preceding call in the same
+   agent span.
+4. **Condensation view:** forgotten events beside the replacement summary.
+5. **Budget view:** token contribution by message, tool schema, and content
+   category when tokenization data is available.
+
+If completion logging is disabled, the UI marks context as reconstructed and
+does not call it exact.
+
+## 13. Intelligent Diagnostics
+
+### 13.1 Rule-based detectors
+
+The MVP implements these detectors first:
+
+| Detector | Trigger | Evidence |
+| --- | --- | --- |
+| Repeated tool call | Same normalized tool and arguments repeated without a relevant workspace change | Tool request and result IDs |
+| Recurring failure | Same normalized error signature occurs at least twice | Test or tool result IDs |
+| No-progress iteration | Iteration completes with no new evidence, artifact, or workspace diff | Iteration and artifact IDs |
+| Context growth | Prompt tokens grow past a configured slope or context percentage | Consecutive LLM call IDs |
+| Context churn | Large context replacement produces semantically equivalent action | LLM and condensation IDs |
+| Lost requirement | A required statement is removed and absent from the condensation summary | Original and condensation IDs |
+| Idle delegation | A delegated agent consumes budget but returns no evidence or artifact | Delegation and child span IDs |
+| Handoff mismatch | Child output does not address the requested handoff contract | Delegation record IDs |
+| Premature finish | Agent finishes while recorded acceptance tests are failing or absent | Finish and test IDs |
+| Budget hotspot | One span consumes more than its configured share of run cost | Span and LLM call IDs |
+
+Normalized fingerprints ignore timestamps, temporary paths, generated IDs, and
+known nondeterministic output.
+
+### 13.2 Diagnostic agent
+
+The diagnostic agent receives:
+
+- Run goal and explicit acceptance criteria
+- Span summaries
+- Existing deterministic findings
+- Selected context diffs
+- Failure signatures
+- Workspace diff summaries
+- Token, cost, and latency outliers
+
+It returns JSON matching:
+
+```json
+{
+  "summary": "string",
+  "findings": [
+    {
+      "category": "loop|context|delegation|tool|cost|termination",
+      "severity": "info|warning|error",
+      "confidence": 0.0,
+      "title": "string",
+      "explanation": "string",
+      "evidence_ids": ["record-or-span-id"],
+      "recommendation": "string"
+    }
+  ]
+}
+```
+
+The service rejects findings with nonexistent evidence IDs. Diagnostic prompt
+content is untrusted data and cannot grant tools or alter system instructions.
+
+### 13.3 Example finding
+
+```text
+Warning: Repeated failure without progress
+
+Iterations 6 through 8 ran the same test command and produced the same failure
+signature. No relevant file changed between those commands.
+
+Evidence: tool-31, test-14, tool-38, test-15, diff-7
+Recommendation: Re-evaluate the suspected implementation path before retrying.
+```
+
+## 14. User Interface
+
+### 14.1 Run list
+
+- Status, task label, duration, cost, tokens, agent count, and finding count
+- Filters for model, status, date, repository, and finding severity
+- Comparison selection for two runs
+
+### 14.2 Trace workspace
+
+The swimlane timeline is the primary experience for understanding a run at a
+glance. It is surrounded by two synchronized panes rather than presented as a
+secondary chart:
+
+```text
++ Task, status, duration, tokens, cost, stop reason -------------------+
+| Trace tree   | Swimlane timeline                     | Inspector     |
+|              |                                       |               |
+| Main agent   | [LLM]--[tool]-----[LLM]               | Input         |
+|   Code scout |      [------ delegated agent ------]   | Output        |
+|   Test scout |      [---- delegated agent ----]       | Context diff  |
+|   Reviewer   |                            [review]     | Metrics       |
+|              |  ! condensation   x failed test        | Evidence      |
++--------------+---------------------------------------+---------------+
+| Findings and workspace-change track                                  |
++----------------------------------------------------------------------+
+```
+
+1. **Trace tree:** agents, iterations, LLM calls, tools, tests, and findings.
+2. **Swimlane timeline:** duration, parallel work, retries, state changes, and
+  warnings along a shared time axis.
+3. **Inspector:** structured input, output, context, metrics, diffs, and evidence
+  for the current selection.
+
+The timeline uses one stable lane per agent. Child-agent lanes are nested below
+their parent and remain in creation order, so live updates do not rearrange the
+screen. Iterations form subtle lane regions; LLM, tool, test, condensation, and
+delegation spans appear inside them. Bar width always represents elapsed time.
+Tokens and cost are separate labels or tracks and never alter bar width.
+
+Visual semantics are consistent across every run:
+
+- LLM spans use one color and model icon.
+- Tool and test spans use distinct colors and familiar icons.
+- Failed spans use an error outline and terminal marker.
+- Retries connect to the preceding attempt.
+- Condensation and diagnostic findings appear as point markers.
+- Solid lineage indicates recorded parentage; dotted lineage indicates an
+  inferred relationship.
+- Incomplete spans and reconstructed context have visible badges.
+
+Long traces use horizontal zoom, a minimap, virtualized lanes, and collapsible
+iterations. Raw token deltas are hidden by default to avoid overwhelming the
+overview.
+
+### 14.3 Timeline interaction and drill-down
+
+Selecting a bar, marker, or trace-tree item synchronizes all panes and opens the
+inspector without leaving the timeline. The selected item is centered and its
+ancestors, descendants, and evidence references are highlighted.
+
+The inspector provides tabs appropriate to the selected span:
+
+- **Summary:** status, duration, agent, model or tool, and parent relationship.
+- **Input:** handoff request, LLM request, tool arguments, or test command.
+- **Output:** visible model response, tool result, test output, or agent return.
+- **Context:** exact or reconstructed model context and previous-call diff.
+- **Changes:** workspace diff and artifacts produced during the span.
+- **Metrics:** tokens, cache use, cost, latency, retries, and budget percentage.
+- **Evidence:** findings that cite the span and records supporting those findings.
+
+A playback control moves through `sequence` values and reveals the run state at
+that point. Deep links encode `trace_id`, selected `span_id` or `record_id`, and
+the active inspector tab.
+
+### 14.4 Context inspector
+
+- Exact or reconstructed status badge
+- Message and tool-schema token breakdown
+- Previous-call diff
+- Condensation before-and-after view
+- Links from each source event to its place in the timeline
+
+### 14.5 Orchestration view
+
+- Parent-child agent graph
+- Handoff request and returned result
+- Parallel execution and waiting time
+- Per-agent cost and token totals
+- Unverified lineage warning where trace propagation is unavailable
+
+### 14.6 Findings panel
+
+- Severity and confidence
+- Concise explanation
+- Clickable evidence references
+- Suggested experiment or configuration change
+- User disposition: confirmed, dismissed, or unresolved
+
+### 14.7 Python GUI implementation
+
+PySide6 is the required GUI toolkit for the first release. The application uses
+Qt's model/view architecture so trace data is not copied into every widget.
+
+| Visible component | PySide6 implementation |
+| --- | --- |
+| Application shell | `QMainWindow` with persistent geometry and layout |
+| Run browser | `QTableView` backed by `QAbstractTableModel` |
+| Trace hierarchy | `QTreeView` backed by `QAbstractItemModel` |
+| Swimlane timeline | Custom `QGraphicsView` and `QGraphicsScene` |
+| Detail inspector | `QTabWidget` containing read-only structured views |
+| Context and text diff | Read-only `QPlainTextEdit` with syntax highlighting |
+| Metrics | Lightweight custom Qt charts; add PyQtGraph only if profiling shows a need |
+| Findings | Filterable `QListView` with severity delegates |
+| Import and export | `QFileDialog` using `.afr` and `.afr.zip` filters |
+| Status and progress | `QStatusBar` and cancellable `QProgressDialog` |
+
+The custom timeline scene owns viewport-scale rendering, hit testing, zoom, and
+selection. It receives immutable `TimelineLane` and `TimelineItem` view models;
+it does not query SQLite during paint events. Items outside the visible time
+range are not instantiated, which keeps long traces responsive.
+
+Widget selection is coordinated by one `SelectionController`. Selecting a
+timeline item, tree node, evidence link, or workspace change updates the same
+selected record or span and prevents circular signal updates.
+
+### 14.8 Accessibility and desktop behavior
+
+- Full keyboard navigation for the run list, tree, timeline, and inspector.
+- Text alternatives and tooltips for icons, colors, and timeline markers.
+- Status never depends on color alone.
+- High-DPI rendering and platform font metrics determine dimensions.
+- Light and dark palettes follow the operating-system preference.
+- Layout geometry, column widths, and filters persist through `QSettings`.
+- Copy actions use the displayed content.
+- Closing during recording prompts before detaching from an active trace.
+
+## 15. Python Application Interfaces
+
+The GUI depends on Python protocols rather than HTTP endpoints or Qt widgets
+performing direct storage access:
+
+```python
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Protocol
+
+
+class TraceRepository(Protocol):
+  def list_runs(self, query: "RunQuery") -> list["RunSummary"]: ...
+  def get_run(self, trace_id: str) -> "RunDetail": ...
+  def get_timeline(self, trace_id: str) -> "TimelineView": ...
+  def get_span(self, trace_id: str, span_id: str) -> "SpanDetail": ...
+  def iter_records(self, trace_id: str, after: int = 0) -> Iterable["Record"]: ...
+  def get_findings(self, trace_id: str) -> list["Finding"]: ...
+
+
+class BundleService(Protocol):
+  def import_bundle(self, source: Path) -> str: ...
+  def export_bundle(self, trace_id: str, destination: Path) -> Path: ...
+
+
+class TraceSubscription(Protocol):
+  def subscribe(
+    self,
+    trace_id: str,
+    callback: Callable[["CommittedBatch"], None],
+  ) -> "SubscriptionHandle": ...
+
+
+class DiagnosticService(Protocol):
+  def analyze(self, trace_id: str, include_llm: bool = False) -> list["Finding"]: ...
+```
+
+Concrete services use SQLite and `.afr` bundles. Qt worker adapters call these
+interfaces outside the GUI thread and emit success, progress, or typed failure
+signals. Batch ingestion remains idempotent by `record_id`; content services
+provide content by reference.
+
+## 16. Reliability and Performance
+
+Initial service targets:
+
+- Less than 5% median wall-clock overhead with token streaming disabled.
+- Less than 50 ms callback time at the 99th percentile.
+- No lost metadata records during a normal process shutdown.
+- UI receives committed events within 500 ms locally.
+- Opening a trace with 100,000 records reaches an interactive overview within
+  three seconds on the reference development machine.
+- Selection and inspector updates complete within 100 ms for an indexed trace.
+- No database, decompression, diagnostic, or bundle-import work runs on the Qt
+  GUI thread.
+- A recorder failure never changes the OpenHands run result.
+- Bounded memory under prolonged tool output.
+
+Large payloads are truncated at the producer according to configured size limits.
+Records enter a bounded queue. On pressure, the adapter drops live token chunks
+first, then large duplicate content, but preserves run state, errors, final LLM
+records, and drop counters.
+
+## 17. Failure Handling
+
+| Failure | Behavior |
+| --- | --- |
+| Collector unavailable | Buffer to a bounded local spool or continue with a warning |
+| Invalid record | Quarantine metadata and increment validation counter |
+| Database locked | Retry with bounded backoff; preserve queue order |
+| GUI closes or detaches | Continue persistence; resume from the last indexed sequence when reopened |
+| Active-bundle notification missed | Poll from the last sequence and deduplicate by record ID |
+| GUI worker fails | Show a recoverable error without terminating collection |
+| Analyzer failure | Mark analysis failed; retain deterministic findings |
+| Unknown event type | Store type and safe serialized payload as a generic event |
+| Process crash | Mark stale running traces as incomplete on next startup |
+
+## 18. Evaluation Plan
+
+### 18.1 Recorder correctness
+
+- Every observed callback event is represented once.
+- Parent links resolve or are explicitly marked missing.
+- LLM calls correlate with metrics through response IDs.
+- Condensation views remove exactly the recorded forgotten event IDs.
+
+### 18.2 Diagnostic quality
+
+Create seeded traces containing known problems:
+
+- Repeated identical tool calls
+- Repeated tests without code changes
+- Requirement loss after condensation
+- Unbounded context growth
+- Subagent output ignored by its parent
+- Passing tests followed by unnecessary work
+- Failed tests followed by premature completion
+
+Label expected findings and measure precision, recall, evidence validity, and
+false-positive rate for each detector. Compare rules alone with rules plus the
+diagnostic agent.
+
+### 18.3 System performance
+
+Replay the same tasks with recording disabled and enabled. Compare wall time,
+CPU, memory, trace size, and dropped records.
+
+Replay small, medium, and large trace fixtures in the desktop GUI. Measure first
+interactive render, timeline pan and zoom latency, selection latency, peak
+memory, and background indexing time.
+
+## 19. Testing Strategy
+
+### Unit tests
+
+- Envelope validation and schema migration
+- Record fingerprints and deduplication
+- Detector boundaries and false-positive cases
+- State transitions and stop-reason validation
+- Context and condensation reconstruction
+
+### Integration tests
+
+- Local `Conversation` callback ingestion
+- Completion-log callback ingestion
+- Remote `LLMCompletionLogEvent` ingestion
+- Parallel agent trace propagation
+- Collector restart and idempotent batch replay
+- Active `.afr` tailing from a sequence cursor
+- Missed filesystem notification recovery
+- Qt worker success, progress, cancellation, and failure signals
+
+### GUI tests
+
+- Use `pytest-qt` for widget behavior and signal synchronization.
+- Run headlessly with `QT_QPA_PLATFORM=offscreen` in CI.
+- Verify run-table, trace-tree, and timeline view models independently of paint
+  behavior.
+- Verify selection synchronization across tree, timeline, findings, and
+  inspector.
+- Verify zoom, hit testing, keyboard navigation, and incomplete-span rendering.
+- Keep screenshot tests focused on stable layout states rather than font pixels.
+
+### End-to-end tests
+
+- Run a small coding task and inspect the complete timeline.
+- Run a task that triggers condensation and compare contexts.
+- Run parallel subagents and verify the orchestration graph.
+- Produce a repeated failure and verify the evidence-backed warning.
+- Launch the packaged desktop application, import an `.afr.zip`, select an LLM
+  span, and inspect its input, output, context, and metrics.
+
+## 20. Proposed Project Layout
+
+```text
+agent-flight-recorder/
+  pyproject.toml
+  README.md
+  src/flight_recorder/
+    __main__.py
+    app.py
+    adapter/
+      conversation.py
+      llm.py
+      propagation.py
+    collector/
+      queue.py
+      normalize.py
+      persistence.py
+    diagnostics/
+      rules.py
+      analyzer.py
+      schemas.py
+    models/
+      envelopes.py
+      database.py
+      view_models.py
+    services/
+      repository.py
+      bundles.py
+      subscriptions.py
+      diagnostics.py
+    gui/
+      main_window.py
+      palette.py
+      resources.py
+      controllers/
+        selection.py
+      models/
+        run_table.py
+        trace_tree.py
+      timeline/
+        view.py
+        scene.py
+        layout.py
+        items.py
+      inspector/
+        widget.py
+        context.py
+        diff.py
+        metrics.py
+      workers.py
+    cli.py
+  tests/
+    unit/
+    integration/
+    gui/
+    e2e/
+    fixtures/traces/
+```
+
+### 20.1 Python dependencies and packaging
+
+Core runtime dependencies are:
+
+- `PySide6` for the complete desktop interface.
+- `pydantic` for recorder and service models.
+- `zstandard` for compressed content blobs.
+- `platformdirs` for platform-correct application data and cache locations.
+
+SQLite, JSON, hashing, ZIP handling, threading, and queueing use the Python
+standard library where practical. `pytest`, `pytest-qt`, and the repository's
+normal lint and type-check tools are development dependencies.
+
+The `pyproject.toml` exposes a GUI entry point:
+
+```toml
+[project.gui-scripts]
+agent-flight-recorder = "flight_recorder.app:main"
+```
+
+Development runs use `uv run agent-flight-recorder`. Release builds use
+PyInstaller initially, producing a desktop executable that includes the Qt
+plugins required by the target platform. Linux is the first supported packaging
+target; Windows and macOS follow after the trace and GUI contracts stabilize.
+
+## 21. Delivery Plan
+
+### Milestone 1: Deterministic local recorder
+
+- Instrument one local OpenHands conversation.
+- Capture events, LLM completion logs, metrics, and run status.
+- Persist records to an `.afr` bundle.
+- Build the SQLite index and provide a command-line validation summary.
+
+Exit criterion: a recorded sample run can be replayed as an ordered textual
+timeline with correlated LLM usage.
+
+### Milestone 2: Python desktop GUI
+
+- Build the PySide6 application shell, run list, trace tree, swimlane timeline,
+  and inspector.
+- Add live updates through Qt signals and active-bundle tailing.
+- Add context and workspace diff views.
+- Package the Linux application with its Qt runtime dependencies.
+
+Exit criterion: a developer can answer what the model saw, what it did, and how
+much the step cost without reading raw log files or opening a browser.
+
+### Milestone 3: Loop and context diagnostics
+
+- Implement deterministic detectors.
+- Add findings and evidence navigation.
+- Build seeded trace fixtures and detector evaluation.
+
+Exit criterion: seeded loop and context failures are detected with agreed
+precision and no dangling evidence references.
+
+### Milestone 4: Agent orchestration tracing
+
+- Propagate trace context through delegated and workflow agents.
+- Add agent graph, handoff inspection, and per-agent metrics.
+- Trace parallel branches and reducer activity.
+
+Exit criterion: all agents in a sample parallel workflow appear under one trace
+with verified parentage.
+
+### Milestone 5: Intelligent diagnosis
+
+- Build bounded evidence packets.
+- Add the read-only diagnostic agent and structured output validation.
+- Compare rules-only and hybrid diagnostic performance.
+
+Exit criterion: diagnostic output improves labeled-trace recall without
+unacceptable false positives or unsupported claims.
+
+### Milestone 6: Remote Agent Server support
+
+- Ingest remote event and completion-log streams.
+- Handle reconnect, replay, interruption, and incomplete runs.
+
+Exit criterion: local and remote traces render through the same normalized
+query model.
+
+## 22. First Vertical Slice
+
+The first implementation should remain deliberately small:
+
+1. Wrap the condenser example in a recorder-enabled conversation.
+2. Capture conversation events with a callback.
+3. Capture exact LLM logs with the telemetry completion callback.
+4. Append normalized records to an `.afr` bundle.
+5. Build the SQLite index and open the run in a PySide6 `QMainWindow`.
+6. Render stable agent swimlanes with duration, status, tokens, and cost, and
+  open a read-only detail inspector when a span is selected.
+7. Show each condensation event with forgotten IDs and its summary.
+8. Add one repeated-tool-call detector with evidence IDs.
+
+This slice validates the most important architecture assumption: OpenHands event
+callbacks and LLM telemetry can be correlated into one useful, interactive
+desktop trace without changing the agent loop.
+
+## 23. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Callback overhead changes agent behavior | Nonblocking queue, batching, overhead benchmarks |
+| Event and LLM records do not correlate | Use response IDs and explicit adapter correlation; mark uncertainty |
+| Cross-agent parentage is lost | Propagate trace context at orchestration boundaries |
+| Diagnostic model hallucinates causes | Require existing evidence IDs and display confidence |
+| Trace volume becomes excessive | Content addressing, compression, truncation, retention |
+| SDK event schemas evolve | Version envelopes and preserve unknown event types |
+| Users confuse reconstructed and exact context | Prominent provenance status in every context view |
+| Large traces stall the GUI | Background indexing, immutable view models, visible-range scene items |
+| Qt packaging differs by platform | Package and test one operating system first, then add platform CI |
+
+## 24. Open Questions
+
+1. Which orchestration boundary is the cleanest place to propagate trace context
+   into every `TaskToolSet` and workflow subagent?
+2. Should artifact content be stored, or should the MVP retain only paths,
+   hashes, and diffs?
+3. Which tokenizer should estimate per-message contributions when provider usage
+   reports only aggregate tokens?
+4. What precision threshold should a detector meet before it is enabled by
+   default?
+5. Which trace fields should map directly to OpenTelemetry GenAI semantic
+   conventions?
+6. Should a later release launch and control OpenHands runs from the GUI, or
+  remain a strictly read-only recorder and trace viewer?
+
+## 25. Acceptance Criteria for the MVP
+
+The MVP is complete when:
+
+- `uv run agent-flight-recorder` launches a standalone PySide6 desktop
+  application without starting a browser or local web server.
+- A local OpenHands run appears in an ordered trace timeline.
+- The timeline uses stable agent swimlanes, shows parallel spans and elapsed
+  time, and opens synchronized details when a span is selected.
+- The trace includes conversation events, exact LLM request and visible response,
+  tool activity, metrics, errors, and stop reason.
+- The run exports as a valid `.afr.zip` bundle and produces the same timeline
+  after import into an empty database.
+- Condensation displays forgotten events and the replacement summary.
+- At least one loop detector produces an evidence-linked finding.
+- Recorder failure does not fail the observed conversation.
+- An automated replay test proves that duplicate batches do not duplicate trace
+  records.
+- GUI interaction, live updates, selection synchronization, and import are
+  covered by headless `pytest-qt` tests.
+- Measured median runtime overhead remains below the initial 5% target.
+
+## 26. Relevant OpenHands References
+
+- `software-agent-sdk/examples/01_standalone_sdk/14_context_condenser.py`
+- `software-agent-sdk/examples/01_standalone_sdk/25_agent_delegation.py`
+- `software-agent-sdk/examples/01_standalone_sdk/31_iterative_refinement.py`
+- `software-agent-sdk/examples/01_standalone_sdk/52_dynamic_workflow.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/event/base.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/event/condenser.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/event/llm_completion_log.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/llm/utils/metrics.py`
+- `software-agent-sdk/openhands-sdk/openhands/sdk/llm/utils/telemetry.py`

--- a/agent-flight-recorder/AGENT_FLIGHT_RECORDER_DESIGN.md
+++ b/agent-flight-recorder/AGENT_FLIGHT_RECORDER_DESIGN.md
@@ -149,10 +149,11 @@ default. The completed response is the durable record.
 
 ### 8.3 Exact LLM calls
 
-Enable OpenHands completion logging and register
-`llm.telemetry.set_log_completions_callback(...)`. The callback receives a
-filename and JSON log payload containing request context, response, cost,
-timestamp, latency, and usage information.
+Enable OpenHands completion logging and register both telemetry callbacks.
+`llm.telemetry.set_log_requests_callback(...)` receives the exact request context
+immediately before each provider transport attempt. The completion callback
+receives the response or final error, cost, timestamp, latency, and usage. A
+generated `llm_call_id` correlates each request with its result.
 
 For remote conversations, consume `LLMCompletionLogEvent`, whose `log_data`
 contains the JSON-encoded completion record and whose fields include model and
@@ -312,6 +313,7 @@ Trace: one user task or orchestration run
   "monotonic_ns": 8273649123000,
   "kind": "llm.response",
   "openhands_event_id": "uuid-or-null",
+  "llm_call_id": "request-attempt-uuid-or-null",
   "llm_response_id": "provider-response-id-or-null",
   "payload": {},
   "content_ref": "sha256-or-null"
@@ -1072,7 +1074,7 @@ The first implementation should remain deliberately small:
 
 1. Wrap the condenser example in a recorder-enabled conversation.
 2. Capture conversation events with a callback.
-3. Capture exact LLM logs with the telemetry completion callback.
+3. Capture exact LLM requests and responses with both telemetry callbacks.
 4. Append normalized records to an `.afr` bundle.
 5. Build the SQLite index and open the run in a PySide6 `QMainWindow`.
 6. Render stable agent swimlanes with duration, status, tokens, and cost, and

--- a/agent-flight-recorder/README.md
+++ b/agent-flight-recorder/README.md
@@ -114,6 +114,22 @@ workspace changes, model context provenance and differences, delegated agents,
 usage, and evidence-backed findings. Reconstructed or inferred information is
 explicitly labeled and unresolved evidence remains visible.
 
+An `llm.request` record is persisted immediately before each provider transport
+attempt. The exact outbound data is under `payload.request`. A correlated
+`llm.response` record is persisted when the provider returns or the final attempt
+fails; its payload contains the response or error, usage, cost, and latency. Both
+records carry the same `llm_call_id`, while the response also carries the
+provider's `llm_response_id` when available. They appear together under **LLM
+Interaction**, with **Request** and **Response** sub-rows. OpenHands-level messages
+appear separately under **User Conversation**, with **User Input** and **Agent
+Response** sub-rows. Legacy combined records are projected into the provider
+sub-rows without modifying the source bundle. Traces recorded without completion
+logging still show their conversation messages, but the missing provider exchange
+cannot be added retroactively. Tool activity appears under **Tool**, with
+**Action** and **Result** sub-rows. With sequential tool execution, each action is
+recorded immediately before its tool runs and its result immediately afterward.
+Parallel batches record all overlapping starts before their ordered results.
+
 ## Package For Linux
 
 ```bash

--- a/agent-flight-recorder/README.md
+++ b/agent-flight-recorder/README.md
@@ -1,0 +1,144 @@
+# OpenHands Agent Flight Recorder
+
+Agent Flight Recorder captures local OpenHands SDK runs without changing their
+execution, stores portable `.afr` traces, and provides a native Linux desktop
+viewer for timeline, context, delegation, and diagnostic investigation.
+
+## Install
+
+From the repository root:
+
+```bash
+make build
+```
+
+For an isolated package environment:
+
+```bash
+uv sync --package openhands-agent-flight-recorder
+```
+
+## Record
+
+A target uses `module:function` syntax. The function receives a live `Recorder`:
+
+```bash
+uv run agent-flight-recorder record \
+  --output ./trace.afr my_project.run:recorded_run
+```
+
+Recorder callbacks are bounded and failure-isolated. Queue pressure may omit
+low-priority stream deltas; omission counts are retained as warning records.
+
+### Record A Delegated Coding Run
+
+Use a disposable worktree or test project because the agent will edit the selected
+workspace. From the repository root:
+
+```bash
+export LLM_API_KEY="..."
+export LLM_MODEL="gpt-5.5"
+export LLM_BASE_URL="https://llm-proxy.app.all-hands.dev"
+export AFR_WORKSPACE="/path/to/disposable-worktree"
+export AFR_PROMPT='Use the task tool to delegate repository analysis and implementation to separate subagents. Implement the requested change, run focused tests, and summarize the result.'
+
+uv run agent-flight-recorder record \
+  --output /tmp/coding-run.afr \
+  scripts.record_coding_delegation:run
+```
+
+The recorder follows opt-in callbacks into local `TaskToolSet` child conversations.
+Ordinary callbacks remain scoped to the parent conversation. Validate and inspect
+the resulting orchestration with:
+
+```bash
+uv run agent-flight-recorder validate /tmp/coding-run.afr
+uv run agent-flight-recorder /tmp/coding-run.afr
+```
+
+In the desktop application, expand the primary agent in the left hierarchy, select
+a child agent, and inspect its handoff, returned result, duration, and usage. The
+timeline shows delegated work in separate agent lanes.
+
+### Record From The Local Web Interface
+
+When a web development checkout launches this repository through
+`OH_AGENT_SERVER_LOCAL_PATH`, enable recording in the same shell:
+
+```bash
+OH_AGENT_SERVER_LOCAL_PATH=/home/jaeyongyoo/openhands-dev/software-agent-sdk \
+OH_ENABLE_FLIGHT_RECORDER=true \
+npm run dev
+```
+
+Create a conversation in the web interface and ask the agent to use the task tool
+for delegated analysis and implementation. After the run, use the conversation ID
+from the web URL to query the local agent server:
+
+```bash
+curl http://127.0.0.1:8000/api/conversations/CONVERSATION_ID/flight-recorder
+```
+
+The response contains `trace_id`, `bundle_path`, and `active`. Open the returned
+local path with:
+
+```bash
+uv run agent-flight-recorder /absolute/path/from/bundle_path
+```
+
+If the local server uses session authentication, include
+`-H "X-Session-API-Key: $SESSION_API_KEY"` in the `curl` command. An active trace
+is a consistent snapshot when opened; reopen it after later web prompts to load
+new activity. Closing or evicting the conversation finalizes checksums, and the
+endpoint continues returning the newest trace without reactivating the runtime.
+
+## Validate And Move Traces
+
+```bash
+uv run agent-flight-recorder validate ./trace.afr
+uv run agent-flight-recorder import ./trace.afr
+uv run agent-flight-recorder export TRACE_ID ./exported-trace.zip
+```
+
+Validation checks format version, trace identity, ordering, record identity, and
+checksums when the bundle is finalized.
+
+## View
+
+```bash
+uv run agent-flight-recorder ./trace.afr
+```
+
+The desktop application shows run and activity hierarchy, a swimlane timeline,
+workspace changes, model context provenance and differences, delegated agents,
+usage, and evidence-backed findings. Reconstructed or inferred information is
+explicitly labeled and unresolved evidence remains visible.
+
+## Package For Linux
+
+```bash
+uv sync --extra package --package openhands-agent-flight-recorder
+uv run pyinstaller agent-flight-recorder/agent-flight-recorder.spec
+```
+
+The executable is written to `dist/agent-flight-recorder`.
+
+## Limitations
+
+- Capture is local and single-process in this release.
+- Exact model context requires captured completion request logs; otherwise the
+  viewer presents an evidence-linked reconstruction.
+- Interpretive diagnostics are optional. Deterministic diagnostics remain
+  available if interpretation is disabled or fails.
+- The recorder observes runs but does not launch, pause, resume, or modify them.
+
+## Troubleshooting
+
+- Set `QT_QPA_PLATFORM=offscreen` for GUI tests on headless Linux.
+- Native X11 launch requires the Qt XCB runtime libraries, including
+  `libxcb-cursor`, `libxcb-keysyms`, `libxcb-render-util`, `libxcb-xkb`, and
+  `libxkbcommon-x11`. Install the corresponding packages for your distribution
+  if PyInstaller reports them as unresolved.
+- Run `validate` before importing a trace received from another machine.
+- Inspect `recorder.warning` records when a trace appears incomplete under load.
+- Re-run `make build` if workspace entry points or imports do not resolve.

--- a/agent-flight-recorder/agent-flight-recorder.spec
+++ b/agent-flight-recorder/agent-flight-recorder.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
+
+
+ROOT = Path.cwd()
+PACKAGE = ROOT / "agent-flight-recorder"
+
+a = Analysis(
+    [str(PACKAGE / "src" / "flight_recorder" / "__main__.py")],
+    pathex=[str(PACKAGE / "src"), str(ROOT / "openhands-sdk")],
+    binaries=[],
+    datas=[
+        *collect_data_files("litellm"),
+        *collect_data_files("tiktoken"),
+        *copy_metadata("openhands-agent-flight-recorder"),
+        *copy_metadata("openhands-sdk"),
+        *copy_metadata("fastmcp"),
+        *copy_metadata("litellm"),
+    ],
+    hiddenimports=[
+        *collect_submodules("flight_recorder"),
+        *collect_submodules("openhands.sdk"),
+        *collect_submodules("tiktoken"),
+        *collect_submodules("tiktoken_ext"),
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="agent-flight-recorder",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)

--- a/agent-flight-recorder/pyproject.toml
+++ b/agent-flight-recorder/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "openhands-agent-flight-recorder"
+version = "0.1.0"
+description = "Local observability and diagnostics for OpenHands agent runs"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "openhands-sdk",
+    "platformdirs>=4.2",
+    "pydantic>=2.12.5",
+    "pyside6>=6.8",
+    "zstandard>=0.23",
+]
+
+[project.optional-dependencies]
+package = ["pyinstaller>=6.16"]
+
+[project.urls]
+Source = "https://github.com/OpenHands/software-agent-sdk"
+"Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"flight_recorder" = ["py.typed"]
+
+[project.scripts]
+agent-flight-recorder = "flight_recorder.__main__:main"

--- a/agent-flight-recorder/src/flight_recorder/__init__.py
+++ b/agent-flight-recorder/src/flight_recorder/__init__.py
@@ -1,0 +1,18 @@
+"""Record and inspect OpenHands agent runs."""
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from flight_recorder.recorder import Recorder
+
+
+__all__ = ["Recorder"]
+
+
+def __getattr__(name: str):
+    if name == "Recorder":
+        from flight_recorder.recorder import Recorder
+
+        return Recorder
+    raise AttributeError(name)

--- a/agent-flight-recorder/src/flight_recorder/__main__.py
+++ b/agent-flight-recorder/src/flight_recorder/__main__.py
@@ -1,0 +1,25 @@
+"""Agent Flight Recorder executable entry point."""
+
+import sys
+from pathlib import Path
+
+from flight_recorder.app import run
+from flight_recorder.cli import build_parser, run_cli
+
+
+def main() -> int:
+    arguments = sys.argv[1:]
+    commands = {"record", "validate", "import", "export"}
+    if (
+        len(arguments) == 1
+        and not arguments[0].startswith("-")
+        and arguments[0] not in commands
+    ):
+        return run(Path(arguments[0]))
+    args = build_parser().parse_args()
+    result = run_cli(args)
+    return run(args.trace) if result is None else result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-flight-recorder/src/flight_recorder/adapter/conversation.py
+++ b/agent-flight-recorder/src/flight_recorder/adapter/conversation.py
@@ -1,0 +1,54 @@
+"""OpenHands conversation event adapter."""
+
+from datetime import datetime
+from typing import Any
+
+from flight_recorder.collector.normalize import condensation_payload, make_record
+from flight_recorder.models.envelopes import Record
+
+from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.event.llm_convertible.action import ActionEvent
+from openhands.sdk.event.llm_convertible.observation import ObservationEvent
+
+
+def normalize_event(
+    event: Any,
+    *,
+    producer_id: str,
+    trace_id: str,
+    agent_span_id: str | None = None,
+    parent_agent_span_id: str | None = None,
+) -> Record:
+    event_type = event.__class__.__name__
+    payload = event.model_dump(mode="json")
+    kind = "conversation.event"
+    span_id = agent_span_id
+    parent_span_id = parent_agent_span_id
+    llm_response_id = None
+    if isinstance(event, Condensation):
+        kind = "context.condensed"
+        payload = condensation_payload(event)
+        llm_response_id = event.llm_response_id
+    elif isinstance(event, ActionEvent):
+        llm_response_id = event.llm_response_id
+        if event.tool_name == "task":
+            kind = "delegation.started"
+            span_id = event.id
+            parent_span_id = agent_span_id
+    elif isinstance(event, ObservationEvent) and event.tool_name == "task":
+        kind = "delegation.finished"
+        span_id = event.action_id
+        parent_span_id = agent_span_id
+    timestamp = datetime.fromisoformat(event.timestamp) if event.timestamp else None
+    return make_record(
+        producer_id=producer_id,
+        trace_id=trace_id,
+        kind=kind,
+        payload={"event_type": event_type, **payload},
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        agent_span_id=agent_span_id,
+        openhands_event_id=event.id,
+        llm_response_id=llm_response_id,
+        source_timestamp=timestamp,
+    )

--- a/agent-flight-recorder/src/flight_recorder/adapter/llm.py
+++ b/agent-flight-recorder/src/flight_recorder/adapter/llm.py
@@ -1,0 +1,40 @@
+"""OpenHands completion log adapter."""
+
+import json
+from typing import Any
+
+from flight_recorder.collector.normalize import make_record
+from flight_recorder.models.envelopes import Record
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+
+
+def normalize_completion_log(
+    filename: str, log_data: str, *, producer_id: str, trace_id: str
+) -> Record:
+    payload: dict[str, Any] = json.loads(log_data)
+    response_id = payload.get("response_id") or payload.get("id")
+    return make_record(
+        producer_id=producer_id,
+        trace_id=trace_id,
+        kind="llm.response",
+        payload={"filename": filename, "completion": payload},
+        llm_response_id=response_id,
+    )
+
+
+def normalize_metrics(
+    stats: ConversationStats,
+    *,
+    producer_id: str,
+    trace_id: str,
+    agent_span_id: str | None = None,
+) -> Record:
+    return make_record(
+        producer_id=producer_id,
+        trace_id=trace_id,
+        kind="metrics.snapshot",
+        payload=stats.model_dump(mode="json", context={"use_snapshot": True}),
+        span_id=agent_span_id,
+        agent_span_id=agent_span_id,
+    )

--- a/agent-flight-recorder/src/flight_recorder/adapter/llm.py
+++ b/agent-flight-recorder/src/flight_recorder/adapter/llm.py
@@ -1,6 +1,8 @@
-"""OpenHands completion log adapter."""
+"""OpenHands LLM telemetry adapters."""
 
 import json
+import math
+from datetime import datetime, timedelta
 from typing import Any
 
 from flight_recorder.collector.normalize import make_record
@@ -9,17 +11,82 @@ from flight_recorder.models.envelopes import Record
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 
 
+_RESPONSE_FIELDS = {
+    "response",
+    "response_id",
+    "id",
+    "raw_response",
+    "error",
+    "usage_summary",
+    "cost",
+    "timestamp",
+    "latency_sec",
+}
+_LOG_METADATA_FIELDS = {"llm_call_id", "timestamp"}
+
+
+def _completion_times(
+    payload: dict[str, Any],
+) -> tuple[datetime | None, datetime | None]:
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int | float):
+        return None, None
+    timestamp = float(timestamp)
+    if not math.isfinite(timestamp):
+        return None, None
+    try:
+        response_time = datetime.fromtimestamp(timestamp)
+    except (OSError, OverflowError, ValueError):
+        return None, None
+    latency = payload.get("latency_sec")
+    if (
+        isinstance(latency, bool)
+        or not isinstance(latency, int | float)
+        or not math.isfinite(latency)
+        or latency < 0
+    ):
+        return response_time, response_time
+    return response_time - timedelta(seconds=latency), response_time
+
+
+def normalize_request_log(
+    llm_call_id: str, log_data: str, *, producer_id: str, trace_id: str
+) -> Record:
+    payload: dict[str, Any] = json.loads(log_data)
+    request_payload = {
+        key: value for key, value in payload.items() if key not in _LOG_METADATA_FIELDS
+    }
+    request_time, _ = _completion_times(payload)
+    return make_record(
+        producer_id=producer_id,
+        trace_id=trace_id,
+        kind="llm.request",
+        payload={"request": request_payload},
+        llm_call_id=llm_call_id,
+        source_timestamp=request_time,
+    )
+
+
 def normalize_completion_log(
     filename: str, log_data: str, *, producer_id: str, trace_id: str
 ) -> Record:
     payload: dict[str, Any] = json.loads(log_data)
-    response_id = payload.get("response_id") or payload.get("id")
+    response = payload.get("response")
+    response_id = response.get("id") if isinstance(response, dict) else None
+    response_id = response_id or payload.get("response_id") or payload.get("id")
+    response_payload = {
+        key: value for key, value in payload.items() if key in _RESPONSE_FIELDS
+    }
+    _, response_time = _completion_times(payload)
+    call_id = payload.get("llm_call_id")
     return make_record(
         producer_id=producer_id,
         trace_id=trace_id,
         kind="llm.response",
-        payload={"filename": filename, "completion": payload},
+        payload={"filename": filename, **response_payload},
+        llm_call_id=call_id if isinstance(call_id, str) else None,
         llm_response_id=response_id,
+        source_timestamp=response_time,
     )
 
 

--- a/agent-flight-recorder/src/flight_recorder/adapter/propagation.py
+++ b/agent-flight-recorder/src/flight_recorder/adapter/propagation.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentTraceContext:
+    trace_id: str
+    agent_span_id: str
+    parent_agent_span_id: str | None = None
+
+    def child(self, agent_span_id: str) -> "AgentTraceContext":
+        return AgentTraceContext(
+            trace_id=self.trace_id,
+            agent_span_id=agent_span_id,
+            parent_agent_span_id=self.agent_span_id,
+        )

--- a/agent-flight-recorder/src/flight_recorder/app.py
+++ b/agent-flight-recorder/src/flight_recorder/app.py
@@ -1,0 +1,40 @@
+"""PySide6 desktop application bootstrap."""
+
+from pathlib import Path
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
+
+from flight_recorder.config import RecorderPaths
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.gui.workers import BundleWorker
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.services.bundles import BundleService
+from flight_recorder.services.repository import TraceRepository
+
+
+def run(trace: Path | None = None) -> int:
+    application = QApplication.instance() or QApplication([])
+    application.setOrganizationName("OpenHands")
+    application.setApplicationName("Agent Flight Recorder")
+    window = MainWindow()
+    window.restore_settings(QSettings())
+    if trace is not None:
+        paths = RecorderPaths.defaults()
+        paths.create()
+        index = TraceIndex(paths.index)
+        repository = TraceRepository(index)
+        worker = BundleWorker(BundleService(index, paths.traces), trace)
+        worker.succeeded.connect(
+            lambda trace_id: window.set_repository(repository, str(trace_id))
+        )
+        worker.failed.connect(lambda message: window.statusBar().showMessage(message))
+
+        def detach() -> None:
+            worker.cancel()
+            worker.wait(1000)
+
+        window.add_detach_callback(detach)
+        worker.start()
+    window.show()
+    return application.exec()

--- a/agent-flight-recorder/src/flight_recorder/cli.py
+++ b/agent-flight-recorder/src/flight_recorder/cli.py
@@ -1,0 +1,79 @@
+"""Command-line interface for trace operations."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from flight_recorder.config import RecorderPaths
+from flight_recorder.errors import FlightRecorderError
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.services.bundles import BundleService
+
+
+if TYPE_CHECKING:
+    from flight_recorder.recorder import Recorder
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agent-flight-recorder")
+    parser.set_defaults(trace=None)
+    commands = parser.add_subparsers(dest="command")
+    record = commands.add_parser("record")
+    record.add_argument("--output", required=True, type=Path)
+    record.add_argument("target")
+    validate = commands.add_parser("validate")
+    validate.add_argument("source", type=Path)
+    import_command = commands.add_parser("import")
+    import_command.add_argument("source", type=Path)
+    export = commands.add_parser("export")
+    export.add_argument("trace_id")
+    export.add_argument("destination", type=Path)
+    return parser
+
+
+def run_cli(args: argparse.Namespace) -> int | None:
+    if args.command is None:
+        return None
+    paths = RecorderPaths.defaults()
+    paths.create()
+    index = TraceIndex(paths.index)
+    service = BundleService(index, paths.traces)
+    try:
+        if args.command == "record":
+            from flight_recorder.recorder import Recorder
+
+            target = _load_record_target(args.target)
+            recorder = Recorder(args.output, index)
+            try:
+                result = target(recorder)
+            finally:
+                recorder.close()
+            print(recorder.trace_id)
+            return 0 if result is None else result
+        if args.command == "validate":
+            result = service.validate_bundle(args.source)
+            print(f"{result.trace_id}: {result.record_count} records")
+        elif args.command == "import":
+            print(service.import_bundle(args.source))
+        elif args.command == "export":
+            print(service.export_bundle(args.trace_id, args.destination))
+    except (FlightRecorderError, OSError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+def _load_record_target(target: str) -> Callable[[Recorder], int | None]:
+    module_name, separator, function_name = target.partition(":")
+    if not separator or not module_name or not function_name:
+        raise ValueError("record target must use module:function syntax")
+    module = importlib.import_module(module_name)
+    function = module.__dict__.get(function_name)
+    if not callable(function):
+        raise ValueError(f"record target is not callable: {target}")
+    return cast("Callable[[Recorder], int | None]", function)

--- a/agent-flight-recorder/src/flight_recorder/collector/normalize.py
+++ b/agent-flight-recorder/src/flight_recorder/collector/normalize.py
@@ -17,6 +17,7 @@ def make_record(
     parent_span_id: str | None = None,
     agent_span_id: str | None = None,
     openhands_event_id: str | None = None,
+    llm_call_id: str | None = None,
     llm_response_id: str | None = None,
     source_timestamp: datetime | None = None,
 ) -> Record:
@@ -29,6 +30,7 @@ def make_record(
         agent_span_id=agent_span_id,
         kind=kind,
         openhands_event_id=openhands_event_id,
+        llm_call_id=llm_call_id,
         llm_response_id=llm_response_id,
         source_timestamp=source_timestamp,
         payload=payload,

--- a/agent-flight-recorder/src/flight_recorder/collector/normalize.py
+++ b/agent-flight-recorder/src/flight_recorder/collector/normalize.py
@@ -1,0 +1,45 @@
+"""Normalize SDK values into recorder records."""
+
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from flight_recorder.models.envelopes import Provenance, Record
+
+
+def make_record(
+    *,
+    producer_id: str,
+    trace_id: str,
+    kind: str,
+    payload: dict[str, Any],
+    span_id: str | None = None,
+    parent_span_id: str | None = None,
+    agent_span_id: str | None = None,
+    openhands_event_id: str | None = None,
+    llm_response_id: str | None = None,
+    source_timestamp: datetime | None = None,
+) -> Record:
+    return Record(
+        record_id=str(uuid4()),
+        producer_id=producer_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        agent_span_id=agent_span_id,
+        kind=kind,
+        openhands_event_id=openhands_event_id,
+        llm_response_id=llm_response_id,
+        source_timestamp=source_timestamp,
+        payload=payload,
+        provenance=Provenance(),
+    )
+
+
+def condensation_payload(event: Any) -> dict[str, Any]:
+    return {
+        "forgotten_event_ids": sorted(event.forgotten_event_ids),
+        "summary": event.summary,
+        "summary_offset": event.summary_offset,
+        "llm_response_id": event.llm_response_id,
+    }

--- a/agent-flight-recorder/src/flight_recorder/collector/persistence.py
+++ b/agent-flight-recorder/src/flight_recorder/collector/persistence.py
@@ -1,0 +1,112 @@
+"""Single-writer append and index collector."""
+
+import json
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from threading import Event, Thread
+
+from flight_recorder.collector.normalize import make_record
+from flight_recorder.collector.queue import RecordQueue
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import CommittedBatch, Record
+
+
+class Collector:
+    def __init__(self, queue: RecordQueue, bundle: Path, index: TraceIndex) -> None:
+        self.queue = queue
+        self.bundle = bundle
+        self.index = index
+        self._stop = Event()
+        self._thread: Thread | None = None
+        self._sequence = 0
+        self._record_ids: set[str] = set()
+        self._reported_drops = 0
+        self._subscribers: list[Callable[[CommittedBatch], None]] = []
+        self.errors = 0
+
+    def start(self) -> None:
+        self.bundle.mkdir(parents=True, exist_ok=True)
+        self._thread = Thread(target=self._run, name="flight-recorder", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def subscribe(self, callback: Callable[[CommittedBatch], None]) -> None:
+        self._subscribers.append(callback)
+
+    def _run(self) -> None:
+        while not self._stop.wait(0.05) or len(self.queue):
+            records = self.queue.drain()
+            if records:
+                if self.queue.dropped > self._reported_drops:
+                    dropped_records = self.queue.dropped - self._reported_drops
+                    self._reported_drops = self.queue.dropped
+                    records.append(
+                        make_record(
+                            producer_id=records[0].producer_id,
+                            trace_id=records[0].trace_id,
+                            kind="recorder.warning",
+                            payload={"dropped_records": dropped_records},
+                        )
+                    )
+                try:
+                    self._commit(records)
+                except Exception:
+                    self.errors += 1
+
+    def _commit(self, records: list[Record]) -> None:
+        unique_records: list[Record] = []
+        batch_ids: set[str] = set()
+        for record in records:
+            if (
+                record.record_id not in self._record_ids
+                and record.record_id not in batch_ids
+            ):
+                unique_records.append(record)
+                batch_ids.add(record.record_id)
+        if not unique_records:
+            return
+
+        committed: list[Record] = []
+        for record in unique_records:
+            self._sequence += 1
+            committed.append(record.model_copy(update={"sequence": self._sequence}))
+        path = self.bundle / "records.jsonl"
+        manifest = self.bundle / "manifest.json"
+        if not manifest.exists():
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "format": "agent-flight-recorder",
+                        "format_version": 1,
+                        "trace_id": committed[0].trace_id,
+                        "created_at": datetime.now().isoformat(),
+                        "status": "running",
+                        "recorder_version": "0.1.0",
+                        "content_encoding": "zstd",
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+        with path.open("a") as stream:
+            for record in committed:
+                stream.write(record.model_dump_json() + "\n")
+            stream.flush()
+        self.index.add_records(committed)
+        self._record_ids.update(batch_ids)
+        batch = CommittedBatch(
+            trace_id=committed[0].trace_id,
+            first_sequence=committed[0].sequence or 1,
+            last_sequence=committed[-1].sequence or 1,
+            record_ids=tuple(record.record_id for record in committed),
+        )
+        for callback in tuple(self._subscribers):
+            try:
+                callback(batch)
+            except Exception:
+                continue

--- a/agent-flight-recorder/src/flight_recorder/collector/queue.py
+++ b/agent-flight-recorder/src/flight_recorder/collector/queue.py
@@ -1,0 +1,46 @@
+"""Bounded, non-blocking handoff from observed runs to persistence."""
+
+from collections import deque
+from threading import Lock
+
+from flight_recorder.models.envelopes import Record
+
+
+_DROPPABLE_KINDS = {"llm.stream_delta"}
+
+
+class RecordQueue:
+    def __init__(self, maxsize: int = 4096) -> None:
+        if maxsize < 1:
+            raise ValueError("maxsize must be positive")
+        self._records: deque[Record] = deque()
+        self._maxsize = maxsize
+        self._lock = Lock()
+        self.dropped = 0
+
+    def put(self, record: Record) -> bool:
+        with self._lock:
+            if len(self._records) < self._maxsize:
+                self._records.append(record)
+                return True
+            if record.kind in _DROPPABLE_KINDS:
+                self.dropped += 1
+                return False
+            for queued in self._records:
+                if queued.kind in _DROPPABLE_KINDS:
+                    self._records.remove(queued)
+                    self._records.append(record)
+                    self.dropped += 1
+                    return True
+            self.dropped += 1
+            return False
+
+    def drain(self, limit: int = 256) -> list[Record]:
+        with self._lock:
+            return [
+                self._records.popleft() for _ in range(min(limit, len(self._records)))
+            ]
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._records)

--- a/agent-flight-recorder/src/flight_recorder/collector/queue.py
+++ b/agent-flight-recorder/src/flight_recorder/collector/queue.py
@@ -19,20 +19,29 @@ class RecordQueue:
         self.dropped = 0
 
     def put(self, record: Record) -> bool:
+        return self.put_many((record,))
+
+    def put_many(self, records: tuple[Record, ...]) -> bool:
+        if not records:
+            return True
         with self._lock:
-            if len(self._records) < self._maxsize:
-                self._records.append(record)
+            required_space = len(records) - (self._maxsize - len(self._records))
+            if required_space <= 0:
+                self._records.extend(records)
                 return True
-            if record.kind in _DROPPABLE_KINDS:
-                self.dropped += 1
-                return False
-            for queued in self._records:
-                if queued.kind in _DROPPABLE_KINDS:
+            droppable = tuple(
+                queued for queued in self._records if queued.kind in _DROPPABLE_KINDS
+            )
+            if (
+                all(record.kind not in _DROPPABLE_KINDS for record in records)
+                and len(droppable) >= required_space
+            ):
+                for queued in droppable[:required_space]:
                     self._records.remove(queued)
-                    self._records.append(record)
-                    self.dropped += 1
-                    return True
-            self.dropped += 1
+                self._records.extend(records)
+                self.dropped += required_space
+                return True
+            self.dropped += len(records)
             return False
 
     def drain(self, limit: int = 256) -> list[Record]:

--- a/agent-flight-recorder/src/flight_recorder/config.py
+++ b/agent-flight-recorder/src/flight_recorder/config.py
@@ -1,0 +1,27 @@
+"""Application filesystem configuration."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from platformdirs import user_cache_path, user_data_path
+
+
+@dataclass(frozen=True)
+class RecorderPaths:
+    data: Path
+    cache: Path
+    traces: Path
+    index: Path
+
+    @classmethod
+    def defaults(cls) -> "RecorderPaths":
+        data = user_data_path("agent-flight-recorder", "OpenHands")
+        cache = user_cache_path("agent-flight-recorder", "OpenHands")
+        return cls(
+            data=data, cache=cache, traces=data / "traces", index=data / "index.db"
+        )
+
+    def create(self) -> None:
+        self.data.mkdir(parents=True, exist_ok=True)
+        self.cache.mkdir(parents=True, exist_ok=True)
+        self.traces.mkdir(parents=True, exist_ok=True)

--- a/agent-flight-recorder/src/flight_recorder/diagnostics/analyzer.py
+++ b/agent-flight-recorder/src/flight_recorder/diagnostics/analyzer.py
@@ -1,0 +1,31 @@
+from collections.abc import Callable
+
+from flight_recorder.diagnostics.schemas import EvidencePacket
+from flight_recorder.errors import DiagnosticFailure
+from flight_recorder.models.envelopes import Finding
+
+
+class AnalyzerFailure(DiagnosticFailure):
+    pass
+
+
+class InterpretiveAnalyzer:
+    def __init__(
+        self,
+        analyze_packet: Callable[[EvidencePacket], list[Finding]] | None = None,
+        *,
+        record_limit: int = 1000,
+    ) -> None:
+        self._analyze_packet = analyze_packet
+        self.record_limit = record_limit
+
+    def analyze(self, packet: EvidencePacket) -> list[Finding]:
+        if self._analyze_packet is None:
+            return []
+        bounded = packet.model_copy(
+            update={"records": packet.records[-self.record_limit :]}
+        )
+        try:
+            return self._analyze_packet(bounded)
+        except Exception as exc:
+            raise AnalyzerFailure(str(exc)) from exc

--- a/agent-flight-recorder/src/flight_recorder/diagnostics/rules.py
+++ b/agent-flight-recorder/src/flight_recorder/diagnostics/rules.py
@@ -1,0 +1,222 @@
+"""Repeatable evidence-backed diagnostic rules."""
+
+import json
+from collections import defaultdict
+from hashlib import sha256
+from typing import Literal
+from uuid import NAMESPACE_URL, uuid5
+
+from flight_recorder.models.envelopes import Finding, Record
+
+
+def fingerprint(record: Record) -> str:
+    payload = {
+        key: value
+        for key, value in record.payload.items()
+        if key not in {"timestamp", "id"}
+    }
+    normalized = json.dumps([record.kind, payload], sort_keys=True, default=str)
+    return sha256(normalized.encode()).hexdigest()
+
+
+def _finding(
+    detector_id: str,
+    records: list[Record],
+    *,
+    category: str,
+    title: str,
+    explanation: str,
+    recommendation: str,
+    severity: Literal["info", "warning", "error"] = "warning",
+) -> Finding:
+    evidence_ids = tuple(record.record_id for record in records)
+    identity = f"{records[0].trace_id}:{detector_id}:{':'.join(evidence_ids)}"
+    return Finding(
+        finding_id=str(uuid5(NAMESPACE_URL, identity)),
+        trace_id=records[0].trace_id,
+        origin="rule",
+        detector_id=detector_id,
+        category=category,
+        severity=severity,
+        confidence=1.0,
+        title=title,
+        explanation=explanation,
+        recommendation=recommendation,
+        evidence_ids=evidence_ids,
+        affected_span_ids=tuple(
+            dict.fromkeys(record.span_id for record in records if record.span_id)
+        ),
+    )
+
+
+def repeated_tool_calls(records: list[Record], threshold: int = 2) -> list[Finding]:
+    groups: dict[str, list[Record]] = defaultdict(list)
+    for record in records:
+        if record.kind == "tool.request":
+            groups[fingerprint(record)].append(record)
+    findings = []
+    for matching in groups.values():
+        if len(matching) < threshold:
+            continue
+        findings.append(
+            _finding(
+                "repeated-tool-call",
+                matching,
+                category="loop",
+                title="Repeated tool call",
+                explanation=f"Equivalent tool call repeated {len(matching)} times.",
+                recommendation="Review the latest result before retrying.",
+            )
+        )
+    return findings
+
+
+def recurring_failures(records: list[Record], threshold: int = 2) -> list[Finding]:
+    groups: dict[str, list[Record]] = defaultdict(list)
+    for record in records:
+        if record.kind.endswith(".error") or record.payload.get("status") == "failed":
+            groups[fingerprint(record)].append(record)
+    return [
+        _finding(
+            "recurring-failure",
+            matching,
+            category="tool",
+            title="Recurring failure",
+            explanation=f"Equivalent failure recurred {len(matching)} times.",
+            recommendation="Change the approach before retrying the failed activity.",
+            severity="error",
+        )
+        for matching in groups.values()
+        if len(matching) >= threshold
+    ]
+
+
+def no_progress_iterations(records: list[Record], threshold: int = 3) -> list[Finding]:
+    findings = []
+    unchanged = []
+    for record in records:
+        if record.kind != "iteration.finished":
+            continue
+        if record.payload.get("made_progress") is False:
+            unchanged.append(record)
+            continue
+        if len(unchanged) >= threshold:
+            findings.append(_no_progress_finding(unchanged))
+        unchanged = []
+    if len(unchanged) >= threshold:
+        findings.append(_no_progress_finding(unchanged))
+    return findings
+
+
+def _no_progress_finding(records: list[Record]) -> Finding:
+    return _finding(
+        "no-progress",
+        records,
+        category="loop",
+        title="Iterations without progress",
+        explanation=f"{len(records)} consecutive iterations reported no progress.",
+        recommendation="Reassess the plan or stop the repeated approach.",
+    )
+
+
+def context_issues(records: list[Record]) -> list[Finding]:
+    affected = [
+        record
+        for record in records
+        if record.kind == "context.reconstructed"
+        and record.provenance.complete is False
+    ]
+    if not affected:
+        return []
+    return [
+        _finding(
+            "incomplete-context",
+            affected,
+            category="context",
+            title="Incomplete reconstructed context",
+            explanation="Model context is reconstructed with missing evidence.",
+            recommendation="Capture authoritative completion request logs.",
+        )
+    ]
+
+
+def delegation_issues(records: list[Record]) -> list[Finding]:
+    affected = [
+        record
+        for record in records
+        if record.kind == "agent.finished"
+        and record.payload.get("result") in {None, ""}
+    ]
+    if not affected:
+        return []
+    return [
+        _finding(
+            "empty-delegation-result",
+            affected,
+            category="delegation",
+            title="Delegation returned no result",
+            explanation="Delegated work finished without a recorded result.",
+            recommendation="Clarify the handoff and required return value.",
+        )
+    ]
+
+
+def premature_finish(records: list[Record]) -> list[Finding]:
+    failed_tests = [
+        record
+        for record in records
+        if record.kind == "test.finished" and record.payload.get("status") == "failed"
+    ]
+    finished = [record for record in records if record.kind == "run.finished"]
+    if not failed_tests or not finished:
+        return []
+    return [
+        _finding(
+            "premature-finish",
+            [failed_tests[-1], finished[-1]],
+            category="termination",
+            title="Run finished after failed tests",
+            explanation="The run ended while the latest recorded test was failing.",
+            recommendation="Resolve or explicitly acknowledge the failed test.",
+        )
+    ]
+
+
+def budget_hotspots(records: list[Record], cost_limit: float = 10.0) -> list[Finding]:
+    affected = []
+    for record in records:
+        if record.kind != "metrics.snapshot":
+            continue
+        snapshots = record.payload.get("usage_to_metrics", {})
+        if isinstance(snapshots, dict) and any(
+            isinstance(value, dict)
+            and isinstance(value.get("accumulated_cost"), int | float)
+            and float(value["accumulated_cost"]) >= cost_limit
+            for value in snapshots.values()
+        ):
+            affected.append(record)
+    if not affected:
+        return []
+    return [
+        _finding(
+            "cost-hotspot",
+            affected,
+            category="cost",
+            title="Cost hotspot",
+            explanation=f"Recorded cost reached at least ${cost_limit:.2f}.",
+            recommendation="Review high-cost model activity and context size.",
+        )
+    ]
+
+
+def deterministic_findings(records: list[Record]) -> list[Finding]:
+    detectors = (
+        repeated_tool_calls,
+        recurring_failures,
+        no_progress_iterations,
+        context_issues,
+        delegation_issues,
+        premature_finish,
+        budget_hotspots,
+    )
+    return [finding for detector in detectors for finding in detector(records)]

--- a/agent-flight-recorder/src/flight_recorder/diagnostics/schemas.py
+++ b/agent-flight-recorder/src/flight_recorder/diagnostics/schemas.py
@@ -1,0 +1,23 @@
+"""Diagnostic request schema."""
+
+from flight_recorder.models.envelopes import Finding, Record
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class EvidencePacket(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    trace_id: str
+    records: tuple[Record, ...]
+    deterministic_findings: tuple[Finding, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_evidence(self) -> "EvidencePacket":
+        if any(record.trace_id != self.trace_id for record in self.records):
+            raise ValueError("all records must belong to the same trace")
+        record_ids = {record.record_id for record in self.records}
+        for finding in self.deterministic_findings:
+            if finding.trace_id != self.trace_id:
+                raise ValueError("all findings must belong to the same trace")
+            if not set(finding.evidence_ids).issubset(record_ids):
+                raise ValueError("finding evidence must resolve in the packet")
+        return self

--- a/agent-flight-recorder/src/flight_recorder/errors.py
+++ b/agent-flight-recorder/src/flight_recorder/errors.py
@@ -1,0 +1,43 @@
+"""Typed failures exposed by recorder services."""
+
+
+class FlightRecorderError(Exception):
+    """Base recorder failure."""
+
+    code = "flight_recorder_error"
+
+
+class TraceNotFound(FlightRecorderError):
+    """A requested trace does not exist."""
+
+    code = "trace_not_found"
+
+
+class SpanNotFound(FlightRecorderError):
+    """A requested span does not exist."""
+
+    code = "span_not_found"
+
+
+class InvalidBundle(FlightRecorderError):
+    """A trace bundle violates the portable contract."""
+
+    code = "invalid_bundle"
+
+
+class UnsupportedFormat(InvalidBundle):
+    """A trace bundle uses an unsupported format version."""
+
+    code = "unsupported_format"
+
+
+class RecorderClosed(FlightRecorderError):
+    """Capture was attempted after recorder shutdown."""
+
+    code = "recorder_closed"
+
+
+class DiagnosticFailure(FlightRecorderError):
+    """Diagnosis failed without affecting trace access."""
+
+    code = "diagnostic_failure"

--- a/agent-flight-recorder/src/flight_recorder/gui/controllers/selection.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/controllers/selection.py
@@ -1,0 +1,31 @@
+from flight_recorder.models.view_models import Selection
+from PySide6.QtCore import QObject, Signal
+
+
+class SelectionController(QObject):
+    selection_changed = Signal(object)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._selection = Selection()
+
+    def select_record(self, record_id: str) -> None:
+        self._set_selection(Selection(record_id=record_id))
+
+    def select_span(self, span_id: str) -> None:
+        self._set_selection(Selection(span_id=span_id))
+
+    def navigate_to_evidence(self, record_id: str) -> None:
+        self.select_record(record_id)
+
+    def current_selection(self) -> Selection:
+        return self._selection
+
+    def clear(self) -> None:
+        self._set_selection(Selection())
+
+    def _set_selection(self, selection: Selection) -> None:
+        if selection == self._selection:
+            return
+        self._selection = selection
+        self.selection_changed.emit(selection)

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/context.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/context.py
@@ -1,0 +1,55 @@
+import json
+
+from flight_recorder.models.envelopes import ProvenanceKind
+from flight_recorder.models.view_models import CondensationView, ContextView
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QLabel, QTextBrowser, QVBoxLayout, QWidget
+
+
+class ContextInspector(QWidget):
+    evidence_requested = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.provenance = QLabel("No context")
+        self.context = QTextBrowser()
+        self.condensation = QTextBrowser()
+        self.context.setOpenLinks(False)
+        self.condensation.setOpenLinks(False)
+        self.context.anchorClicked.connect(
+            lambda url: self.evidence_requested.emit(url.toString())
+        )
+        self.condensation.anchorClicked.connect(
+            lambda url: self.evidence_requested.emit(url.toString())
+        )
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.provenance)
+        layout.addWidget(self.context)
+        layout.addWidget(self.condensation)
+
+    def set_context(self, context: ContextView) -> None:
+        label = (
+            "Exact captured context"
+            if context.provenance.kind is ProvenanceKind.CAPTURED
+            else "Reconstructed context"
+        )
+        self.provenance.setText(label)
+        source_links = " ".join(
+            f'<a href="{source_id}">{source_id}</a>'
+            for source_id in context.provenance.source_ids
+        )
+        messages = json.dumps(context.messages, indent=2)
+        self.context.setHtml(f"<p>{source_links}</p><pre>{messages}</pre>")
+
+    def set_condensation(self, condensation: CondensationView) -> None:
+        resolved = " ".join(
+            f'<a href="{record_id}">{record_id}</a>'
+            for record_id in condensation.resolved_ids
+        )
+        unresolved = ", ".join(condensation.unresolved_ids) or "None"
+        summary = condensation.summary or "No replacement summary recorded"
+        self.condensation.setHtml(
+            f"<p>Forgotten events: {resolved}</p>"
+            f"<p>Unresolved: {unresolved}</p><p>Replacement: {summary}</p>"
+        )

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/context.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/context.py
@@ -1,5 +1,6 @@
-import json
+from html import escape
 
+from flight_recorder.gui.inspector.summary import format_readable_data
 from flight_recorder.models.envelopes import ProvenanceKind
 from flight_recorder.models.view_models import CondensationView, ContextView
 from PySide6.QtCore import Signal
@@ -39,7 +40,7 @@ class ContextInspector(QWidget):
             f'<a href="{source_id}">{source_id}</a>'
             for source_id in context.provenance.source_ids
         )
-        messages = json.dumps(context.messages, indent=2)
+        messages = escape(format_readable_data(list(context.messages)))
         self.context.setHtml(f"<p>{source_links}</p><pre>{messages}</pre>")
 
     def set_condensation(self, condensation: CondensationView) -> None:
@@ -47,8 +48,10 @@ class ContextInspector(QWidget):
             f'<a href="{record_id}">{record_id}</a>'
             for record_id in condensation.resolved_ids
         )
-        unresolved = ", ".join(condensation.unresolved_ids) or "None"
-        summary = condensation.summary or "No replacement summary recorded"
+        unresolved = escape(", ".join(condensation.unresolved_ids) or "None")
+        summary = escape(
+            condensation.summary or "No replacement summary recorded"
+        ).replace("\n", "<br>")
         self.condensation.setHtml(
             f"<p>Forgotten events: {resolved}</p>"
             f"<p>Unresolved: {unresolved}</p><p>Replacement: {summary}</p>"

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/diff.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/diff.py
@@ -1,0 +1,34 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContextDifference:
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+    changed: tuple[str, ...]
+
+
+def diff_contexts(
+    previous: Sequence[dict[str, Any]], current: Sequence[dict[str, Any]]
+) -> ContextDifference:
+    previous_by_id = {
+        str(message.get("id", index)): message for index, message in enumerate(previous)
+    }
+    current_by_id = {
+        str(message.get("id", index)): message for index, message in enumerate(current)
+    }
+    previous_ids = set(previous_by_id)
+    current_ids = set(current_by_id)
+    return ContextDifference(
+        added=tuple(sorted(current_ids - previous_ids)),
+        removed=tuple(sorted(previous_ids - current_ids)),
+        changed=tuple(
+            sorted(
+                message_id
+                for message_id in previous_ids & current_ids
+                if previous_by_id[message_id] != current_by_id[message_id]
+            )
+        ),
+    )

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/explanation.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/explanation.py
@@ -1,0 +1,327 @@
+import json
+from datetime import datetime
+from typing import Any
+
+from flight_recorder.gui.timeline.rows import (
+    ACTIVITY_ROW_TYPES_BY_KEY,
+    classify_record,
+)
+from flight_recorder.models.envelopes import Finding, Record, TokenUsage
+from flight_recorder.models.view_models import AgentDetail, RunSummary
+
+
+def explain_run(run: RunSummary) -> str:
+    timing = _run_timing(run)
+    return (
+        "Run overview\n\n"
+        "WHAT THIS REPRESENTS\n"
+        "This selection represents one recorded OpenHands run. A run is the "
+        "outer container for the primary agent, delegated agents, messages, "
+        "tool activity, model context changes, metrics, and diagnostics stored "
+        "in the trace. The trace ID identifies this recording, not an agent or "
+        "a single model request.\n\n"
+        "CURRENT INTERPRETATION\n"
+        f"Trace ID: {run.trace_id}\n"
+        f"Status: {run.status}\n"
+        f"Recorded entries: {run.record_count}\n"
+        f"Diagnostic findings: {run.finding_count}\n"
+        f"{timing}\n\n"
+        "USAGE AND COST\n"
+        f"{_usage_text(run.total_usage, run.total_cost)}\n"
+        "These are aggregate values reconstructed from the metrics snapshots in "
+        "the trace. They describe attributed model usage; they do not measure "
+        "agent quality, useful work, or elapsed time.\n\n"
+        "HOW TO READ THIS\n"
+        "The timeline groups recorded entries by agent and activity category. "
+        "Lifecycle bars show agent boundaries, while markers show messages, "
+        "actions, results, delegation, context changes, state changes, metrics, "
+        "and errors. Selecting an agent or marker replaces this explanation with "
+        "details about that evidence.\n\n"
+        "EVIDENCE LIMITS\n"
+        "The recorder reports what was captured. A missing entry can mean the "
+        "activity did not occur, was outside the recorder's scope, or was omitted "
+        "under collection pressure. Status and totals should therefore be read "
+        "together with warnings and findings."
+    )
+
+
+def explain_agent(detail: AgentDetail) -> str:
+    relationship = detail.relationship
+    is_primary = relationship.parent_span_id is None
+    role = "primary agent" if is_primary else "delegated agent"
+    name = detail.handoff.get("name")
+    display_name = (
+        name if isinstance(name, str) and name else relationship.child_span_id
+    )
+    parent_text = relationship.parent_span_id or "none; this is the root agent"
+    duration_text = _agent_duration_text(detail, is_primary=is_primary)
+    outcome_text = _agent_outcome_text(detail.returned_result, is_primary=is_primary)
+    handoff_label = "Startup metadata" if is_primary else "Recorded handoff"
+    return (
+        "Agent lifecycle\n\n"
+        "WHAT THIS REPRESENTS\n"
+        f"This selection is the lifecycle of the {role} named {display_name!r}. "
+        "A lifecycle bar groups the records attributed to one agent and shows "
+        "where that agent's recorded activity sits on the shared timeline. It is "
+        "not a model call, tool call, operating-system process, or CPU-usage graph.\n\n"
+        "IDENTITY AND HIERARCHY\n"
+        f"Agent span ID: {relationship.child_span_id}\n"
+        f"Parent agent span ID: {parent_text}\n"
+        f"Role: {role}\n"
+        f"Relationship: {relationship.status.value}\n"
+        f"{_relationship_text(detail)}\n\n"
+        f"{handoff_label.upper()}\n"
+        f"{_json_text(detail.handoff)}\n"
+        + (
+            "For the primary agent this is metadata captured when recording "
+            "started; it is not a delegation request.\n\n"
+            if is_primary
+            else "This is the task metadata passed from the parent agent.\n\n"
+        )
+        + "TIMING\n"
+        f"{duration_text}\n\n"
+        "OUTCOME\n"
+        f"{outcome_text}\n\n"
+        "USAGE AND COST\n"
+        f"{_usage_text(detail.usage, detail.cost)}\n"
+        "Prompt tokens are model-input tokens attributed to this agent. Cache "
+        "and reasoning counts are shown separately when the provider reports "
+        "them. Cost is the captured provider or metrics estimate; it is not "
+        "computed from duration.\n\n"
+        "EVIDENCE LIMITS\n"
+        "This explanation is derived from captured evidence. The lifecycle shows "
+        "recorded boundaries and attribution, not whether the agent's reasoning "
+        "was correct or its work was valuable. Inspect this agent's Messages, "
+        "Actions, Results, Context, Errors, and the evidence attached to findings "
+        "before drawing a causal conclusion."
+    )
+
+
+def explain_finding(finding: Finding) -> str:
+    origin = (
+        "a deterministic recorder rule"
+        if finding.origin == "rule"
+        else "an interpretive model analysis"
+    )
+    affected = ", ".join(finding.affected_span_ids) or "No span explicitly listed"
+    return (
+        "Diagnostic finding\n\n"
+        "WHAT THIS REPRESENTS\n"
+        f"This is a diagnostic conclusion produced by {origin}. It is derived "
+        "from trace evidence and is not itself a raw event emitted by the agent.\n\n"
+        "CLASSIFICATION\n"
+        f"Title: {finding.title}\n"
+        f"Severity: {finding.severity}\n"
+        f"Category: {finding.category}\n"
+        f"Detector: {finding.detector_id}\n"
+        f"Confidence: {finding.confidence:.0%}\n"
+        f"Affected spans: {affected}\n\n"
+        "INTERPRETATION\n"
+        f"{finding.explanation}\n\n"
+        "RECOMMENDED RESPONSE\n"
+        f"{finding.recommendation}\n\n"
+        "SUPPORTING EVIDENCE\n"
+        f"{', '.join(finding.evidence_ids)}\n"
+        "The evidence IDs identify the records or spans used to support the "
+        "finding. Open them to verify the conclusion against captured data.\n\n"
+        "EVIDENCE LIMITS\n"
+        "Severity describes potential impact, while confidence describes support "
+        "for this interpretation; neither guarantees causation. Model-originated "
+        "findings require particular care because they may contain interpretive "
+        "errors even when their evidence references resolve."
+    )
+
+
+def explain_record(record: Record) -> str:
+    category = ACTIVITY_ROW_TYPES_BY_KEY[classify_record(record)]
+    source_time = (
+        _format_datetime(record.source_timestamp)
+        if record.source_timestamp is not None
+        else "Not supplied; recorder observation time is used for placement"
+    )
+    return (
+        "Recorded activity\n\n"
+        "WHAT THIS REPRESENTS\n"
+        f"This is one immutable trace record of kind {record.kind!r}. It appears "
+        f"in the {category.label} row because {category.description.lower()} "
+        f"{_record_kind_text(record)}\n\n"
+        "ORDER AND TIME\n"
+        f"Sequence: {record.sequence if record.sequence is not None else 'unknown'}\n"
+        f"Observed by recorder: {_format_datetime(record.observed_at)}\n"
+        f"Source timestamp: {source_time}\n"
+        "Sequence is the authoritative order within this trace. Source time is "
+        "preferred for timeline placement when available; observed time records "
+        "when the recorder received the activity. Small differences between them "
+        "are expected.\n\n"
+        "ATTRIBUTION\n"
+        f"Record ID: {record.record_id}\n"
+        f"Agent span ID: {record.agent_span_id or 'not attributed'}\n"
+        f"Span ID: {record.span_id or 'no separate span'}\n"
+        f"Parent span ID: {record.parent_span_id or 'none'}\n"
+        f"Producer ID: {record.producer_id}\n\n"
+        "PAYLOAD INTERPRETATION\n"
+        f"{_payload_text(record.payload)}\n\n"
+        "PROVENANCE\n"
+        f"Kind: {record.provenance.kind.value}\n"
+        f"Complete: {'yes' if record.provenance.complete else 'no'}\n"
+        f"Source evidence IDs: "
+        f"{', '.join(record.provenance.source_ids) or 'none'}\n"
+        f"{record.provenance.description or 'No additional provenance note.'}\n\n"
+        "EVIDENCE LIMITS\n"
+        "A record proves that this payload was captured at this position in the "
+        "trace. It does not by itself prove intent, correctness, or causation. "
+        "Correlate tool-call IDs, span IDs, neighboring records, and findings "
+        "before interpreting why the activity occurred."
+    )
+
+
+def _run_timing(run: RunSummary) -> str:
+    if run.started_at is None:
+        return "Start and completion times were not captured."
+    if run.completed_at is None:
+        return f"Started: {_format_datetime(run.started_at)}\nCompleted: not recorded"
+    elapsed = (run.completed_at - run.started_at).total_seconds()
+    return (
+        f"Started: {_format_datetime(run.started_at)}\n"
+        f"Completed: {_format_datetime(run.completed_at)}\n"
+        f"Trace lifetime: {elapsed:.3f} seconds ({_clock_duration(elapsed)})\n"
+        "Trace lifetime spans the first through last record and can include idle time."
+    )
+
+
+def _agent_duration_text(detail: AgentDetail, *, is_primary: bool) -> str:
+    if detail.duration_seconds is None:
+        return (
+            "Duration: incomplete. A matching finish boundary was not captured, "
+            "so the recorder cannot calculate a completed lifecycle."
+        )
+    duration = detail.duration_seconds
+    interpretation = (
+        "For the primary agent, synthetic recorder-shutdown idle time is excluded; "
+        "the value ends at the last recorded activity before shutdown."
+        if is_primary
+        else "For a delegated agent, this is elapsed time between its captured start "
+        "and finish boundaries and may include time spent waiting inside the task."
+    )
+    return (
+        f"Duration: {duration:.3f} seconds ({_clock_duration(duration)}).\n"
+        f"{interpretation} This is wall-clock timing, not CPU time or continuous "
+        "model-execution time."
+    )
+
+
+def _agent_outcome_text(result: Any, *, is_primary: bool) -> str:
+    if result is None:
+        if is_primary:
+            return (
+                "Returned result: none. The primary recorder boundary does not carry "
+                "a delegated-task return value, so this does not imply failure."
+            )
+        return (
+            "Returned result: none captured. This alone does not distinguish an empty "
+            "successful result from interruption, failure, or incomplete capture; "
+            "inspect the agent's state and error records."
+        )
+    return (
+        f"Returned result captured from this delegated lifecycle:\n{_json_text(result)}"
+    )
+
+
+def _relationship_text(detail: AgentDetail) -> str:
+    relationship = detail.relationship
+    meanings = {
+        "verified": (
+            "Captured records explicitly connect this agent to the displayed parent."
+        ),
+        "inferred": (
+            "The parent-child connection was reconstructed from available evidence "
+            "rather than captured directly."
+        ),
+        "unresolved": (
+            "The trace names a parent, but that parent span is missing from the "
+            "available captured evidence. The hierarchy may therefore be incomplete."
+        ),
+    }
+    provenance = relationship.provenance
+    return (
+        f"{meanings[relationship.status.value]} Provenance is "
+        f"{provenance.kind.value} and marked "
+        f"{'complete' if provenance.complete else 'incomplete'}."
+    )
+
+
+def _usage_text(usage: TokenUsage, cost: float) -> str:
+    return (
+        f"Prompt tokens: {usage.prompt_tokens}\n"
+        f"Completion tokens: {usage.completion_tokens}\n"
+        f"Cache-read tokens: {usage.cache_read_tokens}\n"
+        f"Cache-write tokens: {usage.cache_write_tokens}\n"
+        f"Reasoning tokens: {usage.reasoning_tokens}\n"
+        f"Cost: ${cost:.4f}"
+    )
+
+
+def _record_kind_text(record: Record) -> str:
+    event_type = record.payload.get("event_type")
+    event_meanings = {
+        "MessageEvent": "It captures a user or agent message.",
+        "SystemPromptEvent": "It captures system instructions supplied to the agent.",
+        "ActionEvent": "It captures an action or tool call requested by the agent.",
+        "ObservationEvent": "It captures the result returned by an action or tool.",
+        "ConversationStateUpdateEvent": (
+            "It captures a transition in conversation state."
+        ),
+        "Condensation": "It captures a model-context condensation event.",
+    }
+    if isinstance(event_type, str) and event_type in event_meanings:
+        return event_meanings[event_type]
+    kind_meanings = {
+        "run.started": "It marks the beginning of trace collection.",
+        "run.finished": "It marks the end of trace collection.",
+        "agent.started": "It marks the beginning of an agent lifecycle.",
+        "agent.finished": "It marks the end of an agent lifecycle.",
+        "metrics.snapshot": "It captures cumulative usage and cost metrics.",
+        "recorder.warning": "It reports a collection limitation or omission.",
+    }
+    return kind_meanings.get(
+        record.kind,
+        "Its exact semantics are defined by the producer and payload.",
+    )
+
+
+def _payload_text(payload: dict[str, Any]) -> str:
+    if not payload:
+        return "The record has no type-specific payload fields."
+    interpretations = []
+    field_meanings = {
+        "event_type": "OpenHands event class",
+        "tool_name": "tool selected for the action or result",
+        "tool_call_id": "correlation key pairing an action with its result",
+        "status": "state reported by the producer",
+        "result": "returned output",
+        "error": "reported failure detail",
+        "model": "model associated with this activity",
+        "repository": "repository attributed by the producer",
+    }
+    for key, meaning in field_meanings.items():
+        if key in payload:
+            interpretations.append(f"- {key}: {meaning}; value={payload[key]!r}")
+    unknown = sorted(set(payload) - set(field_meanings))
+    if unknown:
+        interpretations.append("- Other captured fields: " + ", ".join(unknown) + ".")
+    return "\n".join(interpretations)
+
+
+def _json_text(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, default=str)
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.isoformat(sep=" ", timespec="milliseconds")
+
+
+def _clock_duration(seconds: float) -> str:
+    whole_seconds = max(0, round(seconds))
+    hours, remainder = divmod(whole_seconds, 3600)
+    minutes, remaining_seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{remaining_seconds:02d}"

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/explanation.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/explanation.py
@@ -3,8 +3,10 @@ from datetime import datetime
 from typing import Any
 
 from flight_recorder.gui.timeline.rows import (
+    ACTIVITY_CATEGORY_TYPES_BY_KEY,
     ACTIVITY_ROW_TYPES_BY_KEY,
     classify_record,
+    row_key_for_category,
 )
 from flight_recorder.models.envelopes import Finding, Record, TokenUsage
 from flight_recorder.models.view_models import AgentDetail, RunSummary
@@ -34,7 +36,8 @@ def explain_run(run: RunSummary) -> str:
         "HOW TO READ THIS\n"
         "The timeline groups recorded entries by agent and activity category. "
         "Lifecycle bars show agent boundaries, while markers show messages, "
-        "actions, results, delegation, context changes, state changes, metrics, "
+        "tool actions and results, delegation, context changes, state changes, "
+        "metrics, "
         "and errors. Selecting an agent or marker replaces this explanation with "
         "details about that evidence.\n\n"
         "EVIDENCE LIMITS\n"
@@ -92,7 +95,7 @@ def explain_agent(detail: AgentDetail) -> str:
         "This explanation is derived from captured evidence. The lifecycle shows "
         "recorded boundaries and attribution, not whether the agent's reasoning "
         "was correct or its work was valuable. Inspect this agent's Messages, "
-        "Actions, Results, Context, Errors, and the evidence attached to findings "
+        "Tool, Context, Errors, and the evidence attached to findings "
         "before drawing a causal conclusion."
     )
 
@@ -133,7 +136,14 @@ def explain_finding(finding: Finding) -> str:
 
 
 def explain_record(record: Record) -> str:
-    category = ACTIVITY_ROW_TYPES_BY_KEY[classify_record(record)]
+    category_key = classify_record(record)
+    category = ACTIVITY_CATEGORY_TYPES_BY_KEY[category_key]
+    row = ACTIVITY_ROW_TYPES_BY_KEY[row_key_for_category(category_key)]
+    location = (
+        f"{row.label} / {category.label} sub-row"
+        if category_key != row.key
+        else f"{row.label} row"
+    )
     source_time = (
         _format_datetime(record.source_timestamp)
         if record.source_timestamp is not None
@@ -143,7 +153,7 @@ def explain_record(record: Record) -> str:
         "Recorded activity\n\n"
         "WHAT THIS REPRESENTS\n"
         f"This is one immutable trace record of kind {record.kind!r}. It appears "
-        f"in the {category.label} row because {category.description.lower()} "
+        f"in the {location} because {category.description.lower()} "
         f"{_record_kind_text(record)}\n\n"
         "ORDER AND TIME\n"
         f"Sequence: {record.sequence if record.sequence is not None else 'unknown'}\n"

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/metrics.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/metrics.py
@@ -1,0 +1,10 @@
+from flight_recorder.models.envelopes import TokenUsage
+from PySide6.QtWidgets import QLabel
+
+
+class MetricsWidget(QLabel):
+    def set_metrics(self, usage: TokenUsage, cost: float) -> None:
+        self.setText(
+            f"Input {usage.prompt_tokens}  Output {usage.completion_tokens}  "
+            f"Cost ${cost:.4f}"
+        )

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/summary.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/summary.py
@@ -36,6 +36,14 @@ def format_record_summary(record: Record) -> str:
 def format_styled_record_summary(
     record: Record, related_user_message: Record | None = None
 ) -> StyledSummary:
+    if record.kind == "llm.request":
+        request_summary = _format_llm_request_summary(record)
+        if request_summary is not None:
+            return request_summary
+    if record.kind == "llm.response":
+        response_summary = _format_llm_response_summary(record)
+        if response_summary is not None:
+            return response_summary
     event_type = record.payload.get("event_type")
     if event_type == "MessageEvent":
         message_summary = _format_message_summary(record)
@@ -47,13 +55,469 @@ def format_styled_record_summary(
         )
         if system_prompt_summary is not None:
             return system_prompt_summary
-    return StyledSummary(
-        text=(
-            f"{record.kind}\nSequence: {record.sequence}\n"
-            f"Agent: {record.agent_span_id or 'None'}\n"
-            f"Payload: {json.dumps(record.payload, indent=2, sort_keys=True)}"
+    return _format_generic_summary(record)
+
+
+def format_readable_data(value: Any) -> str:
+    return "\n".join(_format_value_lines(value))
+
+
+def format_llm_input(record: Record) -> str:
+    request = record.payload.get("request")
+    if not isinstance(request, dict):
+        completion = record.payload.get("completion")
+        if record.kind != "llm.response" or not isinstance(completion, dict):
+            return "This activity is not an LLM request."
+        result_keys = {
+            "response",
+            "raw_response",
+            "error",
+            "usage_summary",
+            "cost",
+            "timestamp",
+            "latency_sec",
+        }
+        request = {
+            key: value for key, value in completion.items() if key not in result_keys
+        }
+    if not request:
+        return "No LLM request fields were captured."
+    sections = _format_llm_request_sections(request)
+    if not sections:
+        return "No readable LLM request fields were captured."
+    return "LLM REQUEST\n\n" + "\n\n".join(section for section, _ in sections)
+
+
+def format_llm_output(record: Record) -> str:
+    if record.kind != "llm.response":
+        return "This activity is not an LLM response."
+    summary = _format_llm_response_summary(record)
+    if summary is None:
+        return "No LLM output was captured."
+    return summary.text
+
+
+def _format_llm_request_summary(record: Record) -> StyledSummary | None:
+    request = record.payload.get("request")
+    if not isinstance(request, dict):
+        return None
+    lines = _record_metadata_lines(record, "LLM request")
+    _append_value(lines, "File", record.payload.get("filename"))
+    _append_value(lines, "LLM path", request.get("llm_path"))
+    _append_value(lines, "Context window", request.get("context_window"))
+    sections = _format_llm_request_sections(request)
+    for section, _ in sections:
+        lines.extend(("", section))
+    return _style_sections("\n".join(lines), sections)
+
+
+def _format_llm_request_sections(
+    request: dict[str, Any],
+) -> list[tuple[str, SummaryTone]]:
+    sections: list[tuple[str, SummaryTone]] = []
+    instructions = _extract_text(request.get("instructions"))
+    if instructions:
+        sections.append((f"SYSTEM INSTRUCTIONS\n{instructions}", SummaryTone.OPENHANDS))
+
+    context_items = request.get("messages")
+    if not isinstance(context_items, list):
+        context_items = request.get("input")
+    if isinstance(context_items, list):
+        for index, item in enumerate(context_items, start=1):
+            if not isinstance(item, dict):
+                continue
+            formatted = _format_llm_request_item(item, index)
+            if formatted is not None:
+                sections.append(formatted)
+
+    tools = request.get("tools")
+    if isinstance(tools, list):
+        names = [
+            name
+            for tool in tools
+            if isinstance(tool, dict) and (name := _request_tool_name(tool)) is not None
+        ]
+        tool_lines = [f"AVAILABLE TOOLS ({len(tools)})"]
+        tool_lines.extend(f"- {name}" for name in names)
+        if not names:
+            tool_lines.append("[No tool names recorded]")
+        sections.append(("\n".join(tool_lines), SummaryTone.OPENHANDS))
+    return sections
+
+
+def _format_llm_request_item(
+    item: dict[str, Any], index: int
+) -> tuple[str, SummaryTone] | None:
+    item_type = item.get("type")
+    role = item.get("role")
+    if item_type == "message" or isinstance(role, str):
+        normalized_role = role.upper() if isinstance(role, str) else "MESSAGE"
+        text = _extract_text(item.get("content"))
+        lines = [f"INPUT {index}: {normalized_role} MESSAGE"]
+        lines.append(text or _non_text_content_summary(item.get("content")))
+        tool_calls = item.get("tool_calls")
+        if isinstance(tool_calls, list):
+            calls = [call for call in tool_calls if isinstance(call, dict)]
+            if calls:
+                lines.extend(("", _format_tool_calls(calls)))
+        tone = (
+            SummaryTone.USER
+            if role == "user"
+            else SummaryTone.OPENHANDS
+            if role in {"system", "developer", "tool"}
+            else SummaryTone.AGENT
+        )
+        return "\n".join(lines), tone
+    if item_type == "function_call":
+        function = item.get("function")
+        function = function if isinstance(function, dict) else item
+        name = function.get("name")
+        lines = [
+            f"INPUT {index}: ASSISTANT TOOL CALL",
+            f"Tool: {name if isinstance(name, str) else 'Unnamed tool'}",
+        ]
+        call_id = item.get("call_id") or item.get("id")
+        if isinstance(call_id, str) and call_id:
+            lines.append(f"Call ID: {call_id}")
+        arguments = function.get("arguments")
+        if arguments is not None:
+            lines.append("Arguments:")
+            lines.extend(_format_value_lines(_parse_structured_string(arguments), 2))
+        return "\n".join(lines), SummaryTone.AGENT
+    if item_type in {"function_call_output", "tool_result"}:
+        lines = [f"INPUT {index}: TOOL RESULT"]
+        call_id = item.get("call_id") or item.get("tool_call_id")
+        if isinstance(call_id, str) and call_id:
+            lines.append(f"Call ID: {call_id}")
+        output = item.get("output", item.get("content"))
+        lines.extend(_format_value_lines(_parse_structured_string(output)))
+        return "\n".join(lines), SummaryTone.OPENHANDS
+    if item_type == "reasoning":
+        reasoning = _extract_text(item.get("summary") or item.get("content"))
+        if reasoning:
+            return f"INPUT {index}: MODEL REASONING\n{reasoning}", SummaryTone.AGENT
+    return None
+
+
+def _request_tool_name(tool: dict[str, Any]) -> str | None:
+    function = tool.get("function")
+    definition = function if isinstance(function, dict) else tool
+    name = definition.get("name")
+    return name if isinstance(name, str) and name else None
+
+
+def _non_text_content_summary(content: Any) -> str:
+    if not isinstance(content, list):
+        return "[No text content]"
+    content_types = [
+        item_type
+        for item in content
+        if isinstance(item, dict) and isinstance((item_type := item.get("type")), str)
+    ]
+    if not content_types:
+        return "[No text content]"
+    return f"[Non-text content: {', '.join(content_types)}]"
+
+
+def _format_llm_response_summary(record: Record) -> StyledSummary | None:
+    completion = record.payload.get("completion", record.payload)
+    if not isinstance(completion, dict):
+        return None
+    response = completion.get("response")
+    error = completion.get("error")
+    if not isinstance(response, dict) and not isinstance(error, dict):
+        return None
+
+    title = "LLM error" if isinstance(error, dict) else "LLM response"
+    lines = _record_metadata_lines(record, title)
+    _append_value(lines, "File", record.payload.get("filename"))
+    if isinstance(response, dict):
+        _append_value(lines, "Response ID", response.get("id"))
+        _append_value(lines, "Model", response.get("model"))
+        _append_value(lines, "Response type", response.get("object"))
+        finish_reasons = _finish_reasons(response)
+        if finish_reasons:
+            lines.append(f"Finish reason: {', '.join(finish_reasons)}")
+    _append_seconds(lines, "Latency", completion.get("latency_sec"))
+    _append_cost(lines, completion.get("cost"))
+
+    messages = completion.get("messages")
+    input_items = completion.get("input")
+    tools = completion.get("tools")
+    request_lines = []
+    if isinstance(messages, list):
+        request_lines.append(f"Messages: {len(messages)}")
+    if isinstance(input_items, list):
+        request_lines.append(f"Input items: {len(input_items)}")
+    if isinstance(tools, list):
+        request_lines.append(f"Available tools: {len(tools)}")
+    if request_lines:
+        lines.extend(("", "REQUEST", *request_lines))
+
+    highlighted_sections: list[tuple[str, SummaryTone]] = []
+    if isinstance(error, dict):
+        error_section = "PROVIDER ERROR\n" + format_readable_data(error)
+        lines.extend(("", error_section))
+        highlighted_sections.append((error_section, SummaryTone.AGENT))
+    elif isinstance(response, dict):
+        output_text, reasoning_text, tool_calls = _response_output(response)
+        output_section = "MODEL OUTPUT\n" + (
+            output_text or "[No assistant text returned]"
+        )
+        lines.extend(("", output_section))
+        highlighted_sections.append((output_section, SummaryTone.AGENT))
+        if reasoning_text:
+            reasoning_section = f"MODEL REASONING\n{reasoning_text}"
+            lines.extend(("", reasoning_section))
+            highlighted_sections.append((reasoning_section, SummaryTone.AGENT))
+        if tool_calls:
+            tool_section = _format_tool_calls(tool_calls)
+            lines.extend(("", tool_section))
+            highlighted_sections.append((tool_section, SummaryTone.AGENT))
+
+    usage = completion.get("usage_summary")
+    if not isinstance(usage, dict) and isinstance(response, dict):
+        candidate = response.get("usage")
+        usage = candidate if isinstance(candidate, dict) else None
+    if isinstance(usage, dict):
+        usage_section = "TOKEN USAGE\n" + format_readable_data(usage)
+        lines.extend(("", usage_section))
+
+    return _style_sections("\n".join(lines), highlighted_sections)
+
+
+def _format_generic_summary(record: Record) -> StyledSummary:
+    event_type = record.payload.get("event_type")
+    title_by_event = {
+        "ActionEvent": "Tool action",
+        "ObservationEvent": "Tool result",
+        "ConversationStateUpdateEvent": "Conversation state update",
+        "Condensation": "Context condensation",
+    }
+    title_by_kind = {
+        "run.started": "Run started",
+        "run.finished": "Run finished",
+        "agent.started": "Agent started",
+        "agent.finished": "Agent finished",
+        "metrics.snapshot": "Metrics snapshot",
+        "recorder.warning": "Recorder warning",
+    }
+    title = (
+        title_by_event.get(event_type) if isinstance(event_type, str) else None
+    ) or title_by_kind.get(record.kind, _field_label(record.kind))
+    lines = _record_metadata_lines(record, title)
+    metadata_keys = {
+        "event_type",
+        "id",
+        "timestamp",
+        "source",
+        "kind",
+        "llm_response_id",
+    }
+    details = {
+        key: value for key, value in record.payload.items() if key not in metadata_keys
+    }
+    if details:
+        lines.extend(("", "DETAILS", format_readable_data(details)))
+    else:
+        lines.extend(("", "[No additional details recorded]"))
+    return StyledSummary(text="\n".join(lines))
+
+
+def _record_metadata_lines(record: Record, title: str) -> list[str]:
+    lines = [
+        title,
+        f"Kind: {record.kind}",
+        f"Sequence: {record.sequence or 'pending'}",
+        f"Agent: {record.agent_span_id or 'None'}",
+    ]
+    _append_value(lines, "Source", record.payload.get("source"))
+    _append_value(lines, "Timestamp", record.payload.get("timestamp"))
+    _append_value(lines, "Event ID", record.payload.get("id"))
+    _append_value(lines, "LLM call ID", record.llm_call_id)
+    response_id = record.llm_response_id or record.payload.get("llm_response_id")
+    _append_value(lines, "LLM response ID", response_id)
+    return lines
+
+
+def _response_output(
+    response: dict[str, Any],
+) -> tuple[str, str, list[dict[str, Any]]]:
+    output_parts = []
+    reasoning_parts = []
+    tool_calls = []
+    choices = response.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            message = choice.get("message")
+            if not isinstance(message, dict):
+                continue
+            text = _extract_text(message.get("content"))
+            if text:
+                output_parts.append(text)
+            reasoning = _extract_text(message.get("reasoning_content"))
+            if reasoning:
+                reasoning_parts.append(reasoning)
+            calls = message.get("tool_calls")
+            if isinstance(calls, list):
+                tool_calls.extend(call for call in calls if isinstance(call, dict))
+
+    output = response.get("output")
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "function_call":
+                tool_calls.append(item)
+            elif item_type == "reasoning":
+                reasoning = _extract_text(item.get("summary") or item.get("content"))
+                if reasoning:
+                    reasoning_parts.append(reasoning)
+            else:
+                text = _extract_text(item.get("content") or item.get("text"))
+                if text:
+                    output_parts.append(text)
+    top_level_text = _extract_text(response.get("output_text"))
+    if top_level_text:
+        output_parts.append(top_level_text)
+    return (
+        "\n\n".join(dict.fromkeys(output_parts)),
+        "\n\n".join(dict.fromkeys(reasoning_parts)),
+        tool_calls,
+    )
+
+
+def _extract_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts = [_extract_text(item) for item in value]
+        return "\n\n".join(part for part in parts if part)
+    if isinstance(value, dict):
+        for key in ("text", "output_text", "content", "value"):
+            if key in value:
+                text = _extract_text(value[key])
+                if text:
+                    return text
+    return ""
+
+
+def _format_tool_calls(tool_calls: list[dict[str, Any]]) -> str:
+    lines = [f"TOOL CALLS ({len(tool_calls)})"]
+    for index, tool_call in enumerate(tool_calls, start=1):
+        function = tool_call.get("function")
+        function = function if isinstance(function, dict) else tool_call
+        name = function.get("name")
+        lines.append(f"{index}. {name if isinstance(name, str) else 'Unnamed tool'}")
+        call_id = tool_call.get("call_id") or tool_call.get("id")
+        if isinstance(call_id, str) and call_id:
+            lines.append(f"   Call ID: {call_id}")
+        arguments = function.get("arguments")
+        if arguments is not None:
+            lines.append("   Arguments:")
+            lines.extend(_format_value_lines(_parse_structured_string(arguments), 6))
+    return "\n".join(lines)
+
+
+def _finish_reasons(response: dict[str, Any]) -> list[str]:
+    choices = response.get("choices")
+    if not isinstance(choices, list):
+        return []
+    return list(
+        dict.fromkeys(
+            reason
+            for choice in choices
+            if isinstance(choice, dict)
+            and isinstance((reason := choice.get("finish_reason")), str)
+            and reason
         )
     )
+
+
+def _format_value_lines(value: Any, indent: int = 0) -> list[str]:
+    prefix = " " * indent
+    if isinstance(value, dict):
+        if not value:
+            return [prefix + "[None recorded]"]
+        lines = []
+        for key, item in value.items():
+            item = _parse_structured_string(item) if key == "arguments" else item
+            label = _field_label(str(key))
+            if isinstance(item, (dict, list)):
+                lines.append(f"{prefix}{label}:")
+                lines.extend(_format_value_lines(item, indent + 2))
+            elif isinstance(item, str) and "\n" in item:
+                lines.append(f"{prefix}{label}:")
+                lines.extend(
+                    f"{' ' * (indent + 2)}{line}" for line in item.splitlines()
+                )
+            else:
+                lines.append(f"{prefix}{label}: {_format_scalar(item)}")
+        return lines
+    if isinstance(value, list):
+        if not value:
+            return [prefix + "[None recorded]"]
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                lines.append(prefix + "-")
+                lines.extend(_format_value_lines(item, indent + 2))
+            else:
+                lines.append(f"{prefix}- {_format_scalar(item)}")
+        return lines
+    return [prefix + _format_scalar(value)]
+
+
+def _parse_structured_string(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+    return parsed if isinstance(parsed, (dict, list)) else value
+
+
+def _format_scalar(value: Any) -> str:
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, str):
+        return value or "[Empty]"
+    return str(value)
+
+
+def _field_label(key: str) -> str:
+    words = key.replace(".", " ").replace("_", " ").split()
+    labels = []
+    for word in words:
+        lowered = word.lower()
+        if word.isupper():
+            labels.append(word)
+        elif lowered in {"id", "llm", "api", "url", "ui"}:
+            labels.append(lowered.upper())
+        else:
+            labels.append(word.capitalize())
+    return " ".join(labels) or "Details"
+
+
+def _append_value(lines: list[str], label: str, value: Any) -> None:
+    if value is not None and value != "":
+        lines.append(f"{label}: {_format_scalar(value)}")
+
+
+def _append_seconds(lines: list[str], label: str, value: Any) -> None:
+    if isinstance(value, int | float):
+        lines.append(f"{label}: {value:.3f}s")
+
+
+def _append_cost(lines: list[str], value: Any) -> None:
+    if isinstance(value, int | float):
+        lines.append(f"Cost: ${value:.6f}")
 
 
 def _format_message_summary(record: Record) -> StyledSummary | None:

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/summary.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/summary.py
@@ -1,0 +1,242 @@
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from flight_recorder.models.envelopes import Record
+from pydantic import ValidationError
+
+from openhands.sdk.llm.message import ImageContent, Message, TextContent
+
+
+class SummaryTone(StrEnum):
+    OPENHANDS = "openhands"
+    USER = "user"
+    AGENT = "agent"
+
+
+@dataclass(frozen=True)
+class SummaryHighlight:
+    start: int
+    end: int
+    tone: SummaryTone
+
+
+@dataclass(frozen=True)
+class StyledSummary:
+    text: str
+    highlights: tuple[SummaryHighlight, ...] = ()
+
+
+def format_record_summary(record: Record) -> str:
+    return format_styled_record_summary(record).text
+
+
+def format_styled_record_summary(
+    record: Record, related_user_message: Record | None = None
+) -> StyledSummary:
+    event_type = record.payload.get("event_type")
+    if event_type == "MessageEvent":
+        message_summary = _format_message_summary(record)
+        if message_summary is not None:
+            return message_summary
+    elif event_type == "SystemPromptEvent":
+        system_prompt_summary = _format_system_prompt_summary(
+            record, related_user_message
+        )
+        if system_prompt_summary is not None:
+            return system_prompt_summary
+    return StyledSummary(
+        text=(
+            f"{record.kind}\nSequence: {record.sequence}\n"
+            f"Agent: {record.agent_span_id or 'None'}\n"
+            f"Payload: {json.dumps(record.payload, indent=2, sort_keys=True)}"
+        )
+    )
+
+
+def _format_message_summary(record: Record) -> StyledSummary | None:
+    raw_message = record.payload.get("llm_message")
+    if not isinstance(raw_message, dict):
+        return None
+    try:
+        message = Message.model_validate(raw_message)
+    except ValidationError:
+        return None
+
+    lines = [
+        "Message",
+        f"Sequence: {record.sequence}",
+        f"Agent: {record.agent_span_id or 'None'}",
+        f"Source: {_metadata_value(record.payload, 'source')}",
+        f"Role: {message.role}",
+    ]
+    _append_metadata(lines, record.payload, "sender", "Sender")
+    _append_metadata(lines, record.payload, "timestamp", "Timestamp")
+    _append_metadata(lines, record.payload, "id", "Message ID")
+    _append_metadata(lines, record.payload, "llm_response_id", "LLM response ID")
+
+    source = _metadata_value(record.payload, "source")
+    if source == "user":
+        content_label = "USER PROMPT"
+        content_tone = SummaryTone.USER
+    else:
+        content_label = "AGENT MESSAGE"
+        content_tone = SummaryTone.AGENT
+    content_section = f"{content_label}\n{_format_content(message.content)}"
+    lines.extend(("", content_section))
+    highlighted_sections = [(content_section, content_tone)]
+
+    extended_content = _parse_extended_content(record.payload)
+    if extended_content:
+        extension_section = "OPENHANDS PROMPT EXTENSION\n" + _format_content(
+            extended_content
+        )
+        lines.extend(("", extension_section))
+        highlighted_sections.append((extension_section, SummaryTone.OPENHANDS))
+
+    activated_skills = record.payload.get("activated_skills")
+    if isinstance(activated_skills, list):
+        skill_names = [skill for skill in activated_skills if isinstance(skill, str)]
+        if skill_names:
+            skills_section = f"Activated skills: {', '.join(skill_names)}"
+            lines.extend(("", skills_section))
+            highlighted_sections.append((skills_section, SummaryTone.OPENHANDS))
+
+    if message.tool_calls:
+        tool_names = ", ".join(tool_call.name for tool_call in message.tool_calls)
+        lines.extend(("", f"Tool calls: {tool_names}"))
+
+    return _style_sections("\n".join(lines), highlighted_sections)
+
+
+def _format_system_prompt_summary(
+    record: Record, related_user_message: Record | None
+) -> StyledSummary | None:
+    system_prompt = _parse_text_content(record.payload.get("system_prompt"))
+    if system_prompt is None:
+        return None
+
+    lines = [
+        "System prompt",
+        f"Sequence: {record.sequence}",
+        f"Agent: {record.agent_span_id or 'None'}",
+        f"Source: {_metadata_value(record.payload, 'source')}",
+    ]
+    _append_metadata(lines, record.payload, "timestamp", "Timestamp")
+    _append_metadata(lines, record.payload, "id", "Event ID")
+    highlighted_sections = []
+    user_request = _format_related_user_request(related_user_message)
+    if user_request is not None:
+        lines.extend(("", user_request))
+        highlighted_sections.append((user_request, SummaryTone.USER))
+    system_section = (
+        f"OPENHANDS TEMPLATE\nSYSTEM INSTRUCTIONS\n{_format_text(system_prompt.text)}"
+    )
+    lines.extend(("", system_section))
+    highlighted_sections.append((system_section, SummaryTone.OPENHANDS))
+
+    dynamic_context = _parse_text_content(record.payload.get("dynamic_context"))
+    if dynamic_context is not None:
+        context_section = "OPENHANDS DYNAMIC CONTEXT\n" + _format_text(
+            dynamic_context.text
+        )
+        lines.extend(("", context_section))
+        highlighted_sections.append((context_section, SummaryTone.OPENHANDS))
+
+    tools = record.payload.get("tools")
+    if isinstance(tools, list):
+        tool_names = [
+            tool["name"]
+            for tool in tools
+            if isinstance(tool, dict)
+            and isinstance(tool.get("name"), str)
+            and tool["name"]
+        ]
+        tools_lines = [f"AVAILABLE TOOLS ({len(tools)})"]
+        tools_lines.extend(f"- {name}" for name in tool_names)
+        if not tool_names:
+            tools_lines.append("[No tool names recorded]")
+        tools_section = "\n".join(tools_lines)
+        lines.extend(("", tools_section))
+        highlighted_sections.append((tools_section, SummaryTone.OPENHANDS))
+
+    return _style_sections("\n".join(lines), highlighted_sections)
+
+
+def _format_related_user_request(record: Record | None) -> str | None:
+    if record is None or record.payload.get("source") != "user":
+        return None
+    raw_message = record.payload.get("llm_message")
+    if not isinstance(raw_message, dict):
+        return None
+    try:
+        message = Message.model_validate(raw_message)
+    except ValidationError:
+        return None
+    return (
+        f"USER REQUEST (SEQUENCE {record.sequence})\n{_format_content(message.content)}"
+    )
+
+
+def _style_sections(
+    text: str, sections: list[tuple[str, SummaryTone]]
+) -> StyledSummary:
+    highlights = []
+    search_start = 0
+    for section, tone in sections:
+        start = text.index(section, search_start)
+        end = start + len(section)
+        highlights.append(SummaryHighlight(start=start, end=end, tone=tone))
+        search_start = end
+    return StyledSummary(text=text, highlights=tuple(highlights))
+
+
+def _format_content(content: Sequence[TextContent | ImageContent]) -> str:
+    blocks = []
+    for item in content:
+        if isinstance(item, TextContent):
+            blocks.append(item.text.strip() or "[Empty text block]")
+        else:
+            image_count = len(item.image_urls)
+            noun = "image" if image_count == 1 else "images"
+            blocks.append(f"[Image attachment: {image_count} {noun}]")
+    return "\n\n".join(blocks) if blocks else "[No message content]"
+
+
+def _parse_text_content(value: Any) -> TextContent | None:
+    try:
+        return TextContent.model_validate(value)
+    except ValidationError:
+        return None
+
+
+def _format_text(text: str) -> str:
+    return text.strip() or "[Empty text block]"
+
+
+def _parse_extended_content(payload: dict[str, Any]) -> list[TextContent]:
+    raw_content = payload.get("extended_content")
+    if not isinstance(raw_content, list):
+        return []
+    parsed = []
+    for item in raw_content:
+        try:
+            parsed.append(TextContent.model_validate(item))
+        except ValidationError:
+            continue
+    return parsed
+
+
+def _append_metadata(
+    lines: list[str], payload: dict[str, Any], key: str, label: str
+) -> None:
+    value = payload.get(key)
+    if isinstance(value, str) and value:
+        lines.append(f"{label}: {value}")
+
+
+def _metadata_value(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else "unknown"

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py
@@ -1,5 +1,3 @@
-import json
-
 from flight_recorder.gui.inspector.explanation import (
     explain_agent,
     explain_finding,
@@ -10,17 +8,35 @@ from flight_recorder.gui.inspector.metrics import MetricsWidget
 from flight_recorder.gui.inspector.summary import (
     StyledSummary,
     SummaryTone,
+    format_llm_input,
+    format_llm_output,
+    format_readable_data,
     format_styled_record_summary,
 )
 from flight_recorder.models.envelopes import Finding, Record
 from flight_recorder.models.view_models import AgentDetail, RunSummary
-from PySide6.QtGui import QColor, QFontDatabase, QTextCursor
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import (
+    QColor,
+    QFontDatabase,
+    QKeyEvent,
+    QKeySequence,
+    QShortcut,
+    QTextCursor,
+    QTextDocument,
+)
 from PySide6.QtWidgets import (
+    QHBoxLayout,
     QLabel,
+    QLineEdit,
     QPlainTextEdit,
     QSizePolicy,
+    QStyle,
     QTabWidget,
     QTextEdit,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
 )
 
 
@@ -65,7 +81,24 @@ class InspectorTextView(QPlainTextEdit):
         self.setExtraSelections(selections)
 
 
-class InspectorWidget(QTabWidget):
+class InspectorFindEdit(QLineEdit):
+    navigate_requested = Signal(bool)
+    dismiss_requested = Signal()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802
+        if event.key() in {Qt.Key.Key_Return, Qt.Key.Key_Enter}:
+            backward = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+            self.navigate_requested.emit(backward)
+            event.accept()
+            return
+        if event.key() == Qt.Key.Key_Escape:
+            self.dismiss_requested.emit()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
+class InspectorWidget(QWidget):
     def __init__(self) -> None:
         super().__init__()
         self.setObjectName("inspector")
@@ -74,20 +107,188 @@ class InspectorWidget(QTabWidget):
             QSizePolicy.Policy.Ignored,
             QSizePolicy.Policy.Expanding,
         )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.find_bar = QWidget()
+        self.find_bar.setObjectName("inspector-find-bar")
+        find_layout = QHBoxLayout(self.find_bar)
+        find_layout.setContentsMargins(4, 4, 4, 0)
+        find_layout.setSpacing(2)
+        self.find_input = InspectorFindEdit()
+        self.find_input.setObjectName("inspector-find-input")
+        self.find_input.setPlaceholderText("Find")
+        self.find_input.setClearButtonEnabled(True)
+        self.find_status = QLabel()
+        self.find_status.setObjectName("inspector-find-status")
+        self.find_status.setMinimumWidth(34)
+        self.find_previous = QToolButton()
+        self.find_previous.setObjectName("inspector-find-previous")
+        self.find_previous.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_ArrowUp)
+        )
+        self.find_previous.setToolTip("Previous match")
+        self.find_next = QToolButton()
+        self.find_next.setObjectName("inspector-find-next")
+        self.find_next.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_ArrowDown)
+        )
+        self.find_next.setToolTip("Next match")
+        self.find_close = QToolButton()
+        self.find_close.setObjectName("inspector-find-close")
+        self.find_close.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_TitleBarCloseButton)
+        )
+        self.find_close.setToolTip("Close find")
+        find_layout.addWidget(self.find_input, 1)
+        find_layout.addWidget(self.find_status)
+        find_layout.addWidget(self.find_previous)
+        find_layout.addWidget(self.find_next)
+        find_layout.addWidget(self.find_close)
+        layout.addWidget(self.find_bar)
+
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs, 1)
         self.summary = InspectorTextView("No selection")
         self.explanation = InspectorTextView(
             "Select a run, agent, finding, or activity to see its explanation."
         )
+        self.input = InspectorTextView("No LLM request selected.")
+        self.output = InspectorTextView("No LLM response selected.")
         self.metrics = MetricsWidget()
         self.addTab(self.summary, "Summary")
         self.addTab(self.explanation, "Explanation")
-        self.addTab(QLabel(), "Input")
-        self.addTab(QLabel(), "Output")
+        self.addTab(self.input, "Input")
+        self.addTab(self.output, "Output")
         self.addTab(self.metrics, "Metrics")
         self.addTab(QLabel(), "Changes")
         self.addTab(QLabel(), "Evidence")
+        self.find_bar.hide()
+
+        self.find_shortcut = QShortcut(QKeySequence.StandardKey.Find, self)
+        self.find_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
+        self.find_shortcut.activated.connect(self.show_find)
+        self.find_input.textChanged.connect(self._find_text_changed)
+        self.find_input.navigate_requested.connect(self._find_match)
+        self.find_input.dismiss_requested.connect(self.hide_find)
+        self.find_previous.clicked.connect(lambda: self._find_match(True))
+        self.find_next.clicked.connect(lambda: self._find_match(False))
+        self.find_close.clicked.connect(self.hide_find)
+        self.tabs.currentChanged.connect(self._active_tab_changed)
+        for view in (self.summary, self.explanation, self.input, self.output):
+            view.textChanged.connect(self._active_document_changed)
+
+    def addTab(self, widget: QWidget, label: str) -> int:  # noqa: N802
+        return self.tabs.addTab(widget, label)
+
+    def count(self) -> int:
+        return self.tabs.count()
+
+    def indexOf(self, widget: QWidget) -> int:  # noqa: N802
+        return self.tabs.indexOf(widget)
+
+    def tabText(self, index: int) -> str:  # noqa: N802
+        return self.tabs.tabText(index)
+
+    def currentWidget(self) -> QWidget | None:  # noqa: N802
+        return self.tabs.currentWidget()
+
+    def setCurrentIndex(self, index: int) -> None:  # noqa: N802
+        self.tabs.setCurrentIndex(index)
+
+    def setCurrentWidget(self, widget: QWidget) -> None:  # noqa: N802
+        self.tabs.setCurrentWidget(widget)
+
+    def show_find(self) -> None:
+        self.find_bar.show()
+        self.find_input.setFocus()
+        self.find_input.selectAll()
+        self._find_match(False, reset=True)
+
+    def hide_find(self) -> None:
+        self.find_bar.hide()
+        current = self.currentWidget()
+        if current is not None:
+            current.setFocus()
+
+    def _active_text_view(self) -> InspectorTextView | None:
+        current = self.currentWidget()
+        return current if isinstance(current, InspectorTextView) else None
+
+    def _find_text_changed(self) -> None:
+        self._find_match(False, reset=True)
+
+    def _active_tab_changed(self) -> None:
+        if self.find_bar.isVisible():
+            self._find_match(False, reset=True)
+
+    def _active_document_changed(self) -> None:
+        if self.find_bar.isVisible() and self.sender() is self.currentWidget():
+            self._find_match(False, reset=True)
+
+    def _find_match(self, backward: bool, *, reset: bool = False) -> None:
+        view = self._active_text_view()
+        query = self.find_input.text()
+        searchable = view is not None and bool(query)
+        self.find_previous.setEnabled(searchable)
+        self.find_next.setEnabled(searchable)
+        if view is None:
+            self.find_status.setText("N/A")
+            return
+        if not query:
+            self.find_status.clear()
+            return
+
+        matches = self._find_ranges(view.document(), query)
+        if not matches:
+            self.find_status.setText("0/0")
+            cursor = view.textCursor()
+            cursor.clearSelection()
+            view.setTextCursor(cursor)
+            return
+
+        current_start = view.textCursor().selectionStart()
+        if reset:
+            match_index = len(matches) - 1 if backward else 0
+        elif backward:
+            match_index = next(
+                (
+                    index
+                    for index in range(len(matches) - 1, -1, -1)
+                    if matches[index][0] < current_start
+                ),
+                len(matches) - 1,
+            )
+        else:
+            match_index = next(
+                (
+                    index
+                    for index, match in enumerate(matches)
+                    if match[0] > current_start
+                ),
+                0,
+            )
+        start, end = matches[match_index]
+        cursor = QTextCursor(view.document())
+        cursor.setPosition(start)
+        cursor.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
+        view.setTextCursor(cursor)
+        view.ensureCursorVisible()
+        self.find_status.setText(f"{match_index + 1}/{len(matches)}")
+
+    @staticmethod
+    def _find_ranges(document: QTextDocument, query: str) -> list[tuple[int, int]]:
+        matches = []
+        cursor = QTextCursor(document)
+        while True:
+            cursor = document.find(query, cursor)
+            if cursor.isNull():
+                return matches
+            matches.append((cursor.selectionStart(), cursor.selectionEnd()))
 
     def show_run(self, run: RunSummary) -> None:
+        self._clear_exchange()
         self.summary.setText(
             f"{run.trace_id}\nStatus: {run.status}\nRecords: {run.record_count}\n"
             f"Cost: ${run.total_cost:.4f}"
@@ -96,6 +297,7 @@ class InspectorWidget(QTabWidget):
         self.metrics.set_metrics(run.total_usage, run.total_cost)
 
     def show_agent(self, detail: AgentDetail) -> None:
+        self._clear_exchange()
         duration = (
             f"{detail.duration_seconds:.3f}s"
             if detail.duration_seconds is not None
@@ -105,8 +307,8 @@ class InspectorWidget(QTabWidget):
             f"Agent: {detail.relationship.child_span_id}\n"
             f"Parent: {detail.relationship.parent_span_id or 'Root'}\n"
             f"Relationship: {detail.relationship.status.value}\n"
-            f"Handoff: {json.dumps(detail.handoff, sort_keys=True)}\n"
-            f"Returned: {detail.returned_result}\n"
+            f"Handoff:\n{format_readable_data(detail.handoff)}\n"
+            f"Returned:\n{format_readable_data(detail.returned_result)}\n"
             f"Duration: {duration}\n"
             f"Prompt tokens: {detail.usage.prompt_tokens}\n"
             f"Cost: ${detail.cost:.4f}"
@@ -115,6 +317,7 @@ class InspectorWidget(QTabWidget):
         self.metrics.set_metrics(detail.usage, detail.cost)
 
     def show_finding(self, finding: Finding) -> None:
+        self._clear_exchange()
         self.summary.setText(
             f"{finding.severity.upper()}: {finding.title}\n"
             f"{finding.explanation}\n"
@@ -130,3 +333,9 @@ class InspectorWidget(QTabWidget):
             format_styled_record_summary(record, related_user_message)
         )
         self.explanation.setText(explain_record(record))
+        self.input.setText(format_llm_input(record))
+        self.output.setText(format_llm_output(record))
+
+    def _clear_exchange(self) -> None:
+        self.input.setText("No LLM request selected.")
+        self.output.setText("No LLM response selected.")

--- a/agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py
@@ -1,0 +1,132 @@
+import json
+
+from flight_recorder.gui.inspector.explanation import (
+    explain_agent,
+    explain_finding,
+    explain_record,
+    explain_run,
+)
+from flight_recorder.gui.inspector.metrics import MetricsWidget
+from flight_recorder.gui.inspector.summary import (
+    StyledSummary,
+    SummaryTone,
+    format_styled_record_summary,
+)
+from flight_recorder.models.envelopes import Finding, Record
+from flight_recorder.models.view_models import AgentDetail, RunSummary
+from PySide6.QtGui import QColor, QFontDatabase, QTextCursor
+from PySide6.QtWidgets import (
+    QLabel,
+    QPlainTextEdit,
+    QSizePolicy,
+    QTabWidget,
+    QTextEdit,
+)
+
+
+SUMMARY_TONE_COLORS = {
+    SummaryTone.OPENHANDS: ("#e5eff8", "#174a70"),
+    SummaryTone.USER: ("#e5f5eb", "#20583a"),
+    SummaryTone.AGENT: ("#fff0dc", "#704315"),
+}
+
+
+class InspectorTextView(QPlainTextEdit):
+    def __init__(self, text: str = "") -> None:
+        super().__init__(text)
+        self.setReadOnly(True)
+        self.setLineWrapMode(QPlainTextEdit.LineWrapMode.WidgetWidth)
+        self.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
+        self.setSizePolicy(
+            QSizePolicy.Policy.Ignored,
+            QSizePolicy.Policy.Expanding,
+        )
+
+    def text(self) -> str:
+        return self.toPlainText()
+
+    def setText(self, text: str) -> None:  # noqa: N802
+        self.setPlainText(text)
+        self.setExtraSelections([])
+
+    def set_styled_summary(self, summary: StyledSummary) -> None:
+        self.setPlainText(summary.text)
+        selections = []
+        for highlight in summary.highlights:
+            background, foreground = SUMMARY_TONE_COLORS[highlight.tone]
+            selection = QTextEdit.ExtraSelection()
+            cursor = QTextCursor(self.document())
+            cursor.setPosition(highlight.start)
+            cursor.setPosition(highlight.end, QTextCursor.MoveMode.KeepAnchor)
+            selection.cursor = cursor
+            selection.format.setBackground(QColor(background))
+            selection.format.setForeground(QColor(foreground))
+            selections.append(selection)
+        self.setExtraSelections(selections)
+
+
+class InspectorWidget(QTabWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setObjectName("inspector")
+        self.setAccessibleName("Activity inspector")
+        self.setSizePolicy(
+            QSizePolicy.Policy.Ignored,
+            QSizePolicy.Policy.Expanding,
+        )
+        self.summary = InspectorTextView("No selection")
+        self.explanation = InspectorTextView(
+            "Select a run, agent, finding, or activity to see its explanation."
+        )
+        self.metrics = MetricsWidget()
+        self.addTab(self.summary, "Summary")
+        self.addTab(self.explanation, "Explanation")
+        self.addTab(QLabel(), "Input")
+        self.addTab(QLabel(), "Output")
+        self.addTab(self.metrics, "Metrics")
+        self.addTab(QLabel(), "Changes")
+        self.addTab(QLabel(), "Evidence")
+
+    def show_run(self, run: RunSummary) -> None:
+        self.summary.setText(
+            f"{run.trace_id}\nStatus: {run.status}\nRecords: {run.record_count}\n"
+            f"Cost: ${run.total_cost:.4f}"
+        )
+        self.explanation.setText(explain_run(run))
+        self.metrics.set_metrics(run.total_usage, run.total_cost)
+
+    def show_agent(self, detail: AgentDetail) -> None:
+        duration = (
+            f"{detail.duration_seconds:.3f}s"
+            if detail.duration_seconds is not None
+            else "incomplete"
+        )
+        self.summary.setText(
+            f"Agent: {detail.relationship.child_span_id}\n"
+            f"Parent: {detail.relationship.parent_span_id or 'Root'}\n"
+            f"Relationship: {detail.relationship.status.value}\n"
+            f"Handoff: {json.dumps(detail.handoff, sort_keys=True)}\n"
+            f"Returned: {detail.returned_result}\n"
+            f"Duration: {duration}\n"
+            f"Prompt tokens: {detail.usage.prompt_tokens}\n"
+            f"Cost: ${detail.cost:.4f}"
+        )
+        self.explanation.setText(explain_agent(detail))
+        self.metrics.set_metrics(detail.usage, detail.cost)
+
+    def show_finding(self, finding: Finding) -> None:
+        self.summary.setText(
+            f"{finding.severity.upper()}: {finding.title}\n"
+            f"{finding.explanation}\n"
+            f"Recommendation: {finding.recommendation}\n"
+            f"Evidence: {', '.join(finding.evidence_ids)}"
+        )
+        self.explanation.setText(explain_finding(finding))
+
+    def show_record(
+        self, record: Record, related_user_message: Record | None = None
+    ) -> None:
+        self.summary.set_styled_summary(
+            format_styled_record_summary(record, related_user_message)
+        )
+        self.explanation.setText(explain_record(record))

--- a/agent-flight-recorder/src/flight_recorder/gui/main_window.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/main_window.py
@@ -14,7 +14,7 @@ from flight_recorder.gui.timeline.rows import (
 )
 from flight_recorder.gui.timeline.view import TimelineViewWidget
 from flight_recorder.models.envelopes import Finding
-from flight_recorder.models.view_models import RunQuery
+from flight_recorder.models.view_models import RunQuery, Selection
 from flight_recorder.services.repository import TraceRepository
 from PySide6.QtCore import QByteArray, QModelIndex, QSettings, Qt
 from PySide6.QtGui import QAction, QCloseEvent
@@ -146,6 +146,7 @@ class MainWindow(QMainWindow):
         center_layout.addLayout(timeline_controls)
         self.timeline.span_activated.connect(self.navigate_to_agent)
         self.timeline.record_activated.connect(self.navigate_to_record)
+        self.selection.selection_changed.connect(self._selection_changed)
         changes = QLabel("Workspace changes")
         changes.setObjectName("workspace-changes")
         center_layout.addWidget(self.timeline)
@@ -220,6 +221,9 @@ class MainWindow(QMainWindow):
             return
         self.timeline.timeline_scene.set_enabled_row_types(enabled)
         self._sync_timeline_row_actions()
+
+    def _selection_changed(self, selection: Selection) -> None:
+        self.timeline.timeline_scene.set_selected_record(selection.record_id)
 
     def navigate_to_agent(self, span_id: str) -> None:
         self.selection.select_span(span_id)

--- a/agent-flight-recorder/src/flight_recorder/gui/main_window.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/main_window.py
@@ -1,0 +1,349 @@
+"""Main trace investigation window."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from flight_recorder.gui.controllers.selection import SelectionController
+from flight_recorder.gui.inspector.widget import InspectorWidget
+from flight_recorder.gui.models.findings import FindingsModel
+from flight_recorder.gui.models.run_table import RunTableModel
+from flight_recorder.gui.models.trace_tree import TraceTreeModel
+from flight_recorder.gui.timeline.rows import (
+    ACTIVITY_ROW_TYPES,
+    DEFAULT_ACTIVITY_ROW_TYPES,
+)
+from flight_recorder.gui.timeline.view import TimelineViewWidget
+from flight_recorder.models.envelopes import Finding
+from flight_recorder.models.view_models import RunQuery
+from flight_recorder.services.repository import TraceRepository
+from PySide6.QtCore import QByteArray, QModelIndex, QSettings, Qt
+from PySide6.QtGui import QAction, QCloseEvent
+from PySide6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMenu,
+    QSplitter,
+    QTableView,
+    QToolButton,
+    QTreeView,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+DEFAULT_WINDOW_WIDTH = 1200
+DEFAULT_WINDOW_HEIGHT = 760
+
+
+class MainWindow(QMainWindow):
+    def __init__(
+        self,
+        trace: Path | None = None,
+        *,
+        repository: TraceRepository | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._detach_callbacks: list[Callable[[], None]] = []
+        self._detached = False
+        self._settings: QSettings | None = None
+        self._repository: TraceRepository | None = None
+        self._trace_id: str | None = None
+        self._hidden_timeline_row_types = {
+            row.key
+            for row in ACTIVITY_ROW_TYPES
+            if row.key not in DEFAULT_ACTIVITY_ROW_TYPES
+        }
+        self._updating_timeline_row_actions = False
+        self.selection = SelectionController()
+        self.setWindowTitle("Agent Flight Recorder")
+        self.resize(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT)
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.splitter.setObjectName("workspace-splitter")
+        self.splitter.setHandleWidth(8)
+        self.splitter.setOpaqueResize(True)
+        self.splitter.setStyleSheet(
+            "QSplitter::handle:horizontal {"
+            "background: #c7ceca; border-left: 1px solid #9ba7a1; "
+            "border-right: 1px solid #9ba7a1; margin: 2px 1px;"
+            "}"
+            "QSplitter::handle:horizontal:hover, "
+            "QSplitter::handle:horizontal:pressed { background: #5d8b78; }"
+        )
+        navigation = QWidget()
+        navigation.setMinimumWidth(160)
+        navigation_layout = QVBoxLayout(navigation)
+        run_table = QTableView()
+        run_table.setObjectName("runs")
+        self.run_model = RunTableModel(parent=run_table)
+        run_table.setModel(self.run_model)
+        self.tree = QTreeView()
+        self.tree.setObjectName("trace-tree")
+        self.tree_model = TraceTreeModel(parent=self.tree)
+        self.tree.setModel(self.tree_model)
+        self.tree.clicked.connect(self._tree_item_selected)
+        navigation_layout.addWidget(run_table)
+        navigation_layout.addWidget(self.tree)
+        self.findings = QTableView()
+        self.findings.setObjectName("findings")
+        self.findings_model = FindingsModel(parent=self.findings)
+        self.findings.setModel(self.findings_model)
+        self.findings.doubleClicked.connect(self._finding_selected)
+        navigation_layout.addWidget(self.findings)
+
+        center = QWidget()
+        center.setMinimumWidth(240)
+        center_layout = QVBoxLayout(center)
+        timeline_controls = QHBoxLayout()
+        timeline_controls.addStretch()
+        self.timeline = TimelineViewWidget()
+        self.timeline_zoom_out = QToolButton()
+        self.timeline_zoom_out.setObjectName("timeline-zoom-out")
+        self.timeline_zoom_out.setText("−")
+        self.timeline_zoom_out.setToolTip("Zoom out (mouse wheel down)")
+        self.timeline_zoom_out.clicked.connect(self.timeline.zoom_out)
+        self.timeline_fit = QToolButton()
+        self.timeline_fit.setObjectName("timeline-zoom-fit")
+        self.timeline_fit.setText("Fit")
+        self.timeline_fit.setToolTip("Fit elapsed timeline (0)")
+        self.timeline_zoom_value = QLabel("100%")
+        self.timeline_zoom_value.setMinimumWidth(44)
+        self.timeline_zoom_value.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.timeline_zoom_in = QToolButton()
+        self.timeline_zoom_in.setObjectName("timeline-zoom-in")
+        self.timeline_zoom_in.setText("+")
+        self.timeline_zoom_in.setToolTip("Zoom in (mouse wheel up)")
+        self.timeline_fit.clicked.connect(self.timeline.zoom_to_fit)
+        self.timeline_zoom_in.clicked.connect(self.timeline.zoom_in)
+        self.timeline.zoom_changed.connect(
+            lambda zoom: self.timeline_zoom_value.setText(f"{zoom * 100:.0f}%")
+        )
+        self.timeline_rows_button = QToolButton()
+        self.timeline_rows_button.setObjectName("timeline-row-types")
+        self.timeline_rows_button.setText("Rows")
+        self.timeline_rows_button.setPopupMode(
+            QToolButton.ToolButtonPopupMode.InstantPopup
+        )
+        row_menu = QMenu(self.timeline_rows_button)
+        self.timeline_row_actions: dict[str, QAction] = {}
+        for row_type in ACTIVITY_ROW_TYPES:
+            action = row_menu.addAction(row_type.label)
+            action.setCheckable(True)
+            action.toggled.connect(
+                lambda checked, key=row_type.key: self._timeline_row_type_toggled(
+                    key, checked
+                )
+            )
+            self.timeline_row_actions[row_type.key] = action
+        self.timeline_rows_button.setMenu(row_menu)
+        timeline_controls.addWidget(self.timeline_rows_button)
+        timeline_controls.addWidget(self.timeline_zoom_out)
+        timeline_controls.addWidget(self.timeline_fit)
+        timeline_controls.addWidget(self.timeline_zoom_in)
+        timeline_controls.addWidget(self.timeline_zoom_value)
+        center_layout.addLayout(timeline_controls)
+        self.timeline.span_activated.connect(self.navigate_to_agent)
+        self.timeline.record_activated.connect(self.navigate_to_record)
+        changes = QLabel("Workspace changes")
+        changes.setObjectName("workspace-changes")
+        center_layout.addWidget(self.timeline)
+        center_layout.addWidget(changes)
+
+        self.inspector = InspectorWidget()
+        self.inspector.setMinimumWidth(160)
+        if trace is not None:
+            self.inspector.summary.setText(str(trace))
+        self.splitter.addWidget(navigation)
+        self.splitter.addWidget(center)
+        self.splitter.addWidget(self.inspector)
+        self.splitter.setChildrenCollapsible(False)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+        self.splitter.setStretchFactor(2, 0)
+        self.splitter.setSizes([250, 700, 250])
+        self.setCentralWidget(self.splitter)
+        if repository is not None:
+            self.set_repository(repository, trace_id)
+
+    def set_repository(
+        self, repository: TraceRepository, trace_id: str | None = None
+    ) -> None:
+        self._repository = repository
+        runs = repository.list_runs(RunQuery())
+        self.run_model.set_runs(runs)
+        selected_trace_id = trace_id or (runs[0].trace_id if runs else None)
+        if selected_trace_id is None:
+            return
+        self._trace_id = selected_trace_id
+        run = repository.get_run(selected_trace_id)
+        timeline = repository.get_timeline(selected_trace_id)
+        self.tree_model.set_timeline(timeline)
+        current_sequence = timeline.records[-1].sequence or 1
+        self.timeline.timeline_scene.set_timeline(
+            timeline.spans,
+            timeline.records,
+            current_sequence=current_sequence,
+            enabled_row_types={
+                row.key
+                for row in ACTIVITY_ROW_TYPES
+                if row.key not in self._hidden_timeline_row_types
+            },
+        )
+        self._sync_timeline_row_actions()
+        self.inspector.show_run(run)
+
+    def _sync_timeline_row_actions(self) -> None:
+        available = set(self.timeline.timeline_scene.available_row_types)
+        enabled = set(self.timeline.timeline_scene.enabled_row_types)
+        self._updating_timeline_row_actions = True
+        try:
+            for key, action in self.timeline_row_actions.items():
+                action.setEnabled(key in available)
+                action.setChecked(key in enabled)
+        finally:
+            self._updating_timeline_row_actions = False
+
+    def _timeline_row_type_toggled(self, key: str, checked: bool) -> None:
+        if self._updating_timeline_row_actions:
+            return
+        if checked:
+            self._hidden_timeline_row_types.discard(key)
+        else:
+            self._hidden_timeline_row_types.add(key)
+        available = set(self.timeline.timeline_scene.available_row_types)
+        enabled = available - self._hidden_timeline_row_types
+        if not enabled:
+            self._hidden_timeline_row_types.discard(key)
+            self._sync_timeline_row_actions()
+            return
+        self.timeline.timeline_scene.set_enabled_row_types(enabled)
+        self._sync_timeline_row_actions()
+
+    def navigate_to_agent(self, span_id: str) -> None:
+        self.selection.select_span(span_id)
+        index = self.tree_model.index_for_id(span_id)
+        if index.isValid():
+            parent = index.parent()
+            while parent.isValid():
+                self.tree.expand(parent)
+                parent = parent.parent()
+            self.tree.setCurrentIndex(index)
+            self.tree.scrollTo(index)
+        if self._repository is not None and self._trace_id is not None:
+            self.inspector.show_agent(
+                self._repository.get_agent_detail(self._trace_id, span_id)
+            )
+
+    def set_findings(self, findings: list[Finding]) -> None:
+        self.findings_model.set_findings(findings)
+
+    def navigate_to_finding(self, row: int) -> None:
+        finding = self.findings_model.finding_at(row)
+        self.findings.setCurrentIndex(self.findings_model.index(row, 0))
+        self.inspector.show_finding(finding)
+        self.selection.navigate_to_evidence(finding.evidence_ids[0])
+
+    def navigate_to_record(self, record_id: str) -> None:
+        self.selection.select_record(record_id)
+        if self._repository is not None and self._trace_id is not None:
+            record = self._repository.get_record(self._trace_id, record_id)
+            related_user_message = None
+            if (
+                record.sequence is not None
+                and record.payload.get("event_type") == "SystemPromptEvent"
+            ):
+                related_user_message = self._repository.get_next_user_message(
+                    self._trace_id,
+                    after_sequence=record.sequence,
+                    agent_span_id=record.agent_span_id,
+                )
+            self.inspector.show_record(
+                record, related_user_message=related_user_message
+            )
+
+    def _finding_selected(self, index: QModelIndex) -> None:
+        self.navigate_to_finding(index.row())
+
+    def _tree_item_selected(self, index: QModelIndex) -> None:
+        item_id = index.data(Qt.ItemDataRole.UserRole + 1)
+        if isinstance(item_id, str):
+            span_ids = {span.span_id for span in self.tree_model_timeline_spans()}
+            if item_id in span_ids:
+                self.navigate_to_agent(item_id)
+            else:
+                self.navigate_to_record(item_id)
+
+    def tree_model_timeline_spans(self) -> tuple:
+        if self._repository is None or self._trace_id is None:
+            return ()
+        return self._repository.get_timeline(self._trace_id).spans
+
+    def save_settings(self, settings: QSettings) -> None:
+        settings.setValue("window/width", self.width())
+        settings.setValue("window/height", self.height())
+        settings.setValue("window/splitter", self.splitter.saveState())
+        settings.setValue(
+            "timeline/hidden-row-types",
+            sorted(self._hidden_timeline_row_types),
+        )
+        settings.sync()
+
+    def restore_settings(self, settings: QSettings) -> None:
+        self._settings = settings
+        width = settings.value("window/width")
+        height = settings.value("window/height")
+        if width is not None and height is not None:
+            screen = QApplication.primaryScreen()
+            available = screen.availableGeometry() if screen is not None else None
+            maximum_width = max(
+                DEFAULT_WINDOW_WIDTH,
+                available.width() if available is not None else 0,
+            )
+            maximum_height = max(
+                DEFAULT_WINDOW_HEIGHT,
+                available.height() if available is not None else 0,
+            )
+            self.resize(
+                min(max(int(width), self.minimumSizeHint().width()), maximum_width),
+                min(max(int(height), self.minimumSizeHint().height()), maximum_height),
+            )
+        splitter_state = settings.value("window/splitter")
+        if isinstance(splitter_state, QByteArray):
+            self.splitter.restoreState(splitter_state)
+        if settings.contains("timeline/hidden-row-types"):
+            stored_row_types = settings.value("timeline/hidden-row-types", [])
+            if isinstance(stored_row_types, str):
+                hidden_row_types = [stored_row_types]
+            elif isinstance(stored_row_types, list):
+                hidden_row_types = [str(key) for key in stored_row_types]
+            else:
+                hidden_row_types = []
+            known_row_types = {row.key for row in ACTIVITY_ROW_TYPES}
+            self._hidden_timeline_row_types = {
+                str(key) for key in hidden_row_types if str(key) in known_row_types
+            }
+        if self._repository is not None:
+            self.timeline.timeline_scene.set_enabled_row_types(
+                set(self.timeline.timeline_scene.available_row_types)
+                - self._hidden_timeline_row_types
+            )
+            self._sync_timeline_row_actions()
+
+    def add_detach_callback(self, callback: Callable[[], None]) -> None:
+        self._detach_callbacks.append(callback)
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802
+        if not self._detached:
+            self._detached = True
+            for callback in self._detach_callbacks:
+                callback()
+            if self._settings is not None:
+                self.save_settings(self._settings)
+        super().closeEvent(event)
+
+    def centralWidget(self) -> QWidget:  # noqa: N802
+        widget = super().centralWidget()
+        assert widget is not None
+        return widget

--- a/agent-flight-recorder/src/flight_recorder/gui/models/findings.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/models/findings.py
@@ -1,0 +1,85 @@
+from collections.abc import Sequence
+
+from flight_recorder.models.envelopes import Finding
+from PySide6.QtCore import (
+    QAbstractTableModel,
+    QModelIndex,
+    QObject,
+    QPersistentModelIndex,
+    Qt,
+)
+
+
+_EMPTY_INDEX = QModelIndex()
+
+
+class FindingsModel(QAbstractTableModel):
+    _HEADERS = ("Severity", "Category", "Finding", "Evidence")
+
+    def __init__(
+        self, findings: Sequence[Finding] = (), parent: QObject | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._all_findings = list(findings)
+        self._findings = list(findings)
+
+    def rowCount(  # noqa: N802
+        self, parent: QModelIndex | QPersistentModelIndex = _EMPTY_INDEX
+    ) -> int:
+        return 0 if parent.isValid() else len(self._findings)
+
+    def columnCount(  # noqa: N802
+        self, parent: QModelIndex | QPersistentModelIndex = _EMPTY_INDEX
+    ) -> int:
+        return 0 if parent.isValid() else len(self._HEADERS)
+
+    def data(
+        self,
+        index: QModelIndex | QPersistentModelIndex,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ):
+        if not index.isValid() or role != Qt.ItemDataRole.DisplayRole:
+            return None
+        finding = self._findings[index.row()]
+        values = (
+            finding.severity,
+            finding.category,
+            finding.title,
+            ", ".join(finding.evidence_ids),
+        )
+        return values[index.column()]
+
+    def headerData(  # noqa: N802
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ):
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
+            return self._HEADERS[section]
+        return None
+
+    def set_findings(self, findings: Sequence[Finding]) -> None:
+        self.beginResetModel()
+        self._all_findings = list(findings)
+        self._findings = list(findings)
+        self.endResetModel()
+
+    def set_filters(self, *, severity: str | None, category: str | None) -> None:
+        self.beginResetModel()
+        self._findings = [
+            finding
+            for finding in self._all_findings
+            if (severity is None or finding.severity == severity)
+            and (category is None or finding.category == category)
+        ]
+        self.endResetModel()
+
+    def finding_at(self, row: int) -> Finding:
+        return self._findings[row]
+
+    def evidence_at(self, row: int) -> tuple[str, ...]:
+        return self.finding_at(row).evidence_ids

--- a/agent-flight-recorder/src/flight_recorder/gui/models/run_table.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/models/run_table.py
@@ -1,0 +1,77 @@
+from collections.abc import Sequence
+
+from flight_recorder.models.view_models import RunSummary
+from PySide6.QtCore import (
+    QAbstractTableModel,
+    QModelIndex,
+    QObject,
+    QPersistentModelIndex,
+    Qt,
+)
+
+
+_EMPTY_INDEX = QModelIndex()
+
+
+class RunTableModel(QAbstractTableModel):
+    _HEADERS = ("Trace", "Status", "Records", "Cost")
+
+    def __init__(
+        self, runs: Sequence[RunSummary] = (), parent: QObject | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._all_runs = list(runs)
+        self._runs = list(runs)
+
+    def rowCount(  # noqa: N802
+        self, parent: QModelIndex | QPersistentModelIndex = _EMPTY_INDEX
+    ) -> int:
+        return 0 if parent.isValid() else len(self._runs)
+
+    def columnCount(  # noqa: N802
+        self, parent: QModelIndex | QPersistentModelIndex = _EMPTY_INDEX
+    ) -> int:
+        return 0 if parent.isValid() else len(self._HEADERS)
+
+    def data(
+        self,
+        index: QModelIndex | QPersistentModelIndex,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ):
+        if not index.isValid() or role != Qt.ItemDataRole.DisplayRole:
+            return None
+        run = self._runs[index.row()]
+        values = (run.trace_id, run.status, run.record_count, f"${run.total_cost:.4f}")
+        return values[index.column()]
+
+    def headerData(  # noqa: N802
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ):
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
+            return self._HEADERS[section]
+        return None
+
+    def set_runs(self, runs: Sequence[RunSummary]) -> None:
+        self.beginResetModel()
+        self._all_runs = list(runs)
+        self._runs = list(runs)
+        self.endResetModel()
+
+    def set_filter(self, text: str) -> None:
+        needle = text.casefold()
+        self.beginResetModel()
+        self._runs = [
+            run
+            for run in self._all_runs
+            if needle in run.trace_id.casefold() or needle in run.status.casefold()
+        ]
+        self.endResetModel()
+
+    def run_at(self, row: int) -> RunSummary:
+        return self._runs[row]

--- a/agent-flight-recorder/src/flight_recorder/gui/models/trace_tree.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/models/trace_tree.py
@@ -1,0 +1,58 @@
+from flight_recorder.models.view_models import TimelineView
+from PySide6.QtCore import QModelIndex, QObject
+from PySide6.QtGui import QStandardItem, QStandardItemModel
+
+
+class TraceTreeModel(QStandardItemModel):
+    def __init__(
+        self, timeline: TimelineView | None = None, parent: QObject | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.setHorizontalHeaderLabels(["Activity"])
+        if timeline is not None:
+            self.set_timeline(timeline)
+
+    def set_timeline(self, timeline: TimelineView) -> None:
+        self.removeRows(0, self.rowCount())
+        has_agent_hierarchy = any(
+            span.span_type == "agent" and span.parent_span_id is not None
+            for span in timeline.spans
+        )
+        if not has_agent_hierarchy:
+            for record in timeline.records:
+                item = QStandardItem(record.kind)
+                item.setData(record.record_id)
+                self.invisibleRootItem().appendRow(item)
+            return
+
+        span_items: dict[str, QStandardItem] = {}
+        for span in sorted(
+            timeline.spans, key=lambda item: (item.start_sequence, item.span_id)
+        ):
+            item = QStandardItem(span.name)
+            item.setData(span.span_id)
+            item.setToolTip(f"{span.relationship_status.value} relationship")
+            span_items[span.span_id] = item
+        for span in sorted(
+            timeline.spans, key=lambda item: (item.start_sequence, item.span_id)
+        ):
+            item = span_items[span.span_id]
+            parent = span_items.get(span.parent_span_id or "")
+            (parent or self.invisibleRootItem()).appendRow(item)
+
+        for record in timeline.records:
+            item = QStandardItem(record.kind)
+            item.setData(record.record_id)
+            parent = span_items.get(record.span_id or record.parent_span_id or "")
+            (parent or self.invisibleRootItem()).appendRow(item)
+
+    def index_for_id(self, item_id: str) -> QModelIndex:
+        pending = [self.invisibleRootItem()]
+        while pending:
+            parent = pending.pop()
+            for row in range(parent.rowCount()):
+                item = parent.child(row)
+                if item.data() == item_id:
+                    return item.index()
+                pending.append(item)
+        return QModelIndex()

--- a/agent-flight-recorder/src/flight_recorder/gui/models/trace_tree.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/models/trace_tree.py
@@ -1,3 +1,4 @@
+from flight_recorder.gui.timeline.items import record_label
 from flight_recorder.models.view_models import TimelineView
 from PySide6.QtCore import QModelIndex, QObject
 from PySide6.QtGui import QStandardItem, QStandardItemModel
@@ -20,7 +21,7 @@ class TraceTreeModel(QStandardItemModel):
         )
         if not has_agent_hierarchy:
             for record in timeline.records:
-                item = QStandardItem(record.kind)
+                item = QStandardItem(record_label(record))
                 item.setData(record.record_id)
                 self.invisibleRootItem().appendRow(item)
             return
@@ -41,7 +42,7 @@ class TraceTreeModel(QStandardItemModel):
             (parent or self.invisibleRootItem()).appendRow(item)
 
         for record in timeline.records:
-            item = QStandardItem(record.kind)
+            item = QStandardItem(record_label(record))
             item.setData(record.record_id)
             parent = span_items.get(record.span_id or record.parent_span_id or "")
             (parent or self.invisibleRootItem()).appendRow(item)

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
@@ -2,15 +2,16 @@ from collections.abc import Callable
 
 from flight_recorder.gui.timeline.layout import SpanLayout
 from flight_recorder.gui.timeline.rows import (
-    ACTIVITY_ROW_TYPES_BY_KEY,
+    ACTIVITY_CATEGORY_TYPES_BY_KEY,
     classify_record,
 )
 from flight_recorder.gui.timeline.time import RecordInterval
 from flight_recorder.models.envelopes import Record, RelationshipStatus
-from PySide6.QtCore import QRectF, Qt
-from PySide6.QtGui import QBrush, QColor, QPen
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import QBrush, QColor, QPainterPath, QPen
 from PySide6.QtWidgets import (
     QGraphicsItem,
+    QGraphicsPathItem,
     QGraphicsRectItem,
     QGraphicsSceneMouseEvent,
 )
@@ -20,6 +21,16 @@ SEQUENCE_WIDTH = 12.0
 LANE_HEIGHT = 76.0
 LABEL_WIDTH = 220.0
 HEADER_HEIGHT = 42.0
+MIN_RECORD_WIDTH = 8.0
+RECORD_TOP = 44.0
+RECORD_HEIGHT = 16.0
+
+
+def record_width(interval: RecordInterval, pixels_per_second: float) -> float:
+    return max(
+        MIN_RECORD_WIDTH,
+        interval.duration_seconds * pixels_per_second,
+    )
 
 
 class TimelineSpanItem(QGraphicsRectItem):
@@ -31,6 +42,7 @@ class TimelineSpanItem(QGraphicsRectItem):
         on_activated: Callable[[str], None] | None = None,
         pixels_per_second: float = 1.0,
         lane: int | None = None,
+        row_top: float | None = None,
     ) -> None:
         start_seconds = float(layout.start) if start_seconds is None else start_seconds
         end_seconds = float(layout.end) if end_seconds is None else end_seconds
@@ -38,12 +50,15 @@ class TimelineSpanItem(QGraphicsRectItem):
             8.0,
             (end_seconds - start_seconds) * pixels_per_second,
         )
+        lane_top = (
+            HEADER_HEIGHT + (layout.lane if lane is None else lane) * LANE_HEIGHT
+            if row_top is None
+            else row_top
+        )
         super().__init__(
             QRectF(
                 LABEL_WIDTH + start_seconds * pixels_per_second,
-                HEADER_HEIGHT
-                + (layout.lane if lane is None else lane) * LANE_HEIGHT
-                + 10,
+                lane_top + 10,
                 width,
                 28,
             )
@@ -70,7 +85,22 @@ class TimelineSpanItem(QGraphicsRectItem):
 
 
 def record_label(record: Record) -> str:
+    if record.kind == "llm.request":
+        return "LLM request"
+    if record.kind == "llm.response":
+        completion = record.payload.get("completion", record.payload)
+        if isinstance(completion, dict) and isinstance(completion.get("error"), dict):
+            return "LLM error"
+        return "LLM response"
     event_type = record.payload.get("event_type")
+    if event_type == "SystemPromptEvent":
+        return "System prompt"
+    if event_type == "MessageEvent":
+        message = record.payload.get("llm_message")
+        role = message.get("role") if isinstance(message, dict) else None
+        if record.payload.get("source") == "user" or role == "user":
+            return "User prompt"
+        return "Assistant message"
     tool_name = record.payload.get("tool_name")
     if isinstance(tool_name, str) and tool_name:
         return f"{event_type or record.kind}: {tool_name}"
@@ -80,7 +110,38 @@ def record_label(record: Record) -> str:
 
 
 def record_color(record: Record) -> QColor:
-    return QColor(ACTIVITY_ROW_TYPES_BY_KEY[classify_record(record)].color)
+    return QColor(ACTIVITY_CATEGORY_TYPES_BY_KEY[classify_record(record)].color)
+
+
+class TimelineSequenceArrowItem(QGraphicsPathItem):
+    def __init__(
+        self,
+        previous_record_id: str,
+        next_record_id: str,
+        start: QPointF,
+        end: QPointF,
+    ) -> None:
+        path = QPainterPath(start)
+        if start.y() == end.y():
+            path.lineTo(end)
+        else:
+            midpoint_x = (start.x() + end.x()) / 2
+            path.lineTo(midpoint_x, start.y())
+            path.lineTo(midpoint_x, end.y())
+            path.lineTo(end)
+        path.moveTo(end.x() - 4, end.y() - 3)
+        path.lineTo(end)
+        path.lineTo(end.x() - 4, end.y() + 3)
+        super().__init__(path)
+        self.previous_record_id = previous_record_id
+        self.next_record_id = next_record_id
+        self.start = start
+        self.end = end
+        self.setData(0, "record-sequence-arrow")
+        self.setData(1, previous_record_id)
+        self.setData(2, next_record_id)
+        self.setPen(QPen(QColor("#68766f"), 1.25, Qt.PenStyle.SolidLine))
+        self.setZValue(1)
 
 
 class TimelineRecordItem(QGraphicsRectItem):
@@ -92,27 +153,52 @@ class TimelineRecordItem(QGraphicsRectItem):
         lane: int,
         on_activated: Callable[[str], None],
         pixels_per_second: float,
+        row_top: float | None = None,
+        display_start_pixels: float | None = None,
+        display_y: float | None = None,
     ) -> None:
-        x = LABEL_WIDTH + interval.start_seconds * pixels_per_second
-        width = max(
-            2.0,
-            interval.duration_seconds * pixels_per_second,
+        recorded_start_pixels = interval.start_seconds * pixels_per_second
+        visible_start_pixels = (
+            recorded_start_pixels
+            if display_start_pixels is None
+            else display_start_pixels
         )
-        y = HEADER_HEIGHT + lane * LANE_HEIGHT + 44
-        super().__init__(QRectF(x, y, width, 16))
+        x = LABEL_WIDTH + visible_start_pixels
+        width = record_width(interval, pixels_per_second)
+        lane_top = HEADER_HEIGHT + lane * LANE_HEIGHT if row_top is None else row_top
+        y = lane_top + RECORD_TOP if display_y is None else display_y
+        super().__init__(QRectF(x, y, width, RECORD_HEIGHT))
         self.record_id = record.record_id
         self._on_activated = on_activated
         self.setBrush(QBrush(record_color(record)))
-        self.setPen(QPen(QColor("#f7f9f8"), 1))
+        self._default_pen = QPen(QColor("#f7f9f8"), 1)
+        self._selected_pen = QPen(QColor("#f4b400"), 3)
+        self._selected = False
+        self.setPen(self._default_pen)
         self.setZValue(2)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsFocusable, True)
-        self.setToolTip(
+        tooltip = (
             f"{record_label(record)}\n"
-            f"Start: +{interval.start_seconds:.3f}s\n"
+            f"Recorded start: +{interval.start_seconds:.3f}s\n"
             f"Duration: {interval.duration_seconds:.3f}s\n"
-            f"Kind: {record.kind}\nClick to inspect the recorded payload"
+            f"Kind: {record.kind}"
         )
+        if visible_start_pixels != recorded_start_pixels:
+            tooltip += (
+                "\nDisplay-aligned start: "
+                f"+{visible_start_pixels / pixels_per_second:.3f}s"
+            )
+        self.setToolTip(tooltip + "\nClick to inspect the recorded payload")
+
+    @property
+    def selected(self) -> bool:
+        return self._selected
+
+    def set_selected(self, selected: bool) -> None:
+        self._selected = selected
+        self.setPen(self._selected_pen if selected else self._default_pen)
+        self.setZValue(5 if selected else 2)
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # noqa: N802
         self._on_activated(self.record_id)

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
@@ -1,0 +1,119 @@
+from collections.abc import Callable
+
+from flight_recorder.gui.timeline.layout import SpanLayout
+from flight_recorder.gui.timeline.rows import (
+    ACTIVITY_ROW_TYPES_BY_KEY,
+    classify_record,
+)
+from flight_recorder.gui.timeline.time import RecordInterval
+from flight_recorder.models.envelopes import Record, RelationshipStatus
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QBrush, QColor, QPen
+from PySide6.QtWidgets import (
+    QGraphicsItem,
+    QGraphicsRectItem,
+    QGraphicsSceneMouseEvent,
+)
+
+
+SEQUENCE_WIDTH = 12.0
+LANE_HEIGHT = 76.0
+LABEL_WIDTH = 220.0
+HEADER_HEIGHT = 42.0
+
+
+class TimelineSpanItem(QGraphicsRectItem):
+    def __init__(
+        self,
+        layout: SpanLayout,
+        start_seconds: float | None = None,
+        end_seconds: float | None = None,
+        on_activated: Callable[[str], None] | None = None,
+        pixels_per_second: float = 1.0,
+        lane: int | None = None,
+    ) -> None:
+        start_seconds = float(layout.start) if start_seconds is None else start_seconds
+        end_seconds = float(layout.end) if end_seconds is None else end_seconds
+        width = max(
+            8.0,
+            (end_seconds - start_seconds) * pixels_per_second,
+        )
+        super().__init__(
+            QRectF(
+                LABEL_WIDTH + start_seconds * pixels_per_second,
+                HEADER_HEIGHT
+                + (layout.lane if lane is None else lane) * LANE_HEIGHT
+                + 10,
+                width,
+                28,
+            )
+        )
+        self.span_id = layout.span_id
+        self._on_activated = on_activated
+        self.setToolTip(
+            f"{layout.span_id} ({layout.relationship_status.value} relationship)"
+        )
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setBrush(QColor("#c96d3b") if layout.incomplete else QColor("#2f7d67"))
+        pen = QPen(QColor("#1f2926"), 1)
+        if layout.relationship_status is RelationshipStatus.INFERRED:
+            pen.setStyle(Qt.PenStyle.DashLine)
+        elif layout.relationship_status is RelationshipStatus.UNRESOLVED:
+            pen.setStyle(Qt.PenStyle.DotLine)
+            pen.setWidth(2)
+        self.setPen(pen)
+
+    def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # noqa: N802
+        if self._on_activated is not None:
+            self._on_activated(self.span_id)
+        super().mousePressEvent(event)
+
+
+def record_label(record: Record) -> str:
+    event_type = record.payload.get("event_type")
+    tool_name = record.payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name:
+        return f"{event_type or record.kind}: {tool_name}"
+    if isinstance(event_type, str) and event_type:
+        return event_type
+    return record.kind
+
+
+def record_color(record: Record) -> QColor:
+    return QColor(ACTIVITY_ROW_TYPES_BY_KEY[classify_record(record)].color)
+
+
+class TimelineRecordItem(QGraphicsRectItem):
+    def __init__(
+        self,
+        record: Record,
+        interval: RecordInterval,
+        *,
+        lane: int,
+        on_activated: Callable[[str], None],
+        pixels_per_second: float,
+    ) -> None:
+        x = LABEL_WIDTH + interval.start_seconds * pixels_per_second
+        width = max(
+            2.0,
+            interval.duration_seconds * pixels_per_second,
+        )
+        y = HEADER_HEIGHT + lane * LANE_HEIGHT + 44
+        super().__init__(QRectF(x, y, width, 16))
+        self.record_id = record.record_id
+        self._on_activated = on_activated
+        self.setBrush(QBrush(record_color(record)))
+        self.setPen(QPen(QColor("#f7f9f8"), 1))
+        self.setZValue(2)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsFocusable, True)
+        self.setToolTip(
+            f"{record_label(record)}\n"
+            f"Start: +{interval.start_seconds:.3f}s\n"
+            f"Duration: {interval.duration_seconds:.3f}s\n"
+            f"Kind: {record.kind}\nClick to inspect the recorded payload"
+        )
+
+    def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # noqa: N802
+        self._on_activated(self.record_id)
+        super().mousePressEvent(event)

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/layout.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/layout.py
@@ -1,0 +1,74 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from flight_recorder.models.envelopes import RelationshipStatus, Span
+
+
+@dataclass(frozen=True)
+class SpanLayout:
+    span_id: str
+    lane: int
+    start: int
+    end: int
+    incomplete: bool
+    relationship_status: RelationshipStatus
+    depth: int
+
+
+def project_spans(
+    spans: Iterable[Span],
+    *,
+    current_sequence: int,
+    visible_range: tuple[int, int] | None = None,
+) -> list[SpanLayout]:
+    ordered = sorted(spans, key=lambda span: (span.start_sequence, span.span_id))
+    lane_ids = list(
+        dict.fromkeys(span.agent_span_id or span.span_id for span in ordered)
+    )
+    lanes = {lane_id: index for index, lane_id in enumerate(lane_ids)}
+    spans_by_id = {span.span_id: span for span in ordered}
+    depth_by_id: dict[str, int] = {}
+
+    def depth(span: Span) -> int:
+        cached = depth_by_id.get(span.span_id)
+        if cached is not None:
+            return cached
+        lineage = []
+        parent_id = span.parent_span_id
+        visited = {span.span_id}
+        while parent_id is not None and parent_id not in visited:
+            cached_parent = depth_by_id.get(parent_id)
+            if cached_parent is not None:
+                result = cached_parent + len(lineage) + 1
+                break
+            parent = spans_by_id.get(parent_id)
+            if parent is None:
+                result = len(lineage)
+                break
+            lineage.append(parent_id)
+            visited.add(parent_id)
+            parent_id = parent.parent_span_id
+        else:
+            result = len(lineage)
+        depth_by_id[span.span_id] = result
+        return result
+
+    projected = []
+    for span in ordered:
+        end = span.end_sequence or current_sequence
+        if visible_range is not None:
+            visible_start, visible_end = visible_range
+            if end < visible_start or span.start_sequence > visible_end:
+                continue
+        projected.append(
+            SpanLayout(
+                span_id=span.span_id,
+                lane=lanes[span.agent_span_id or span.span_id],
+                start=span.start_sequence,
+                end=max(span.start_sequence, end),
+                incomplete=span.end_sequence is None,
+                relationship_status=span.relationship_status,
+                depth=depth(span),
+            )
+        )
+    return projected

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/rows.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/rows.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from flight_recorder.models.envelopes import Record
+
+
+@dataclass(frozen=True)
+class ActivityRowType:
+    key: str
+    label: str
+    color: str
+    description: str
+
+
+ACTIVITY_ROW_TYPES = (
+    ActivityRowType(
+        "lifecycle",
+        "Lifecycle",
+        "#53645d",
+        "When this agent started, remained active, and finished.",
+    ),
+    ActivityRowType(
+        "messages",
+        "Messages",
+        "#3d74b8",
+        "Messages and system prompts received or produced by this agent.",
+    ),
+    ActivityRowType(
+        "actions",
+        "Actions",
+        "#d06b3c",
+        "Tool calls and other actions requested by this agent.",
+    ),
+    ActivityRowType(
+        "results",
+        "Results",
+        "#298f74",
+        "Observations and outputs returned by the agent's actions.",
+    ),
+    ActivityRowType(
+        "delegation",
+        "Delegation",
+        "#8e5aa9",
+        "Work handed off to child agents.",
+    ),
+    ActivityRowType(
+        "context",
+        "Context",
+        "#d39b24",
+        "Changes to model context, including condensation.",
+    ),
+    ActivityRowType(
+        "state",
+        "State",
+        "#78837e",
+        "Conversation status and state transitions.",
+    ),
+    ActivityRowType(
+        "metrics",
+        "Metrics",
+        "#397f8f",
+        "Token usage and cost snapshots.",
+    ),
+    ActivityRowType(
+        "errors",
+        "Errors",
+        "#c0392b",
+        "Recorded errors and recorder warnings.",
+    ),
+    ActivityRowType(
+        "other",
+        "Other",
+        "#78837e",
+        "Recorded activity that does not match another category.",
+    ),
+)
+ACTIVITY_ROW_TYPES_BY_KEY = {row.key: row for row in ACTIVITY_ROW_TYPES}
+DEFAULT_ACTIVITY_ROW_TYPES = frozenset(
+    {
+        "lifecycle",
+        "messages",
+        "actions",
+        "results",
+        "delegation",
+        "context",
+        "errors",
+    }
+)
+
+
+def classify_record(record: Record) -> str:
+    event_type = record.payload.get("event_type")
+    tool_name = record.payload.get("tool_name")
+    if (
+        record.kind.endswith(".error")
+        or record.kind == "recorder.warning"
+        or record.payload.get("is_error") is True
+    ):
+        return "errors"
+    if (
+        record.kind.startswith("delegation.")
+        or tool_name == "launch_child_conversation"
+    ):
+        return "delegation"
+    if record.kind.startswith("context.") or event_type == "Condensation":
+        return "context"
+    if event_type in {"MessageEvent", "SystemPromptEvent"}:
+        return "messages"
+    if event_type == "ActionEvent":
+        return "actions"
+    if event_type == "ObservationEvent":
+        return "results"
+    if event_type == "ConversationStateUpdateEvent":
+        return "state"
+    if record.kind == "metrics.snapshot":
+        return "metrics"
+    if record.kind.startswith(("run.", "agent.")):
+        return "lifecycle"
+    return "other"

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/rows.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/rows.py
@@ -4,11 +4,20 @@ from flight_recorder.models.envelopes import Record
 
 
 @dataclass(frozen=True)
+class ActivitySubRowType:
+    key: str
+    label: str
+    color: str
+    description: str
+
+
+@dataclass(frozen=True)
 class ActivityRowType:
     key: str
     label: str
     color: str
     description: str
+    subrows: tuple[ActivitySubRowType, ...] = ()
 
 
 ACTIVITY_ROW_TYPES = (
@@ -19,22 +28,64 @@ ACTIVITY_ROW_TYPES = (
         "When this agent started, remained active, and finished.",
     ),
     ActivityRowType(
-        "messages",
-        "Messages",
+        "user_conversation",
+        "User Conversation",
         "#3d74b8",
-        "Messages and system prompts received or produced by this agent.",
+        "Messages exchanged through the OpenHands conversation.",
+        (
+            ActivitySubRowType(
+                "user_input",
+                "User Input",
+                "#3d74b8",
+                "System context and messages supplied by the user.",
+            ),
+            ActivitySubRowType(
+                "agent_response",
+                "Agent Response",
+                "#d06b3c",
+                "Assistant messages returned through the conversation.",
+            ),
+        ),
     ),
     ActivityRowType(
-        "actions",
-        "Actions",
+        "llm_interaction",
+        "LLM Interaction",
+        "#7556a5",
+        "Exact requests and responses exchanged with a language model.",
+        (
+            ActivitySubRowType(
+                "llm_request",
+                "Request",
+                "#7556a5",
+                "Prompts and requests sent to a language model.",
+            ),
+            ActivitySubRowType(
+                "llm_response",
+                "Response",
+                "#2f7d67",
+                "Responses and errors returned by a language model.",
+            ),
+        ),
+    ),
+    ActivityRowType(
+        "tool",
+        "Tool",
         "#d06b3c",
-        "Tool calls and other actions requested by this agent.",
-    ),
-    ActivityRowType(
-        "results",
-        "Results",
-        "#298f74",
-        "Observations and outputs returned by the agent's actions.",
+        "Tool calls and their returned observations.",
+        (
+            ActivitySubRowType(
+                "tool_action",
+                "Action",
+                "#d06b3c",
+                "Tool calls and other actions requested by this agent.",
+            ),
+            ActivitySubRowType(
+                "tool_result",
+                "Result",
+                "#298f74",
+                "Observations and outputs returned by the agent's actions.",
+            ),
+        ),
     ),
     ActivityRowType(
         "delegation",
@@ -74,12 +125,22 @@ ACTIVITY_ROW_TYPES = (
     ),
 )
 ACTIVITY_ROW_TYPES_BY_KEY = {row.key: row for row in ACTIVITY_ROW_TYPES}
+ACTIVITY_SUBROW_TYPES_BY_KEY = {
+    subrow.key: subrow for row in ACTIVITY_ROW_TYPES for subrow in row.subrows
+}
+ACTIVITY_CATEGORY_TYPES_BY_KEY = {
+    **ACTIVITY_ROW_TYPES_BY_KEY,
+    **ACTIVITY_SUBROW_TYPES_BY_KEY,
+}
+ACTIVITY_ROW_KEY_BY_CATEGORY = {
+    subrow.key: row.key for row in ACTIVITY_ROW_TYPES for subrow in row.subrows
+}
 DEFAULT_ACTIVITY_ROW_TYPES = frozenset(
     {
         "lifecycle",
-        "messages",
-        "actions",
-        "results",
+        "user_conversation",
+        "llm_interaction",
+        "tool",
         "delegation",
         "context",
         "errors",
@@ -90,6 +151,18 @@ DEFAULT_ACTIVITY_ROW_TYPES = frozenset(
 def classify_record(record: Record) -> str:
     event_type = record.payload.get("event_type")
     tool_name = record.payload.get("tool_name")
+    if record.kind == "llm.request":
+        return "llm_request"
+    if record.kind == "llm.response":
+        return "llm_response"
+    if event_type == "SystemPromptEvent":
+        return "user_input"
+    if event_type == "MessageEvent":
+        message = record.payload.get("llm_message")
+        role = message.get("role") if isinstance(message, dict) else None
+        if record.payload.get("source") == "user" or role == "user":
+            return "user_input"
+        return "agent_response"
     if (
         record.kind.endswith(".error")
         or record.kind == "recorder.warning"
@@ -103,12 +176,10 @@ def classify_record(record: Record) -> str:
         return "delegation"
     if record.kind.startswith("context.") or event_type == "Condensation":
         return "context"
-    if event_type in {"MessageEvent", "SystemPromptEvent"}:
-        return "messages"
     if event_type == "ActionEvent":
-        return "actions"
+        return "tool_action"
     if event_type == "ObservationEvent":
-        return "results"
+        return "tool_result"
     if event_type == "ConversationStateUpdateEvent":
         return "state"
     if record.kind == "metrics.snapshot":
@@ -116,3 +187,7 @@ def classify_record(record: Record) -> str:
     if record.kind.startswith(("run.", "agent.")):
         return "lifecycle"
     return "other"
+
+
+def row_key_for_category(category: str) -> str:
+    return ACTIVITY_ROW_KEY_BY_CATEGORY.get(category, category)

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/scene.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/scene.py
@@ -4,26 +4,104 @@ from flight_recorder.gui.timeline.items import (
     HEADER_HEIGHT,
     LABEL_WIDTH,
     LANE_HEIGHT,
+    RECORD_HEIGHT,
+    RECORD_TOP,
     SEQUENCE_WIDTH,
     TimelineRecordItem,
+    TimelineSequenceArrowItem,
     TimelineSpanItem,
     record_label,
+    record_width,
 )
 from flight_recorder.gui.timeline.layout import SpanLayout, project_spans
 from flight_recorder.gui.timeline.rows import (
     ACTIVITY_ROW_TYPES,
     DEFAULT_ACTIVITY_ROW_TYPES,
+    ActivityRowType,
     classify_record,
+    row_key_for_category,
 )
 from flight_recorder.gui.timeline.time import (
     RecordInterval,
     project_record_intervals,
 )
 from flight_recorder.models.envelopes import Record, Span
-from PySide6.QtCore import QLineF, QRectF, Qt, Signal
+from PySide6.QtCore import QLineF, QPointF, QRectF, Qt, Signal
 from PySide6.QtGui import QBrush, QColor, QFont, QPen
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
 from shiboken6 import isValid
+
+
+_RECORD_SEQUENCE_GAP = 6.0
+_GROUP_HEADER_HEIGHT = 28.0
+_SUBROW_HEIGHT = 32.0
+
+
+def _row_height(row_type: ActivityRowType) -> float:
+    if not row_type.subrows:
+        return LANE_HEIGHT
+    return _GROUP_HEADER_HEIGHT + len(row_type.subrows) * _SUBROW_HEIGHT
+
+
+def _record_display_y(
+    row_top: float,
+    row_type: ActivityRowType,
+    category: str,
+) -> float:
+    if not row_type.subrows:
+        return row_top + RECORD_TOP
+    subrow_index = next(
+        index for index, subrow in enumerate(row_type.subrows) if subrow.key == category
+    )
+    return (
+        row_top
+        + _GROUP_HEADER_HEIGHT
+        + subrow_index * _SUBROW_HEIGHT
+        + (_SUBROW_HEIGHT - RECORD_HEIGHT) / 2
+    )
+
+
+def _project_record_layouts(
+    records: Sequence[Record],
+    row_by_record: dict[str, int],
+    intervals: dict[str, RecordInterval],
+    pixels_per_second: float,
+) -> tuple[dict[str, float], list[tuple[str, str]]]:
+    indexed_records = [
+        (source_index, record)
+        for source_index, record in enumerate(records)
+        if record.record_id in row_by_record and record.sequence is not None
+    ]
+    ordered_records = [
+        record
+        for _, record in sorted(
+            indexed_records,
+            key=lambda item: (
+                item[1].sequence or 0,
+                item[0],
+            ),
+        )
+    ]
+    display_start_by_record = {}
+    transitions = []
+    previous_record = None
+    for record in ordered_records:
+        interval = intervals[record.record_id]
+        display_start = interval.start_seconds * pixels_per_second
+        if previous_record is not None:
+            previous_start = display_start_by_record[previous_record.record_id]
+            previous_interval = intervals[previous_record.record_id]
+            previous_end = previous_start + record_width(
+                previous_interval, pixels_per_second
+            )
+            display_start = max(
+                display_start,
+                previous_end + _RECORD_SEQUENCE_GAP,
+            )
+            transitions.append((previous_record.record_id, record.record_id))
+        display_start_by_record[record.record_id] = display_start
+        previous_record = record
+    return display_start_by_record, transitions
 
 
 class TimelineScene(QGraphicsScene):
@@ -36,6 +114,8 @@ class TimelineScene(QGraphicsScene):
         self._record_lanes: dict[str, tuple[int, int]] = {}
         self._record_intervals: dict[str, RecordInterval] = {}
         self._record_labels: dict[str, str] = {}
+        self._record_items: dict[str, TimelineRecordItem] = {}
+        self._selected_record_id: str | None = None
         self._span_lanes: dict[str, int] = {}
         self._floating_labels: list[tuple[QGraphicsItem, float]] = []
         self._spans: tuple[Span, ...] = ()
@@ -70,6 +150,7 @@ class TimelineScene(QGraphicsScene):
         self._record_lanes = {}
         self._record_intervals = {}
         self._record_labels = {}
+        self._record_items = {}
         self._span_lanes = {}
         time_projection = project_record_intervals(list(records))
         self.elapsed_seconds = time_projection.elapsed_seconds
@@ -112,7 +193,7 @@ class TimelineScene(QGraphicsScene):
         for record in records:
             agent_id = record.agent_span_id or default_agent_id
             present_by_agent.setdefault(agent_id, set()).add(
-                category_by_record[record.record_id]
+                row_key_for_category(category_by_record[record.record_id])
             )
         for layout in self._layouts:
             span = spans_by_id[layout.span_id]
@@ -143,23 +224,53 @@ class TimelineScene(QGraphicsScene):
                     agent_id, set()
                 ):
                     row_by_agent_type[(agent_id, row_type.key)] = len(rows)
-                    rows.append(
-                        (
-                            agent_id,
-                            agent_names[agent_id],
-                            row_type.label,
-                            row_type.color,
-                            row_type.description,
-                        )
-                    )
+                    rows.append((agent_id, agent_names[agent_id], row_type))
         self.lane_names = tuple(
-            f"{row_label} · {agent_name}" for _, agent_name, row_label, _, _ in rows
+            f"{row_type.label} · {agent_name}" for _, agent_name, row_type in rows
         )
 
-        scene_width = (
-            LABEL_WIDTH + max(1.0, self.elapsed_seconds) * self.pixels_per_second + 24
+        row_by_record = {}
+        for record in records:
+            agent_id = record.agent_span_id or default_agent_id
+            row = row_by_agent_type.get(
+                (
+                    agent_id,
+                    row_key_for_category(category_by_record[record.record_id]),
+                )
+            )
+            if row is not None:
+                row_by_record[record.record_id] = row
+        display_start_by_record, sequence_transitions = _project_record_layouts(
+            records,
+            row_by_record,
+            time_projection.intervals,
+            self.pixels_per_second,
         )
-        scene_height = HEADER_HEIGHT + max(1, len(rows)) * LANE_HEIGHT
+        row_heights = [_row_height(row_type) for _, _, row_type in rows]
+        row_tops = []
+        next_row_top = HEADER_HEIGHT
+        for row_height in row_heights:
+            row_tops.append(next_row_top)
+            next_row_top += row_height
+
+        drawn_record_end = max(
+            (
+                display_start_by_record[record.record_id]
+                + record_width(
+                    time_projection.intervals[record.record_id],
+                    self.pixels_per_second,
+                )
+                for record in records
+                if record.record_id in display_start_by_record
+            ),
+            default=0.0,
+        )
+        timeline_width = max(
+            max(1.0, self.elapsed_seconds) * self.pixels_per_second,
+            drawn_record_end,
+        )
+        scene_width = LABEL_WIDTH + timeline_width + 24
+        scene_height = max(HEADER_HEIGHT + LANE_HEIGHT, next_row_top)
         self.setBackgroundBrush(QBrush(QColor("#f4f6f5")))
         header = self.addRect(
             QRectF(0, 0, scene_width, HEADER_HEIGHT),
@@ -197,33 +308,28 @@ class TimelineScene(QGraphicsScene):
             tick += tick_step
         self.axis_labels = tuple(axis_labels)
 
-        for lane, (
-            _,
-            agent_name,
-            row_label,
-            row_color,
-            row_description,
-        ) in enumerate(rows):
-            y = HEADER_HEIGHT + lane * LANE_HEIGHT
+        for lane, (_, agent_name, row_type) in enumerate(rows):
+            y = row_tops[lane]
+            row_height = row_heights[lane]
             fill = QColor("#ffffff") if lane % 2 == 0 else QColor("#eef2f0")
             self.addRect(
-                QRectF(0, y, scene_width, LANE_HEIGHT),
+                QRectF(0, y, scene_width, row_height),
                 QPen(QColor("#d4dad7"), 1),
                 QBrush(fill),
             ).setZValue(-2)
             label_background = self.addRect(
-                QRectF(0, y, LABEL_WIDTH, LANE_HEIGHT),
+                QRectF(0, y, LABEL_WIDTH, row_height),
                 QPen(QColor("#d4dad7"), 1),
                 QBrush(fill),
             )
             label_background.setZValue(3)
-            row_tooltip = f"{row_label} · {agent_name}\n{row_description}"
+            row_tooltip = f"{row_type.label} · {agent_name}\n{row_type.description}"
             label_background.setToolTip(row_tooltip)
             self._floating_labels.append((label_background, 0.0))
             row_marker = self.addRect(
                 QRectF(6, y + 16, 4, 24),
                 QPen(Qt.PenStyle.NoPen),
-                QBrush(QColor(row_color)),
+                QBrush(QColor(row_type.color)),
             )
             row_marker.setZValue(4)
             row_marker.setToolTip(row_tooltip)
@@ -231,13 +337,46 @@ class TimelineScene(QGraphicsScene):
             display_agent = (
                 agent_name if len(agent_name) <= 27 else agent_name[:24] + "..."
             )
-            display_name = f"{row_label}\n{display_agent}"
-            text = self.addText(display_name)
-            text.setPos(16, y + 10)
-            text.setDefaultTextColor(QColor("#26332e"))
-            text.setToolTip(row_tooltip)
-            text.setZValue(4)
-            self._floating_labels.append((text, 16.0))
+            if row_type.subrows:
+                title = self.addText(f"{row_type.label} · {display_agent}")
+                title.setPos(16, y + 2)
+                title.setDefaultTextColor(QColor("#26332e"))
+                title.setToolTip(row_tooltip)
+                title.setZValue(4)
+                self._floating_labels.append((title, 16.0))
+                for subrow_index, subrow in enumerate(row_type.subrows):
+                    subrow_top = (
+                        y + _GROUP_HEADER_HEIGHT + subrow_index * _SUBROW_HEIGHT
+                    )
+                    self.addLine(
+                        QLineF(0, subrow_top, scene_width, subrow_top),
+                        QPen(QColor("#d4dad7"), 1),
+                    ).setZValue(-1)
+                    subrow_tooltip = (
+                        f"{row_type.label} / {subrow.label} · {agent_name}\n"
+                        f"{subrow.description}"
+                    )
+                    subrow_marker = self.addRect(
+                        QRectF(16, subrow_top + 9, 3, 14),
+                        QPen(Qt.PenStyle.NoPen),
+                        QBrush(QColor(subrow.color)),
+                    )
+                    subrow_marker.setToolTip(subrow_tooltip)
+                    subrow_marker.setZValue(4)
+                    self._floating_labels.append((subrow_marker, 0.0))
+                    subrow_text = self.addText(subrow.label)
+                    subrow_text.setPos(24, subrow_top + 4)
+                    subrow_text.setDefaultTextColor(QColor("#52615b"))
+                    subrow_text.setToolTip(subrow_tooltip)
+                    subrow_text.setZValue(4)
+                    self._floating_labels.append((subrow_text, 24.0))
+            else:
+                text = self.addText(f"{row_type.label}\n{display_agent}")
+                text.setPos(16, y + 10)
+                text.setDefaultTextColor(QColor("#26332e"))
+                text.setToolTip(row_tooltip)
+                text.setZValue(4)
+                self._floating_labels.append((text, 16.0))
 
         for layout in self._layouts:
             span = spans_by_id[layout.span_id]
@@ -261,16 +400,36 @@ class TimelineScene(QGraphicsScene):
                 for record in span_records
                 if record.record_id in time_projection.intervals
             ]
-            start_seconds = (
-                min(interval.start_seconds for interval in span_intervals)
-                if span_intervals
-                else 0.0
-            )
-            end_seconds = (
-                max(interval.end_seconds for interval in span_intervals)
-                if span_intervals
-                else self.elapsed_seconds
-            )
+            display_bounds = [
+                (
+                    display_start_by_record[record.record_id],
+                    display_start_by_record[record.record_id]
+                    + record_width(
+                        time_projection.intervals[record.record_id],
+                        self.pixels_per_second,
+                    ),
+                )
+                for record in span_records
+                if record.record_id in display_start_by_record
+            ]
+            if display_bounds:
+                start_seconds = (
+                    min(start for start, _ in display_bounds) / self.pixels_per_second
+                )
+                end_seconds = (
+                    max(end for _, end in display_bounds) / self.pixels_per_second
+                )
+            else:
+                start_seconds = (
+                    min(interval.start_seconds for interval in span_intervals)
+                    if span_intervals
+                    else 0.0
+                )
+                end_seconds = (
+                    max(interval.end_seconds for interval in span_intervals)
+                    if span_intervals
+                    else self.elapsed_seconds
+                )
             self.addItem(
                 TimelineSpanItem(
                     layout,
@@ -279,31 +438,70 @@ class TimelineScene(QGraphicsScene):
                     self.span_activated.emit,
                     self.pixels_per_second,
                     row,
+                    row_tops[row],
                 )
             )
+        record_items = {}
         for record in records:
             if record.sequence is None:
                 continue
-            agent_id = record.agent_span_id or default_agent_id
-            lane = row_by_agent_type.get(
-                (agent_id, category_by_record[record.record_id])
-            )
+            lane = row_by_record.get(record.record_id)
             if lane is None:
                 continue
             self._record_lanes[record.record_id] = (record.sequence, lane)
             self._record_labels[record.record_id] = record_label(record)
             interval = time_projection.intervals[record.record_id]
             self._record_intervals[record.record_id] = interval
-            self.addItem(
-                TimelineRecordItem(
-                    record,
-                    interval,
-                    lane=lane,
-                    on_activated=self.record_activated.emit,
-                    pixels_per_second=self.pixels_per_second,
-                )
+            item = TimelineRecordItem(
+                record,
+                interval,
+                lane=lane,
+                on_activated=self.record_activated.emit,
+                pixels_per_second=self.pixels_per_second,
+                row_top=row_tops[lane],
+                display_start_pixels=display_start_by_record[record.record_id],
+                display_y=_record_display_y(
+                    row_tops[lane],
+                    rows[lane][2],
+                    category_by_record[record.record_id],
+                ),
             )
+            record_items[record.record_id] = item
+            item.set_selected(record.record_id == self._selected_record_id)
+            self.addItem(item)
+        self._record_items = record_items
+        records_by_id = {record.record_id: record for record in records}
+        for previous_id, next_id in sequence_transitions:
+            previous_item = record_items[previous_id]
+            next_item = record_items[next_id]
+            previous_rect = previous_item.rect()
+            next_rect = next_item.rect()
+            arrow = TimelineSequenceArrowItem(
+                previous_id,
+                next_id,
+                QPointF(previous_rect.right(), previous_rect.center().y()),
+                QPointF(next_rect.left(), next_rect.center().y()),
+            )
+            previous_sequence = records_by_id[previous_id].sequence
+            next_sequence = records_by_id[next_id].sequence
+            arrow.setToolTip(f"Sequence {previous_sequence} to {next_sequence}")
+            self.addItem(arrow)
         self.setSceneRect(QRectF(0, 0, scene_width, scene_height))
+
+    def set_selected_record(self, record_id: str | None) -> None:
+        if self._selected_record_id == record_id:
+            return
+        previous = self._record_items.get(self._selected_record_id or "")
+        if previous is not None:
+            previous.set_selected(False)
+        self._selected_record_id = record_id
+        selected = self._record_items.get(record_id or "")
+        if selected is not None:
+            selected.set_selected(True)
+
+    @property
+    def selected_record_id(self) -> str | None:
+        return self._selected_record_id
 
     def set_label_offset(self, offset: float) -> None:
         self._floating_labels = [

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/scene.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/scene.py
@@ -1,0 +1,378 @@
+from collections.abc import Sequence
+
+from flight_recorder.gui.timeline.items import (
+    HEADER_HEIGHT,
+    LABEL_WIDTH,
+    LANE_HEIGHT,
+    SEQUENCE_WIDTH,
+    TimelineRecordItem,
+    TimelineSpanItem,
+    record_label,
+)
+from flight_recorder.gui.timeline.layout import SpanLayout, project_spans
+from flight_recorder.gui.timeline.rows import (
+    ACTIVITY_ROW_TYPES,
+    DEFAULT_ACTIVITY_ROW_TYPES,
+    classify_record,
+)
+from flight_recorder.gui.timeline.time import (
+    RecordInterval,
+    project_record_intervals,
+)
+from flight_recorder.models.envelopes import Record, Span
+from PySide6.QtCore import QLineF, QRectF, Qt, Signal
+from PySide6.QtGui import QBrush, QColor, QFont, QPen
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
+from shiboken6 import isValid
+
+
+class TimelineScene(QGraphicsScene):
+    record_activated = Signal(str)
+    span_activated = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._layouts: list[SpanLayout] = []
+        self._record_lanes: dict[str, tuple[int, int]] = {}
+        self._record_intervals: dict[str, RecordInterval] = {}
+        self._record_labels: dict[str, str] = {}
+        self._span_lanes: dict[str, int] = {}
+        self._floating_labels: list[tuple[QGraphicsItem, float]] = []
+        self._spans: tuple[Span, ...] = ()
+        self._records: tuple[Record, ...] = ()
+        self._current_sequence = 1
+        self.lane_names: tuple[str, ...] = ()
+        self.axis_labels: tuple[str, ...] = ()
+        self.available_row_types: tuple[str, ...] = ()
+        self.enabled_row_types: tuple[str, ...] = ()
+        self.sequence_width = SEQUENCE_WIDTH
+        self.time_zoom = 1.0
+        self.pixels_per_second = 1.0
+        self.elapsed_seconds = 0.0
+
+    def set_spans(self, spans: Sequence[Span], *, current_sequence: int) -> None:
+        self.set_timeline(spans, (), current_sequence=current_sequence)
+
+    def set_timeline(
+        self,
+        spans: Sequence[Span],
+        records: Sequence[Record],
+        *,
+        current_sequence: int,
+        enabled_row_types: set[str] | None = None,
+    ) -> None:
+        self._spans = tuple(spans)
+        self._records = tuple(records)
+        self._current_sequence = current_sequence
+        self._floating_labels = []
+        self.clear()
+        self._layouts = project_spans(spans, current_sequence=current_sequence)
+        self._record_lanes = {}
+        self._record_intervals = {}
+        self._record_labels = {}
+        self._span_lanes = {}
+        time_projection = project_record_intervals(list(records))
+        self.elapsed_seconds = time_projection.elapsed_seconds
+        self.pixels_per_second = (
+            max(
+                0.5,
+                min(80.0, 1800.0 / max(1.0, self.elapsed_seconds)),
+            )
+            * self.time_zoom
+        )
+        spans_by_id = {span.span_id: span for span in spans}
+        agent_ids = []
+        for layout in self._layouts:
+            span = spans_by_id[layout.span_id]
+            agent_id = span.agent_span_id or span.span_id
+            if agent_id not in agent_ids:
+                agent_ids.append(agent_id)
+        for record in records:
+            if record.agent_span_id and record.agent_span_id not in agent_ids:
+                agent_ids.append(record.agent_span_id)
+        if not agent_ids:
+            agent_ids.append("session")
+        default_agent_id = agent_ids[0]
+        agent_names = {
+            agent_id: (
+                spans_by_id[agent_id].name
+                if agent_id in spans_by_id
+                else "Session"
+                if agent_id == "session"
+                else agent_id
+            )
+            for agent_id in agent_ids
+        }
+        category_by_record = {
+            record.record_id: classify_record(record) for record in records
+        }
+        present_by_agent: dict[str, set[str]] = {
+            agent_id: set() for agent_id in agent_ids
+        }
+        for record in records:
+            agent_id = record.agent_span_id or default_agent_id
+            present_by_agent.setdefault(agent_id, set()).add(
+                category_by_record[record.record_id]
+            )
+        for layout in self._layouts:
+            span = spans_by_id[layout.span_id]
+            present_by_agent[span.agent_span_id or span.span_id].add("lifecycle")
+        present_types = {
+            row_type
+            for row_types in present_by_agent.values()
+            for row_type in row_types
+        }
+        self.available_row_types = tuple(
+            row.key for row in ACTIVITY_ROW_TYPES if row.key in present_types
+        )
+        enabled = (
+            set(self.available_row_types) & DEFAULT_ACTIVITY_ROW_TYPES
+            if enabled_row_types is None
+            else set(enabled_row_types) & present_types
+        )
+        if not enabled and self.available_row_types:
+            enabled.add(self.available_row_types[0])
+        self.enabled_row_types = tuple(
+            row.key for row in ACTIVITY_ROW_TYPES if row.key in enabled
+        )
+        rows = []
+        row_by_agent_type: dict[tuple[str, str], int] = {}
+        for agent_id in agent_ids:
+            for row_type in ACTIVITY_ROW_TYPES:
+                if row_type.key in enabled and row_type.key in present_by_agent.get(
+                    agent_id, set()
+                ):
+                    row_by_agent_type[(agent_id, row_type.key)] = len(rows)
+                    rows.append(
+                        (
+                            agent_id,
+                            agent_names[agent_id],
+                            row_type.label,
+                            row_type.color,
+                            row_type.description,
+                        )
+                    )
+        self.lane_names = tuple(
+            f"{row_label} · {agent_name}" for _, agent_name, row_label, _, _ in rows
+        )
+
+        scene_width = (
+            LABEL_WIDTH + max(1.0, self.elapsed_seconds) * self.pixels_per_second + 24
+        )
+        scene_height = HEADER_HEIGHT + max(1, len(rows)) * LANE_HEIGHT
+        self.setBackgroundBrush(QBrush(QColor("#f4f6f5")))
+        header = self.addRect(
+            QRectF(0, 0, scene_width, HEADER_HEIGHT),
+            QPen(Qt.PenStyle.NoPen),
+            QBrush(QColor("#e8ecea")),
+        )
+        header.setZValue(-1)
+        label_header_background = self.addRect(
+            QRectF(0, 0, LABEL_WIDTH, HEADER_HEIGHT),
+            QPen(QColor("#bdc7c2"), 1),
+            QBrush(QColor("#e8ecea")),
+        )
+        label_header_background.setZValue(3)
+        self._floating_labels.append((label_header_background, 0.0))
+        label_header = self.addText("Agent / activity rows")
+        label_header.setPos(10, 9)
+        label_header.setDefaultTextColor(QColor("#26332e"))
+        label_header.setFont(QFont("", 9, QFont.Weight.DemiBold))
+        label_header.setZValue(4)
+        self._floating_labels.append((label_header, 10.0))
+        tick_step = self._time_tick_step(self.elapsed_seconds)
+        axis_labels = []
+        tick = 0.0
+        while tick <= self.elapsed_seconds:
+            x = LABEL_WIDTH + tick * self.pixels_per_second
+            self.addLine(
+                QLineF(x, HEADER_HEIGHT - 7, x, scene_height),
+                QPen(QColor("#d7ddda"), 1, Qt.PenStyle.DotLine),
+            ).setZValue(-1)
+            label = self._time_label(tick)
+            axis_labels.append(label)
+            text = self.addText(label)
+            text.setPos(x + 3, 7)
+            text.setDefaultTextColor(QColor("#52615b"))
+            tick += tick_step
+        self.axis_labels = tuple(axis_labels)
+
+        for lane, (
+            _,
+            agent_name,
+            row_label,
+            row_color,
+            row_description,
+        ) in enumerate(rows):
+            y = HEADER_HEIGHT + lane * LANE_HEIGHT
+            fill = QColor("#ffffff") if lane % 2 == 0 else QColor("#eef2f0")
+            self.addRect(
+                QRectF(0, y, scene_width, LANE_HEIGHT),
+                QPen(QColor("#d4dad7"), 1),
+                QBrush(fill),
+            ).setZValue(-2)
+            label_background = self.addRect(
+                QRectF(0, y, LABEL_WIDTH, LANE_HEIGHT),
+                QPen(QColor("#d4dad7"), 1),
+                QBrush(fill),
+            )
+            label_background.setZValue(3)
+            row_tooltip = f"{row_label} · {agent_name}\n{row_description}"
+            label_background.setToolTip(row_tooltip)
+            self._floating_labels.append((label_background, 0.0))
+            row_marker = self.addRect(
+                QRectF(6, y + 16, 4, 24),
+                QPen(Qt.PenStyle.NoPen),
+                QBrush(QColor(row_color)),
+            )
+            row_marker.setZValue(4)
+            row_marker.setToolTip(row_tooltip)
+            self._floating_labels.append((row_marker, 0.0))
+            display_agent = (
+                agent_name if len(agent_name) <= 27 else agent_name[:24] + "..."
+            )
+            display_name = f"{row_label}\n{display_agent}"
+            text = self.addText(display_name)
+            text.setPos(16, y + 10)
+            text.setDefaultTextColor(QColor("#26332e"))
+            text.setToolTip(row_tooltip)
+            text.setZValue(4)
+            self._floating_labels.append((text, 16.0))
+
+        for layout in self._layouts:
+            span = spans_by_id[layout.span_id]
+            row = row_by_agent_type.get(
+                (span.agent_span_id or span.span_id, "lifecycle")
+            )
+            if row is None:
+                continue
+            self._span_lanes[layout.span_id] = row
+            span_records = [
+                record
+                for record in records
+                if record.span_id == span.span_id
+                or (
+                    span.span_type == "agent"
+                    and record.agent_span_id == span.agent_span_id
+                )
+            ]
+            span_intervals = [
+                time_projection.intervals[record.record_id]
+                for record in span_records
+                if record.record_id in time_projection.intervals
+            ]
+            start_seconds = (
+                min(interval.start_seconds for interval in span_intervals)
+                if span_intervals
+                else 0.0
+            )
+            end_seconds = (
+                max(interval.end_seconds for interval in span_intervals)
+                if span_intervals
+                else self.elapsed_seconds
+            )
+            self.addItem(
+                TimelineSpanItem(
+                    layout,
+                    start_seconds,
+                    end_seconds,
+                    self.span_activated.emit,
+                    self.pixels_per_second,
+                    row,
+                )
+            )
+        for record in records:
+            if record.sequence is None:
+                continue
+            agent_id = record.agent_span_id or default_agent_id
+            lane = row_by_agent_type.get(
+                (agent_id, category_by_record[record.record_id])
+            )
+            if lane is None:
+                continue
+            self._record_lanes[record.record_id] = (record.sequence, lane)
+            self._record_labels[record.record_id] = record_label(record)
+            interval = time_projection.intervals[record.record_id]
+            self._record_intervals[record.record_id] = interval
+            self.addItem(
+                TimelineRecordItem(
+                    record,
+                    interval,
+                    lane=lane,
+                    on_activated=self.record_activated.emit,
+                    pixels_per_second=self.pixels_per_second,
+                )
+            )
+        self.setSceneRect(QRectF(0, 0, scene_width, scene_height))
+
+    def set_label_offset(self, offset: float) -> None:
+        self._floating_labels = [
+            (item, base_x) for item, base_x in self._floating_labels if isValid(item)
+        ]
+        for item, base_x in self._floating_labels:
+            item.setX(offset + base_x)
+
+    def set_enabled_row_types(self, enabled_row_types: set[str]) -> None:
+        self.set_timeline(
+            self._spans,
+            self._records,
+            current_sequence=self._current_sequence,
+            enabled_row_types=enabled_row_types,
+        )
+
+    def set_time_zoom(self, zoom: float) -> None:
+        self.time_zoom = zoom
+        self.set_timeline(
+            self._spans,
+            self._records,
+            current_sequence=self._current_sequence,
+            enabled_row_types=set(self.enabled_row_types),
+        )
+
+    @staticmethod
+    def _time_tick_step(elapsed_seconds: float) -> float:
+        if elapsed_seconds <= 10:
+            return 1
+        if elapsed_seconds <= 60:
+            return 5
+        if elapsed_seconds <= 300:
+            return 30
+        if elapsed_seconds <= 1800:
+            return 120
+        return 300
+
+    @staticmethod
+    def _time_label(seconds: float) -> str:
+        if seconds < 60:
+            return f"+{seconds:g}s"
+        minutes, remainder = divmod(int(seconds), 60)
+        return f"+{minutes}m{remainder:02d}s"
+
+    def span_at(self, *, sequence: int, lane: int) -> str | None:
+        for layout in self._layouts:
+            if (
+                self._span_lanes.get(layout.span_id) == lane
+                and layout.start <= sequence <= layout.end
+            ):
+                return layout.span_id
+        return None
+
+    def record_at(self, *, sequence: int, lane: int) -> str | None:
+        return next(
+            (
+                record_id
+                for record_id, position in self._record_lanes.items()
+                if position == (sequence, lane)
+            ),
+            None,
+        )
+
+    def record_label(self, record_id: str) -> str:
+        return self._record_labels[record_id]
+
+    def record_interval(self, record_id: str) -> RecordInterval:
+        return self._record_intervals[record_id]
+
+    @property
+    def lane_height(self) -> float:
+        return LANE_HEIGHT

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/time.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/time.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+
+from flight_recorder.models.envelopes import Record
+from flight_recorder.services.repository import _recorder_shutdown_record_ids
+
+
+@dataclass(frozen=True)
+class RecordInterval:
+    start_seconds: float
+    end_seconds: float
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.end_seconds - self.start_seconds
+
+
+@dataclass(frozen=True)
+class TimelineTimeProjection:
+    intervals: dict[str, RecordInterval]
+    elapsed_seconds: float
+
+
+def project_record_intervals(records: list[Record]) -> TimelineTimeProjection:
+    if not records:
+        return TimelineTimeProjection(intervals={}, elapsed_seconds=0)
+
+    timestamps = {
+        record.record_id: (record.source_timestamp or record.observed_at).timestamp()
+        for record in records
+    }
+    shutdown_record_ids = _recorder_shutdown_record_ids(tuple(records))
+    activity_timestamps = [
+        timestamp
+        for record_id, timestamp in timestamps.items()
+        if record_id not in shutdown_record_ids
+    ]
+    if shutdown_record_ids and activity_timestamps:
+        last_activity_timestamp = max(activity_timestamps)
+        for record_id in shutdown_record_ids:
+            timestamps[record_id] = last_activity_timestamp
+    origin = min(timestamps.values())
+    starts = {
+        record_id: max(0.0, timestamp - origin)
+        for record_id, timestamp in timestamps.items()
+    }
+    intervals = {
+        record.record_id: RecordInterval(
+            start_seconds=starts[record.record_id],
+            end_seconds=starts[record.record_id],
+        )
+        for record in records
+    }
+
+    actions_by_tool_call: dict[str, Record] = {}
+    for record in sorted(
+        records,
+        key=lambda item: (starts[item.record_id], item.sequence or 0),
+    ):
+        event_type = record.payload.get("event_type")
+        tool_call_id = record.payload.get("tool_call_id")
+        if not isinstance(tool_call_id, str):
+            continue
+        if event_type == "ActionEvent":
+            actions_by_tool_call[tool_call_id] = record
+        elif event_type == "ObservationEvent":
+            action = actions_by_tool_call.pop(tool_call_id, None)
+            if action is not None:
+                start = starts[action.record_id]
+                intervals[action.record_id] = RecordInterval(
+                    start_seconds=start,
+                    end_seconds=max(start, starts[record.record_id]),
+                )
+
+    return TimelineTimeProjection(
+        intervals=intervals,
+        elapsed_seconds=max(starts.values()),
+    )

--- a/agent-flight-recorder/src/flight_recorder/gui/timeline/view.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/timeline/view.py
@@ -1,0 +1,101 @@
+from flight_recorder.gui.timeline.items import LABEL_WIDTH
+from flight_recorder.gui.timeline.scene import TimelineScene
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QKeyEvent, QPainter, QResizeEvent, QWheelEvent
+from PySide6.QtWidgets import QGraphicsView
+
+
+class TimelineViewWidget(QGraphicsView):
+    span_activated = Signal(str)
+    record_activated = Signal(str)
+    zoom_changed = Signal(float)
+
+    def __init__(self, scene: TimelineScene | None = None) -> None:
+        self.timeline_scene = scene if scene is not None else TimelineScene()
+        super().__init__(self.timeline_scene)
+        self.zoom_factor = 1.0
+        self.setObjectName("timeline")
+        self.setAccessibleName("Agent activity timeline")
+        self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        self.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        self.timeline_scene.span_activated.connect(self.span_activated.emit)
+        self.timeline_scene.record_activated.connect(self.record_activated.emit)
+        self.timeline_scene.sceneRectChanged.connect(self._update_minimap)
+        self.horizontalScrollBar().valueChanged.connect(self._sync_floating_labels)
+        self.minimap = QGraphicsView(self.timeline_scene, self)
+        self.minimap.setObjectName("timeline-minimap")
+        self.minimap.setAccessibleName("Timeline overview")
+        self.minimap.setFixedSize(180, 72)
+        self.minimap.setInteractive(False)
+        self.minimap.setStyleSheet("border: 1px solid #9ba7a1; background: white;")
+
+    def resizeEvent(self, event: QResizeEvent) -> None:  # noqa: N802
+        super().resizeEvent(event)
+        self.minimap.move(
+            max(8, self.viewport().width() - self.minimap.width() - 12),
+            max(8, self.viewport().height() - self.minimap.height() - 12),
+        )
+        self._update_minimap()
+
+    def _update_minimap(self) -> None:
+        scene_rect = self.timeline_scene.sceneRect()
+        if not scene_rect.isEmpty():
+            self.minimap.fitInView(scene_rect, Qt.AspectRatioMode.KeepAspectRatio)
+        self._sync_floating_labels()
+
+    def _sync_floating_labels(self) -> None:
+        self.timeline_scene.set_label_offset(max(0.0, self.mapToScene(0, 0).x()))
+
+    def zoom_in(self) -> None:
+        self._set_zoom(self.zoom_factor * 1.25, self.viewport().rect().center().x())
+
+    def zoom_out(self) -> None:
+        self._set_zoom(self.zoom_factor / 1.25, self.viewport().rect().center().x())
+
+    def zoom_to_fit(self) -> None:
+        self.resetTransform()
+        self.zoom_factor = 1.0
+        self.timeline_scene.set_time_zoom(1.0)
+        self.horizontalScrollBar().setValue(0)
+        self._sync_floating_labels()
+        self.zoom_changed.emit(self.zoom_factor)
+
+    def _set_zoom(self, zoom: float, anchor_x: int) -> None:
+        zoom = min(20.0, max(0.25, zoom))
+        if zoom == self.zoom_factor:
+            return
+        old_pixels_per_second = self.timeline_scene.pixels_per_second
+        scene_x = self.mapToScene(anchor_x, 0).x()
+        elapsed_at_anchor = max(
+            0.0,
+            (scene_x - LABEL_WIDTH) / max(old_pixels_per_second, 0.001),
+        )
+        self.zoom_factor = zoom
+        self.timeline_scene.set_time_zoom(zoom)
+        new_scene_x = (
+            LABEL_WIDTH + elapsed_at_anchor * self.timeline_scene.pixels_per_second
+        )
+        self.horizontalScrollBar().setValue(round(new_scene_x - anchor_x))
+        self._sync_floating_labels()
+        self.zoom_changed.emit(self.zoom_factor)
+
+    def wheelEvent(self, event: QWheelEvent) -> None:  # noqa: N802
+        anchor_x = event.position().toPoint().x()
+        if event.angleDelta().y() > 0:
+            self._set_zoom(self.zoom_factor * 1.25, anchor_x)
+        elif event.angleDelta().y() < 0:
+            self._set_zoom(self.zoom_factor / 1.25, anchor_x)
+        event.accept()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802
+        if event.key() in (43, 61):
+            self.zoom_in()
+            return
+        if event.key() == 45:
+            self.zoom_out()
+            return
+        if event.key() == Qt.Key.Key_0:
+            self.zoom_to_fit()
+            return
+        super().keyPressEvent(event)

--- a/agent-flight-recorder/src/flight_recorder/gui/workers.py
+++ b/agent-flight-recorder/src/flight_recorder/gui/workers.py
@@ -1,0 +1,68 @@
+from collections.abc import Callable
+from pathlib import Path
+
+from flight_recorder.models.envelopes import CommittedBatch
+from flight_recorder.services.bundles import BundleService
+from flight_recorder.services.repository import TraceRepository
+from flight_recorder.services.subscriptions import SubscriptionHandle, TraceSubscription
+from PySide6.QtCore import QObject, QThread, Signal
+
+
+class TaskWorker(QThread):
+    succeeded = Signal(object)
+    failed = Signal(str)
+
+    def __init__(self, task: Callable[[Callable[[], bool]], object]) -> None:
+        super().__init__()
+        self._task = task
+
+    def cancel(self) -> None:
+        self.requestInterruption()
+
+    def run(self) -> None:
+        try:
+            result = self._task(self.isInterruptionRequested)
+            if not self.isInterruptionRequested():
+                self.succeeded.emit(result)
+        except Exception as exc:
+            if not self.isInterruptionRequested():
+                self.failed.emit(str(exc))
+
+
+class RepositoryWorker(TaskWorker):
+    def __init__(self, repository: TraceRepository, trace_id: str) -> None:
+        super().__init__(lambda _cancelled: repository.get_timeline(trace_id))
+
+
+class BundleWorker(TaskWorker):
+    def __init__(self, service: BundleService, source: Path) -> None:
+        super().__init__(lambda _cancelled: service.import_bundle(source))
+
+
+class SubscriptionWorker(QObject):
+    batch_received = Signal(object)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._handle: SubscriptionHandle | None = None
+
+    def attach(
+        self,
+        service: TraceSubscription,
+        trace_id: str,
+        after_sequence: int,
+    ) -> None:
+        self.cancel()
+        self._handle = service.subscribe(
+            trace_id,
+            after_sequence,
+            self._on_batch,
+        )
+
+    def _on_batch(self, batch: CommittedBatch) -> None:
+        self.batch_received.emit(batch)
+
+    def cancel(self) -> None:
+        if self._handle is not None:
+            self._handle.unsubscribe()
+            self._handle = None

--- a/agent-flight-recorder/src/flight_recorder/models/database.py
+++ b/agent-flight-recorder/src/flight_recorder/models/database.py
@@ -1,0 +1,149 @@
+"""Rebuildable SQLite query index."""
+
+import sqlite3
+from pathlib import Path
+
+from flight_recorder.models.envelopes import Record
+
+
+SCHEMA = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS runs (
+    trace_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    started_at TEXT,
+    completed_at TEXT,
+    stop_reason TEXT,
+    attributes_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS spans (
+    span_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    parent_span_id TEXT,
+    agent_span_id TEXT,
+    span_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    attributes_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS records (
+    record_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    span_id TEXT,
+    agent_span_id TEXT,
+    observed_at TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    record_json TEXT NOT NULL,
+    UNIQUE(trace_id, sequence)
+);
+CREATE INDEX IF NOT EXISTS records_trace_kind ON records(trace_id, kind);
+CREATE INDEX IF NOT EXISTS records_trace_span ON records(trace_id, span_id);
+CREATE INDEX IF NOT EXISTS records_trace_agent ON records(trace_id, agent_span_id);
+CREATE TABLE IF NOT EXISTS llm_calls (
+    span_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    response_id TEXT,
+    model TEXT NOT NULL,
+    usage_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS artifacts (
+    artifact_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    span_id TEXT,
+    kind TEXT NOT NULL,
+    attributes_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS findings (
+    finding_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    detector_id TEXT NOT NULL,
+    evidence_json TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS content_blobs (
+    digest TEXT PRIMARY KEY,
+    compression TEXT NOT NULL,
+    media_type TEXT,
+    byte_length INTEGER NOT NULL,
+    content BLOB NOT NULL
+);
+"""
+
+
+class TraceIndex:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+        with self.connect() as connection:
+            connection.executescript(SCHEMA)
+
+    def connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def add_records(self, records: list[Record]) -> None:
+        values = self._record_values(records)
+        with self.connect() as connection:
+            connection.executemany(
+                """INSERT OR IGNORE INTO records
+                (record_id, trace_id, sequence, kind, span_id, agent_span_id,
+                 observed_at, payload_json, record_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                values,
+            )
+
+    def replace_trace_records(self, trace_id: str, records: list[Record]) -> None:
+        if any(record.trace_id != trace_id for record in records):
+            raise ValueError("all records must belong to the rebuilt trace")
+        values = self._record_values(records)
+        with self.connect() as connection:
+            for table in ("findings", "artifacts", "llm_calls", "spans", "runs"):
+                connection.execute(
+                    f"DELETE FROM {table} WHERE trace_id = ?", (trace_id,)
+                )
+            connection.execute("DELETE FROM records WHERE trace_id = ?", (trace_id,))
+            connection.executemany(
+                """INSERT INTO records
+                (record_id, trace_id, sequence, kind, span_id, agent_span_id,
+                 observed_at, payload_json, record_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                values,
+            )
+
+    @staticmethod
+    def _record_values(records: list[Record]) -> list[tuple[object, ...]]:
+        values = []
+        for record in records:
+            if record.sequence is None:
+                raise ValueError("committed records require a sequence")
+            values.append(
+                (
+                    record.record_id,
+                    record.trace_id,
+                    record.sequence,
+                    record.kind,
+                    record.span_id,
+                    record.agent_span_id,
+                    record.observed_at.isoformat(),
+                    record.model_dump_json(include={"payload"}),
+                    record.model_dump_json(),
+                )
+            )
+        return values
+
+    def iter_records(self, trace_id: str, after_sequence: int = 0) -> list[Record]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT record_json FROM records "
+                "WHERE trace_id = ? AND sequence > ? ORDER BY sequence",
+                (trace_id, after_sequence),
+            ).fetchall()
+        return [Record.model_validate_json(row["record_json"]) for row in rows]
+
+    def list_trace_ids(self) -> list[str]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT DISTINCT trace_id FROM records ORDER BY trace_id"
+            ).fetchall()
+        return [str(row["trace_id"]) for row in rows]

--- a/agent-flight-recorder/src/flight_recorder/models/envelopes.py
+++ b/agent-flight-recorder/src/flight_recorder/models/envelopes.py
@@ -54,6 +54,7 @@ class Record(FrozenModel):
     monotonic_ns: int | None = Field(default=None, ge=0)
     kind: str
     openhands_event_id: str | None = None
+    llm_call_id: str | None = None
     llm_response_id: str | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
     content_ref: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")

--- a/agent-flight-recorder/src/flight_recorder/models/envelopes.py
+++ b/agent-flight-recorder/src/flight_recorder/models/envelopes.py
@@ -1,0 +1,154 @@
+"""Canonical recorder records and derived domain entities."""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class ProvenanceKind(StrEnum):
+    CAPTURED = "captured"
+    RECONSTRUCTED = "reconstructed"
+    DERIVED = "derived"
+    INTERPRETED = "interpreted"
+
+
+class RelationshipStatus(StrEnum):
+    VERIFIED = "verified"
+    INFERRED = "inferred"
+    UNRESOLVED = "unresolved"
+
+
+class RunStatus(StrEnum):
+    CREATED = "created"
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+class Provenance(FrozenModel):
+    kind: ProvenanceKind = ProvenanceKind.CAPTURED
+    source_ids: tuple[str, ...] = ()
+    description: str | None = None
+    complete: bool = True
+
+
+class Record(FrozenModel):
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    producer_id: str
+    trace_id: str
+    span_id: str | None = None
+    parent_span_id: str | None = None
+    agent_span_id: str | None = None
+    sequence: int | None = Field(default=None, ge=1)
+    observed_at: datetime = Field(default_factory=datetime.now)
+    source_timestamp: datetime | None = None
+    monotonic_ns: int | None = Field(default=None, ge=0)
+    kind: str
+    openhands_event_id: str | None = None
+    llm_response_id: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    content_ref: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")
+    provenance: Provenance = Field(default_factory=Provenance)
+
+
+class Trace(FrozenModel):
+    trace_id: str
+    format_version: int = Field(default=1, ge=1)
+    status: RunStatus = RunStatus.CREATED
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    stop_reason: str | None = None
+    recorder_version: str = "0.1.0"
+    record_count: int | None = Field(default=None, ge=0)
+    finding_count: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def validate_terminal_state(self) -> "Trace":
+        terminal = {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.INTERRUPTED}
+        if self.status in terminal and (
+            self.completed_at is None or not self.stop_reason
+        ):
+            raise ValueError("terminal traces require completed_at and stop_reason")
+        return self
+
+
+class Span(FrozenModel):
+    span_id: str
+    trace_id: str
+    span_type: str
+    name: str = Field(min_length=1)
+    parent_span_id: str | None = None
+    agent_span_id: str | None = None
+    relationship_status: RelationshipStatus = RelationshipStatus.VERIFIED
+    start_sequence: int = Field(ge=1)
+    end_sequence: int | None = Field(default=None, ge=1)
+    started_at: datetime
+    ended_at: datetime | None = None
+    status: str = "running"
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "Span":
+        if self.end_sequence is not None and self.end_sequence < self.start_sequence:
+            raise ValueError("end_sequence precedes start_sequence")
+        if self.ended_at is not None and self.ended_at < self.started_at:
+            raise ValueError("ended_at precedes started_at")
+        return self
+
+
+class TokenUsage(FrozenModel):
+    prompt_tokens: int = Field(default=0, ge=0)
+    completion_tokens: int = Field(default=0, ge=0)
+    cache_read_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+    reasoning_tokens: int = Field(default=0, ge=0)
+
+
+class Artifact(FrozenModel):
+    artifact_id: str
+    trace_id: str
+    span_id: str | None = None
+    kind: str
+    path: str | None = None
+    content_hash: str | None = None
+    size: int | None = Field(default=None, ge=0)
+    created_sequence: int = Field(ge=1)
+    content_ref: str | None = None
+
+
+class Finding(FrozenModel):
+    finding_id: str
+    trace_id: str
+    origin: Literal["rule", "model"]
+    detector_id: str
+    category: str
+    severity: Literal["info", "warning", "error"]
+    confidence: float = Field(ge=0, le=1)
+    title: str = Field(min_length=1)
+    explanation: str = Field(min_length=1)
+    recommendation: str = Field(min_length=1)
+    evidence_ids: tuple[str, ...] = Field(min_length=1)
+    affected_span_ids: tuple[str, ...] = ()
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class CommittedBatch(FrozenModel):
+    trace_id: str
+    first_sequence: int = Field(ge=1)
+    last_sequence: int = Field(ge=1)
+    record_ids: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "CommittedBatch":
+        if self.last_sequence < self.first_sequence:
+            raise ValueError("last_sequence precedes first_sequence")
+        return self

--- a/agent-flight-recorder/src/flight_recorder/models/view_models.py
+++ b/agent-flight-recorder/src/flight_recorder/models/view_models.py
@@ -1,0 +1,85 @@
+"""Immutable query results consumed by CLI and GUI clients."""
+
+from datetime import datetime
+from typing import Any
+
+from flight_recorder.models.envelopes import (
+    Finding,
+    Provenance,
+    Record,
+    RelationshipStatus,
+    Span,
+    TokenUsage,
+)
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ViewModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+
+class RunQuery(ViewModel):
+    status: str | None = None
+    model: str | None = None
+    repository: str | None = None
+
+
+class RunSummary(ViewModel):
+    trace_id: str
+    status: str
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    record_count: int = 0
+    finding_count: int = 0
+    total_usage: TokenUsage = Field(default_factory=TokenUsage)
+    total_cost: float = Field(default=0, ge=0)
+
+
+class RunDetail(ViewModel):
+    summary: RunSummary
+    spans: tuple[Span, ...] = ()
+    findings: tuple[Finding, ...] = ()
+
+
+class TimelineView(ViewModel):
+    trace_id: str
+    records: tuple[Record, ...]
+    spans: tuple[Span, ...] = ()
+
+
+class SpanDetail(ViewModel):
+    span: Span
+    records: tuple[Record, ...]
+
+
+class Selection(ViewModel):
+    record_id: str | None = None
+    span_id: str | None = None
+
+
+class ContextView(ViewModel):
+    record_id: str
+    messages: tuple[dict[str, Any], ...]
+    provenance: Provenance
+
+
+class CondensationView(ViewModel):
+    resolved_ids: tuple[str, ...]
+    unresolved_ids: tuple[str, ...]
+    summary: str | None = None
+
+
+class AgentRelationship(ViewModel):
+    parent_span_id: str | None
+    child_span_id: str
+    status: RelationshipStatus
+    provenance: Provenance
+
+
+class AgentDetail(ViewModel):
+    relationship: AgentRelationship
+    handoff: dict[str, Any] = Field(default_factory=dict)
+    returned_result: Any = None
+    duration_seconds: float | None = Field(default=None, ge=0)
+    usage: TokenUsage = Field(default_factory=TokenUsage)
+    cost: float = Field(default=0, ge=0)

--- a/agent-flight-recorder/src/flight_recorder/recorder.py
+++ b/agent-flight-recorder/src/flight_recorder/recorder.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from uuid import uuid4
 
 from flight_recorder.adapter.conversation import normalize_event
-from flight_recorder.adapter.llm import normalize_completion_log, normalize_metrics
+from flight_recorder.adapter.llm import (
+    normalize_completion_log,
+    normalize_metrics,
+    normalize_request_log,
+)
 from flight_recorder.collector.normalize import make_record
 from flight_recorder.collector.persistence import Collector
 from flight_recorder.collector.queue import RecordQueue
@@ -111,6 +115,16 @@ class Recorder:
         self._capture(
             lambda: normalize_completion_log(
                 filename, log_data, producer_id=self.producer_id, trace_id=self.trace_id
+            )
+        )
+
+    def on_llm_request(self, llm_call_id: str, log_data: str) -> None:
+        self._capture(
+            lambda: normalize_request_log(
+                llm_call_id,
+                log_data,
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
             )
         )
 

--- a/agent-flight-recorder/src/flight_recorder/recorder.py
+++ b/agent-flight-recorder/src/flight_recorder/recorder.py
@@ -1,0 +1,267 @@
+"""Exception-contained recorder facade."""
+
+from collections.abc import Callable
+from pathlib import Path
+from uuid import uuid4
+
+from flight_recorder.adapter.conversation import normalize_event
+from flight_recorder.adapter.llm import normalize_completion_log, normalize_metrics
+from flight_recorder.collector.normalize import make_record
+from flight_recorder.collector.persistence import Collector
+from flight_recorder.collector.queue import RecordQueue
+from flight_recorder.errors import RecorderClosed
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Record
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+
+
+class Recorder:
+    def __init__(self, bundle: Path, index: TraceIndex, max_queue: int = 4096) -> None:
+        self.trace_id = str(uuid4())
+        self.producer_id = str(uuid4())
+        self.agent_span_id = str(uuid4())
+        self.queue = RecordQueue(max_queue)
+        self.collector = Collector(self.queue, bundle, index)
+        self.errors = 0
+        self._closed = False
+        self.collector.start()
+        self._capture(
+            lambda: make_record(
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
+                kind="run.started",
+                payload={"status": "running"},
+            )
+        )
+        self._record_agent_started(
+            agent_span_id=self.agent_span_id,
+            parent_agent_span_id=None,
+            payload={"name": "Primary agent"},
+        )
+
+    @property
+    def warning_counters(self) -> dict[str, int]:
+        return {
+            "callback_errors": self.errors,
+            "dropped_records": self.queue.dropped,
+            "collector_errors": self.collector.errors,
+        }
+
+    def on_event(self, event: object) -> None:
+        self._on_agent_event(
+            event,
+            agent_span_id=self.agent_span_id,
+            parent_agent_span_id=None,
+        )
+
+    def _on_agent_event(
+        self,
+        event: object,
+        *,
+        agent_span_id: str,
+        parent_agent_span_id: str | None,
+    ) -> None:
+        self._capture(
+            lambda: normalize_event(
+                event,
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
+                agent_span_id=agent_span_id,
+                parent_agent_span_id=parent_agent_span_id,
+            )
+        )
+
+    def __call__(self, event: object) -> None:
+        self.on_event(event)
+
+    def for_subagent(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> "_AgentRecorderCallback":
+        return _AgentRecorderCallback(
+            recorder=self,
+            agent_span_id=str(uuid4()),
+            parent_agent_span_id=self.agent_span_id,
+            task_id=task_id,
+            subagent_type=subagent_type,
+            description=description,
+        )
+
+    def finish_subagent(
+        self,
+        *,
+        status: str,
+        result: str | None,
+        error: str | None,
+        stats: ConversationStats,
+    ) -> None:
+        self.record_metrics(stats)
+        self._record_agent_finished(
+            agent_span_id=self.agent_span_id,
+            parent_agent_span_id=None,
+            status=status,
+            result=result,
+            error=error,
+        )
+
+    def on_completion_log(self, filename: str, log_data: str) -> None:
+        self._capture(
+            lambda: normalize_completion_log(
+                filename, log_data, producer_id=self.producer_id, trace_id=self.trace_id
+            )
+        )
+
+    def record_metrics(self, stats: ConversationStats) -> None:
+        self._capture(
+            lambda: normalize_metrics(
+                stats,
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
+                agent_span_id=self.agent_span_id,
+            )
+        )
+
+    def _capture(self, factory: Callable[[], Record]) -> None:
+        try:
+            if self._closed:
+                raise RecorderClosed()
+            if not self.queue.put(factory()):
+                self.errors += 1
+        except Exception:
+            self.errors += 1
+
+    def _record_agent_started(
+        self,
+        *,
+        agent_span_id: str,
+        parent_agent_span_id: str | None,
+        payload: dict[str, object],
+    ) -> None:
+        self._capture(
+            lambda: make_record(
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
+                kind="agent.started",
+                payload=payload,
+                span_id=agent_span_id,
+                parent_span_id=parent_agent_span_id,
+                agent_span_id=agent_span_id,
+            )
+        )
+
+    def _record_agent_finished(
+        self,
+        *,
+        agent_span_id: str,
+        parent_agent_span_id: str | None,
+        status: str,
+        result: str | None,
+        error: str | None,
+    ) -> None:
+        self._capture(
+            lambda: make_record(
+                producer_id=self.producer_id,
+                trace_id=self.trace_id,
+                kind="agent.finished",
+                payload={"status": status, "result": result, "error": error},
+                span_id=agent_span_id,
+                parent_span_id=parent_agent_span_id,
+                agent_span_id=agent_span_id,
+            )
+        )
+
+    def close(self) -> None:
+        if not self._closed:
+            self._record_agent_finished(
+                agent_span_id=self.agent_span_id,
+                parent_agent_span_id=None,
+                status="completed",
+                result=None,
+                error=None,
+            )
+            self._capture(
+                lambda: make_record(
+                    producer_id=self.producer_id,
+                    trace_id=self.trace_id,
+                    kind="run.finished",
+                    payload={"status": "completed", "stop_reason": "recorder_closed"},
+                )
+            )
+            self._closed = True
+            self.collector.stop()
+
+
+class _AgentRecorderCallback:
+    def __init__(
+        self,
+        *,
+        recorder: Recorder,
+        agent_span_id: str,
+        parent_agent_span_id: str,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> None:
+        self.recorder = recorder
+        self.agent_span_id = agent_span_id
+        self.parent_agent_span_id = parent_agent_span_id
+        self.task_id = task_id
+        self.recorder._record_agent_started(
+            agent_span_id=agent_span_id,
+            parent_agent_span_id=parent_agent_span_id,
+            payload={
+                "task_id": task_id,
+                "subagent_type": subagent_type,
+                "name": description or subagent_type,
+            },
+        )
+
+    def __call__(self, event: object) -> None:
+        self.recorder._on_agent_event(
+            event,
+            agent_span_id=self.agent_span_id,
+            parent_agent_span_id=self.parent_agent_span_id,
+        )
+
+    def for_subagent(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> "_AgentRecorderCallback":
+        return _AgentRecorderCallback(
+            recorder=self.recorder,
+            agent_span_id=str(uuid4()),
+            parent_agent_span_id=self.agent_span_id,
+            task_id=task_id,
+            subagent_type=subagent_type,
+            description=description,
+        )
+
+    def finish_subagent(
+        self,
+        *,
+        status: str,
+        result: str | None,
+        error: str | None,
+        stats: ConversationStats,
+    ) -> None:
+        self.recorder._capture(
+            lambda: normalize_metrics(
+                stats,
+                producer_id=self.recorder.producer_id,
+                trace_id=self.recorder.trace_id,
+                agent_span_id=self.agent_span_id,
+            )
+        )
+        self.recorder._record_agent_finished(
+            agent_span_id=self.agent_span_id,
+            parent_agent_span_id=self.parent_agent_span_id,
+            status=status,
+            result=result,
+            error=error,
+        )

--- a/agent-flight-recorder/src/flight_recorder/services/bundles.py
+++ b/agent-flight-recorder/src/flight_recorder/services/bundles.py
@@ -1,0 +1,333 @@
+"""Portable trace bundle storage and validation."""
+
+import hashlib
+import json
+import shutil
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from flight_recorder.errors import InvalidBundle, UnsupportedFormat
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Record
+
+
+@dataclass(frozen=True)
+class BundleValidation:
+    trace_id: str
+    record_count: int
+
+
+@dataclass(frozen=True)
+class BundleMergeSource:
+    path: Path
+    parent_trace_id: str | None = None
+    agent_name: str | None = None
+
+
+def _safe_zip_name(name: str) -> bool:
+    path = Path(name)
+    return not path.is_absolute() and ".." not in path.parts
+
+
+class BundleService:
+    def __init__(
+        self, index: TraceIndex | None = None, traces: Path | None = None
+    ) -> None:
+        self.index = index
+        self.traces = traces
+
+    def validate_bundle(self, source: Path) -> BundleValidation:
+        root, temporary = self._open(source)
+        try:
+            manifest_path = root / "manifest.json"
+            records_path = root / "records.jsonl"
+            if not manifest_path.is_file() or not records_path.is_file():
+                raise InvalidBundle("manifest.json and records.jsonl are required")
+            self._validate_checksums(root)
+            manifest = json.loads(manifest_path.read_text())
+            if manifest.get("format") != "agent-flight-recorder":
+                raise InvalidBundle("unexpected bundle format")
+            if manifest.get("format_version") != 1:
+                raise UnsupportedFormat(str(manifest.get("format_version")))
+            trace_id = str(manifest["trace_id"])
+            records = list(self.iter_record_file(records_path))
+            if any(record.trace_id != trace_id for record in records):
+                raise InvalidBundle("record trace_id differs from manifest")
+            sequences = [record.sequence for record in records]
+            if any(sequence is None for sequence in sequences):
+                raise InvalidBundle("persisted records require a sequence")
+            concrete_sequences = [
+                sequence for sequence in sequences if sequence is not None
+            ]
+            if concrete_sequences != sorted(set(concrete_sequences)):
+                raise InvalidBundle("record sequences must strictly increase")
+            if len({record.record_id for record in records}) != len(records):
+                raise InvalidBundle("record IDs must be unique")
+            return BundleValidation(trace_id=trace_id, record_count=len(records))
+        finally:
+            if temporary is not None:
+                temporary.cleanup()
+
+    def import_bundle(self, source: Path) -> str:
+        validation = self.validate_bundle(source)
+        if self.index is None:
+            raise ValueError("import requires an index")
+        root, temporary = self._open(source)
+        try:
+            records = list(self.iter_record_file(root / "records.jsonl"))
+            self.index.replace_trace_records(validation.trace_id, records)
+            if self.traces is not None:
+                self.traces.mkdir(parents=True, exist_ok=True)
+                destination = self.traces / f"{validation.trace_id}.afr"
+                staging = self.traces / f".{validation.trace_id}.afr.tmp"
+                shutil.rmtree(staging, ignore_errors=True)
+                shutil.copytree(root, staging)
+                shutil.rmtree(destination, ignore_errors=True)
+                staging.replace(destination)
+        finally:
+            if temporary is not None:
+                temporary.cleanup()
+        return validation.trace_id
+
+    def export_bundle(self, source: Path | str, destination: Path) -> Path:
+        if isinstance(source, str):
+            if self.traces is None:
+                raise ValueError("export by trace ID requires managed trace storage")
+            source = self.traces / f"{source}.afr"
+        validation = self.validate_bundle(source)
+        if source.is_dir():
+            self._finalize(source, validation)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.suffix == ".zip":
+            with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as archive:
+                for path in sorted(source.rglob("*")):
+                    if path.is_file():
+                        archive.write(
+                            path, Path(source.name) / path.relative_to(source)
+                        )
+        else:
+            shutil.copytree(source, destination, dirs_exist_ok=True)
+        return destination
+
+    def finalize_bundle(self, source: Path) -> BundleValidation:
+        if not source.is_dir():
+            raise ValueError("in-place finalization requires a bundle directory")
+        validation = self.validate_bundle(source)
+        self._finalize(source, validation)
+        return self.validate_bundle(source)
+
+    def merge_bundles(
+        self, sources: list[BundleMergeSource], destination: Path
+    ) -> BundleValidation:
+        if not sources:
+            raise ValueError("at least one bundle is required")
+        if any(source.path == destination for source in sources):
+            raise ValueError("merge destination must differ from every source")
+
+        loaded = [
+            (
+                source,
+                self.validate_bundle(source.path),
+                list(self.iter_record_file(source.path / "records.jsonl")),
+            )
+            for source in sources
+        ]
+        trace_id = loaded[0][1].trace_id
+        root_agents = {
+            validation.trace_id: next(
+                (
+                    record.span_id
+                    for record in records
+                    if record.kind == "agent.started" and record.parent_span_id is None
+                ),
+                None,
+            )
+            for _, validation, records in loaded
+        }
+        merged = []
+        for source_index, (source, validation, records) in enumerate(loaded):
+            root_agent = root_agents[validation.trace_id]
+            parent_agent = root_agents.get(source.parent_trace_id or "")
+            for record in records:
+                parent_span_id = record.parent_span_id
+                if (
+                    source.parent_trace_id is not None
+                    and record.span_id == root_agent
+                    and parent_span_id is None
+                ):
+                    parent_span_id = parent_agent
+                payload = record.payload
+                if (
+                    source.agent_name is not None
+                    and record.kind == "agent.started"
+                    and record.span_id == root_agent
+                ):
+                    payload = {**payload, "name": source.agent_name}
+                merged.append(
+                    (
+                        source_index,
+                        record.model_copy(
+                            update={
+                                "trace_id": trace_id,
+                                "parent_span_id": parent_span_id,
+                                "payload": payload,
+                                "sequence": None,
+                            }
+                        ),
+                    )
+                )
+        merged.sort(
+            key=lambda item: (
+                item[1].observed_at.isoformat(),
+                item[0],
+                item[1].sequence or 0,
+                item[1].record_id,
+            )
+        )
+        records = [
+            record.model_copy(update={"sequence": sequence})
+            for sequence, (_, record) in enumerate(merged, start=1)
+        ]
+        if len({record.record_id for record in records}) != len(records):
+            raise InvalidBundle("record IDs collide across merged bundles")
+
+        shutil.rmtree(destination, ignore_errors=True)
+        destination.mkdir(parents=True)
+        (destination / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "format": "agent-flight-recorder",
+                    "format_version": 1,
+                    "trace_id": trace_id,
+                    "status": "snapshot",
+                    "recorder_version": "0.1.0",
+                    "content_encoding": "zstd",
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (destination / "records.jsonl").write_text(
+            "".join(record.model_dump_json() + "\n" for record in records)
+        )
+        (destination / "findings.jsonl").touch()
+        for source, _, _ in loaded:
+            content = source.path / "content"
+            if content.is_dir():
+                shutil.copytree(content, destination / "content", dirs_exist_ok=True)
+        return self.finalize_bundle(destination)
+
+    def _finalize(self, root: Path, validation: BundleValidation) -> None:
+        findings_path = root / "findings.jsonl"
+        findings_path.touch(exist_ok=True)
+        finding_count = sum(
+            1 for line in findings_path.read_text().splitlines() if line
+        )
+
+        manifest_path = root / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest.update(
+            record_count=validation.record_count,
+            finding_count=finding_count,
+        )
+        temporary_manifest = manifest_path.with_suffix(".json.tmp")
+        temporary_manifest.write_text(json.dumps(manifest, indent=2) + "\n")
+        temporary_manifest.replace(manifest_path)
+
+        portable_files = [manifest_path, root / "records.jsonl", findings_path]
+        content = root / "content"
+        if content.is_dir():
+            portable_files.extend(path for path in content.rglob("*") if path.is_file())
+        checksum_lines = [
+            f"{self.checksum(path)}  {path.relative_to(root).as_posix()}"
+            for path in sorted(
+                portable_files, key=lambda path: path.relative_to(root).as_posix()
+            )
+        ]
+        checksum_path = root / "checksums.sha256"
+        temporary_checksums = checksum_path.with_suffix(".sha256.tmp")
+        temporary_checksums.write_text("\n".join(checksum_lines) + "\n")
+        temporary_checksums.replace(checksum_path)
+
+    def _validate_checksums(self, root: Path) -> None:
+        checksum_path = root / "checksums.sha256"
+        if not checksum_path.is_file():
+            return
+
+        checksums: dict[str, str] = {}
+        for line in checksum_path.read_text().splitlines():
+            try:
+                digest, relative_path = line.split("  ", maxsplit=1)
+            except ValueError as exc:
+                raise InvalidBundle("invalid checksum entry") from exc
+            if (
+                len(digest) != 64
+                or any(character not in "0123456789abcdef" for character in digest)
+                or not _safe_zip_name(relative_path)
+                or relative_path in checksums
+                or relative_path == checksum_path.name
+            ):
+                raise InvalidBundle("invalid checksum entry")
+            checksums[relative_path] = digest
+
+        expected_paths = {"manifest.json", "records.jsonl", "findings.jsonl"}
+        content = root / "content"
+        if content.is_dir():
+            expected_paths.update(
+                path.relative_to(root).as_posix()
+                for path in content.rglob("*")
+                if path.is_file()
+            )
+        if checksums.keys() != expected_paths:
+            raise InvalidBundle("checksum entries do not match bundle files")
+        for relative_path, expected_digest in checksums.items():
+            path = root / relative_path
+            if not path.is_file() or self.checksum(path) != expected_digest:
+                raise InvalidBundle(f"checksum mismatch for {relative_path}")
+
+    @staticmethod
+    def iter_record_file(path: Path) -> Iterable[Record]:
+        with path.open() as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.endswith("\n"):
+                    break
+                try:
+                    yield Record.model_validate_json(line)
+                except ValueError as exc:
+                    raise InvalidBundle(
+                        f"invalid record at line {line_number}"
+                    ) from exc
+
+    @staticmethod
+    def checksum(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _open(source: Path) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
+        if source.is_dir():
+            return source, None
+        temporary = tempfile.TemporaryDirectory()
+        try:
+            with zipfile.ZipFile(source) as archive:
+                if any(
+                    not _safe_zip_name(item.filename) for item in archive.infolist()
+                ):
+                    raise InvalidBundle("unsafe ZIP entry")
+                archive.extractall(temporary.name)
+            roots = list(Path(temporary.name).iterdir())
+            root = (
+                roots[0]
+                if len(roots) == 1 and roots[0].is_dir()
+                else Path(temporary.name)
+            )
+            return root, temporary
+        except Exception:
+            temporary.cleanup()
+            raise

--- a/agent-flight-recorder/src/flight_recorder/services/diagnostics.py
+++ b/agent-flight-recorder/src/flight_recorder/services/diagnostics.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from flight_recorder.diagnostics.analyzer import AnalyzerFailure, InterpretiveAnalyzer
+from flight_recorder.diagnostics.rules import deterministic_findings
+from flight_recorder.diagnostics.schemas import EvidencePacket
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Finding
+
+
+class DiagnosticService:
+    def __init__(
+        self,
+        index: TraceIndex,
+        analyzer: InterpretiveAnalyzer | None = None,
+        findings_path: Path | None = None,
+    ) -> None:
+        self.index = index
+        self.analyzer = analyzer
+        self.findings_path = findings_path
+        self.analyzer_failure: AnalyzerFailure | None = None
+
+    def analyze(
+        self, trace_id: str, include_interpretive: bool = False
+    ) -> list[Finding]:
+        records = self.index.iter_records(trace_id)
+        findings = deterministic_findings(records)
+        packet = EvidencePacket(
+            trace_id=trace_id,
+            records=tuple(records),
+            deterministic_findings=tuple(findings),
+        )
+        self.analyzer_failure = None
+        if include_interpretive and self.analyzer is not None:
+            try:
+                findings.extend(self.analyzer.analyze(packet))
+            except AnalyzerFailure as exc:
+                self.analyzer_failure = exc
+        valid = self._valid_findings(trace_id, records, findings)
+        self._persist(valid)
+        return valid
+
+    @staticmethod
+    def _valid_findings(
+        trace_id: str, records: list, findings: list[Finding]
+    ) -> list[Finding]:
+        record_ids = {record.record_id for record in records}
+        return [
+            finding
+            for finding in findings
+            if finding.trace_id == trace_id
+            and set(finding.evidence_ids).issubset(record_ids)
+        ]
+
+    def _persist(self, findings: list[Finding]) -> None:
+        if self.findings_path is None:
+            return
+        self.findings_path.parent.mkdir(parents=True, exist_ok=True)
+        content = "".join(f"{finding.model_dump_json()}\n" for finding in findings)
+        temporary = self.findings_path.with_suffix(".tmp")
+        temporary.write_text(content)
+        temporary.replace(self.findings_path)

--- a/agent-flight-recorder/src/flight_recorder/services/repository.py
+++ b/agent-flight-recorder/src/flight_recorder/services/repository.py
@@ -1,0 +1,422 @@
+"""Read-only trace query service."""
+
+from collections.abc import Iterable
+
+from flight_recorder.errors import SpanNotFound, TraceNotFound
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import (
+    Artifact,
+    Provenance,
+    ProvenanceKind,
+    Record,
+    RelationshipStatus,
+    Span,
+    TokenUsage,
+)
+from flight_recorder.models.view_models import (
+    AgentDetail,
+    AgentRelationship,
+    CondensationView,
+    ContextView,
+    RunQuery,
+    RunSummary,
+    SpanDetail,
+    TimelineView,
+)
+
+
+def _recorder_shutdown_record_ids(records: tuple[Record, ...]) -> frozenset[str]:
+    if len(records) < 2:
+        return frozenset()
+    agent_finished, run_finished = records[-2:]
+    if (
+        agent_finished.kind != "agent.finished"
+        or agent_finished.parent_span_id is not None
+        or agent_finished.span_id != agent_finished.agent_span_id
+        or run_finished.kind != "run.finished"
+        or run_finished.payload.get("stop_reason") != "recorder_closed"
+        or agent_finished.producer_id != run_finished.producer_id
+        or agent_finished.sequence is None
+        or run_finished.sequence != agent_finished.sequence + 1
+    ):
+        return frozenset()
+    return frozenset((agent_finished.record_id, run_finished.record_id))
+
+
+class TraceRepository:
+    def __init__(self, index: TraceIndex) -> None:
+        self.index = index
+
+    def iter_records(self, trace_id: str, after_sequence: int = 0) -> Iterable[Record]:
+        return self.index.iter_records(trace_id, after_sequence)
+
+    def get_record(self, trace_id: str, record_id: str) -> Record:
+        record = next(
+            (
+                item
+                for item in self.index.iter_records(trace_id)
+                if item.record_id == record_id
+            ),
+            None,
+        )
+        if record is None:
+            raise TraceNotFound(trace_id)
+        return record
+
+    def get_next_user_message(
+        self,
+        trace_id: str,
+        *,
+        after_sequence: int,
+        agent_span_id: str | None,
+    ) -> Record | None:
+        return next(
+            (
+                record
+                for record in self.index.iter_records(trace_id, after_sequence)
+                if record.agent_span_id == agent_span_id
+                and record.payload.get("event_type") == "MessageEvent"
+                and record.payload.get("source") == "user"
+            ),
+            None,
+        )
+
+    def list_runs(self, query: RunQuery) -> list[RunSummary]:
+        runs = []
+        for trace_id in self.index.list_trace_ids():
+            records = tuple(self.index.iter_records(trace_id))
+            run = self.get_run(trace_id)
+            if query.status is not None and run.status != query.status:
+                continue
+            if query.repository is not None and not any(
+                record.payload.get("repository") == query.repository
+                for record in records
+            ):
+                continue
+            if query.model is not None and not self._has_model(records, query.model):
+                continue
+            runs.append(run)
+        return sorted(
+            runs,
+            key=lambda run: run.started_at.isoformat() if run.started_at else "",
+            reverse=True,
+        )
+
+    def get_timeline(self, trace_id: str) -> TimelineView:
+        records = tuple(self.index.iter_records(trace_id))
+        if not records:
+            raise TraceNotFound(trace_id)
+        span_ids = dict.fromkeys(
+            record.span_id for record in records if record.span_id is not None
+        )
+        spans = tuple(self.get_span(trace_id, span_id).span for span_id in span_ids)
+        return TimelineView(trace_id=trace_id, records=records, spans=spans)
+
+    def get_run(self, trace_id: str) -> RunSummary:
+        records = tuple(self.index.iter_records(trace_id))
+        if not records:
+            raise TraceNotFound(trace_id)
+        total_usage, total_cost = self._aggregate_usage(records)
+        return RunSummary(
+            trace_id=trace_id,
+            status="completed"
+            if any(item.kind == "run.finished" for item in records)
+            else "running",
+            started_at=records[0].observed_at,
+            completed_at=records[-1].observed_at,
+            record_count=len(records),
+            total_usage=total_usage,
+            total_cost=total_cost,
+        )
+
+    def get_span(self, trace_id: str, span_id: str) -> SpanDetail:
+        trace_records = tuple(self.index.iter_records(trace_id))
+        records = tuple(record for record in trace_records if record.span_id == span_id)
+        if not records:
+            raise SpanNotFound(span_id)
+        terminal = len(records) > 1
+        parent_resolves = any(
+            record.span_id == records[0].parent_span_id for record in trace_records
+        )
+        if records[0].parent_span_id is not None and not parent_resolves:
+            relationship_status = RelationshipStatus.UNRESOLVED
+        elif records[0].provenance.kind is ProvenanceKind.DERIVED:
+            relationship_status = RelationshipStatus.INFERRED
+        else:
+            relationship_status = RelationshipStatus.VERIFIED
+        span = Span(
+            span_id=span_id,
+            trace_id=trace_id,
+            span_type=records[0].kind.partition(".")[0],
+            name=str(records[0].payload.get("name", span_id)),
+            parent_span_id=records[0].parent_span_id,
+            agent_span_id=records[0].agent_span_id,
+            relationship_status=relationship_status,
+            start_sequence=records[0].sequence or 1,
+            end_sequence=records[-1].sequence if terminal else None,
+            started_at=records[0].observed_at,
+            ended_at=records[-1].observed_at if terminal else None,
+            status="completed" if terminal else "incomplete",
+        )
+        return SpanDetail(span=span, records=records)
+
+    def get_workspace_changes(
+        self, trace_id: str, span_id: str | None = None
+    ) -> list[Artifact]:
+        changes = []
+        for record in self.index.iter_records(trace_id):
+            if not record.kind.startswith("workspace.") or (
+                span_id is not None and record.span_id != span_id
+            ):
+                continue
+            changes.append(
+                Artifact(
+                    artifact_id=record.record_id,
+                    trace_id=trace_id,
+                    span_id=record.span_id,
+                    kind=record.kind,
+                    path=record.payload.get("path"),
+                    content_hash=record.payload.get("content_hash"),
+                    size=record.payload.get("size"),
+                    created_sequence=record.sequence or 1,
+                    content_ref=record.content_ref,
+                )
+            )
+        return changes
+
+    def get_model_context(self, trace_id: str, record_id: str) -> ContextView:
+        records = tuple(self.index.iter_records(trace_id))
+        target = next(
+            (record for record in records if record.record_id == record_id), None
+        )
+        if target is None:
+            raise TraceNotFound(trace_id)
+        completion = target.payload.get("completion")
+        if isinstance(completion, dict):
+            messages = completion.get("messages")
+            if isinstance(messages, list):
+                return ContextView(
+                    record_id=record_id,
+                    messages=tuple(
+                        message for message in messages if isinstance(message, dict)
+                    ),
+                    provenance=Provenance(),
+                )
+
+        source_records = [
+            record
+            for record in records
+            if (record.sequence or 0) < (target.sequence or 0)
+            and record.payload.get("event_type")
+            in {"MessageEvent", "ActionEvent", "ObservationEvent", "SystemPromptEvent"}
+        ]
+        messages = []
+        source_ids = []
+        for record in source_records:
+            message = record.payload.get("llm_message")
+            if isinstance(message, dict):
+                messages.append(message)
+                source_ids.append(record.record_id)
+        return ContextView(
+            record_id=record_id,
+            messages=tuple(messages),
+            provenance=Provenance(
+                kind=ProvenanceKind.RECONSTRUCTED,
+                source_ids=tuple(source_ids),
+                description="Reconstructed from conversation events",
+                complete=False,
+            ),
+        )
+
+    def get_agent_relationships(self, trace_id: str) -> list[AgentRelationship]:
+        records = tuple(self.index.iter_records(trace_id))
+        span_ids = {record.span_id for record in records if record.span_id is not None}
+        relationships = []
+        seen_children = set()
+        for record in records:
+            if (
+                record.kind != "agent.started"
+                or record.span_id is None
+                or record.parent_span_id is None
+                or record.span_id in seen_children
+            ):
+                continue
+            seen_children.add(record.span_id)
+            if record.parent_span_id not in span_ids:
+                status = RelationshipStatus.UNRESOLVED
+            elif record.provenance.kind is ProvenanceKind.DERIVED:
+                status = RelationshipStatus.INFERRED
+            else:
+                status = RelationshipStatus.VERIFIED
+            relationships.append(
+                AgentRelationship(
+                    parent_span_id=record.parent_span_id,
+                    child_span_id=record.span_id,
+                    status=status,
+                    provenance=record.provenance,
+                )
+            )
+        return relationships
+
+    def get_agent_usage(
+        self, trace_id: str, agent_span_id: str
+    ) -> tuple[TokenUsage, float]:
+        records = tuple(self.index.iter_records(trace_id))
+        direct_records = tuple(
+            record for record in records if record.agent_span_id == agent_span_id
+        )
+        if any(record.kind == "metrics.snapshot" for record in direct_records):
+            return self._aggregate_usage(direct_records, include_delegated=False)
+
+        started = next(
+            (
+                record
+                for record in records
+                if record.kind == "agent.started" and record.span_id == agent_span_id
+            ),
+            None,
+        )
+        task_id = started.payload.get("task_id") if started is not None else None
+        task_usage_id = f"task:{task_id}" if isinstance(task_id, str) else None
+        task_snapshots = {}
+        for record in records:
+            if record.kind != "metrics.snapshot":
+                continue
+            usage_to_metrics = record.payload.get("usage_to_metrics", {})
+            if isinstance(usage_to_metrics, dict):
+                snapshot = (
+                    usage_to_metrics.get(task_usage_id)
+                    if task_usage_id is not None
+                    else None
+                )
+                if isinstance(snapshot, dict):
+                    assert task_usage_id is not None
+                    task_snapshots[task_usage_id] = snapshot
+        if task_snapshots:
+            return self._aggregate_snapshots(task_snapshots)
+        return TokenUsage(), 0.0
+
+    def get_agent_detail(self, trace_id: str, agent_span_id: str) -> AgentDetail:
+        relationship = next(
+            (
+                item
+                for item in self.get_agent_relationships(trace_id)
+                if item.child_span_id == agent_span_id
+            ),
+            None,
+        )
+        if relationship is None:
+            detail = self.get_span(trace_id, agent_span_id)
+            if detail.span.parent_span_id is not None:
+                raise SpanNotFound(agent_span_id)
+            relationship = AgentRelationship(
+                parent_span_id=None,
+                child_span_id=agent_span_id,
+                status=RelationshipStatus.VERIFIED,
+                provenance=Provenance(),
+            )
+        trace_records = tuple(self.index.iter_records(trace_id))
+        records = tuple(
+            record
+            for record in trace_records
+            if record.agent_span_id == agent_span_id or record.span_id == agent_span_id
+        )
+        started = next(
+            (record for record in records if record.kind == "agent.started"), None
+        )
+        finished = next(
+            (record for record in reversed(records) if record.kind == "agent.finished"),
+            None,
+        )
+        duration = None
+        if started is not None and finished is not None:
+            ended = finished
+            shutdown_record_ids = _recorder_shutdown_record_ids(trace_records)
+            if finished.record_id in shutdown_record_ids:
+                ended = max(
+                    (
+                        record
+                        for record in trace_records
+                        if record.record_id not in shutdown_record_ids
+                    ),
+                    key=lambda record: record.observed_at,
+                    default=started,
+                )
+            duration = (ended.observed_at - started.observed_at).total_seconds()
+        usage, cost = self.get_agent_usage(trace_id, agent_span_id)
+        return AgentDetail(
+            relationship=relationship,
+            handoff=started.payload if started is not None else {},
+            returned_result=finished.payload.get("result") if finished else None,
+            duration_seconds=duration,
+            usage=usage,
+            cost=cost,
+        )
+
+    @staticmethod
+    def _has_model(records: tuple[Record, ...], model: str) -> bool:
+        for record in records:
+            if record.payload.get("model") == model:
+                return True
+            metrics = record.payload.get("usage_to_metrics")
+            if isinstance(metrics, dict) and any(
+                isinstance(snapshot, dict) and snapshot.get("model_name") == model
+                for snapshot in metrics.values()
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _aggregate_usage(
+        records: tuple[Record, ...], *, include_delegated: bool = True
+    ) -> tuple[TokenUsage, float]:
+        snapshots: dict[str, dict[str, object]] = {}
+        for record in records:
+            if record.kind == "metrics.snapshot":
+                usage_to_metrics = record.payload.get("usage_to_metrics", {})
+                if isinstance(usage_to_metrics, dict):
+                    snapshots.update(
+                        {
+                            usage_id: snapshot
+                            for usage_id, snapshot in usage_to_metrics.items()
+                            if isinstance(snapshot, dict)
+                            and (include_delegated or not usage_id.startswith("task:"))
+                        }
+                    )
+
+        return TraceRepository._aggregate_snapshots(snapshots)
+
+    @staticmethod
+    def _aggregate_snapshots(
+        snapshots: dict[str, dict[str, object]],
+    ) -> tuple[TokenUsage, float]:
+        totals = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        }
+        total_cost = 0.0
+        for snapshot in snapshots.values():
+            usage = snapshot.get("accumulated_token_usage")
+            if isinstance(usage, dict):
+                for field in totals:
+                    totals[field] += int(usage.get(field, 0))
+            accumulated_cost = snapshot.get("accumulated_cost", 0)
+            if isinstance(accumulated_cost, int | float):
+                total_cost += float(accumulated_cost)
+        return TokenUsage(**totals), total_cost
+
+
+def resolve_condensation(
+    payload: dict[str, object], known_record_ids: set[str]
+) -> CondensationView:
+    forgotten = payload.get("forgotten_event_ids", [])
+    ids = [str(item) for item in forgotten] if isinstance(forgotten, list) else []
+    summary = payload.get("summary")
+    return CondensationView(
+        resolved_ids=tuple(item for item in ids if item in known_record_ids),
+        unresolved_ids=tuple(item for item in ids if item not in known_record_ids),
+        summary=summary if isinstance(summary, str) else None,
+    )

--- a/agent-flight-recorder/src/flight_recorder/services/repository.py
+++ b/agent-flight-recorder/src/flight_recorder/services/repository.py
@@ -1,6 +1,8 @@
 """Read-only trace query service."""
 
+import math
 from collections.abc import Iterable
+from datetime import datetime, timedelta
 
 from flight_recorder.errors import SpanNotFound, TraceNotFound
 from flight_recorder.models.database import TraceIndex
@@ -23,6 +25,100 @@ from flight_recorder.models.view_models import (
     SpanDetail,
     TimelineView,
 )
+
+
+_LLM_RESPONSE_FIELDS = {
+    "llm_call_id",
+    "response",
+    "response_id",
+    "id",
+    "raw_response",
+    "error",
+    "usage_summary",
+    "cost",
+    "timestamp",
+    "latency_sec",
+}
+
+
+def _legacy_completion_times(
+    completion: dict[str, object],
+) -> tuple[datetime | None, datetime | None]:
+    timestamp = completion.get("timestamp")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int | float):
+        return None, None
+    timestamp = float(timestamp)
+    if not math.isfinite(timestamp):
+        return None, None
+    try:
+        response_time = datetime.fromtimestamp(timestamp)
+    except (OSError, OverflowError, ValueError):
+        return None, None
+    latency = completion.get("latency_sec")
+    if (
+        isinstance(latency, bool)
+        or not isinstance(latency, int | float)
+        or not math.isfinite(latency)
+        or latency < 0
+    ):
+        return response_time, response_time
+    return response_time - timedelta(seconds=latency), response_time
+
+
+def _project_legacy_llm_exchange(record: Record) -> tuple[Record, ...]:
+    completion = record.payload.get("completion")
+    if record.kind != "llm.response" or not isinstance(completion, dict):
+        return (record,)
+    request_payload = {
+        key: value
+        for key, value in completion.items()
+        if key not in _LLM_RESPONSE_FIELDS
+    }
+    if not request_payload:
+        return (record,)
+    provenance = Provenance(
+        kind=ProvenanceKind.DERIVED,
+        source_ids=(record.record_id,),
+        description="Projected from a legacy combined LLM completion record",
+    )
+    common_payload = {"filename": record.payload.get("filename")}
+    request_time, response_time = _legacy_completion_times(completion)
+    llm_call_id = record.llm_call_id or record.record_id
+    request = record.model_copy(
+        update={
+            "record_id": f"{record.record_id}/request",
+            "kind": "llm.request",
+            "llm_call_id": llm_call_id,
+            "payload": {**common_payload, "request": request_payload},
+            "provenance": provenance,
+            "source_timestamp": request_time,
+        }
+    )
+    response = record.model_copy(
+        update={
+            "record_id": f"{record.record_id}/response",
+            "llm_call_id": llm_call_id,
+            "payload": {
+                **common_payload,
+                **{
+                    key: value
+                    for key, value in completion.items()
+                    if key in _LLM_RESPONSE_FIELDS
+                },
+            },
+            "provenance": provenance,
+            "source_timestamp": response_time,
+        }
+    )
+    return request, response
+
+
+def _project_timeline_records(records: tuple[Record, ...]) -> tuple[Record, ...]:
+    return tuple(
+        projected
+        for record in records
+        for projected in _project_legacy_llm_exchange(record)
+    )
 
 
 def _recorder_shutdown_record_ids(records: tuple[Record, ...]) -> frozenset[str]:
@@ -51,10 +147,11 @@ class TraceRepository:
         return self.index.iter_records(trace_id, after_sequence)
 
     def get_record(self, trace_id: str, record_id: str) -> Record:
+        records = tuple(self.index.iter_records(trace_id))
         record = next(
             (
                 item
-                for item in self.index.iter_records(trace_id)
+                for item in (*records, *_project_timeline_records(records))
                 if item.record_id == record_id
             ),
             None,
@@ -110,7 +207,11 @@ class TraceRepository:
             record.span_id for record in records if record.span_id is not None
         )
         spans = tuple(self.get_span(trace_id, span_id).span for span_id in span_ids)
-        return TimelineView(trace_id=trace_id, records=records, spans=spans)
+        return TimelineView(
+            trace_id=trace_id,
+            records=_project_timeline_records(records),
+            spans=spans,
+        )
 
     def get_run(self, trace_id: str) -> RunSummary:
         records = tuple(self.index.iter_records(trace_id))
@@ -132,31 +233,45 @@ class TraceRepository:
     def get_span(self, trace_id: str, span_id: str) -> SpanDetail:
         trace_records = tuple(self.index.iter_records(trace_id))
         records = tuple(record for record in trace_records if record.span_id == span_id)
-        if not records:
+        first_record = next(iter(records), None)
+        if first_record is None:
             raise SpanNotFound(span_id)
-        terminal = len(records) > 1
+        span_type = first_record.kind.partition(".")[0]
+        if span_type == "agent":
+            terminal_record = next(
+                (
+                    record
+                    for record in reversed(records)
+                    if record.kind == "agent.finished"
+                ),
+                None,
+            )
+        else:
+            terminal_record = (
+                next(reversed(records), None) if len(records) > 1 else None
+            )
         parent_resolves = any(
-            record.span_id == records[0].parent_span_id for record in trace_records
+            record.span_id == first_record.parent_span_id for record in trace_records
         )
-        if records[0].parent_span_id is not None and not parent_resolves:
+        if first_record.parent_span_id is not None and not parent_resolves:
             relationship_status = RelationshipStatus.UNRESOLVED
-        elif records[0].provenance.kind is ProvenanceKind.DERIVED:
+        elif first_record.provenance.kind is ProvenanceKind.DERIVED:
             relationship_status = RelationshipStatus.INFERRED
         else:
             relationship_status = RelationshipStatus.VERIFIED
         span = Span(
             span_id=span_id,
             trace_id=trace_id,
-            span_type=records[0].kind.partition(".")[0],
-            name=str(records[0].payload.get("name", span_id)),
-            parent_span_id=records[0].parent_span_id,
-            agent_span_id=records[0].agent_span_id,
+            span_type=span_type,
+            name=str(first_record.payload.get("name", span_id)),
+            parent_span_id=first_record.parent_span_id,
+            agent_span_id=first_record.agent_span_id,
             relationship_status=relationship_status,
-            start_sequence=records[0].sequence or 1,
-            end_sequence=records[-1].sequence if terminal else None,
-            started_at=records[0].observed_at,
-            ended_at=records[-1].observed_at if terminal else None,
-            status="completed" if terminal else "incomplete",
+            start_sequence=first_record.sequence or 1,
+            end_sequence=terminal_record.sequence if terminal_record else None,
+            started_at=first_record.observed_at,
+            ended_at=terminal_record.observed_at if terminal_record else None,
+            status="completed" if terminal_record else "incomplete",
         )
         return SpanDetail(span=span, records=records)
 
@@ -191,14 +306,18 @@ class TraceRepository:
         )
         if target is None:
             raise TraceNotFound(trace_id)
-        completion = target.payload.get("completion")
-        if isinstance(completion, dict):
-            messages = completion.get("messages")
-            if isinstance(messages, list):
+        request = target.payload.get("request")
+        if not isinstance(request, dict):
+            request = target.payload.get("completion")
+        if isinstance(request, dict):
+            context_items = request.get("messages")
+            if not isinstance(context_items, list):
+                context_items = request.get("input")
+            if isinstance(context_items, list):
                 return ContextView(
                     record_id=record_id,
                     messages=tuple(
-                        message for message in messages if isinstance(message, dict)
+                        item for item in context_items if isinstance(item, dict)
                     ),
                     provenance=Provenance(),
                 )

--- a/agent-flight-recorder/src/flight_recorder/services/subscriptions.py
+++ b/agent-flight-recorder/src/flight_recorder/services/subscriptions.py
@@ -1,0 +1,88 @@
+"""Committed record subscription helpers."""
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from threading import Lock
+
+from flight_recorder.models.envelopes import CommittedBatch
+
+
+@dataclass
+class SubscriptionHandle:
+    _unsubscribe: Callable[[], None] | None
+
+    def unsubscribe(self) -> None:
+        if self._unsubscribe is not None:
+            unsubscribe = self._unsubscribe
+            self._unsubscribe = None
+            unsubscribe()
+
+
+@dataclass
+class _Subscriber:
+    trace_id: str
+    after_sequence: int
+    callback: Callable[[CommittedBatch], None]
+    active: bool = True
+
+
+class TraceSubscription:
+    def __init__(self, max_workers: int = 8) -> None:
+        self._subscribers: list[_Subscriber] = []
+        self._lock = Lock()
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="flight-recorder-subscription",
+        )
+        self._closed = False
+
+    def subscribe(
+        self,
+        trace_id: str,
+        after_sequence: int,
+        callback: Callable[[CommittedBatch], None],
+    ) -> SubscriptionHandle:
+        subscriber = _Subscriber(trace_id, after_sequence, callback)
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("subscription service is closed")
+            self._subscribers.append(subscriber)
+
+        def unsubscribe() -> None:
+            with self._lock:
+                subscriber.active = False
+
+        return SubscriptionHandle(unsubscribe)
+
+    def publish(self, batch: CommittedBatch) -> None:
+        with self._lock:
+            subscribers = [
+                subscriber
+                for subscriber in self._subscribers
+                if subscriber.active
+                and subscriber.trace_id == batch.trace_id
+                and batch.last_sequence > subscriber.after_sequence
+            ]
+            for subscriber in subscribers:
+                subscriber.after_sequence = batch.last_sequence
+        for subscriber in subscribers:
+            self._executor.submit(self._deliver, subscriber, batch)
+
+    @staticmethod
+    def _deliver(subscriber: _Subscriber, batch: CommittedBatch) -> None:
+        if not subscriber.active:
+            return
+        try:
+            subscriber.callback(batch)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            for subscriber in self._subscribers:
+                subscriber.active = False
+        self._executor.shutdown(wait=True)

--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -64,6 +64,17 @@ The server can be configured using environment variables or a JSON configuration
 | `OH_TELEMETRY_CONSENT_MODE` | `seed` (applies only while consent is `unset`) or `override` (wins over settings). | `seed` |
 | `OH_TELEMETRY_SALT` | Key used to pseudonymize conversation ids. Falls back to `OH_SECRET_KEY`, then to a per-process random salt. | None |
 | `OH_LOG_LLM_IO` | Set to `true` to write structured `llm_input` and `llm_output`/`llm_error` records to the application log and complete exchanges to `${LOG_DIR}/llm-io.jsonl`. Includes full prompt and response content; use only for local debugging. | `false` |
+| `OH_ENABLE_FLIGHT_RECORDER` | Record local web conversations and delegated subagents as portable `.afr` traces. Intended for local debugging. | `false` |
+
+Flight recording requires the `openhands-agent-server[flight-recorder]` optional
+extra. Repository development environments created with `make build` already
+include the workspace package.
+
+For local web development, start the frontend with
+`OH_ENABLE_FLIGHT_RECORDER=true` alongside `OH_AGENT_SERVER_LOCAL_PATH`. The
+newest trace for a conversation is available from
+`GET /api/conversations/{conversation_id}/flight-recorder`; the response provides
+the local bundle path and whether its event service is still active.
 | `DO_NOT_TRACK` | Set to `1` to force telemetry off, overriding consent and env. | Unset |
 
 ### Configuration File

--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -63,7 +63,7 @@ The server can be configured using environment variables or a JSON configuration
 | `OH_TELEMETRY_CONSENT` | `granted` or `denied`. Seeds or overrides the persisted consent value. | Unset |
 | `OH_TELEMETRY_CONSENT_MODE` | `seed` (applies only while consent is `unset`) or `override` (wins over settings). | `seed` |
 | `OH_TELEMETRY_SALT` | Key used to pseudonymize conversation ids. Falls back to `OH_SECRET_KEY`, then to a per-process random salt. | None |
-| `OH_LOG_LLM_IO` | Set to `true` to write paired `llm_input` and `llm_output`/`llm_error` records to agent-server logs. Includes full prompt and response content; use only for local debugging. | `false` |
+| `OH_LOG_LLM_IO` | Set to `true` to write structured `llm_input` and `llm_output`/`llm_error` records to the application log and complete exchanges to `${LOG_DIR}/llm-io.jsonl`. Includes full prompt and response content; use only for local debugging. | `false` |
 | `DO_NOT_TRACK` | Set to `1` to force telemetry off, overriding consent and env. | Unset |
 
 ### Configuration File
@@ -111,7 +111,7 @@ It is **disabled by default** and does nothing unless a deployment opts in.
 |---|---|---|
 | **Telemetry** (this section) | Allowlisted lifecycle/failure events. Never prompts, messages, file contents, paths, secrets, request/response bodies, or tracebacks. | PostHog, when configured |
 | **LLM completion logging** (`log_completions`) | Full prompts, responses, and raw provider payloads — deliberately high fidelity for debugging. | Local disk only |
-| **LLM I/O server logging** (`OH_LOG_LLM_IO=true`) | Full normalized prompts and responses, tool names, usage, cost, and latency. Omits transport kwargs and tool schemas, but message content may still contain sensitive data. | Agent-server application log |
+| **LLM I/O server logging** (`OH_LOG_LLM_IO=true`) | Full normalized prompts and responses, tool names, usage, cost, and latency. Omits transport kwargs, but message content and tool schemas may still contain sensitive data. | Native `llm_io` objects in the application log and one complete exchange per line in `${LOG_DIR}/llm-io.jsonl` |
 | **Laminar / OpenTelemetry tracing** | Distributed traces and spans for latency analysis. | Your OTel/Laminar backend |
 
 Nothing from completion logging or tracing is ever forwarded to telemetry.

--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -63,6 +63,7 @@ The server can be configured using environment variables or a JSON configuration
 | `OH_TELEMETRY_CONSENT` | `granted` or `denied`. Seeds or overrides the persisted consent value. | Unset |
 | `OH_TELEMETRY_CONSENT_MODE` | `seed` (applies only while consent is `unset`) or `override` (wins over settings). | `seed` |
 | `OH_TELEMETRY_SALT` | Key used to pseudonymize conversation ids. Falls back to `OH_SECRET_KEY`, then to a per-process random salt. | None |
+| `OH_LOG_LLM_IO` | Set to `true` to write paired `llm_input` and `llm_output`/`llm_error` records to agent-server logs. Includes full prompt and response content; use only for local debugging. | `false` |
 | `DO_NOT_TRACK` | Set to `1` to force telemetry off, overriding consent and env. | Unset |
 
 ### Configuration File
@@ -110,6 +111,7 @@ It is **disabled by default** and does nothing unless a deployment opts in.
 |---|---|---|
 | **Telemetry** (this section) | Allowlisted lifecycle/failure events. Never prompts, messages, file contents, paths, secrets, request/response bodies, or tracebacks. | PostHog, when configured |
 | **LLM completion logging** (`log_completions`) | Full prompts, responses, and raw provider payloads — deliberately high fidelity for debugging. | Local disk only |
+| **LLM I/O server logging** (`OH_LOG_LLM_IO=true`) | Full normalized prompts and responses, tool names, usage, cost, and latency. Omits transport kwargs and tool schemas, but message content may still contain sensitive data. | Agent-server application log |
 | **Laminar / OpenTelemetry tracing** | Distributed traces and spans for latency analysis. | Your OTel/Laminar backend |
 
 Nothing from completion logging or tracing is ever forwarded to telemetry.

--- a/openhands-agent-server/openhands/agent_server/__main__.py
+++ b/openhands-agent-server/openhands/agent_server/__main__.py
@@ -5,13 +5,15 @@ import importlib
 import os
 import signal
 import sys
+from pathlib import Path
 from types import FrameType
 
 import uvicorn
 from uvicorn import Config
 
+from openhands.agent_server.execution_environment import ExecutionEnvironmentTracker
 from openhands.agent_server.logging_config import LOGGING_CONFIG
-from openhands.sdk.logger import DEBUG, get_logger
+from openhands.sdk.logger import DEBUG, ENV_LOG_DIR, get_logger
 
 
 logger = get_logger(__name__)
@@ -179,6 +181,14 @@ class LoggingServer(uvicorn.Server):
     termination signals are received, ensuring visibility into why the
     server is shutting down.
     """
+
+    def run(self, sockets=None) -> None:
+        tracker = ExecutionEnvironmentTracker(Path(ENV_LOG_DIR))
+        tracker.start()
+        try:
+            super().run(sockets=sockets)
+        finally:
+            tracker.stop()
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
         """Handle exit signals with logging before delegating to parent."""

--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -67,6 +67,7 @@ PATHEX = [
     project_root / "openhands-sdk",
     project_root / "openhands-tools",
     project_root / "openhands-workspace",
+    project_root / "agent-flight-recorder" / "src",
 ]
 
 # Entry script for the agent server package (namespace: openhands/agent_server/__main__.py)
@@ -142,6 +143,7 @@ a = Analysis(
         *copy_metadata("openhands-sdk"),
         *copy_metadata("openhands-tools"),
         *copy_metadata("openhands-workspace"),
+        *copy_metadata("openhands-agent-flight-recorder"),
         *copy_metadata("fastmcp"),
         *copy_metadata("litellm"),
 
@@ -154,6 +156,7 @@ a = Analysis(
         *collect_submodules("openhands.tools"),
         *collect_submodules("openhands.workspace"),
         *collect_submodules("openhands.agent_server"),
+        *collect_submodules("flight_recorder"),
 
         # Third-party dynamic imports
         *collect_submodules("tiktoken"),

--- a/openhands-agent-server/openhands/agent_server/api.py.orig
+++ b/openhands-agent-server/openhands/agent_server/api.py.orig
@@ -40,9 +40,6 @@ from openhands.agent_server.dependencies import (
 from openhands.agent_server.desktop_router import desktop_router
 from openhands.agent_server.desktop_service import get_desktop_service
 from openhands.agent_server.event_router import event_router
-from openhands.agent_server.execution_environment import (
-    log_async_execution_environment,
-)
 from openhands.agent_server.file_router import file_router
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
@@ -160,7 +157,6 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
         _cleanup_stale_tmux_sessions()
 
         config: Config = api.state.config
-        log_async_execution_environment(max_concurrent_runs=config.max_concurrent_runs)
         deferred = config.deferred_init
 
         # Deferred pods boot with telemetry disabled and are rebuilt by

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -322,6 +322,13 @@ class Config(BaseModel):
         default=False,
         description="Whether to enable VNC desktop functionality",
     )
+    enable_flight_recorder: bool = Field(
+        default=False,
+        description=(
+            "Record each active local conversation as a portable Agent Flight "
+            "Recorder trace. Intended for local development and debugging."
+        ),
+    )
     preload_tools: bool = Field(
         default=True,
         description="Whether to preload tools",

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -32,6 +32,7 @@ from openhands.agent_server.models import (
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
+    FlightRecorderTraceInfo,
     ForkConversationRequest,
     NavigateConversationRequest,
     SendMessageRequest,
@@ -177,6 +178,21 @@ async def get_conversation_agent_final_response(
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     response = await event_service.get_agent_final_response()
     return AgentResponseResult(response=response)
+
+
+@conversation_router.get(
+    "/{conversation_id}/flight-recorder",
+    responses={404: {"description": "Flight recorder trace not found"}},
+)
+async def get_flight_recorder_trace(
+    conversation_id: UUID,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> FlightRecorderTraceInfo:
+    """Return the newest local flight-recorder trace for a conversation."""
+    info = await conversation_service.get_flight_recorder_info(conversation_id)
+    if info is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    return info
 
 
 @conversation_router.get("")

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -28,6 +28,7 @@ from openhands.agent_server.models import (
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
+    FlightRecorderTraceInfo,
     LaunchedAgentProfile,
     StartConversationRequest,
     StoredConversation,
@@ -640,6 +641,7 @@ class ConversationService:
     conversation_worktree_root: Path = field(
         default=Path("/tmp/conversation-worktrees")
     )
+    enable_flight_recorder: bool = False
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_records: dict[UUID, _ConversationRecord] = field(
         default_factory=dict, init=False
@@ -653,6 +655,9 @@ class ConversationService:
     _run_executor: ThreadPoolExecutor | None = field(default=None, init=False)
     _credential_bindings: dict[UUID, dict[str, VersionedCredentialBinding]] = field(
         default_factory=dict, init=False
+    )
+    _flight_recorder_merge_lock: asyncio.Lock = field(
+        default_factory=asyncio.Lock, init=False
     )
 
     def _load_catalog_sync(self) -> dict[UUID, _ConversationRecord]:
@@ -1794,6 +1799,97 @@ class ConversationService:
     async def get_event_service(self, conversation_id: UUID) -> EventService | None:
         return await self._get_or_load_event_service(conversation_id)
 
+    async def get_flight_recorder_info(
+        self, conversation_id: UUID
+    ) -> FlightRecorderTraceInfo | None:
+        root = await self._get_single_flight_recorder_info(conversation_id)
+        if root is None:
+            return None
+
+        descendants = []
+        pending = list(self._children_of(conversation_id))
+        while pending:
+            child_id = pending.pop(0)
+            child = await self._get_single_flight_recorder_info(child_id)
+            if child is not None:
+                descendants.append((child_id, child))
+            pending.extend(self._children_of(child_id))
+        if not descendants:
+            return root
+
+        async with self._flight_recorder_merge_lock:
+            from flight_recorder.services.bundles import (
+                BundleMergeSource,
+                BundleService,
+            )
+
+            info_by_conversation = {
+                conversation_id: root,
+                **dict(descendants),
+            }
+            root_title = self._conversation_records[conversation_id].stored.title
+            sources = [
+                BundleMergeSource(
+                    Path(root.bundle_path),
+                    agent_name=root_title or "Primary agent",
+                )
+            ]
+            for child_id, child in descendants:
+                parent_id = self._conversation_records[
+                    child_id
+                ].stored.parent_conversation_id
+                parent = info_by_conversation.get(parent_id) if parent_id else None
+                sources.append(
+                    BundleMergeSource(
+                        Path(child.bundle_path),
+                        parent_trace_id=parent.trace_id if parent else None,
+                        agent_name=(
+                            self._conversation_records[child_id].stored.title
+                            or "Child agent"
+                        ),
+                    )
+                )
+            destination = (
+                self.conversations_dir
+                / conversation_id.hex
+                / "flight-recorder"
+                / "orchestration.afr"
+            )
+            validation = await asyncio.to_thread(
+                BundleService().merge_bundles,
+                sources,
+                destination,
+            )
+        return FlightRecorderTraceInfo(
+            conversation_id=conversation_id,
+            trace_id=validation.trace_id,
+            bundle_path=str(destination.resolve()),
+            active=root.active or any(info.active for _, info in descendants),
+        )
+
+    async def _get_single_flight_recorder_info(
+        self, conversation_id: UUID
+    ) -> FlightRecorderTraceInfo | None:
+        if conversation_id not in self._conversation_records:
+            return None
+        event_services = self._event_services
+        if event_services is not None:
+            event_service = event_services.get(conversation_id)
+            if event_service is not None:
+                return event_service.get_flight_recorder_info()
+        path = (
+            self.conversations_dir
+            / conversation_id.hex
+            / "flight-recorder"
+            / "latest.json"
+        )
+        try:
+            return FlightRecorderTraceInfo.model_validate_json(
+                await asyncio.to_thread(path.read_text)
+            )
+        except (OSError, ValueError):
+            return None
+
     async def generate_conversation_title(
         self, conversation_id: UUID, max_length: int = 50, llm: LLM | None = None
     ) -> str | None:
@@ -2178,6 +2274,7 @@ class ConversationService:
             lease_ttl_seconds=config.lease_ttl_seconds,
             conversation_idle_ttl_seconds=config.conversation_idle_ttl_seconds,
             conversation_worktree_root=config.conversation_worktree_root,
+            enable_flight_recorder=config.enable_flight_recorder,
         )
 
     async def _start_event_service(
@@ -2206,6 +2303,7 @@ class ConversationService:
             credential_bindings=credential_bindings,
             owner_instance_id=self.owner_instance_id,
             lease_ttl_seconds=self.lease_ttl_seconds,
+            enable_flight_recorder=self.enable_flight_recorder,
         )
         # Lease renewal is handled by the centralized
         # _renew_all_leases_loop task on ConversationService.

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import os
 import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -83,9 +85,90 @@ LEASE_RENEW_INTERVAL_SECONDS = 15.0
 # Bounds initial-state push so subscribe_to_events does not stall on a
 # subscriber whose __call__ blocks (e.g. WS with a full TCP send buffer).
 INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
+LLM_IO_LOGGING_ENV = "OH_LOG_LLM_IO"
 
 
 logger = get_logger(__name__)
+
+
+def _llm_io_logging_enabled() -> bool:
+    return os.getenv(LLM_IO_LOGGING_ENV, "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _tool_names(tools: object) -> list[str]:
+    if not isinstance(tools, list):
+        return []
+    names: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def _log_llm_io(
+    *,
+    conversation_id: UUID,
+    usage_id: str,
+    model_name: str,
+    completion_id: str,
+    log_data: str,
+) -> None:
+    data = json.loads(log_data)
+    common = {
+        "conversation_id": str(conversation_id),
+        "usage_id": usage_id,
+        "model": model_name,
+        "completion_id": completion_id,
+        "api": data.get("llm_path", "chat_completions"),
+    }
+    llm_input = {
+        **common,
+        "messages": data.get("messages"),
+        "instructions": data.get("instructions"),
+        "input": data.get("input"),
+        "tool_names": _tool_names(data.get("tools")),
+    }
+    logger.info(
+        "llm_input %s",
+        json.dumps(llm_input, ensure_ascii=False, separators=(",", ":")),
+    )
+
+    if "error" in data:
+        error = data.get("error")
+        llm_error = {
+            **common,
+            "error": {
+                "type": error.get("type"),
+                "message": error.get("message"),
+            }
+            if isinstance(error, dict)
+            else error,
+            "latency_sec": data.get("latency_sec"),
+        }
+        logger.info(
+            "llm_error %s",
+            json.dumps(llm_error, ensure_ascii=False, separators=(",", ":")),
+        )
+        return
+
+    llm_output = {
+        **common,
+        "response": data.get("response"),
+        "usage": data.get("usage_summary"),
+        "cost": data.get("cost"),
+        "latency_sec": data.get("latency_sec"),
+    }
+    logger.info(
+        "llm_output %s",
+        json.dumps(llm_output, ensure_ascii=False, separators=(",", ":")),
+    )
 
 
 class CredentialBindingActivationTooLate(RuntimeError):
@@ -844,26 +927,46 @@ class EventService:
 
     def _setup_llm_log_streaming(self, agent: AgentBase) -> None:
         """Configure LLM log callbacks to stream logs via events."""
+        log_to_server = _llm_io_logging_enabled()
         for llm in agent.get_all_llms():
-            if not llm.log_completions:
+            log_to_events = llm.log_completions
+            if not log_to_events and not log_to_server:
                 continue
+
+            # Telemetry only captures request context when logging is enabled.
+            # The callback below owns the destination in agent-server mode.
+            llm.telemetry.log_enabled = True
 
             # Capture variables for closure
             usage_id = llm.usage_id
             model_name = llm.model
 
             def log_callback(
-                filename: str, log_data: str, uid=usage_id, model=model_name
+                filename: str,
+                log_data: str,
+                uid=usage_id,
+                model=model_name,
+                emit_event=log_to_events,
+                emit_server_log=log_to_server,
             ) -> None:
                 """Callback to emit LLM completion logs as events."""
                 try:
-                    event = LLMCompletionLogEvent(
-                        filename=filename,
-                        log_data=log_data,
-                        model_name=model,
-                        usage_id=uid,
-                    )
-                    self._emit_event_from_thread(event)
+                    if emit_server_log:
+                        _log_llm_io(
+                            conversation_id=self.stored.id,
+                            usage_id=uid,
+                            model_name=model,
+                            completion_id=filename,
+                            log_data=log_data,
+                        )
+                    if emit_event:
+                        event = LLMCompletionLogEvent(
+                            filename=filename,
+                            log_data=log_data,
+                            model_name=model,
+                            usage_id=uid,
+                        )
+                        self._emit_event_from_thread(event)
                 except Exception:
                     logger.exception("Failed to emit LLM completion log event")
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import os
@@ -9,7 +11,7 @@ from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
 from pydantic import ValidationError
@@ -23,6 +25,7 @@ from openhands.agent_server.models import (
     ConfirmationResponseRequest,
     EventPage,
     EventSortOrder,
+    FlightRecorderTraceInfo,
     StoredConversation,
 )
 from openhands.agent_server.pub_sub import PubSub, Subscriber
@@ -56,6 +59,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.conversation.types import ConversationCallbackType
 from openhands.sdk.credential import (
     CredentialBindingError,
     CredentialNeedsReauthentication,
@@ -93,6 +97,10 @@ _LLM_IO_FILE_LOCK = threading.Lock()
 
 
 logger = get_logger(__name__)
+
+
+if TYPE_CHECKING:
+    from flight_recorder.recorder import Recorder
 
 
 def _llm_io_logging_enabled() -> bool:
@@ -246,7 +254,12 @@ class EventService:
     )
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
+    enable_flight_recorder: bool = False
     _conversation: LocalConversation | None = field(default=None, init=False)
+    _flight_recorder: Recorder | None = field(default=None, init=False)
+    _flight_recorder_info: FlightRecorderTraceInfo | None = field(
+        default=None, init=False
+    )
     _pub_sub: PubSub[Event] = field(
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
     )
@@ -281,6 +294,70 @@ class EventService:
     @property
     def conversation_dir(self):
         return self.conversations_dir / self.stored.id.hex
+
+    @property
+    def flight_recorder_metadata_path(self) -> Path:
+        return self.conversation_dir / "flight-recorder" / "latest.json"
+
+    def get_flight_recorder_info(self) -> FlightRecorderTraceInfo | None:
+        if self._flight_recorder_info is not None:
+            return self._flight_recorder_info
+        try:
+            return FlightRecorderTraceInfo.model_validate_json(
+                self.flight_recorder_metadata_path.read_text()
+            )
+        except (OSError, ValueError):
+            return None
+
+    def _write_flight_recorder_info(self, *, active: bool) -> None:
+        info = self._flight_recorder_info
+        if info is None:
+            return
+        info = info.model_copy(update={"active": active})
+        self._flight_recorder_info = info
+        path = self.flight_recorder_metadata_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(path, info.model_dump_json())
+
+    def _start_flight_recorder(self) -> Recorder | None:
+        if not self.enable_flight_recorder:
+            return None
+        try:
+            from flight_recorder.models.database import TraceIndex
+            from flight_recorder.recorder import Recorder
+        except ImportError as exc:
+            raise RuntimeError(
+                "OH_ENABLE_FLIGHT_RECORDER requires the agent-server "
+                "flight-recorder extra"
+            ) from exc
+        trace_dir = self.conversation_dir / "flight-recorder"
+        bundle = trace_dir / f"{uuid4().hex}.afr"
+        index = TraceIndex(self.conversations_dir / ".flight-recorder" / "index.db")
+        recorder = Recorder(bundle, index)
+        self._flight_recorder = recorder
+        self._flight_recorder_info = FlightRecorderTraceInfo(
+            conversation_id=self.stored.id,
+            trace_id=recorder.trace_id,
+            bundle_path=str(bundle.resolve()),
+            active=True,
+        )
+        self._write_flight_recorder_info(active=True)
+        return recorder
+
+    def _close_flight_recorder(self) -> None:
+        recorder = self._flight_recorder
+        info = self._flight_recorder_info
+        if recorder is None or info is None:
+            return
+        recorder.close()
+        try:
+            from flight_recorder.services.bundles import BundleService
+
+            BundleService().finalize_bundle(Path(info.bundle_path))
+        except Exception:
+            logger.exception("Failed to finalize flight recorder trace")
+        self._flight_recorder = None
+        self._write_flight_recorder_info(active=False)
 
     async def load_meta(self):
         meta_file = self.conversation_dir / "meta.json"
@@ -1193,27 +1270,38 @@ class EventService:
                     reasoning_content=reasoning if isinstance(reasoning, str) else None,
                 )
 
-        conversation = LocalConversation(
-            agent=agent,
-            workspace=workspace,
-            plugins=self.stored.plugins,
-            persistence_dir=str(self.conversations_dir),
-            conversation_id=self.stored.id,
-            callbacks=[self._callback_wrapper],
-            token_callbacks=([_token_streaming_callback] if streaming_enabled else []),
-            max_iteration_per_run=self.stored.max_iterations,
-            stuck_detection=self.stored.stuck_detection,
-            visualizer=None,
-            secrets=self.stored.secrets,
-            cipher=self.cipher,
-            hook_config=self.stored.hook_config,
-            tags=self.stored.tags,
-            user_id=self.stored.user_id,
-            observability_metadata=self.stored.observability_metadata,
-            observability_tags=self.stored.observability_tags,
-            observability_span_name=self.stored.observability_span_name,
-            mcp_tool_provider=self.mcp_tool_provider,
-        )
+        recorder = self._start_flight_recorder()
+        assert self._callback_wrapper is not None
+        callbacks: list[ConversationCallbackType] = [self._callback_wrapper]
+        if recorder is not None:
+            callbacks.append(recorder)
+        try:
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=workspace,
+                plugins=self.stored.plugins,
+                persistence_dir=str(self.conversations_dir),
+                conversation_id=self.stored.id,
+                callbacks=callbacks,
+                token_callbacks=(
+                    [_token_streaming_callback] if streaming_enabled else []
+                ),
+                max_iteration_per_run=self.stored.max_iterations,
+                stuck_detection=self.stored.stuck_detection,
+                visualizer=None,
+                secrets=self.stored.secrets,
+                cipher=self.cipher,
+                hook_config=self.stored.hook_config,
+                tags=self.stored.tags,
+                user_id=self.stored.user_id,
+                observability_metadata=self.stored.observability_metadata,
+                observability_tags=self.stored.observability_tags,
+                observability_span_name=self.stored.observability_span_name,
+                mcp_tool_provider=self.mcp_tool_provider,
+            )
+        except Exception:
+            self._close_flight_recorder()
+            raise
 
         conversation.set_confirmation_policy(self.stored.confirmation_policy)
         conversation.set_security_analyzer(self.stored.security_analyzer)
@@ -1375,6 +1463,10 @@ class EventService:
                     # misleading non-error state.
                     await loop.run_in_executor(None, self._mark_error_status_sync)
                 finally:
+                    if self._flight_recorder is not None:
+                        self._flight_recorder.record_metrics(
+                            conversation.conversation_stats
+                        )
                     # Wait for all pending events to be published via
                     # AsyncCallbackWrapper before publishing the final state update.
                     # This prevents a race condition where the conversation status
@@ -1865,6 +1957,7 @@ class EventService:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self._conversation.close)
             self._conversation = None
+        await asyncio.to_thread(self._close_flight_recorder)
         self.credential_bindings = {}
 
         if self._lease is not None and self._lease_generation is not None:
@@ -1872,9 +1965,7 @@ class EventService:
         self._lease_generation = None
         self._lease = None
 
-    async def generate_title(
-        self, llm: "LLM | None" = None, max_length: int = 50
-    ) -> str:
+    async def generate_title(self, llm: LLM | None = None, max_length: int = 50) -> str:
         """Generate a title for the conversation.
 
         Resolves the provided LLM via the conversation's registry if a usage_id is

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1041,14 +1041,17 @@ class EventService:
     def _setup_llm_log_streaming(self, agent: AgentBase) -> None:
         """Configure LLM log callbacks to stream logs via events."""
         log_to_server = _llm_io_logging_enabled()
+        recorder = self._flight_recorder
         for llm in agent.get_all_llms():
             log_to_events = llm.log_completions
-            if not log_to_events and not log_to_server:
+            if not log_to_events and not log_to_server and recorder is None:
                 continue
 
             # Telemetry only captures request context when logging is enabled.
             # The callback below owns the destination in agent-server mode.
             llm.telemetry.log_enabled = True
+            if recorder is not None:
+                llm.telemetry.set_log_requests_callback(recorder.on_llm_request)
 
             # Capture variables for closure
             usage_id = llm.usage_id
@@ -1061,9 +1064,12 @@ class EventService:
                 model=model_name,
                 emit_event=log_to_events,
                 emit_server_log=log_to_server,
+                flight_recorder=recorder,
             ) -> None:
                 """Callback to emit LLM completion logs as events."""
                 try:
+                    if flight_recorder is not None:
+                        flight_recorder.on_completion_log(filename, log_data)
                     if emit_server_log:
                         _log_llm_io(
                             conversation_id=self.stored.id,

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import threading
 import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -72,6 +73,7 @@ from openhands.sdk.event.llm_completion_log import LLMCompletionLogEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.llm.streaming import LLMStreamChunk
+from openhands.sdk.logger import ENV_LOG_DIR
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
@@ -86,6 +88,8 @@ LEASE_RENEW_INTERVAL_SECONDS = 15.0
 # subscriber whose __call__ blocks (e.g. WS with a full TCP send buffer).
 INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
 LLM_IO_LOGGING_ENV = "OH_LOG_LLM_IO"
+LLM_IO_LOG_FILENAME = "llm-io.jsonl"
+_LLM_IO_FILE_LOCK = threading.Lock()
 
 
 logger = get_logger(__name__)
@@ -112,6 +116,16 @@ def _tool_names(tools: object) -> list[str]:
     return names
 
 
+def _write_llm_exchange(exchange: dict[str, object]) -> None:
+    """Append one complete, natively structured LLM exchange as JSON Lines."""
+    log_path = Path(ENV_LOG_DIR) / LLM_IO_LOG_FILENAME
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(exchange, ensure_ascii=False, separators=(",", ":"))
+    with _LLM_IO_FILE_LOCK, log_path.open("a", encoding="utf-8") as handle:
+        handle.write(serialized)
+        handle.write("\n")
+
+
 def _log_llm_io(
     *,
     conversation_id: UUID,
@@ -135,10 +149,15 @@ def _log_llm_io(
         "input": data.get("input"),
         "tool_names": _tool_names(data.get("tools")),
     }
-    logger.info(
-        "llm_input %s",
-        json.dumps(llm_input, ensure_ascii=False, separators=(",", ":")),
-    )
+    logger.info("llm_input", extra={"event": "llm_input", "llm_io": llm_input})
+
+    request = {
+        "messages": data.get("messages"),
+        "instructions": data.get("instructions"),
+        "input": data.get("input"),
+        "tools": data.get("tools"),
+        "tool_names": llm_input["tool_names"],
+    }
 
     if "error" in data:
         error = data.get("error")
@@ -152,9 +171,15 @@ def _log_llm_io(
             else error,
             "latency_sec": data.get("latency_sec"),
         }
-        logger.info(
-            "llm_error %s",
-            json.dumps(llm_error, ensure_ascii=False, separators=(",", ":")),
+        logger.info("llm_error", extra={"event": "llm_error", "llm_io": llm_error})
+        _write_llm_exchange(
+            {
+                "event": "llm_exchange",
+                **common,
+                "request": request,
+                "error": llm_error["error"],
+                "latency_sec": llm_error["latency_sec"],
+            }
         )
         return
 
@@ -165,9 +190,20 @@ def _log_llm_io(
         "cost": data.get("cost"),
         "latency_sec": data.get("latency_sec"),
     }
-    logger.info(
-        "llm_output %s",
-        json.dumps(llm_output, ensure_ascii=False, separators=(",", ":")),
+    logger.info("llm_output", extra={"event": "llm_output", "llm_io": llm_output})
+    _write_llm_exchange(
+        {
+            "event": "llm_exchange",
+            **common,
+            "request": request,
+            "result": {
+                "response": llm_output["response"],
+                "raw_response": data.get("raw_response"),
+                "usage": llm_output["usage"],
+                "cost": llm_output["cost"],
+                "latency_sec": llm_output["latency_sec"],
+            },
+        }
     )
 
 

--- a/openhands-agent-server/openhands/agent_server/execution_environment.py
+++ b/openhands-agent-server/openhands/agent_server/execution_environment.py
@@ -1,0 +1,168 @@
+"""Structured diagnostics for the agent-server execution environment."""
+
+import asyncio
+import logging
+import os
+import platform
+import sys
+import threading
+import traceback
+from collections.abc import Callable
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+from openhands.sdk.logger import ExecutionContextJsonFormatter
+
+
+_LOGGER_NAME = "openhands.execution_environment"
+_TRACKER_LOCK = threading.Lock()
+_active_tracker: "ExecutionEnvironmentTracker | None" = None
+
+
+def _thread_details(thread: threading.Thread) -> dict[str, Any]:
+    return {
+        "thread_id": thread.ident,
+        "native_thread_id": thread.native_id,
+        "thread_name": thread.name,
+        "thread_class": type(thread).__qualname__,
+        "daemon": thread.daemon,
+        "alive": thread.is_alive(),
+    }
+
+
+class ExecutionEnvironmentTracker:
+    """Write process topology and newly started threads to a dedicated log."""
+
+    def __init__(self, log_dir: str | Path) -> None:
+        self.log_path = Path(log_dir) / "execution-env.log"
+        self._logger = logging.getLogger(_LOGGER_NAME)
+        self._handler: TimedRotatingFileHandler | None = None
+        self._original_thread_start: Callable[..., Any] | None = None
+        self._wrapped_thread_start: Callable[..., Any] | None = None
+
+    def start(self) -> None:
+        global _active_tracker
+
+        with _TRACKER_LOCK:
+            if _active_tracker is not None:
+                raise RuntimeError("Execution environment tracking is already active")
+
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            handler = TimedRotatingFileHandler(
+                self.log_path,
+                when=os.getenv("LOG_ROTATE_WHEN", "midnight"),
+                backupCount=int(os.getenv("LOG_BACKUP_COUNT", "7")),
+                encoding="utf-8",
+            )
+            handler.setLevel(logging.INFO)
+            handler.setFormatter(
+                ExecutionContextJsonFormatter(
+                    fmt="%(asctime)s %(levelname)s %(name)s %(message)s"
+                )
+            )
+
+            self._logger.setLevel(logging.INFO)
+            self._logger.propagate = False
+            self._logger.addHandler(handler)
+            self._handler = handler
+
+            original_thread_start = threading.Thread.start
+
+            def wrapped_thread_start(thread: threading.Thread) -> None:
+                creation_stack = [
+                    {
+                        "filename": frame.filename,
+                        "line_number": frame.lineno,
+                        "function": frame.name,
+                        "source": frame.line,
+                    }
+                    for frame in traceback.extract_stack(limit=12)[:-1]
+                ]
+                original_thread_start(thread)
+                self._logger.info(
+                    "Thread started: %s",
+                    thread.name,
+                    extra={
+                        "event": "thread_started",
+                        "created_thread": _thread_details(thread),
+                        "creation_stack": creation_stack,
+                        "active_thread_count": threading.active_count(),
+                    },
+                )
+
+            self._original_thread_start = original_thread_start
+            self._wrapped_thread_start = wrapped_thread_start
+            setattr(threading.Thread, "start", wrapped_thread_start)
+            _active_tracker = self
+
+        self._logger.info(
+            "Execution environment tracking started",
+            extra={
+                "event": "execution_environment_started",
+                "parent_process_id": os.getppid(),
+                "python_version": platform.python_version(),
+                "python_implementation": platform.python_implementation(),
+                "python_executable": sys.executable,
+                "platform": platform.platform(),
+                "cpu_count": os.cpu_count(),
+                "uvicorn_worker_count": 1,
+                "active_threads": [
+                    _thread_details(thread) for thread in threading.enumerate()
+                ],
+            },
+        )
+
+    def log_async_environment(self, *, max_concurrent_runs: int) -> None:
+        """Record the live event loop and configured conversation executor."""
+        loop = asyncio.get_running_loop()
+        default_executor = getattr(loop, "_default_executor", None)
+        self._logger.info(
+            "Async execution environment initialized",
+            extra={
+                "event": "async_execution_environment_initialized",
+                "event_loop_id": id(loop),
+                "event_loop_class": type(loop).__qualname__,
+                "asyncio_task_count": len(asyncio.all_tasks(loop)),
+                "conversation_run_max_workers": max_concurrent_runs,
+                "default_executor_initialized": default_executor is not None,
+                "default_executor_max_workers": getattr(
+                    default_executor, "_max_workers", None
+                ),
+            },
+        )
+
+    def stop(self) -> None:
+        global _active_tracker
+
+        with _TRACKER_LOCK:
+            if _active_tracker is not self:
+                return
+            if (
+                self._original_thread_start is not None
+                and threading.Thread.start is self._wrapped_thread_start
+            ):
+                setattr(threading.Thread, "start", self._original_thread_start)
+            _active_tracker = None
+
+        self._logger.info(
+            "Execution environment tracking stopped",
+            extra={
+                "event": "execution_environment_stopped",
+                "active_threads": [
+                    _thread_details(thread) for thread in threading.enumerate()
+                ],
+            },
+        )
+
+        if self._handler is not None:
+            self._logger.removeHandler(self._handler)
+            self._handler.close()
+            self._handler = None
+
+
+def log_async_execution_environment(*, max_concurrent_runs: int) -> None:
+    """Add event-loop details when tracking was enabled by the server entry point."""
+    tracker = _active_tracker
+    if tracker is not None:
+        tracker.log_async_environment(max_concurrent_runs=max_concurrent_runs)

--- a/openhands-agent-server/openhands/agent_server/logging_config.py
+++ b/openhands-agent-server/openhands/agent_server/logging_config.py
@@ -3,12 +3,15 @@
 import logging
 from typing import Any
 
-from pythonjsonlogger.json import JsonFormatter
+from openhands.sdk.logger import (
+    ENV_JSON,
+    ENV_LOG_LEVEL,
+    IN_CI,
+    ExecutionContextJsonFormatter,
+)
 
-from openhands.sdk.logger import ENV_JSON, ENV_LOG_LEVEL, IN_CI
 
-
-class UvicornAccessJsonFormatter(JsonFormatter):
+class UvicornAccessJsonFormatter(ExecutionContextJsonFormatter):
     """JSON formatter for uvicorn access logs that extracts HTTP fields.
 
     Uvicorn access logs pass structured data in record.args as a tuple:

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -74,6 +74,13 @@ class EventSortOrder(StrEnum):
     TIMESTAMP_DESC = "TIMESTAMP_DESC"
 
 
+class FlightRecorderTraceInfo(BaseModel):
+    conversation_id: UUID
+    trace_id: str
+    bundle_path: str
+    active: bool
+
+
 class StoredConversation(ConversationConfig):
     """Stored details about a conversation.
 

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -350,12 +350,26 @@ async def events_socket(
                 data = await websocket.receive_json()
                 if _is_auth_control_message(data):
                     logger.debug(
-                        "ignoring redundant auth control frame: %s",
+                        "websocket_auth_control_received channel=conversation "
+                        "conversation_id=%s redundant=true",
                         conversation_id,
                     )
                     continue
-                logger.info(f"Received message: {conversation_id}")
                 message = Message.model_validate(data)
+                content_types = sorted(
+                    {
+                        getattr(content, "type", type(content).__name__)
+                        for content in message.content
+                    }
+                )
+                logger.info(
+                    "websocket_message_received conversation_id=%s role=%s "
+                    "content_part_count=%d content_types=%s run=true",
+                    conversation_id,
+                    message.role,
+                    len(message.content),
+                    content_types,
+                )
                 await event_service.send_message(message, True)
             except WebSocketDisconnect:
                 logger.info("Event websocket disconnected")
@@ -447,9 +461,18 @@ async def bash_events_socket(
                 # Keep the connection alive and handle any incoming messages
                 data = await websocket.receive_json()
                 if _is_auth_control_message(data):
+                    logger.debug(
+                        "websocket_auth_control_received channel=bash redundant=true"
+                    )
                     continue
-                logger.info("Received bash request")
                 request = ExecuteBashRequest.model_validate(data)
+                logger.info(
+                    "bash_websocket_request_received command_length=%d "
+                    "has_cwd=%s timeout=%d",
+                    len(request.command),
+                    request.cwd is not None,
+                    request.timeout,
+                )
                 await bash_service.start_bash_command(request)
             except WebSocketDisconnect:
                 logger.info("Bash websocket disconnected")

--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+flight-recorder = ["openhands-agent-flight-recorder"]
 # Product-analytics exporter. Optional on purpose: the core server and every
 # library/headless consumer must be able to run without a vendor analytics SDK
 # on the import path. Pinned to the major already resolved in uv.lock (6.7.7,

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -4,6 +4,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from pydantic import PrivateAttr, ValidationError, model_validator
@@ -573,19 +574,65 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         conversation: LocalConversation,
         action_events: list[ActionEvent],
         on_event: ConversationCallbackType,
+        *,
+        emit_actions: bool = False,
     ) -> None:
         """Prepare a batch, emit results, and handle finish."""
         state = conversation.state
-        batch = _ActionBatch.prepare(
-            action_events,
-            state=state,
-            executor=self._parallel_executor,
-            tool_runner=lambda ae: self._execute_action_event(conversation, ae),
-            tools=self.tools_map,
-            cancel_token=conversation.cancel_token,
-            span_owner=conversation,
-        )
-        batch.emit(conversation, on_event)
+        action_events, has_finish = _ActionBatch._truncate_at_finish(action_events)
+
+        def tool_runner(action_event: ActionEvent) -> list[Event]:
+            return self._execute_action_event(conversation, action_event)
+
+        if self.tool_concurrency_limit == 1:
+            blocked_reasons = {}
+            results_by_id = {}
+            emitted_actions = []
+            for action_event in action_events:
+                if emit_actions:
+                    action_event = action_event.model_copy(
+                        update={"timestamp": datetime.now().isoformat()}
+                    )
+                    on_event(action_event)
+                emitted_actions.append(action_event)
+                item = _ActionBatch.prepare(
+                    [action_event],
+                    state=state,
+                    executor=self._parallel_executor,
+                    tool_runner=tool_runner,
+                    tools=self.tools_map,
+                    cancel_token=conversation.cancel_token,
+                    span_owner=conversation,
+                )
+                item.emit(conversation, on_event)
+                blocked_reasons.update(item.blocked_reasons)
+                results_by_id.update(item.results_by_id)
+            batch = _ActionBatch(
+                action_events=emitted_actions,
+                has_finish=has_finish,
+                blocked_reasons=blocked_reasons,
+                results_by_id=results_by_id,
+            )
+        else:
+            if emit_actions:
+                action_events = [
+                    action_event.model_copy(
+                        update={"timestamp": datetime.now().isoformat()}
+                    )
+                    for action_event in action_events
+                ]
+                for action_event in action_events:
+                    on_event(action_event)
+            batch = _ActionBatch.prepare(
+                action_events,
+                state=state,
+                executor=self._parallel_executor,
+                tool_runner=tool_runner,
+                tools=self.tools_map,
+                cancel_token=conversation.cancel_token,
+                span_owner=conversation,
+            )
+            batch.emit(conversation, on_event)
         batch.finalize(
             on_event=on_event,
             check_iterative_refinement=lambda ae: (
@@ -603,6 +650,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         conversation: LocalConversation,
         action_events: list[ActionEvent],
         on_event: ConversationCallbackType,
+        *,
+        emit_actions: bool = False,
     ) -> None:
         """Async variant of :meth:`_execute_actions`.
 
@@ -611,16 +660,60 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         loop an ``await`` boundary between every tool invocation.
         """
         state = conversation.state
-        batch = await _ActionBatch.aprepare(
-            action_events,
-            state=state,
-            executor=self._parallel_executor,
-            tool_runner=lambda ae: self._execute_action_event(conversation, ae),
-            tools=self.tools_map,
-            cancel_token=conversation.cancel_token,
-            span_owner=conversation,
-        )
-        batch.emit(conversation, on_event)
+        action_events, has_finish = _ActionBatch._truncate_at_finish(action_events)
+
+        def tool_runner(action_event: ActionEvent) -> list[Event]:
+            return self._execute_action_event(conversation, action_event)
+
+        if self.tool_concurrency_limit == 1:
+            blocked_reasons = {}
+            results_by_id = {}
+            emitted_actions = []
+            for action_event in action_events:
+                if emit_actions:
+                    action_event = action_event.model_copy(
+                        update={"timestamp": datetime.now().isoformat()}
+                    )
+                    on_event(action_event)
+                emitted_actions.append(action_event)
+                item = await _ActionBatch.aprepare(
+                    [action_event],
+                    state=state,
+                    executor=self._parallel_executor,
+                    tool_runner=tool_runner,
+                    tools=self.tools_map,
+                    cancel_token=conversation.cancel_token,
+                    span_owner=conversation,
+                )
+                item.emit(conversation, on_event)
+                blocked_reasons.update(item.blocked_reasons)
+                results_by_id.update(item.results_by_id)
+            batch = _ActionBatch(
+                action_events=emitted_actions,
+                has_finish=has_finish,
+                blocked_reasons=blocked_reasons,
+                results_by_id=results_by_id,
+            )
+        else:
+            if emit_actions:
+                action_events = [
+                    action_event.model_copy(
+                        update={"timestamp": datetime.now().isoformat()}
+                    )
+                    for action_event in action_events
+                ]
+                for action_event in action_events:
+                    on_event(action_event)
+            batch = await _ActionBatch.aprepare(
+                action_events,
+                state=state,
+                executor=self._parallel_executor,
+                tool_runner=tool_runner,
+                tools=self.tools_map,
+                cancel_token=conversation.cancel_token,
+                span_owner=conversation,
+            )
+            batch.emit(conversation, on_event)
         batch.finalize(
             on_event=on_event,
             check_iterative_refinement=lambda ae: (
@@ -1338,7 +1431,6 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                     update={"critic_result": critic_result}
                 )
 
-        on_event(action_event)
         return action_event
 
     def _execute_action_event(

--- a/openhands-sdk/openhands/sdk/agent/response_dispatch.py
+++ b/openhands-sdk/openhands/sdk/agent/response_dispatch.py
@@ -113,6 +113,8 @@ class ResponseDispatchMixin:
             conversation: LocalConversation,
             action_events: list[ActionEvent],
             on_event: ConversationCallbackType,
+            *,
+            emit_actions: bool = False,
         ) -> None: ...
 
         async def _aexecute_actions(
@@ -120,6 +122,8 @@ class ResponseDispatchMixin:
             conversation: LocalConversation,
             action_events: list[ActionEvent],
             on_event: ConversationCallbackType,
+            *,
+            emit_actions: bool = False,
         ) -> None: ...
 
         def _requires_user_confirmation(
@@ -178,10 +182,14 @@ class ResponseDispatchMixin:
             action_events.append(action_event)
 
         if self._requires_user_confirmation(state, action_events):
+            for action_event in action_events:
+                on_event(action_event)
             return
 
         if action_events:
-            self._execute_actions(conversation, action_events, on_event)
+            self._execute_actions(
+                conversation, action_events, on_event, emit_actions=True
+            )
 
         self._maybe_emit_vllm_tokens(llm_response, on_event)
 
@@ -228,10 +236,14 @@ class ResponseDispatchMixin:
             action_events.append(action_event)
 
         if self._requires_user_confirmation(state, action_events):
+            for action_event in action_events:
+                on_event(action_event)
             return
 
         if action_events:
-            await self._aexecute_actions(conversation, action_events, on_event)
+            await self._aexecute_actions(
+                conversation, action_events, on_event, emit_actions=True
+            )
 
         self._maybe_emit_vllm_tokens(llm_response, on_event)
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -29,6 +29,7 @@ from openhands.sdk.conversation.types import (
     ConversationID,
     ConversationTokenCallbackType,
     StuckDetectionThresholds,
+    SubagentEventCallback,
     TraceMetadataValue,
 )
 from openhands.sdk.conversation.visualizer import (
@@ -183,6 +184,7 @@ class LocalConversation(BaseConversation):
     _visualizer: ConversationVisualizerBase | None
     _on_event: ConversationCallbackType
     _on_token: ConversationTokenCallbackType | None
+    _external_callbacks: tuple[ConversationCallbackType, ...]
     max_iteration_per_run: int
     _stuck_detector: StuckDetector | None
     llm_registry: LLMRegistry
@@ -424,6 +426,7 @@ class LocalConversation(BaseConversation):
                 self._state.last_user_message_id = e.id
 
         callback_list = list(callbacks) if callbacks else []
+        self._external_callbacks = tuple(callback_list)
         composed_list = callback_list + [_default_callback]
         # Handle visualization configuration
         if isinstance(visualizer, ConversationVisualizerBase):
@@ -2541,6 +2544,33 @@ class LocalConversation(BaseConversation):
         with self._state:
             self._state.confirmation_policy = policy
         logger.info(f"Confirmation policy set to: {policy}")
+
+    def create_subagent_callbacks(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> list[SubagentEventCallback]:
+        callbacks = []
+        for callback in self._external_callbacks:
+            if not isinstance(callback, SubagentEventCallback):
+                continue
+            try:
+                callbacks.append(
+                    callback.for_subagent(
+                        task_id=task_id,
+                        subagent_type=subagent_type,
+                        description=description,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Subagent observer setup failed for task %s",
+                    task_id,
+                    exc_info=True,
+                )
+        return callbacks
 
     def set_token_callbacks(
         self, token_callbacks: list[ConversationTokenCallbackType] | None

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import re
 import uuid
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, BeforeValidator, Field
 
@@ -9,8 +11,37 @@ from openhands.sdk.event.base import Event
 from openhands.sdk.llm.streaming import TokenCallbackType
 
 
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.conversation_stats import ConversationStats
+
+
 ConversationCallbackType = Callable[[Event], None]
 """Type alias for event callback functions."""
+
+
+@runtime_checkable
+class SubagentEventCallback(Protocol):
+    """Event callback that opts into delegated conversation observation."""
+
+    def __call__(self, event: Event) -> None: ...
+
+    def for_subagent(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> SubagentEventCallback: ...
+
+    def finish_subagent(
+        self,
+        *,
+        status: str,
+        result: str | None,
+        error: str | None,
+        stats: ConversationStats,
+    ) -> None: ...
+
 
 ConversationTokenCallbackType = TokenCallbackType
 """Callback type invoked for streaming LLM deltas."""

--- a/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
@@ -288,8 +288,8 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
         self._console = _create_console()
         self._skip_user_messages = skip_user_messages
         self._highlight_patterns = highlight_regex or {}
-        # Previous ActionEvent's response id; used by ``_claim_batch_primary``
-        # to spot parallel tool-call siblings (#4189).
+        # Previous ActionEvent's response id; non-action events do not disturb it,
+        # so sequential action/result pairs still share one metrics primary (#4189).
         self._last_action_response_id: str | None = None
 
     def on_event(self, event: Event) -> None:
@@ -420,8 +420,8 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
         Parallel tool calls share one ``llm_response_id`` and one per-request
         ``TokenUsage``; showing it under every sibling reads as N separate
         requests (#4189), so only the first "claims" the per-request numbers.
-        Stateful -- call once per event in render order. Batches render
-        consecutively, so tracking the previous response id is enough (O(1)).
+        Stateful -- call once per event in render order. Non-action events do not
+        change the tracked response id, so tracking the previous action is enough.
         """
         if not isinstance(event, ActionEvent):
             return True

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -719,7 +719,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         # Azure default version
         if model_val.startswith("azure") and not d.get("api_version"):
-            d["api_version"] = "2024-12-01-preview"
+            d["api_version"] = "2025-03-01-preview"
 
         # Fix base_url for direct OpenAI - API expects /v1 suffix
         # If base_url is "https://api.openai.com", set to None to use LiteLLM default

--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -44,8 +44,12 @@ class Telemetry(BaseModel):
 
     # --- Runtime fields (not serialized) ---
     _req_start: float = PrivateAttr(default=0.0)
+    _req_id: str | None = PrivateAttr(default=None)
     _req_ctx: dict[str, Any] = PrivateAttr(default_factory=dict)
     _last_latency: float = PrivateAttr(default=0.0)
+    _log_requests_callback: Callable[[str, str], None] | None = PrivateAttr(
+        default=None
+    )
     _log_completions_callback: Callable[[str, str], None] | None = PrivateAttr(
         default=None
     )
@@ -56,6 +60,12 @@ class Telemetry(BaseModel):
     )
 
     # ---------- Lifecycle ----------
+    def set_log_requests_callback(
+        self, callback: Callable[[str, str], None] | None
+    ) -> None:
+        """Set a callback for request payloads immediately before transport."""
+        self._log_requests_callback = callback
+
     def set_log_completions_callback(
         self, callback: Callable[[str, str], None] | None
     ) -> None:
@@ -78,7 +88,22 @@ class Telemetry(BaseModel):
 
     def on_request(self, telemetry_ctx: dict | None) -> None:
         self._req_start = time.time()
+        self._req_id = str(uuid.uuid4())
         self._req_ctx = telemetry_ctx or {}
+        if self._log_requests_callback is None:
+            return
+        try:
+            data = {
+                **self._req_ctx,
+                "llm_call_id": self._req_id,
+                "timestamp": self._req_start,
+            }
+            self._log_requests_callback(
+                self._req_id,
+                json.dumps(data, default=_safe_json, ensure_ascii=False),
+            )
+        except Exception as exc:
+            warnings.warn(f"Telemetry request logging failed: {exc}")
 
     def on_response(
         self,
@@ -142,6 +167,7 @@ class Telemetry(BaseModel):
             )
 
             data = self._req_ctx.copy()
+            data["llm_call_id"] = self._req_id
             data["error"] = {
                 "type": type(_err).__name__,
                 "message": str(_err),
@@ -309,6 +335,7 @@ class Telemetry(BaseModel):
             )
 
             data = self._req_ctx.copy()
+            data["llm_call_id"] = self._req_id
             data["response"] = (
                 resp  # ModelResponse | ResponsesAPIResponse;
                 # serialized via _safe_json

--- a/openhands-sdk/openhands/sdk/logger/__init__.py
+++ b/openhands-sdk/openhands/sdk/logger/__init__.py
@@ -4,6 +4,7 @@ from .logger import (
     ENV_LOG_DIR,
     ENV_LOG_LEVEL,
     IN_CI,
+    ExecutionContextJsonFormatter,
     get_logger,
     setup_logging,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "ENV_JSON",
     "ENV_LOG_LEVEL",
     "ENV_LOG_DIR",
+    "ExecutionContextJsonFormatter",
     "IN_CI",
     "rolling_log_view",
 ]

--- a/openhands-sdk/openhands/sdk/logger/logger.py
+++ b/openhands-sdk/openhands/sdk/logger/logger.py
@@ -9,9 +9,11 @@ Usage:
     logger.info("Hello from this module!")
 """
 
+import asyncio
 import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
+from typing import Any
 
 import litellm
 from pythonjsonlogger.json import JsonFormatter
@@ -51,6 +53,30 @@ ENV_RICH_TRACEBACKS = os.getenv("LOG_RICH_TRACEBACKS", "true").lower() in {
 
 ENV_AUTO_CONFIG = os.getenv("LOG_AUTO_CONFIG", "true").lower() in {"1", "true", "yes"}
 ENV_DEBUG_LLM = os.getenv("DEBUG_LLM", "false").lower() in {"1", "true", "yes"}
+
+
+class ExecutionContextJsonFormatter(JsonFormatter):
+    """Add process, thread, and asyncio task identity to structured logs."""
+
+    def add_fields(
+        self,
+        log_data: dict[str, Any],
+        record: logging.LogRecord,
+        message_dict: dict[str, Any],
+    ) -> None:
+        super().add_fields(log_data, record, message_dict)
+        log_data["process_id"] = record.process
+        log_data["process_name"] = record.processName
+        log_data["thread_id"] = record.thread
+        log_data["thread_name"] = record.threadName
+
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
+        if task is not None:
+            log_data["task_id"] = id(task)
+            log_data["task_name"] = task.get_name()
 
 
 # ========= LiteLLM controls =========
@@ -123,7 +149,7 @@ def setup_logging(
             ch = logging.StreamHandler()
             ch.setLevel(lvl)
             ch.setFormatter(
-                JsonFormatter(
+                ExecutionContextJsonFormatter(
                     fmt="%(asctime)s %(levelname)s %(name)s "
                     "%(filename)s %(lineno)d %(message)s"
                 )
@@ -151,7 +177,7 @@ def setup_logging(
         fh.setLevel(lvl)
         if ENV_JSON:
             fh.setFormatter(
-                JsonFormatter(
+                ExecutionContextJsonFormatter(
                     fmt="%(asctime)s %(levelname)s %(name)s "
                     "%(filename)s %(lineno)d %(message)s"
                 )

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -28,7 +28,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
-from openhands.sdk.conversation.types import TraceMetadataValue
+from openhands.sdk.conversation.types import SubagentEventCallback, TraceMetadataValue
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks.config import HookConfig
 from openhands.sdk.logger import get_logger
@@ -103,6 +103,7 @@ class TaskManager:
         self._confirmation_handler = confirmation_handler
 
         self._tasks: dict[str, Task] = {}
+        self._subagent_callbacks: dict[str, tuple[SubagentEventCallback, ...]] = {}
         self._tasks_lock = threading.Lock()
 
         # Set once in _ensure_parent: uses the parent's subagents dir
@@ -213,12 +214,19 @@ class TaskManager:
             worker_agent = self._get_sub_agent_from_factory(factory)
             conversation_id = self._tasks[resume].conversation_id
             with detached_delegate_context() as link:
+                callbacks = self.parent_conversation.create_subagent_callbacks(
+                    task_id=resume,
+                    subagent_type=subagent_type,
+                    description=None,
+                )
+                self._subagent_callbacks[resume] = tuple(callbacks)
                 conversation = LocalConversation(
                     agent=worker_agent,
                     workspace=self.parent_conversation.state.workspace.working_dir,
                     persistence_dir=self._persistence_dir,
                     conversation_id=conversation_id,
                     hook_config=factory.definition.hooks,
+                    callbacks=list(callbacks),
                     delete_on_close=True,
                     observability_metadata=self._delegate_observability_metadata(
                         task_id=resume, subagent_type=subagent_type, link=link
@@ -312,6 +320,12 @@ class TaskManager:
             visualizer = parent_visualizer.create_sub_visualizer(label)
 
         with detached_delegate_context() as link:
+            callbacks = parent.create_subagent_callbacks(
+                task_id=task_id,
+                subagent_type=subagent_type,
+                description=description,
+            )
+            self._subagent_callbacks[task_id] = tuple(callbacks)
             return LocalConversation(
                 agent=worker_agent,
                 workspace=parent.state.workspace.working_dir,
@@ -321,6 +335,7 @@ class TaskManager:
                 max_iteration_per_run=max_iteration_per_run,
                 max_budget_per_run=max_budget_per_run,
                 hook_config=hook_config,
+                callbacks=list(callbacks),
                 delete_on_close=True,
                 prompt_cache_key=str(parent.state.id),
                 observability_metadata=self._delegate_observability_metadata(
@@ -405,10 +420,31 @@ class TaskManager:
             task.set_error(str(e))
             logger.warning(f"Task {task.id} failed with error: {e}")
         finally:
+            self._finish_subagent_callbacks(task)
             self._update_parent_metrics(parent, task)
             self._evict_task(task)
 
         return task
+
+    def _finish_subagent_callbacks(self, task: Task) -> None:
+        with self._tasks_lock:
+            callbacks = self._subagent_callbacks.pop(task.id, ())
+        if task.conversation is None:
+            return
+        for callback in callbacks:
+            try:
+                callback.finish_subagent(
+                    status=task.status.value,
+                    result=task.result,
+                    error=task.error,
+                    stats=task.conversation.conversation_stats,
+                )
+            except Exception:
+                logger.warning(
+                    "Subagent observer cleanup failed for task %s",
+                    task.id,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _run_stop_detail(
@@ -494,3 +530,4 @@ class TaskManager:
 
         with self._tasks_lock:
             self._tasks.clear()
+            self._subagent_callbacks.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # UV workspace configuration
 [tool.uv.workspace]
-members = ["openhands-sdk", "openhands-tools", "openhands-workspace", "openhands-agent-server"]
+members = ["openhands-sdk", "openhands-tools", "openhands-workspace", "openhands-agent-server", "agent-flight-recorder"]
 
 # Security: Apply workspace-wide dependency guardrails.
 [tool.uv]
@@ -24,6 +24,7 @@ openhands-sdk = { workspace = true }
 openhands-tools = { workspace = true }
 openhands-workspace = { workspace = true }
 openhands-agent-server = { workspace = true }
+openhands-agent-flight-recorder = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -39,6 +40,7 @@ dev = [
     "pytest-asyncio>=1.1.0",
     "pytest-forked>=1.6.0",
     "pytest-xdist>=3.6.0",
+    "pytest-qt>=4.5.0",
     "tabulate>=0.9.0",
     "pyinstaller>=6.16.0",
     "streamlit>=1.49.1",
@@ -112,13 +114,15 @@ include = [
     "openhands-agent-server",
     "examples",
     "tests",
-    "scripts"
+    "scripts",
+    "agent-flight-recorder",
 ]
 extraPaths = [
     "openhands-sdk",
     "openhands-tools",
     "openhands-workspace",
-    "openhands-agent-server"
+    "openhands-agent-server",
+    "agent-flight-recorder/src"
 ]
 venvPath = "."
 venv = ".venv"

--- a/scripts/record_coding_delegation.py
+++ b/scripts/record_coding_delegation.py
@@ -28,6 +28,9 @@ def run(recorder: Recorder) -> int:
         base_url=os.environ.get("LLM_BASE_URL"),
         usage_id="primary-agent",
     )
+    llm.telemetry.log_enabled = True
+    llm.telemetry.set_log_requests_callback(recorder.on_llm_request)
+    llm.telemetry.set_log_completions_callback(recorder.on_completion_log)
     agent = Agent(
         llm=llm,
         tools=[

--- a/scripts/record_coding_delegation.py
+++ b/scripts/record_coding_delegation.py
@@ -1,0 +1,56 @@
+"""Record a live delegated coding run for Agent Flight Recorder."""
+
+import os
+from pathlib import Path
+
+from flight_recorder.recorder import Recorder
+
+from openhands.sdk import LLM, Agent, Conversation, Tool
+from openhands.sdk.conversation import get_agent_final_response
+from openhands.tools import register_builtins_agents
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.task import TaskToolSet
+from openhands.tools.task_tracker import TaskTrackerTool
+from openhands.tools.terminal import TerminalTool
+
+
+def run(recorder: Recorder) -> int:
+    prompt = os.environ.get("AFR_PROMPT")
+    if not prompt:
+        raise ValueError("AFR_PROMPT must contain the implementation request")
+    workspace = Path(os.environ.get("AFR_WORKSPACE", os.getcwd())).resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    register_builtins_agents(enable_browser=False)
+    llm = LLM(
+        model=os.environ.get("LLM_MODEL", "gpt-5.5"),
+        api_key=os.environ.get("LLM_API_KEY"),
+        base_url=os.environ.get("LLM_BASE_URL"),
+        usage_id="primary-agent",
+    )
+    agent = Agent(
+        llm=llm,
+        tools=[
+            Tool(name=TaskToolSet.name),
+            Tool(name=TerminalTool.name),
+            Tool(name=FileEditorTool.name),
+            Tool(name=TaskTrackerTool.name),
+        ],
+        tool_concurrency_limit=2,
+    )
+    conversation = Conversation(
+        agent=agent,
+        workspace=workspace,
+        callbacks=[recorder],
+        visualizer=None,
+    )
+    try:
+        conversation.send_message(prompt)
+        conversation.run()
+        recorder.record_metrics(conversation.conversation_stats)
+        result = get_agent_final_response(conversation.state.events)
+        if result:
+            print(result)
+    finally:
+        conversation.close()
+    return 0

--- a/specs/001-agent-flight-recorder/checklists/requirements.md
+++ b/specs/001-agent-flight-recorder/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Agent Flight Recorder
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on the first review.
+- No clarification markers remain.

--- a/specs/001-agent-flight-recorder/contracts/python-services.md
+++ b/specs/001-agent-flight-recorder/contracts/python-services.md
@@ -1,0 +1,136 @@
+# Contract: Python Recorder and Application Services
+
+## Principles
+
+- Public callbacks return quickly and never raise into OpenHands.
+- Domain services contain no Qt imports.
+- Query and diagnostic services do not control an observed conversation.
+- Returned view models are immutable snapshots.
+- Missing records, invalid bundles, and unavailable traces use typed failures.
+
+## Recorder
+
+```python
+class Recorder(Protocol):
+    @property
+    def trace_id(self) -> str: ...
+
+    def on_event(self, event: Event) -> None: ...
+    def on_completion_log(self, filename: str, log_data: str) -> None: ...
+    def record_metrics(self, stats: ConversationStats) -> None: ...
+    def close(self) -> None: ...
+```
+
+`on_event`, `on_completion_log`, and `record_metrics` normalize and attempt a
+non-blocking enqueue. They contain recorder errors and expose them later as recorder
+warnings/counters. `close` requests a bounded flush and is idempotent.
+
+## TraceRepository
+
+```python
+class TraceRepository(Protocol):
+    def list_runs(self, query: RunQuery) -> list[RunSummary]: ...
+    def get_run(self, trace_id: str) -> RunDetail: ...
+    def get_timeline(self, trace_id: str) -> TimelineView: ...
+    def get_span(self, trace_id: str, span_id: str) -> SpanDetail: ...
+    def iter_records(
+        self, trace_id: str, after_sequence: int = 0
+    ) -> Iterable[Record]: ...
+    def get_findings(self, trace_id: str) -> list[Finding]: ...
+    def get_workspace_changes(
+        self, trace_id: str, span_id: str | None = None
+    ) -> list[Artifact]: ...
+```
+
+Ordering is deterministic. `iter_records` returns records with sequence strictly
+greater than `after_sequence`. Unknown record kinds appear as generic activities.
+Missing trace/span identities raise `TraceNotFound`/`SpanNotFound`.
+
+## BundleService
+
+```python
+class BundleService(Protocol):
+    def validate_bundle(self, source: Path) -> BundleValidation: ...
+    def import_bundle(self, source: Path) -> str: ...
+    def export_bundle(self, trace_id: str, destination: Path) -> Path: ...
+```
+
+Validation performs no index mutation. Import validates first, is idempotent by
+trace and record identity, builds a fresh index transactionally, and returns the
+trace ID. Export finalizes counts and checksums before atomically placing the result.
+Invalid input raises `InvalidBundle` with a machine-readable code and source path.
+
+## TraceSubscription
+
+```python
+class TraceSubscription(Protocol):
+    def subscribe(
+        self,
+        trace_id: str,
+        after_sequence: int,
+        callback: Callable[[CommittedBatch], None],
+    ) -> SubscriptionHandle: ...
+```
+
+Only durably committed batches are published. Delivery may repeat, so consumers use
+record identity and sequence for idempotency. A handle supports idempotent
+`unsubscribe()`. Slow subscribers cannot block the collector.
+
+## DiagnosticService
+
+```python
+class DiagnosticService(Protocol):
+    def analyze(
+        self, trace_id: str, include_interpretive: bool = False
+    ) -> list[Finding]: ...
+```
+
+Deterministic rules always run. Interpretive analysis is optional and receives a
+bounded immutable evidence packet. All returned findings pass the same schema and
+evidence-resolution checks before storage or display. Analyzer failure returns a
+typed diagnostic failure while existing traces and deterministic findings remain
+available.
+
+## SelectionController
+
+```python
+class SelectionController(Protocol):
+    def select_record(self, record_id: str) -> None: ...
+    def select_span(self, span_id: str) -> None: ...
+    def current_selection(self) -> Selection: ...
+```
+
+The Qt implementation emits one canonical selection change. Tree, timeline,
+inspector, findings, and workspace views subscribe to it and must not create
+circular updates.
+
+## Command Contract
+
+```text
+agent-flight-recorder [TRACE]
+agent-flight-recorder record --output DESTINATION TARGET
+agent-flight-recorder validate TRACE
+agent-flight-recorder import TRACE
+agent-flight-recorder export TRACE_ID DESTINATION
+```
+
+With no subcommand, the desktop application opens and optionally selects `TRACE`.
+`record` runs a supported local target with recording attached and writes an active
+bundle to `DESTINATION`. `validate` performs headless bundle validation and exits 0
+for valid, 1 for invalid, and 2 for invocation errors. Import prints the trace ID.
+Export prints the resulting bundle path. Errors go to stderr; successful
+machine-readable values go to stdout.
+
+## Typed Failures
+
+| Failure | Meaning |
+| --- | --- |
+| `TraceNotFound` | Trace ID is absent from the index |
+| `SpanNotFound` | Span ID is absent from the trace |
+| `InvalidBundle` | Portable contract or integrity validation failed |
+| `UnsupportedFormat` | Bundle major version is unsupported |
+| `RecorderClosed` | Producer attempted capture after close |
+| `DiagnosticFailure` | Analysis failed without affecting trace access |
+
+Recorder callback methods contain these failures. User-initiated service and command
+operations surface them explicitly.

--- a/specs/001-agent-flight-recorder/contracts/trace-bundle.md
+++ b/specs/001-agent-flight-recorder/contracts/trace-bundle.md
@@ -1,0 +1,104 @@
+# Contract: Agent Flight Recorder Trace Bundle
+
+## Purpose
+
+The bundle is the portable, canonical representation of one recorded run. Readers
+must be able to validate and replay it without the originating SQLite index.
+
+## Names and Layout
+
+An active bundle is a directory named `<trace_id>.afr`. A finalized bundle may be
+the same directory or `<trace_id>.afr.zip` with this internal layout:
+
+```text
+<trace_id>.afr/
+├── manifest.json
+├── records.jsonl
+├── findings.jsonl
+├── content/
+│   └── <sha256>.<media-suffix>.zst
+└── checksums.sha256
+```
+
+ZIP entries use forward slashes and paths relative to the bundle root. Importers
+reject absolute paths, parent traversal, duplicate entries, and unsupported entry
+types.
+
+## Manifest
+
+Required fields:
+
+| Field | Active | Finalized | Contract |
+| --- | --- | --- | --- |
+| `format` | required | required | Literal `agent-flight-recorder` |
+| `format_version` | required | required | Positive major version |
+| `trace_id` | required | required | Matches directory identity and all records |
+| `created_at` | required | required | ISO 8601 timestamp |
+| `completed_at` | optional | required | ISO 8601 terminal timestamp |
+| `status` | required | required | Recorded run status |
+| `stop_reason` | optional | required | Required for terminal status |
+| `recorder_version` | required | required | Semantic version |
+| `record_count` | optional | required | Number of valid record lines |
+| `finding_count` | optional | required | Number of valid finding lines |
+| `content_encoding` | required | required | `zstd` for compressed blobs |
+
+Finalization writes a temporary manifest and atomically replaces the prior file.
+Adding findings invalidates final counts and checksums until finalization runs again.
+
+## Record Stream
+
+`records.jsonl` is UTF-8 append-only JSON Lines. Each complete line:
+
+- validates as a Record from [the data model](../data-model.md#record);
+- ends with a newline;
+- has a unique `record_id`;
+- has a `sequence` strictly greater than the preceding complete line;
+- carries the manifest `trace_id`;
+- preserves unknown fields and record kinds.
+
+A truncated final line caused by a crash is ignored and reported as a
+`recorder.warning`. Invalid complete lines fail import and identify their line
+number. Re-importing an existing `record_id` does not create another record.
+
+## Findings Stream
+
+`findings.jsonl` is UTF-8 JSON Lines. Every finding validates against
+[the Finding model](../data-model.md#finding). Each evidence and affected-span ID
+must resolve within the same bundle. Invalid findings are rejected without changing
+the record stream.
+
+## Content Objects
+
+`content_ref` uses `sha256:<digest>`. The corresponding filename begins with the
+same digest. Readers decompress the object, hash the uncompressed bytes, and reject
+a mismatch. Multiple records may reference one object. Unreferenced objects may be
+reported but do not invalidate replay.
+
+## Checksums
+
+A finalized `checksums.sha256` lists the SHA-256 digest and relative path of the
+manifest, both JSONL files, and every content object. Paths are sorted
+lexicographically. The checksum file does not list itself. Import validates all
+listed entries and rejects missing, duplicate, or mismatched entries.
+
+## Compatibility
+
+- Readers reject unsupported `format_version` major values.
+- Readers ignore unknown object fields and retain them on round trip.
+- Readers retain unknown record kinds as generic activities.
+- Writers emit only the current format version.
+- Schema migrations transform imported records before indexing but do not rewrite
+  the source bundle unless the user explicitly exports a new bundle.
+
+## Replay Guarantees
+
+For a valid bundle, export followed by import preserves:
+
+1. Record identity and sequence order.
+2. Span lifecycle and relationship status.
+3. Model-call correlation and aggregate usage.
+4. Artifact associations.
+5. Finding identity and evidence links.
+6. Explicit provenance and uncertainty.
+
+SQLite files are never part of the contract and may always be reconstructed.

--- a/specs/001-agent-flight-recorder/data-model.md
+++ b/specs/001-agent-flight-recorder/data-model.md
@@ -1,0 +1,225 @@
+# Data Model: Agent Flight Recorder
+
+## Model Rules
+
+- The `.afr` bundle is authoritative; SQLite is a disposable projection.
+- `record_id` is immutable and unique within a trace.
+- `sequence` is assigned by the collector and strictly increases within a trace.
+- Source timestamps describe occurrence time; sequence determines replay order.
+- `monotonic_ns` is valid only for durations from the same producer.
+- Unknown record kinds and fields are preserved during import and export.
+- Every derived object retains the record or span IDs from which it was produced.
+
+## Trace
+
+Represents one observed OpenHands run.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `trace_id` | UUID string | Stable bundle identity |
+| `format_version` | positive integer | Major incompatibility requires reader rejection |
+| `status` | RunStatus | Follows the state machine below |
+| `started_at` | timestamp | Required after recording starts |
+| `completed_at` | timestamp or null | Required for terminal states |
+| `stop_reason` | StopReason or null | Required for terminal states |
+| `repository_identity` | string or null | Descriptive only |
+| `recorder_version` | semantic version | Required |
+| `record_count` | non-negative integer | Finalized traces only |
+| `finding_count` | non-negative integer | Finalized traces only |
+| `total_usage` | UsageTotals | Derived from correlated metrics |
+| `integrity_state` | IntegrityState | `active`, `verified`, `incomplete`, or `invalid` |
+
+### Run state transitions
+
+```text
+created -> running -> completed
+                   -> failed
+                   -> interrupted
+                   -> paused -> running
+```
+
+Only `paused` may transition back to `running`. A terminal state requires both
+`completed_at` and `stop_reason`. A stale `running` trace discovered after process
+restart becomes `incomplete` for display but retains its last recorded run status.
+
+## Span
+
+Represents a duration-based activity projected from one or more records.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `span_id` | UUID string | Stable within trace |
+| `trace_id` | UUID string | Must identify owning trace |
+| `parent_span_id` | UUID string or null | Must resolve or carry unresolved status |
+| `agent_span_id` | UUID string or null | Owning swimlane; required for agent work |
+| `span_type` | SpanType | `run`, `agent`, `iteration`, `llm`, `tool`, `test`, `delegation`, `condensation`, `evaluation` |
+| `name` | string | Non-empty display name |
+| `relationship_status` | RelationshipStatus | `verified`, `inferred`, or `unresolved` |
+| `start_sequence` | positive integer | References starting record |
+| `end_sequence` | positive integer or null | Null means incomplete |
+| `started_at` | timestamp | Required |
+| `ended_at` | timestamp or null | Must not precede start |
+| `status` | SpanStatus | `running`, `completed`, `failed`, `interrupted`, or `incomplete` |
+| `attributes` | object | Kind-specific searchable metadata |
+
+Starting and terminal records use the same `span_id`. Instantaneous activities may
+use a containing span without creating a new duration span.
+
+## Record
+
+Immutable observed or recorder-generated activity.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `schema_version` | positive integer | Required |
+| `record_id` | UUID string | Unique in bundle |
+| `producer_id` | string | Stable for one recorder process |
+| `trace_id` | UUID string | Must match bundle trace |
+| `span_id` | UUID string or null | Owning or represented span |
+| `parent_span_id` | UUID string or null | Preserves hierarchy |
+| `agent_span_id` | UUID string or null | Denormalized lane identity |
+| `sequence` | positive integer | Strictly increasing and unique per trace |
+| `observed_at` | timestamp | Recorder observation time |
+| `source_timestamp` | timestamp or null | Original event time |
+| `monotonic_ns` | non-negative integer or null | Same-producer duration only |
+| `kind` | string | Known or preserved unknown kind |
+| `openhands_event_id` | string or null | Source event correlation |
+| `llm_response_id` | string or null | Model/metrics correlation |
+| `payload` | object | Kind-specific data |
+| `content_ref` | ContentRef or null | Large payload reference |
+| `provenance` | Provenance | Captured, reconstructed, derived, or interpreted |
+
+Known lifecycle pairs are:
+
+| Span | Start | Terminal |
+| --- | --- | --- |
+| Run | `run.started` | `run.finished` |
+| Agent | `agent.started` | `agent.finished` |
+| Iteration | `iteration.started` | `iteration.finished` |
+| LLM | `llm.request` | `llm.response` or `llm.error` |
+| Tool | `tool.request` | `tool.result` or `tool.error` |
+| Test | `test.started` | `test.finished` |
+| Delegation | `delegation.started` | `delegation.finished` |
+
+## Provenance
+
+Distinguishes facts from projections and interpretation.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `kind` | enum | `captured`, `reconstructed`, `derived`, or `interpreted` |
+| `source_ids` | list of IDs | Required for non-captured data |
+| `description` | string or null | Explains reconstruction or derivation |
+| `complete` | boolean | False when evidence is known to be missing |
+
+Authoritative completion-log requests use `captured`. Context projected from
+conversation events uses `reconstructed` and identifies contributing event IDs.
+
+## CondensationPayload
+
+Payload for `context.condensed`.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `forgotten_event_ids` | unique list of strings | Required; may be empty |
+| `summary` | string or null | Preserves SDK value |
+| `summary_offset` | integer or null | Non-negative when present |
+| `llm_response_id` | string | Required |
+
+The context view resolves forgotten event IDs to records when possible and exposes
+unresolved IDs rather than dropping them.
+
+## LLMCall
+
+Queryable projection joining request, response, and metrics records.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `span_id` | UUID string | Primary identity |
+| `usage_id` | string | Identifies configured LLM usage |
+| `response_id` | string or null | Primary correlation key when available |
+| `model` | string | Required |
+| `request_record_id` | UUID string | Required |
+| `response_record_id` | UUID string or null | Null while incomplete |
+| `context_provenance` | Provenance | Exact or reconstructed status |
+| `finish_reason` | string or null | Preserved provider value |
+| `usage` | TokenUsage | Non-negative counts |
+| `cost` | decimal or null | Must be non-negative |
+| `latency_ms` | non-negative number or null | Derived from telemetry |
+| `retry_count` | non-negative integer | Defaults to zero |
+
+## TokenUsage and UsageTotals
+
+Contains prompt, completion, cache-read, cache-write, reasoning, and total tokens.
+Per-call usage may also include context-window size. Counts are non-negative. Trace,
+agent, and span totals are derived only from correlated per-call metrics to prevent
+double counting.
+
+## Artifact
+
+Represents an output or workspace change associated with activity.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `artifact_id` | UUID string | Unique within trace |
+| `trace_id` | UUID string | Required |
+| `span_id` | UUID string or null | Producing span when known |
+| `kind` | string | Examples: `workspace.diff`, `test.result`, `file` |
+| `path` | string or null | Slash-normalized when present |
+| `content_hash` | SHA-256 or null | Content identity |
+| `size` | non-negative integer or null | Bytes when applicable |
+| `created_sequence` | positive integer | Links artifact to replay order |
+| `content_ref` | ContentRef or null | Optional payload |
+
+A workspace-diff record may project to one or more artifacts; the source record
+remains authoritative.
+
+## ContentRef
+
+A string of the form `sha256:<64 lowercase hexadecimal characters>`. The importer
+verifies the digest after decompression. Content files must remain below the bundle's
+`content/` directory and use a supported media suffix.
+
+## Finding
+
+Evidence-backed diagnostic output.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `finding_id` | UUID string | Unique within trace |
+| `trace_id` | UUID string | Required |
+| `origin` | enum | `rule` or `model` |
+| `detector_id` | string | Required |
+| `category` | enum | `loop`, `context`, `delegation`, `tool`, `cost`, `termination` |
+| `severity` | enum | `info`, `warning`, or `error` |
+| `confidence` | number | Inclusive range 0 through 1 |
+| `title` | string | Non-empty |
+| `explanation` | string | Non-empty |
+| `recommendation` | string | Non-empty |
+| `evidence_ids` | unique list of IDs | At least one; every ID must resolve |
+| `affected_span_ids` | unique list of span IDs | Every ID must resolve |
+| `created_at` | timestamp | Required |
+
+Findings with missing evidence are rejected. Finding records use `derived` or
+`interpreted` provenance according to origin.
+
+## CommittedBatch
+
+Notification unit delivered after durable append and index commit.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `trace_id` | UUID string | Required |
+| `first_sequence` | positive integer | First included record |
+| `last_sequence` | positive integer | At least `first_sequence` |
+| `record_ids` | ordered list of UUID strings | Must match inclusive batch order |
+
+Subscribers may resume with the last processed sequence. Repeated batch delivery is
+safe because record identity is idempotent.
+
+## SQLite Projection
+
+The index contains `runs`, `spans`, `records`, `llm_calls`, `artifacts`, `findings`,
+and `content_blobs`. It enforces unique `(trace_id, sequence)` and `record_id`, indexes
+parent/agent span IDs and common filters, and can be deleted and rebuilt from the
+bundle without loss of authoritative data.

--- a/specs/001-agent-flight-recorder/plan.md
+++ b/specs/001-agent-flight-recorder/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Agent Flight Recorder
+
+**Branch**: `001-agent-flight-recorder` | **Date**: 2026-09-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/001-agent-flight-recorder/spec.md`
+
+**Note**: This plan covers research and design. Implementation tasks are generated separately by `/speckit-tasks`.
+
+## Summary
+
+Build a local desktop recorder and trace viewer for OpenHands runs. An in-process
+adapter converts SDK events, completion logs, and metrics into immutable versioned
+records, then hands them to a bounded queue. A single background collector assigns
+canonical sequence numbers and appends records to a portable `.afr` bundle while
+maintaining a rebuildable SQLite query index. UI-agnostic services project those
+records into trace trees, agent swimlanes, context comparisons, and evidence-backed
+findings consumed by a PySide6 desktop application.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+
+**Primary Dependencies**: `openhands-sdk`, PySide6, Pydantic 2, zstandard,
+platformdirs; Python standard-library `sqlite3`, `json`, `zipfile`, `hashlib`,
+`queue`, and `threading`
+
+**Storage**: Versioned `.afr` directory/ZIP bundle as source of truth; SQLite in
+WAL mode as a local, rebuildable query index; content-addressed compressed blobs
+for large payloads
+
+**Testing**: pytest, pytest-qt with `QT_QPA_PLATFORM=offscreen`, seeded trace
+fixtures, integration replay tests, and focused performance benchmarks
+
+**Target Platform**: Linux desktop first; Windows and macOS after trace and GUI
+contracts stabilize
+
+**Project Type**: Distributable Python package with recorder library, CLI
+validation commands, and native desktop application
+
+**Performance Goals**: Less than 5% median run overhead with token streaming
+disabled; callback p99 below 50 ms; committed records visible within 500 ms p95;
+100,000-record overview interactive within 3 seconds; indexed selection updates
+within 100 ms p95
+
+**Constraints**: Recording cannot influence the observed run; callbacks perform no
+database or network I/O; memory remains bounded; capture is deterministic;
+diagnosis reads only committed records; SQLite, decompression, analysis, and bundle
+import never execute on the GUI thread
+
+**Scale/Scope**: One local developer and one local OpenHands run per trace in the
+first release; traces up to 100,000 records; local conversations first, with the
+data model retaining producer and lineage fields needed for later remote and
+multi-process support
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Observe Without Influence — PASS**: SDK callbacks only normalize and enqueue;
+  queue overflow and collector errors become recorder warnings. No recorder path
+  invokes conversation control APIs or changes run state.
+- **Facts Before Interpretation — PASS**: The append-only record is authoritative.
+  Derived spans, projections, and findings retain evidence IDs and explicit
+  provenance or relationship confidence.
+- **Capture and Diagnosis Stay Separate — PASS**: Deterministic capture and storage
+  have no dependency on diagnostics. Rules and optional interpretation consume
+  committed records through read-only services and cannot access workspace tools.
+- **Enduring Boundaries — PASS**: The product observes existing runs and does not
+  replace conversation persistence or launch, pause, resume, or stop agents.
+
+**Post-design re-check**: PASS. The data model encodes provenance and uncertainty;
+the service contracts keep capture, querying, diagnosis, and Qt presentation
+separate; bundle import reconstructs an index rather than replacing OpenHands state.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-agent-flight-recorder/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── python-services.md
+│   └── trace-bundle.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+agent-flight-recorder/
+├── AGENTS.md
+├── pyproject.toml
+├── README.md
+└── src/flight_recorder/
+    ├── __init__.py
+    ├── __main__.py
+    ├── app.py
+    ├── adapter/
+    │   ├── conversation.py
+    │   ├── llm.py
+    │   └── propagation.py
+    ├── collector/
+    │   ├── normalize.py
+    │   ├── persistence.py
+    │   └── queue.py
+    ├── diagnostics/
+    │   ├── analyzer.py
+    │   ├── rules.py
+    │   └── schemas.py
+    ├── models/
+    │   ├── database.py
+    │   ├── envelopes.py
+    │   └── view_models.py
+    ├── services/
+    │   ├── bundles.py
+    │   ├── diagnostics.py
+    │   ├── repository.py
+    │   └── subscriptions.py
+    ├── gui/
+    │   ├── controllers/
+    │   ├── inspector/
+    │   ├── models/
+    │   ├── timeline/
+    │   ├── main_window.py
+    │   └── workers.py
+    └── cli.py
+
+tests/agent_flight_recorder/
+├── unit/
+├── integration/
+├── gui/
+├── e2e/
+├── performance/
+└── fixtures/traces/
+```
+
+**Structure Decision**: Extend the existing `agent-flight-recorder/` design
+directory into an independent `src`-layout workspace package. Keep capture,
+storage, diagnostics, services, and GUI as explicit boundaries. Mirror the package
+under the repository-level `tests/agent_flight_recorder/` domain, consistent with
+the monorepo test organization. Add the package to the root uv workspace, but keep
+PySide6 and recorder-specific dependencies in its package metadata.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/001-agent-flight-recorder/quickstart.md
+++ b/specs/001-agent-flight-recorder/quickstart.md
@@ -1,0 +1,147 @@
+# Quickstart Validation: Agent Flight Recorder
+
+This guide validates the repository implementation before packaging or release.
+
+## Prerequisites
+
+- Linux desktop or Linux CI runner
+- Python 3.12 or newer
+- `uv` compatible with the repository
+- Repository dependencies configured with `make build`
+- A test LLM configuration for live recording, or the checked-in deterministic
+  conversation fixture
+
+For headless GUI checks, set `QT_QPA_PLATFORM=offscreen`.
+
+## 1. Validate the Package
+
+From the repository root:
+
+```bash
+make build
+uv run pre-commit run --files \
+  $(find agent-flight-recorder tests/agent_flight_recorder -type f)
+uv run pytest tests/agent_flight_recorder
+```
+
+Expected outcome:
+
+- Package imports resolve from the uv workspace.
+- Static checks pass.
+- Model, lifecycle, queue, SQLite, bundle, collector, diagnostic, and GUI
+  tests pass.
+
+## 2. Inspect the Current CLI
+
+From the repository root:
+
+```bash
+uv run agent-flight-recorder --help
+uv run agent-flight-recorder validate --help
+```
+
+Expected outcome:
+
+- The executable resolves from the workspace package.
+- The `record`, `validate`, `import`, and `export` commands are listed.
+
+## 3. Validate Bundle Behavior
+
+```bash
+uv run pytest \
+  tests/agent_flight_recorder/unit/test_bundle_primitives.py \
+  tests/agent_flight_recorder/integration/test_bundle_roundtrip.py
+```
+
+Expected outcome:
+
+- Unsupported formats and unsafe ZIP paths are rejected.
+- A truncated final JSONL record is ignored.
+- Repeated imports do not duplicate indexed records.
+- Content checksums are deterministic.
+
+## 4. Validate Failure Isolation and Collection
+
+```bash
+uv run pytest \
+  tests/agent_flight_recorder/integration/test_failure_isolation.py \
+  tests/agent_flight_recorder/unit/test_queue.py \
+  tests/agent_flight_recorder/unit/test_collector.py
+```
+
+Expected outcome:
+
+- Invalid callback data does not escape into the observed run.
+- Queue pressure discards stream deltas before lifecycle records.
+- The collector assigns canonical sequence numbers and publishes committed batches.
+
+## 5. Open the Current Desktop Shell
+
+```bash
+uv run agent-flight-recorder
+```
+
+Expected outcome:
+
+- A native desktop window opens without starting a browser or local server.
+- The three-panel trace workspace shell is visible.
+- Close the window to end the command.
+
+For automated headless verification:
+
+```bash
+QT_QPA_PLATFORM=offscreen uv run pytest tests/agent_flight_recorder/gui
+```
+
+## 6. Validate Investigation Workflows
+
+```bash
+QT_QPA_PLATFORM=offscreen uv run pytest \
+  tests/agent_flight_recorder/e2e \
+  tests/agent_flight_recorder/integration/test_diagnostic_quality.py
+```
+
+Expected outcome:
+
+- Recorded bundles replay with preserved usage.
+- Context, condensation, delegation, and finding evidence are navigable.
+- Every deterministic detector meets the labeled-corpus quality threshold.
+
+## 7. Validate Performance Targets
+
+```bash
+QT_QPA_PLATFORM=offscreen uv run pytest \
+  tests/agent_flight_recorder/performance/test_performance_targets.py
+```
+
+To generate a portable 100,000-record fixture manually:
+
+```bash
+uv run python \
+  tests/agent_flight_recorder/fixtures/generate_large_trace.py \
+  /tmp/large-trace.afr
+```
+
+## 8. Build The Linux Application
+
+```bash
+uv run pyinstaller agent-flight-recorder/agent-flight-recorder.spec
+```
+
+Expected outcome: `dist/agent-flight-recorder` is created.
+
+On headless Linux, smoke-test the binary with:
+
+```bash
+QT_QPA_PLATFORM=offscreen ./dist/agent-flight-recorder --help
+```
+
+PyInstaller may warn about unresolved Qt XCB libraries on a headless build host.
+Native X11 launch requires the distribution packages providing `libxcb-cursor`,
+`libxcb-keysyms`, `libxcb-render-util`, `libxcb-xkb`, and `libxkbcommon-x11`.
+
+## Contract References
+
+- [Data model](data-model.md)
+- [Portable trace bundle](contracts/trace-bundle.md)
+- [Python and command services](contracts/python-services.md)

--- a/specs/001-agent-flight-recorder/research.md
+++ b/specs/001-agent-flight-recorder/research.md
@@ -1,0 +1,212 @@
+# Phase 0 Research: Agent Flight Recorder
+
+## Package and Runtime Boundary
+
+**Decision**: Develop `agent-flight-recorder/` as a uv workspace member named
+`openhands-agent-flight-recorder`, versioned initially at `0.1.0`, with a
+`src/flight_recorder` import package and Python 3.12 minimum.
+
+**Rationale**: The recorder is independently distributable and has large desktop
+runtime dependencies that do not belong in the SDK. Python 3.12 matches the SDK's
+minimum. A `src` layout prevents accidental imports from the checkout, while the
+existing design already establishes `flight_recorder` as the import namespace.
+
+**Alternatives considered**:
+
+- Add recorder modules to `openhands-sdk`: rejected because GUI and persistence
+  dependencies would expand the core SDK and blur product boundaries.
+- Use `openhands.agent_flight_recorder`: consistent with other monorepo packages,
+  but rejected for the first release because the approved design uses a standalone
+  package and entry point. This can only change before public release.
+- Keep the recorder outside the uv workspace: rejected because it would bypass the
+  repository's lockfile, build, lint, and test workflow.
+
+## OpenHands Event Capture
+
+**Decision**: Attach a lightweight callable through
+`LocalConversation(callbacks=[recorder.on_event])`. Convert each `Event` into a
+producer record using `id`, `timestamp`, `source`, `parent_id`, discriminated event
+type, and serialized payload. Never read conversation state from inside this
+callback.
+
+**Rationale**: `ConversationCallbackType` is `Callable[[Event], None]` and is the
+stable event observation surface. Local conversation callbacks run while state is
+locked and before default persistence, so blocking or re-entering state would risk
+influencing the observed run.
+
+**Alternatives considered**:
+
+- Poll `conversation.state.events`: rejected because it introduces ordering races
+  and misses the callback's authoritative observation point.
+- Modify the agent loop to emit recorder records: rejected because recording would
+  control or couple to the observed execution.
+
+## LLM Requests, Responses, and Metrics
+
+**Decision**: Register a completion-log callback on each observed LLM telemetry
+instance and parse its `(filename, log_data)` JSON as the authoritative provider-call
+record. Correlate it with actions and metrics through response IDs and `usage_id`.
+Use `ConversationStats` snapshots outside event callbacks to capture accumulated and
+per-call token, cost, latency, cache, context-window, and reasoning-token counts.
+
+**Rationale**: Conversation events do not contain the final provider request after
+projection, merging, tool-schema insertion, and condensation. Completion telemetry
+is therefore the only exact request source. `ActionEvent.llm_response_id`, metrics
+`response_id`, and `LLMCompletionLogEvent` identifiers provide explicit correlation.
+
+**Alternatives considered**:
+
+- Reconstruct every request from conversation events: retained only as a clearly
+  labeled fallback because it cannot be authoritative.
+- Persist streaming chunks individually: rejected by default because they increase
+  volume without improving durable replay; the completed response is authoritative.
+
+## Condensation
+
+**Decision**: Normalize each SDK `Condensation` into one `context.condensed` record
+containing forgotten event IDs, summary, summary offset, and producing LLM response
+ID. The context service applies these recorded facts to build before/after views.
+
+**Rationale**: These SDK fields directly encode what was removed and inserted, so
+no semantic guess is needed.
+
+**Alternatives considered**:
+
+- Diff projected contexts only: rejected because it loses the SDK's explicit
+  forgotten-event identity and can misattribute unrelated context changes.
+
+## Agent and Delegation Lineage
+
+**Decision**: Preserve SDK event `parent_id` exactly and assign recorder
+`parent_span_id`, `agent_span_id`, and a relationship status of `verified`,
+`inferred`, or `unresolved`. The first release supports one local process. Trace
+context propagation across delegated conversations is a later compatible extension.
+
+**Rationale**: Explicit relationship status satisfies the requirement not to present
+inference as fact. Deferring multi-process collection keeps the first collector's
+sequence ordering unambiguous.
+
+**Alternatives considered**:
+
+- Infer all lineage from timestamps and names: rejected as unsupported causality.
+- Implement distributed ordering in the first release: rejected as unnecessary for
+  the local MVP and likely to complicate deterministic replay.
+
+## Canonical Ordering and Queue Pressure
+
+**Decision**: The adapter performs bounded normalization and a non-blocking enqueue.
+One collector assigns a strictly increasing sequence per trace at commit time.
+Queue policy preserves lifecycle, errors, final model records, and omission counters;
+it discards stream deltas first and duplicate oversized content second.
+
+**Rationale**: A single writer gives deterministic order and simple SQLite behavior.
+Explicit omission records keep the trace honest under pressure while recorder work
+remains isolated from the run.
+
+**Alternatives considered**:
+
+- Block producers when full: rejected because it changes run timing and behavior.
+- Unbounded buffering: rejected because large tool output can exhaust memory.
+- Sequence at each producer: rejected because multi-producer sequences cannot form a
+  canonical total order without additional coordination.
+
+## Portable Storage and Query Index
+
+**Decision**: Treat a versioned `.afr` bundle as the source of truth. Store ordered
+records as append-only JSONL, findings separately, large payloads as SHA-256-addressed
+zstandard blobs, and finalized integrity hashes in `checksums.sha256`. Build a
+SQLite WAL index with Python's `sqlite3`; never include the database in exports.
+
+**Rationale**: JSONL supports append and crash recovery, content addressing avoids
+duplication, and an expendable index keeps the portable contract independent from a
+database engine. One writer plus read-only query connections does not require an ORM
+or async database abstraction.
+
+**Alternatives considered**:
+
+- SQLite as the portable source of truth: rejected because it couples compatibility
+  to schema migrations and complicates partial-run portability.
+- SQLAlchemy and Alembic: rejected for the first release because direct SQL is
+  smaller and the database can always be regenerated.
+- OpenTelemetry export as the canonical format: rejected because required context,
+  condensation, workspace, and finding data exceed current semantic conventions;
+  compatible field mapping remains possible later.
+
+## Desktop UI and Concurrency
+
+**Decision**: Use PySide6 with model/view widgets, `QGraphicsView` for the virtualized
+swimlane timeline, and one selection controller. Execute indexing, bundle I/O,
+diagnostics, decompression, and large queries in workers; deliver immutable results
+to the GUI thread through Qt signals.
+
+**Rationale**: PySide6 satisfies the native Python desktop requirement. Qt's
+model/view and scene architecture supports large, synchronized, accessible views
+without a browser runtime.
+
+**Alternatives considered**:
+
+- Browser-based UI: rejected by product scope.
+- Custom painting all widgets directly: rejected because it weakens accessibility,
+  testing, and virtualization.
+- Let widgets query SQLite directly: rejected because it couples presentation to
+  persistence and risks GUI stalls.
+
+## Service Boundaries
+
+**Decision**: Define typed Python protocols for trace queries, bundle import/export,
+subscriptions, and diagnostics. Services contain no Qt imports. Qt workers adapt
+service results for presentation.
+
+**Rationale**: Headless services make the contracts testable and reusable by both
+CLI and GUI while keeping diagnostics separate from capture.
+
+**Alternatives considered**:
+
+- Local HTTP API: rejected because an in-process protocol is simpler and the first
+  release has no remote client.
+- Put query logic in view models: rejected because it prevents headless validation
+  and mixes UI state with domain behavior.
+
+## Diagnostics
+
+**Decision**: Implement repeated-tool-call, recurring-failure, and no-progress rules
+first. Each finding includes detector identity, severity, confidence, explanation,
+recommendation, affected spans, and resolvable evidence IDs. Optional model analysis
+accepts a bounded evidence packet and returns the same validated finding schema with
+no tools or workspace access.
+
+**Rationale**: Deterministic detectors establish measurable value and a stable
+finding contract. Evidence validation enforces the constitution regardless of the
+finding producer.
+
+**Alternatives considered**:
+
+- Start with model-only diagnosis: rejected because results would be less repeatable
+  and capture would appear dependent on interpretation.
+- Store unsupported findings with warnings: rejected because displayed claims must
+  have evidence; invalid findings are rejected.
+
+## Packaging and Validation
+
+**Decision**: Keep PySide6, zstandard, platformdirs, Pydantic, and `openhands-sdk` in
+the recorder package dependencies. Add pytest-qt to repository development
+dependencies. Expose `agent-flight-recorder` as the GUI command and a `validate`
+subcommand for headless bundle checks. Use PyInstaller for the first Linux package.
+
+**Rationale**: Dependency ownership stays with the product that needs it. A headless
+validator proves portability independently from Qt rendering, and PyInstaller is
+already used in this repository.
+
+**Alternatives considered**:
+
+- Add PySide6 to root runtime packages: rejected because unrelated SDK consumers do
+  not need Qt.
+- Ship all three desktop platforms initially: rejected until trace and GUI contracts
+  stabilize on Linux.
+
+## Resolved Clarifications
+
+No planning unknowns remain. The plan fixes the first-release boundary at one local
+process, chooses the `.afr` bundle as canonical storage, uses explicit context
+provenance and relationship status, and keeps optional interpretive analysis outside
+capture.

--- a/specs/001-agent-flight-recorder/spec.md
+++ b/specs/001-agent-flight-recorder/spec.md
@@ -1,0 +1,271 @@
+# Feature Specification: Agent Flight Recorder
+
+**Feature Branch**: `001-agent-flight-recorder`
+
+**Created**: 2026-09-01
+
+**Status**: Draft
+
+**Input**: User description: "Based on the Agent Flight Recorder design, write a
+specification."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Record and Replay an Agent Run (Priority: P1)
+
+As an agent developer, I can record an OpenHands run and replay its ordered
+activity so that I can understand what happened without reconstructing the run
+from terminal logs.
+
+**Why this priority**: A reliable record is the foundation for every
+investigation and diagnostic capability.
+
+**Independent Test**: Record a representative local run, reopen the resulting
+trace in a clean recorder installation, and verify that its activity, ordering,
+relationships, status, and usage totals are preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** recording is enabled for an OpenHands run, **When** the run produces
+   agent, model, tool, workspace, test, or status activity, **Then** each observed
+   activity appears once in a stable order with its source and relationships.
+2. **Given** a completed trace, **When** a user exports and reimports it, **Then**
+   the replay contains the same ordered activity, relationships, run result, and
+   usage totals.
+3. **Given** the recorder encounters a failure, **When** the observed run
+   continues, **Then** the recorder reports its failure without changing the
+   observed run's result.
+
+---
+
+### User Story 2 - Investigate a Run Visually (Priority: P2)
+
+As a run investigator, I can navigate a desktop timeline of agents, model calls,
+tools, tests, and changes so that I can identify what happened, when it happened,
+and where time and cost were spent.
+
+**Why this priority**: A synchronized visual investigation turns recorded data
+into a practical debugging tool.
+
+**Independent Test**: Open a trace containing concurrent agent activity, model
+calls, tools, failures, and usage data, then answer a fixed set of investigation
+questions using only the trace workspace.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recorded run, **When** the user opens it, **Then** the application
+   shows stable agent lanes, elapsed time, parallel activity, run status, errors,
+   token usage, and cost where available.
+2. **Given** an activity is selected in the hierarchy, timeline, or findings,
+   **When** the selection changes, **Then** all linked views show the same
+   activity and its available input, output, metrics, changes, and evidence.
+3. **Given** recording is still active, **When** new activity is committed,
+   **Then** it appears without requiring the trace to be reopened or disrupting
+   the current investigation.
+
+---
+
+### User Story 3 - Inspect Model Context Changes (Priority: P3)
+
+As a context engineer, I can inspect what was visible to a model call and compare
+it with earlier calls so that I can identify context growth, loss, and
+condensation effects.
+
+**Why this priority**: Context changes frequently explain otherwise confusing
+agent decisions and repeated work.
+
+**Independent Test**: Open a run that contains multiple model calls and a
+condensation event, then verify the call context, previous-call differences,
+forgotten activity, and replacement summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authoritative model-call record is available, **When** the user
+   inspects that call, **Then** the application shows its visible input, visible
+   output, usage, latency, cost, finish reason, and contributing activity where
+   known.
+2. **Given** authoritative input is unavailable, **When** the application shows
+   reconstructed context, **Then** it labels the view as reconstructed and
+   identifies missing evidence.
+3. **Given** a condensation occurred, **When** the user inspects it, **Then** the
+   application shows which activity was forgotten and what summary replaced it.
+
+---
+
+### User Story 4 - Trace Agent Delegation (Priority: P4)
+
+As an orchestration designer, I can follow parent and child agents, handoffs, and
+parallel branches so that I can determine whether delegated work contributed to
+the final result.
+
+**Why this priority**: Multi-agent runs cannot be understood accurately from a
+single flat event sequence.
+
+**Independent Test**: Open a seeded run with parallel delegated agents and verify
+that each branch, handoff, returned result, duration, and contribution is
+navigable from one trace.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run with delegated agents, **When** the trace is opened, **Then**
+   verified parent-child relationships and parallel execution are visible in one
+   hierarchy and timeline.
+2. **Given** a relationship cannot be verified, **When** it is displayed,
+   **Then** the application marks it as unresolved or inferred rather than fact.
+3. **Given** a delegated agent is selected, **When** its details are opened,
+   **Then** the user can inspect its handoff, returned result, activity, duration,
+   and usage totals.
+
+---
+
+### User Story 5 - Diagnose Unproductive Behavior (Priority: P5)
+
+As an agent developer, I can review evidence-backed findings for loops, recurring
+failures, context problems, poor handoffs, and premature completion so that I can
+make a focused improvement to the next run.
+
+**Why this priority**: Findings reduce investigation time, but they depend on a
+trustworthy trace and must never replace the underlying evidence.
+
+**Independent Test**: Analyze labeled traces containing known productive and
+unproductive patterns, then verify finding accuracy and evidence navigation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a trace contains a supported unproductive pattern, **When** analysis
+   runs, **Then** the resulting finding identifies its category, severity,
+   confidence, explanation, recommendation, and supporting evidence.
+2. **Given** a finding is selected, **When** the user follows its evidence,
+   **Then** each cited record or activity opens in the trace workspace.
+3. **Given** a proposed finding cites missing evidence, **When** results are
+   validated, **Then** the unsupported finding is rejected.
+4. **Given** optional interpretive analysis is unavailable, **When** the trace is
+   opened, **Then** recording, replay, and deterministic findings remain usable.
+
+### Edge Cases
+
+- A process stops before a run finishes; committed activity remains available and
+  the run is identified as incomplete.
+- Duplicate activity is received during retry or replay; it does not create
+  duplicate records or inflate totals.
+- Parent activity is missing; the child remains visible with an unresolved
+  relationship.
+- An unfamiliar future activity type is recorded; it remains inspectable without
+  preventing the rest of the trace from loading.
+- Activity volume exceeds the live buffer; essential lifecycle, error, final
+  response, and loss-counter records remain available.
+- The viewer closes or becomes unavailable while recording continues; reopening
+  resumes from the last committed activity.
+- A trace contains incomplete spans or inconsistent timestamps; ordering remains
+  deterministic and uncertainty is visible.
+- A very large trace is opened; the initial overview remains responsive while
+  additional detail becomes available.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record the visible execution history of a local
+  OpenHands run.
+- **FR-002**: The recorded history MUST include available conversation, agent,
+  model, tool, workspace, test, condensation, retry, error, usage, and termination
+  activity.
+- **FR-003**: Every recorded activity MUST have a stable identity, ordering value,
+  source, timestamp, type, and relationship information when available.
+- **FR-004**: The system MUST distinguish observed facts, derived measurements,
+  reconstructed views, and interpretive findings.
+- **FR-005**: The system MUST expose missing or uncertain relationships and MUST
+  NOT present inferred relationships as verified facts.
+- **FR-006**: Recorder failure MUST be isolated from the observed run and MUST NOT
+  alter that run's behavior, result, or termination reason.
+- **FR-007**: Users MUST be able to export a complete trace and import it into an
+  installation with no prior data.
+- **FR-008**: Exported traces MUST include integrity information and enough data
+  to reproduce the same ordered history, relationships, findings, and usage
+  totals after import.
+- **FR-009**: Reprocessing the same recorded activity MUST be idempotent.
+- **FR-010**: Users MUST be able to browse runs by status, date, repository,
+  model, and finding severity.
+- **FR-011**: The trace workspace MUST provide a synchronized hierarchy,
+  time-based view, detail inspector, workspace-change track, and findings view.
+- **FR-012**: The time-based view MUST preserve stable agent lanes and represent
+  duration, concurrency, retries, state changes, failures, and incomplete work.
+- **FR-013**: Selecting an item or evidence reference in one view MUST select and
+  reveal the same item in all applicable views.
+- **FR-014**: The application MUST display input, visible output, context,
+  workspace changes, usage, cost, latency, retries, and evidence when available
+  for the selected activity.
+- **FR-015**: The application MUST distinguish authoritative model input from
+  reconstructed context and identify the evidence used for reconstruction.
+- **FR-016**: The application MUST show context differences between consecutive
+  model calls and the recorded effects of condensation.
+- **FR-017**: The system MUST represent parent-child agent relationships,
+  delegation handoffs, parallel branches, returned results, and per-agent totals.
+- **FR-018**: The system MUST detect repeated tool calls, recurring failures, and
+  iterations without progress using repeatable rules.
+- **FR-019**: Every finding MUST cite existing evidence and identify its origin,
+  confidence, explanation, and recommended next action.
+- **FR-020**: Optional interpretive analysis MUST use only recorded evidence, MUST
+  remain separate from the observed run, and MUST NOT modify its workspace.
+- **FR-021**: The system MUST continue recording when no viewer is attached and
+  MUST resume display from the last committed activity when a viewer reconnects.
+- **FR-022**: Users MUST be able to navigate primary investigation flows by
+  keyboard, and status MUST NOT depend on color alone.
+- **FR-023**: Unknown activity types and incomplete runs MUST remain inspectable
+  without preventing known activity from loading.
+- **FR-024**: Under recording pressure, the system MUST preserve run lifecycle,
+  errors, final model activity, and counts describing omitted activity.
+
+### Key Entities
+
+- **Trace**: The complete recorded history of one observed run, including its
+  lifecycle, aggregate usage, result, and integrity state.
+- **Activity**: One ordered observation from the run, with identity, source,
+  timing, type, relationships, and associated data.
+- **Span**: A duration-based unit of work, such as a run, agent, iteration, model
+  call, tool call, test, delegation, or condensation.
+- **Agent Relationship**: A verified, inferred, or unresolved connection between
+  parent and child agent work.
+- **Artifact**: A workspace change, test result, or other output associated with
+  recorded activity.
+- **Finding**: An evidence-backed diagnosis with category, severity, confidence,
+  explanation, recommendation, and references to supporting trace data.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In replay tests, 100% of observed activity is represented exactly
+  once and in the same order after export and import.
+- **SC-002**: Injected recorder, storage, viewer, and analyzer failures change 0%
+  of observed run outcomes.
+- **SC-003**: At least 90% of target developers can identify the final stop
+  reason, the most expensive model call, and the cause of a seeded failure within
+  five minutes without reading raw logs.
+- **SC-004**: New committed activity becomes visible to an attached local viewer
+  within 500 milliseconds for at least 95% of updates.
+- **SC-005**: A trace containing 100,000 activities presents an interactive
+  overview within three seconds, and at least 95% of item selections update
+  linked details within 100 milliseconds on the reference workstation.
+- **SC-006**: Recording adds less than 5% median completion time across the
+  reference run corpus when live token display is disabled.
+- **SC-007**: Each supported deterministic detector achieves at least 90%
+  precision and 90% recall on its labeled trace corpus.
+- **SC-008**: 100% of displayed findings cite valid evidence that users can open
+  directly from the finding.
+- **SC-009**: In accessibility tests, all primary investigation actions can be
+  completed using only a keyboard and without relying on color identification.
+
+## Assumptions
+
+- The first release records local OpenHands runs; remote runs are a later feature
+  that will use the same trace concepts.
+- The product observes and explains runs but does not launch, pause, resume, or
+  otherwise control them.
+- The first release supports one developer investigating traces on the same
+  workstation where they are stored.
+- Deterministic findings are available without optional interpretive analysis.
+- Exact model context is shown only when an authoritative record exists;
+  otherwise, the application presents a clearly labeled reconstruction.
+- Trace comparison, remote collaboration, and generalized log-management use
+  cases are outside the initial scope.

--- a/specs/001-agent-flight-recorder/tasks.md
+++ b/specs/001-agent-flight-recorder/tasks.md
@@ -1,0 +1,381 @@
+---
+description: "Implementation tasks for Agent Flight Recorder"
+---
+
+# Tasks: Agent Flight Recorder
+
+**Input**: Design documents from `specs/001-agent-flight-recorder/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`,
+`contracts/`, `quickstart.md`
+
+**Tests**: Tests are included because the specification defines independent tests,
+replay guarantees, failure-isolation requirements, accessibility outcomes, and
+quantitative performance targets.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented
+and validated as an independently useful increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it changes separate files and has no
+  dependency on another incomplete task in the same phase.
+- **[Story]**: Maps the task to a user story from `spec.md`.
+- Every task names the file or directory it changes.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the distributable package and repository integration needed by
+all implementation phases.
+
+- [X] T001 Create package guidance from the approved plan and repository rules in agent-flight-recorder/AGENTS.md
+- [X] T002 Create `openhands-agent-flight-recorder` metadata, Python 3.12 requirement, runtime dependencies, build backend, and command entry point in agent-flight-recorder/pyproject.toml
+- [X] T003 Add agent-flight-recorder as a uv workspace member and add pytest-qt to development dependencies in pyproject.toml
+- [X] T004 Create the `flight_recorder` package and typed-package marker in agent-flight-recorder/src/flight_recorder/__init__.py and agent-flight-recorder/src/flight_recorder/py.typed
+- [X] T005 [P] Create package entry points and argument parser shell in agent-flight-recorder/src/flight_recorder/__main__.py and agent-flight-recorder/src/flight_recorder/cli.py
+- [X] T006 [P] Create test-domain fixtures and headless Qt configuration in tests/agent_flight_recorder/conftest.py
+- [X] T007 Regenerate uv.lock and verify `make build` resolves the new workspace package in uv.lock
+
+**Checkpoint**: The empty package installs, imports, and exposes the planned command.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement shared records, bundle primitives, index schema, failures,
+and bounded collection infrastructure used by every user story.
+
+**Critical**: No user story implementation begins until this phase passes its unit
+tests.
+
+### Tests
+
+- [X] T008 [P] Add model validation and lifecycle transition tests in tests/agent_flight_recorder/unit/test_envelopes.py
+- [X] T009 [P] Add bounded queue priority and non-blocking behavior tests in tests/agent_flight_recorder/unit/test_queue.py
+- [X] T010 [P] Add SQLite schema, uniqueness, and rebuild transaction tests in tests/agent_flight_recorder/unit/test_database.py
+- [X] T011 [P] Add bundle path, JSONL truncation, digest, and format-version tests in tests/agent_flight_recorder/unit/test_bundle_primitives.py
+
+### Implementation
+
+- [X] T012 [P] Implement typed recorder failures and machine-readable failure codes in agent-flight-recorder/src/flight_recorder/errors.py
+- [X] T013 [P] Implement Trace, Span, Record, Provenance, usage, artifact, finding, and committed-batch models in agent-flight-recorder/src/flight_recorder/models/envelopes.py
+- [X] T014 [P] Implement immutable run, timeline, span, selection, and query view models in agent-flight-recorder/src/flight_recorder/models/view_models.py
+- [X] T015 Implement run and span lifecycle validation, including terminal stop-reason rules, in agent-flight-recorder/src/flight_recorder/models/envelopes.py
+- [X] T016 Implement the non-blocking bounded record queue and critical-record drop policy in agent-flight-recorder/src/flight_recorder/collector/queue.py
+- [X] T017 Implement normalized producer records and stable identifiers in agent-flight-recorder/src/flight_recorder/collector/normalize.py
+- [X] T018 Implement SQLite WAL schema creation, constraints, indexes, and transactions in agent-flight-recorder/src/flight_recorder/models/database.py
+- [X] T019 Implement bundle path validation, JSONL parsing, content digest verification, and checksum helpers in agent-flight-recorder/src/flight_recorder/services/bundles.py
+- [X] T020 Implement platform-correct data, cache, and trace directory resolution in agent-flight-recorder/src/flight_recorder/config.py
+
+**Checkpoint**: Shared models reject invalid state, collection remains bounded and
+non-blocking, and bundle/index primitives are independently testable.
+
+---
+
+## Phase 3: User Story 1 - Record and Replay an Agent Run (Priority: P1) MVP
+
+**Goal**: Record one local OpenHands run without influencing it, persist a portable
+trace, validate/import/export it, and replay the same ordered activity.
+
+**Independent Test**: Record a representative local run, import it into an empty
+data directory, export it again, and verify identical record order, relationships,
+run result, and usage totals.
+
+### Tests for User Story 1
+
+- [X] T021 [P] [US1] Add OpenHands event, completion-log, metrics, and condensation normalization tests in tests/agent_flight_recorder/unit/test_normalize.py
+- [X] T022 [P] [US1] Add collector ordering, deduplication, batching, shutdown, and omission-counter tests in tests/agent_flight_recorder/unit/test_collector.py
+- [X] T023 [P] [US1] Add portable bundle contract and round-trip tests in tests/agent_flight_recorder/integration/test_bundle_roundtrip.py
+- [X] T024 [P] [US1] Add injected callback, collector, and storage failure-isolation tests in tests/agent_flight_recorder/integration/test_failure_isolation.py
+- [X] T025 [P] [US1] Add a deterministic local conversation fixture driver in tests/agent_flight_recorder/fixtures/conversation.py
+- [X] T026 [US1] Add end-to-end local recording and replay coverage using the fixture driver in tests/agent_flight_recorder/e2e/test_record_replay.py
+
+### Implementation for User Story 1
+
+- [X] T027 [P] [US1] Implement Event callback normalization with source IDs, timestamps, parent IDs, and discriminated payloads in agent-flight-recorder/src/flight_recorder/adapter/conversation.py
+- [X] T028 [P] [US1] Implement completion-log parsing and response/usage correlation in agent-flight-recorder/src/flight_recorder/adapter/llm.py
+- [X] T029 [P] [US1] Implement condensation payload normalization from forgotten IDs, summary, offset, and response ID in agent-flight-recorder/src/flight_recorder/collector/normalize.py
+- [X] T030 [US1] Implement the Recorder facade with contained callbacks, metrics snapshots, idempotent close, and warning counters in agent-flight-recorder/src/flight_recorder/recorder.py
+- [X] T031 [US1] Implement the single-writer collector with canonical sequence assignment, durable append, SQLite projection, and committed-batch publication in agent-flight-recorder/src/flight_recorder/collector/persistence.py
+- [X] T032 [US1] Implement trace finalization, validation, transactional import, index rebuild, and ZIP export in agent-flight-recorder/src/flight_recorder/services/bundles.py
+- [X] T033 [US1] Implement ordered record iteration, run lookup, and usage aggregation in agent-flight-recorder/src/flight_recorder/services/repository.py
+- [X] T034 [US1] Implement `record`, `validate`, `import`, and `export` command behavior and exit codes in agent-flight-recorder/src/flight_recorder/cli.py
+- [X] T035 [US1] Wire the command entry point to recorder, bundle, and repository services in agent-flight-recorder/src/flight_recorder/__main__.py
+
+**Checkpoint**: User Story 1 is a complete headless MVP. The recorder can be used and
+validated without the desktop UI or diagnostic engine.
+
+---
+
+## Phase 4: User Story 2 - Investigate a Run Visually (Priority: P2)
+
+**Goal**: Open recorded or active traces in a native desktop workspace with a run
+list, hierarchy, stable swimlanes, synchronized inspector, and live updates.
+
+**Independent Test**: Open a seeded concurrent trace and answer the prescribed run
+status, ordering, failure, duration, token, and cost questions using only the GUI.
+
+### Tests for User Story 2
+
+- [X] T036 [P] [US2] Add deterministic timeline projection, stable lane, incomplete span, and visible-range tests in tests/agent_flight_recorder/unit/test_timeline_projection.py
+- [X] T037 [P] [US2] Add repository run-filter, span-detail, workspace-change, and generic-record query tests in tests/agent_flight_recorder/unit/test_repository.py
+- [X] T038 [P] [US2] Add selection synchronization and circular-update prevention tests in tests/agent_flight_recorder/gui/test_selection.py
+- [X] T039 [P] [US2] Add run table, trace tree, timeline hit-testing, zoom, and keyboard tests in tests/agent_flight_recorder/gui/test_trace_workspace.py
+- [X] T040 [P] [US2] Add active-trace subscription resume, duplicate-delivery, and slow-subscriber tests in tests/agent_flight_recorder/integration/test_subscriptions.py
+- [X] T041 [US2] Add desktop trace investigation end-to-end coverage in tests/agent_flight_recorder/e2e/test_desktop_investigation.py
+
+### Implementation for User Story 2
+
+- [X] T042 [P] [US2] Implement run list filtering and trace-tree models in agent-flight-recorder/src/flight_recorder/gui/models/run_table.py and agent-flight-recorder/src/flight_recorder/gui/models/trace_tree.py
+- [X] T043 [P] [US2] Implement deterministic lane and span layout projection in agent-flight-recorder/src/flight_recorder/gui/timeline/layout.py
+- [X] T044 [P] [US2] Implement virtualized timeline graphics items and visual states in agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
+- [X] T045 [US2] Implement timeline scene, hit testing, zoom, minimap, and keyboard navigation in agent-flight-recorder/src/flight_recorder/gui/timeline/scene.py and agent-flight-recorder/src/flight_recorder/gui/timeline/view.py
+- [X] T046 [P] [US2] Implement the canonical cross-view selection controller in agent-flight-recorder/src/flight_recorder/gui/controllers/selection.py
+- [X] T047 [P] [US2] Implement summary, input, output, metrics, changes, and evidence inspector tabs in agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py and agent-flight-recorder/src/flight_recorder/gui/inspector/metrics.py
+- [X] T048 [US2] Implement resumable committed-batch subscriptions that cannot block collection in agent-flight-recorder/src/flight_recorder/services/subscriptions.py
+- [X] T049 [US2] Implement cancellable Qt workers for repository, bundle, and subscription operations in agent-flight-recorder/src/flight_recorder/gui/workers.py
+- [X] T050 [US2] Assemble the run list, hierarchy, swimlane timeline, inspector, and workspace-change track in agent-flight-recorder/src/flight_recorder/gui/main_window.py
+- [X] T051 [US2] Implement desktop startup, trace opening, settings restoration, and clean detach behavior in agent-flight-recorder/src/flight_recorder/app.py
+
+**Checkpoint**: User Story 2 can be demonstrated entirely with a checked-in trace
+fixture and does not require context analysis, delegation support, or diagnostics.
+
+---
+
+## Phase 5: User Story 3 - Inspect Model Context Changes (Priority: P3)
+
+**Goal**: Show authoritative or reconstructed model context, previous-call
+differences, and recorded condensation effects with explicit provenance.
+
+**Independent Test**: Open a trace with multiple model calls and condensation, then
+verify context provenance, differences, forgotten events, and replacement summary.
+
+### Tests for User Story 3
+
+- [X] T052 [P] [US3] Add authoritative versus reconstructed context provenance tests in tests/agent_flight_recorder/unit/test_context_projection.py
+- [X] T053 [P] [US3] Add previous-call diff and unresolved condensation-event tests in tests/agent_flight_recorder/unit/test_context_diff.py
+- [X] T054 [P] [US3] Add context inspector interaction and provenance badge tests in tests/agent_flight_recorder/gui/test_context_inspector.py
+- [X] T055 [US3] Add condensation investigation end-to-end coverage in tests/agent_flight_recorder/e2e/test_condensation_investigation.py
+
+### Implementation for User Story 3
+
+- [X] T056 [US3] Implement exact completion-log context lookup and event-based reconstructed context projection in agent-flight-recorder/src/flight_recorder/services/repository.py
+- [X] T057 [P] [US3] Implement previous-call structured context differences in agent-flight-recorder/src/flight_recorder/gui/inspector/diff.py
+- [X] T058 [P] [US3] Implement exact/reconstructed provenance and condensation before/after views in agent-flight-recorder/src/flight_recorder/gui/inspector/context.py
+- [X] T059 [US3] Connect context source events and condensation IDs to timeline navigation in agent-flight-recorder/src/flight_recorder/gui/controllers/selection.py
+
+**Checkpoint**: User Story 3 works against fixture bundles even if no live recorder or
+diagnostic analyzer is running.
+
+---
+
+## Phase 6: User Story 4 - Trace Agent Delegation (Priority: P4)
+
+**Goal**: Represent verified, inferred, and unresolved parent-child agents, parallel
+branches, handoffs, returns, duration, and per-agent usage.
+
+**Independent Test**: Open a seeded parallel delegation trace and navigate every
+agent branch, handoff, return, relationship status, duration, and usage total.
+
+### Tests for User Story 4
+
+- [X] T060 [P] [US4] Add relationship status, trace propagation, and unresolved-parent model tests in tests/agent_flight_recorder/unit/test_lineage.py
+- [X] T061 [P] [US4] Add parallel branch ordering and per-agent aggregation tests in tests/agent_flight_recorder/unit/test_agent_projection.py
+- [X] T062 [P] [US4] Add orchestration hierarchy, lineage style, and handoff inspector tests in tests/agent_flight_recorder/gui/test_orchestration.py
+- [X] T063 [US4] Add parallel delegated-run investigation coverage in tests/agent_flight_recorder/e2e/test_delegation_trace.py
+
+### Implementation for User Story 4
+
+- [X] T064 [P] [US4] Implement trace and parent-agent context propagation helpers in agent-flight-recorder/src/flight_recorder/adapter/propagation.py
+- [X] T065 [US4] Implement verified, inferred, and unresolved relationship projection in agent-flight-recorder/src/flight_recorder/services/repository.py
+- [X] T066 [P] [US4] Add nested child-agent lanes, parallel branches, and lineage styles in agent-flight-recorder/src/flight_recorder/gui/timeline/layout.py and agent-flight-recorder/src/flight_recorder/gui/timeline/items.py
+- [X] T067 [P] [US4] Add handoff, returned result, per-agent metrics, and relationship provenance details in agent-flight-recorder/src/flight_recorder/gui/inspector/widget.py
+- [X] T068 [US4] Add orchestration navigation and parent-child expansion to agent-flight-recorder/src/flight_recorder/gui/main_window.py
+
+**Checkpoint**: User Story 4 is independently verifiable with a seeded multi-agent
+trace and labels every non-authoritative relationship.
+
+---
+
+## Phase 7: User Story 5 - Diagnose Unproductive Behavior (Priority: P5)
+
+**Goal**: Produce and navigate evidence-backed findings for repeated calls,
+recurring failures, no-progress iterations, context issues, delegation issues, cost
+hotspots, and premature completion.
+
+**Independent Test**: Analyze labeled positive and negative trace corpora, meet the
+specified precision/recall thresholds, and open every cited evidence item.
+
+### Tests for User Story 5
+
+- [X] T069 [P] [US5] Add normalized fingerprint and repeated-tool-call detector boundary tests in tests/agent_flight_recorder/unit/test_repeated_tool_rule.py
+- [X] T070 [P] [US5] Add recurring-failure and no-progress detector boundary tests in tests/agent_flight_recorder/unit/test_progress_rules.py
+- [X] T071 [P] [US5] Add finding schema, missing-evidence rejection, and optional analyzer failure tests in tests/agent_flight_recorder/unit/test_diagnostics.py
+- [X] T072 [P] [US5] Create the labeled positive and negative trace corpus manifest and fixtures from tests/agent_flight_recorder/fixtures/traces/diagnostics/manifest.json
+- [X] T073 [US5] Add detector precision, recall, and evidence-validity evaluation in tests/agent_flight_recorder/integration/test_diagnostic_quality.py
+- [X] T074 [P] [US5] Add findings filtering, selection, and evidence navigation tests in tests/agent_flight_recorder/gui/test_findings.py
+- [X] T075 [US5] Add unproductive-run diagnosis end-to-end coverage in tests/agent_flight_recorder/e2e/test_diagnostic_investigation.py
+
+### Implementation for User Story 5
+
+- [X] T076 [P] [US5] Implement stable tool, error, iteration, context, and delegation fingerprints in agent-flight-recorder/src/flight_recorder/diagnostics/rules.py
+- [X] T077 [US5] Implement repeated-tool-call, recurring-failure, and no-progress detectors in agent-flight-recorder/src/flight_recorder/diagnostics/rules.py
+- [X] T078 [US5] Implement context, delegation, premature-finish, and budget detectors in agent-flight-recorder/src/flight_recorder/diagnostics/rules.py
+- [X] T079 [P] [US5] Implement strict diagnostic input and finding schemas in agent-flight-recorder/src/flight_recorder/diagnostics/schemas.py
+- [X] T080 [P] [US5] Implement bounded read-only interpretive analysis and structured result parsing in agent-flight-recorder/src/flight_recorder/diagnostics/analyzer.py
+- [X] T081 [US5] Implement diagnostic orchestration, evidence resolution, rejection, and finding persistence in agent-flight-recorder/src/flight_recorder/services/diagnostics.py
+- [X] T082 [P] [US5] Implement findings list, filters, severity states, and evidence links in agent-flight-recorder/src/flight_recorder/gui/models/findings.py
+- [X] T083 [US5] Integrate findings and evidence navigation into agent-flight-recorder/src/flight_recorder/gui/main_window.py
+
+**Checkpoint**: User Story 5 remains useful with interpretive analysis disabled and
+never displays a finding whose evidence cannot be opened.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate behavior spanning stories, package the Linux application, and
+document supported use.
+
+- [X] T084 [P] Add 100,000-record trace fixture generation in tests/agent_flight_recorder/fixtures/generate_large_trace.py
+- [X] T085 [P] Add callback latency, run overhead, live-update latency, first-render, and selection benchmarks in tests/agent_flight_recorder/performance/test_performance_targets.py
+- [X] T086 Optimize measured collector, index, and projection bottlenecks in agent-flight-recorder/src/flight_recorder/collector/persistence.py and agent-flight-recorder/src/flight_recorder/services/repository.py
+- [X] T087 [P] Add Linux PyInstaller specification and packaged-resource declarations in agent-flight-recorder/agent-flight-recorder.spec and agent-flight-recorder/pyproject.toml
+- [X] T088 [P] Document installation, recording, validation, trace viewing, limitations, and troubleshooting in agent-flight-recorder/README.md
+- [X] T089 Add package checks and headless GUI tests to the existing test workflow in .github/workflows/tests.yml
+- [X] T090 Run every scenario in specs/001-agent-flight-recorder/quickstart.md and record any environment-specific corrections in specs/001-agent-flight-recorder/quickstart.md
+- [X] T091 Run focused tests, the complete agent-flight-recorder suite, and pre-commit on every changed file listed by git status
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 — Setup**: Starts immediately.
+- **Phase 2 — Foundation**: Depends on Phase 1 and blocks all stories.
+- **Phase 3 — US1**: Depends on Phase 2; produces the MVP and real trace bundles.
+- **Phase 4 — US2**: Depends on Phase 2 and can use seeded bundles; integration with
+  live traces uses US1 subscriptions.
+- **Phase 5 — US3**: Depends on Phase 2 and can use fixtures; full live context uses
+  US1 completion records and US2 inspector/navigation.
+- **Phase 6 — US4**: Depends on Phase 2 and can use fixtures; live delegated capture
+  extends US1 adapters and US2 timeline views.
+- **Phase 7 — US5**: Depends on Phase 2 and can run headlessly on fixtures; GUI
+  navigation integrates with US2.
+- **Phase 8 — Polish**: Depends on every story selected for release.
+
+### User Story Completion Order
+
+```text
+Setup -> Foundation -> US1 (MVP)
+                    -> US2 -> US3
+                           -> US4
+                           -> US5
+```
+
+US2 through US5 can start from seeded bundle fixtures after Foundation. The
+recommended integration order is US1, US2, US3, US4, US5 because later stories add
+views to the trace workspace rather than changing the canonical record contract.
+
+### Within Each User Story
+
+1. Add story tests and confirm they fail for the missing behavior.
+2. Implement or extend story-specific models and projections.
+3. Implement services before GUI integration.
+4. Run the story's unit, integration, GUI, and end-to-end tests.
+5. Stop at the checkpoint and demonstrate the independent user outcome.
+
+## Parallel Opportunities
+
+- Phase 1: T005 and T006 can run in parallel after metadata paths are agreed.
+- Phase 2: T008-T011 and T012-T014 can run in parallel; lifecycle integration then
+  proceeds through T015-T020.
+- US1: Adapter tests and implementations T021-T029 can be split by event,
+  completion, metrics, and bundle concerns.
+- US2: Timeline projection, query, selection, widget, and subscription work in
+  T036-T049 touches separate modules and can proceed concurrently.
+- US3: Context projection, diff, and inspector work in T052-T058 can proceed in
+  parallel after the shared context model is fixed.
+- US4: Propagation, projection, timeline, and inspector work in T060-T067 can be
+  split among independent modules.
+- US5: Detector families, schemas, analyzer, fixtures, and GUI work in T069-T082
+  provide the largest parallel workstream.
+- Phase 8: Performance fixture, packaging, and documentation tasks can proceed in
+  parallel before final workflow and quickstart validation.
+
+## Parallel Examples
+
+### User Story 1
+
+```text
+Task T021: Normalize SDK events and telemetry tests.
+Task T023: Portable bundle round-trip contract tests.
+Task T024: Recorder failure-isolation integration tests.
+Task T027: Conversation event adapter.
+Task T028: Completion-log adapter.
+```
+
+### User Story 2
+
+```text
+Task T042: Run table and trace tree models.
+Task T043: Timeline layout projection.
+Task T046: Selection controller.
+Task T047: Inspector tabs.
+Task T048: Committed-batch subscriptions.
+```
+
+### User Story 3
+
+```text
+Task T052: Context provenance tests.
+Task T053: Context diff tests.
+Task T057: Structured context differences.
+Task T058: Context and condensation inspector.
+```
+
+### User Story 4
+
+```text
+Task T060: Lineage model tests.
+Task T062: Orchestration GUI tests.
+Task T064: Trace propagation helpers.
+Task T067: Handoff inspector details.
+```
+
+### User Story 5
+
+```text
+Task T069: Repeated-tool detector tests.
+Task T070: Progress detector tests.
+Task T072: Labeled diagnostic corpus.
+Task T079: Diagnostic schemas.
+Task T080: Optional analyzer.
+Task T082: Findings GUI model.
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundation.
+2. Complete User Story 1 through T035.
+3. Run US1 tests and bundle round-trip validation.
+4. Stop and demonstrate headless recording, validation, import, export, and replay.
+
+### Incremental Delivery
+
+1. Add US2 for visual investigation using the same bundle contract.
+2. Add US3 for context and condensation analysis.
+3. Add US4 for orchestration traces.
+4. Add US5 for evidence-backed diagnostics.
+5. Complete release-wide performance, packaging, workflow, and documentation tasks.
+
+### Task Discipline
+
+- Keep source comments limited to non-obvious invariants and external workarounds.
+- Follow the closest AGENTS.md before modifying each package.
+- Run `uv run pre-commit run --files` after each changed file.
+- Do not begin a dependent task until its model or service prerequisite is complete.
+- Do not mark a story complete until its independent test passes.

--- a/tests/agent_flight_recorder/conftest.py
+++ b/tests/agent_flight_recorder/conftest.py
@@ -1,0 +1,13 @@
+import os
+from pathlib import Path
+
+import pytest
+from flight_recorder.models.database import TraceIndex
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture
+def trace_index(tmp_path: Path) -> TraceIndex:
+    return TraceIndex(tmp_path / "index.db")

--- a/tests/agent_flight_recorder/e2e/test_condensation_investigation.py
+++ b/tests/agent_flight_recorder/e2e/test_condensation_investigation.py
@@ -1,0 +1,17 @@
+from flight_recorder.gui.controllers.selection import SelectionController
+from flight_recorder.services.repository import resolve_condensation
+
+
+def test_condensation_investigation_keeps_missing_evidence_navigable() -> None:
+    condensation = resolve_condensation(
+        {
+            "forgotten_event_ids": ["recorded", "not-recorded"],
+            "summary": "Prior work",
+        },
+        {"recorded"},
+    )
+    selection = SelectionController()
+    selection.navigate_to_evidence(condensation.resolved_ids[0])
+
+    assert condensation.unresolved_ids == ("not-recorded",)
+    assert selection.current_selection().record_id == "recorded"

--- a/tests/agent_flight_recorder/e2e/test_delegation_trace.py
+++ b/tests/agent_flight_recorder/e2e/test_delegation_trace.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.models.envelopes import Record
+from flight_recorder.services.repository import TraceRepository
+
+
+def test_parallel_delegation_trace_is_navigable(trace_index, qtbot) -> None:
+    def started(
+        record_id: str,
+        sequence: int,
+        span_id: str,
+        parent_span_id: str | None = None,
+    ) -> Record:
+        return Record(
+            record_id=record_id,
+            producer_id="producer",
+            trace_id="trace",
+            span_id=span_id,
+            parent_span_id=parent_span_id,
+            agent_span_id=span_id,
+            sequence=sequence,
+            observed_at=datetime(2026, 9, 1, 12, 0, sequence),
+            kind="agent.started",
+            payload={"task": f"Work for {span_id}"},
+        )
+
+    trace_index.add_records(
+        [
+            started("parent-start", 1, "parent"),
+            started("child-a-start", 2, "child-a", "parent"),
+            started("child-b-start", 3, "child-b", "parent"),
+        ]
+    )
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+
+    window.navigate_to_agent("child-b")
+
+    assert window.selection.current_selection().span_id == "child-b"
+    assert window.tree.currentIndex().data() == "child-b"

--- a/tests/agent_flight_recorder/e2e/test_desktop_investigation.py
+++ b/tests/agent_flight_recorder/e2e/test_desktop_investigation.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.gui.models.run_table import RunTableModel
+from flight_recorder.gui.models.trace_tree import TraceTreeModel
+from flight_recorder.gui.timeline.scene import TimelineScene
+from flight_recorder.gui.timeline.view import TimelineViewWidget
+from flight_recorder.models.envelopes import Record
+from flight_recorder.services.repository import TraceRepository
+
+
+def test_desktop_opens_seeded_trace_for_investigation(qtbot, trace_index) -> None:
+    started_at = datetime(2026, 9, 1, 12)
+    records = [
+        Record(
+            record_id=record_id,
+            producer_id="producer",
+            trace_id="trace",
+            span_id=span_id,
+            agent_span_id="agent" if span_id else None,
+            sequence=sequence,
+            observed_at=started_at + timedelta(seconds=sequence),
+            kind=kind,
+        )
+        for record_id, sequence, kind, span_id in (
+            ("run-start", 1, "run.started", None),
+            ("tool-start", 2, "tool.request", "tool-span"),
+            ("tool-finish", 3, "tool.result", "tool-span"),
+            ("run-finish", 4, "run.finished", None),
+        )
+    ]
+    trace_index.add_records(records)
+
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+
+    run_model = window.findChild(RunTableModel)
+    tree_model = window.findChild(TraceTreeModel)
+    timeline = window.findChild(TimelineViewWidget, "timeline")
+    assert run_model is not None
+    assert run_model.data(run_model.index(0, 1)) == "completed"
+    assert tree_model is not None
+    assert tree_model.rowCount() == 4
+    assert timeline is not None
+    scene = timeline.scene()
+    assert isinstance(scene, TimelineScene)
+    assert scene.span_at(sequence=2, lane=0) == "tool-span"

--- a/tests/agent_flight_recorder/e2e/test_diagnostic_investigation.py
+++ b/tests/agent_flight_recorder/e2e/test_diagnostic_investigation.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.models.envelopes import Record
+from flight_recorder.services.diagnostics import DiagnosticService
+from flight_recorder.services.repository import TraceRepository
+
+
+def test_unproductive_run_finding_opens_its_evidence(trace_index, qtbot) -> None:
+    records = [
+        Record(
+            record_id=f"repeat-{index}",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=index,
+            observed_at=datetime(2026, 9, 1, 12),
+            kind="tool.request",
+            payload={"tool": "terminal", "command": "pytest"},
+        )
+        for index in (1, 2)
+    ]
+    trace_index.add_records(records)
+    findings = DiagnosticService(trace_index).analyze("trace")
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+    window.set_findings(findings)
+
+    window.navigate_to_finding(0)
+
+    assert window.selection.current_selection().record_id == "repeat-1"
+    assert window.findings_model.finding_at(0).detector_id == "repeated-tool-call"

--- a/tests/agent_flight_recorder/e2e/test_live_delegation_recording.py
+++ b/tests/agent_flight_recorder/e2e/test_live_delegation_recording.py
@@ -1,0 +1,124 @@
+import json
+from pathlib import Path
+
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.bundles import BundleService
+from flight_recorder.services.repository import TraceRepository
+from PySide6.QtCore import Qt
+
+from openhands.sdk import Agent, Conversation, Tool
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.subagent.registry import _reset_registry_for_tests, register_agent
+from openhands.sdk.testing import TestLLM
+from openhands.tools.task import TaskToolSet
+
+
+def test_live_delegation_is_recorded_and_navigable(tmp_path: Path, qtbot) -> None:
+    _reset_registry_for_tests()
+    child_llm = TestLLM.from_messages([_text_message("Implemented the helper.")])
+
+    def create_child(llm):
+        return Agent(llm=child_llm, tools=[])
+
+    register_agent(
+        name="implementer",
+        factory_func=create_child,
+        description="Implements a focused change.",
+    )
+    parent_llm = TestLLM.from_messages(
+        [
+            _task_message(),
+            _text_message("The delegated implementation is complete."),
+        ]
+    )
+    bundle = tmp_path / "live-delegation.afr"
+    index = TraceIndex(tmp_path / "trace.db")
+    recorder = Recorder(bundle, index)
+    parent_events = []
+    conversation = Conversation(
+        agent=Agent(llm=parent_llm, tools=[Tool(name=TaskToolSet.name)]),
+        workspace=tmp_path / "workspace",
+        callbacks=[recorder, parent_events.append],
+        visualizer=None,
+    )
+    try:
+        conversation.send_message("Delegate this implementation.")
+        conversation.run()
+        recorder.record_metrics(conversation.conversation_stats)
+    finally:
+        conversation.close()
+        recorder.close()
+        _reset_registry_for_tests()
+
+    archive = BundleService().export_bundle(bundle, tmp_path / "live-delegation.zip")
+    replay_index = TraceIndex(tmp_path / "replay.db")
+    BundleService(replay_index).import_bundle(archive)
+    records = replay_index.iter_records(recorder.trace_id)
+    child_start = next(
+        record
+        for record in records
+        if record.kind == "agent.started" and record.payload.get("task_id")
+    )
+    child_id = child_start.span_id
+    assert child_id is not None
+    assert child_id != "task_00000001"
+    assert any(record.kind == "delegation.started" for record in records)
+    assert any(record.kind == "delegation.finished" for record in records)
+    assert any(
+        record.agent_span_id == child_id
+        and record.payload.get("event_type") == "MessageEvent"
+        for record in records
+    )
+    assert any(
+        record.kind == "agent.finished" and record.span_id == child_id
+        for record in records
+    )
+    child_event_ids = {
+        record.openhands_event_id
+        for record in records
+        if record.agent_span_id == child_id and record.openhands_event_id is not None
+    }
+    assert child_event_ids.isdisjoint(event.id for event in parent_events)
+
+    repository = TraceRepository(replay_index)
+    relationships = repository.get_agent_relationships(recorder.trace_id)
+    assert [(item.child_span_id, item.status.value) for item in relationships] == [
+        (child_id, "verified")
+    ]
+    usage, _ = repository.get_agent_usage(recorder.trace_id, child_id)
+    assert usage.prompt_tokens == 0
+
+    window = MainWindow(repository=repository, trace_id=recorder.trace_id)
+    qtbot.addWidget(window)
+    window.navigate_to_agent(recorder.agent_span_id)
+    assert "Parent: Root" in window.inspector.summary.text()
+    window.navigate_to_agent(child_id)
+    assert window.selection.current_selection().span_id == child_id
+    assert window.tree.currentIndex().data(Qt.ItemDataRole.UserRole + 1) == child_id
+
+
+def _task_message() -> Message:
+    return Message(
+        role="assistant",
+        content=[TextContent(text="")],
+        tool_calls=[
+            MessageToolCall(
+                id="delegate-call",
+                name="task",
+                arguments=json.dumps(
+                    {
+                        "description": "Implement helper",
+                        "prompt": "Implement the requested helper.",
+                        "subagent_type": "implementer",
+                    }
+                ),
+                origin="completion",
+            )
+        ],
+    )
+
+
+def _text_message(text: str) -> Message:
+    return Message(role="assistant", content=[TextContent(text=text)])

--- a/tests/agent_flight_recorder/e2e/test_record_replay.py
+++ b/tests/agent_flight_recorder/e2e/test_record_replay.py
@@ -5,8 +5,10 @@ from flight_recorder.recorder import Recorder
 from flight_recorder.services.bundles import BundleService
 from flight_recorder.services.repository import TraceRepository
 
+from openhands.sdk import Agent, Conversation
 from openhands.sdk.conversation.conversation_stats import ConversationStats
-from openhands.sdk.llm import Metrics
+from openhands.sdk.llm import Message, MessageToolCall, Metrics, TextContent
+from openhands.sdk.testing import TestLLM
 from tests.agent_flight_recorder.fixtures.conversation import (
     run_deterministic_conversation,
 )
@@ -45,3 +47,65 @@ def test_record_and_replay_preserves_run_and_usage(tmp_path: Path) -> None:
     assert run.total_usage.prompt_tokens == 10
     assert run.total_usage.completion_tokens == 4
     assert run.total_cost == 0.25
+
+
+def test_sequential_tool_events_are_recorded_in_execution_order(tmp_path: Path) -> None:
+    llm = TestLLM.from_messages(
+        [
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[
+                    MessageToolCall(
+                        id="call-1",
+                        name="think",
+                        arguments='{"thought":"first"}',
+                        origin="completion",
+                    ),
+                    MessageToolCall(
+                        id="call-2",
+                        name="think",
+                        arguments='{"thought":"second"}',
+                        origin="completion",
+                    ),
+                ],
+            ),
+            Message(role="assistant", content=[TextContent(text="Done")]),
+        ]
+    )
+    index = TraceIndex(tmp_path / "trace.db")
+    recorder = Recorder(tmp_path / "trace.afr", index)
+    conversation = Conversation(
+        agent=Agent(llm=llm, tools=[]),
+        callbacks=[recorder],
+        visualizer=None,
+    )
+    try:
+        conversation.send_message("Run two thoughts.")
+        conversation.run()
+    finally:
+        conversation.close()
+        recorder.close()
+
+    tool_records = [
+        record
+        for record in index.iter_records(recorder.trace_id)
+        if record.payload.get("event_type") in {"ActionEvent", "ObservationEvent"}
+    ]
+    assert [record.payload["event_type"] for record in tool_records] == [
+        "ActionEvent",
+        "ObservationEvent",
+        "ActionEvent",
+        "ObservationEvent",
+    ]
+    assert [record.payload["tool_call_id"] for record in tool_records] == [
+        "call-1",
+        "call-1",
+        "call-2",
+        "call-2",
+    ]
+    timestamps = []
+    for record in tool_records:
+        assert record.source_timestamp is not None
+        timestamps.append(record.source_timestamp)
+    assert timestamps == sorted(timestamps)

--- a/tests/agent_flight_recorder/e2e/test_record_replay.py
+++ b/tests/agent_flight_recorder/e2e/test_record_replay.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.bundles import BundleService
+from flight_recorder.services.repository import TraceRepository
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.llm import Metrics
+from tests.agent_flight_recorder.fixtures.conversation import (
+    run_deterministic_conversation,
+)
+
+
+def test_record_and_replay_preserves_run_and_usage(tmp_path: Path) -> None:
+    bundle = tmp_path / "recorded.afr"
+    source_index = TraceIndex(tmp_path / "source.db")
+    recorder = Recorder(bundle, source_index)
+    metrics = Metrics(model_name="test-model")
+    metrics.add_cost(0.25)
+    metrics.add_token_usage(10, 4, 2, 1, 128, "response-1")
+
+    run_deterministic_conversation(
+        tmp_path / "workspace", callbacks=[recorder.on_event]
+    )
+    recorder.record_metrics(ConversationStats(usage_to_metrics={"agent": metrics}))
+    recorder.close()
+
+    source_records = source_index.iter_records(recorder.trace_id)
+    archive = BundleService().export_bundle(bundle, tmp_path / "recorded.afr.zip")
+    replay_index = TraceIndex(tmp_path / "replay.db")
+    BundleService(replay_index).import_bundle(archive)
+    replay_records = replay_index.iter_records(recorder.trace_id)
+
+    assert replay_records == source_records
+    assert [record.sequence for record in replay_records] == list(
+        range(1, len(replay_records) + 1)
+    )
+    assert replay_records[0].kind == "run.started"
+    assert replay_records[-1].kind == "run.finished"
+
+    run = TraceRepository(replay_index).get_run(recorder.trace_id)
+    assert run.status == "completed"
+    assert run.record_count == len(replay_records)
+    assert run.total_usage.prompt_tokens == 10
+    assert run.total_usage.completion_tokens == 4
+    assert run.total_cost == 0.25

--- a/tests/agent_flight_recorder/fixtures/conversation.py
+++ b/tests/agent_flight_recorder/fixtures/conversation.py
@@ -1,0 +1,78 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.conversation import LocalConversation
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
+from openhands.sdk.conversation.types import (
+    ConversationCallbackType,
+    ConversationTokenCallbackType,
+)
+from openhands.sdk.event import Event
+from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.testing import TestLLM
+
+
+class DeterministicAgent(AgentBase):
+    def __init__(self) -> None:
+        super().__init__(
+            llm=TestLLM.from_messages([]),
+            tools=[],
+            include_default_tools=[],
+        )
+
+    def init_state(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        on_event(
+            SystemPromptEvent(
+                id="system-prompt",
+                timestamp="2026-09-01T12:00:00",
+                source="agent",
+                system_prompt=TextContent(text="Deterministic recorder fixture"),
+                tools=[],
+            )
+        )
+
+    def step(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+    ) -> None:
+        on_event(
+            MessageEvent(
+                id="assistant-message",
+                timestamp="2026-09-01T12:00:02",
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text="Fixture complete")],
+                ),
+            )
+        )
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+
+def run_deterministic_conversation(
+    workspace: Path,
+    callbacks: Sequence[ConversationCallbackType] = (),
+) -> list[Event]:
+    events: list[Event] = []
+    conversation = LocalConversation(
+        agent=DeterministicAgent(),
+        workspace=workspace,
+        callbacks=[*callbacks, events.append],
+        max_iteration_per_run=1,
+        stuck_detection=False,
+    )
+    try:
+        conversation.send_message("Record this deterministic run")
+        conversation.run()
+        return events
+    finally:
+        conversation.close()

--- a/tests/agent_flight_recorder/fixtures/generate_large_trace.py
+++ b/tests/agent_flight_recorder/fixtures/generate_large_trace.py
@@ -1,0 +1,47 @@
+import argparse
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+
+def generate_records(count: int = 100_000) -> Iterator[dict[str, object]]:
+    for sequence in range(1, count + 1):
+        yield {
+            "record_id": f"record-{sequence}",
+            "producer_id": "large-trace-fixture",
+            "trace_id": "large-trace",
+            "sequence": sequence,
+            "kind": "llm.stream_delta" if sequence % 10 else "iteration.finished",
+            "payload": {"made_progress": True},
+        }
+
+
+def write_large_trace(destination: Path, count: int = 100_000) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "manifest.json").write_text(
+        json.dumps(
+            {
+                "format": "agent-flight-recorder",
+                "format_version": 1,
+                "trace_id": "large-trace",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    with (destination / "records.jsonl").open("w") as stream:
+        for record in generate_records(count):
+            stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    return destination
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--count", type=int, default=100_000)
+    args = parser.parse_args()
+    write_large_trace(args.destination, args.count)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/failure-negative.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/failure-negative.jsonl
@@ -1,0 +1,2 @@
+{"record_id":"fn-1","producer_id":"fixture","trace_id":"failure-negative","sequence":1,"kind":"tool.error","payload":{"error":"permission denied"}}
+{"record_id":"fn-2","producer_id":"fixture","trace_id":"failure-negative","sequence":2,"kind":"tool.error","payload":{"error":"timeout"}}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/failure-positive.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/failure-positive.jsonl
@@ -1,0 +1,2 @@
+{"record_id":"fp-1","producer_id":"fixture","trace_id":"failure-positive","sequence":1,"kind":"tool.error","payload":{"error":"permission denied"}}
+{"record_id":"fp-2","producer_id":"fixture","trace_id":"failure-positive","sequence":2,"kind":"tool.error","payload":{"error":"permission denied"}}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/manifest.json
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/manifest.json
@@ -1,0 +1,10 @@
+{
+  "cases": [
+    {"file": "repeat-positive.jsonl", "detector": "repeated-tool-call", "positive": true},
+    {"file": "repeat-negative.jsonl", "detector": "repeated-tool-call", "positive": false},
+    {"file": "failure-positive.jsonl", "detector": "recurring-failure", "positive": true},
+    {"file": "failure-negative.jsonl", "detector": "recurring-failure", "positive": false},
+    {"file": "progress-positive.jsonl", "detector": "no-progress", "positive": true},
+    {"file": "progress-negative.jsonl", "detector": "no-progress", "positive": false}
+  ]
+}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/progress-negative.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/progress-negative.jsonl
@@ -1,0 +1,3 @@
+{"record_id":"pn-1","producer_id":"fixture","trace_id":"progress-negative","sequence":1,"kind":"iteration.finished","payload":{"made_progress":false}}
+{"record_id":"pn-2","producer_id":"fixture","trace_id":"progress-negative","sequence":2,"kind":"iteration.finished","payload":{"made_progress":true}}
+{"record_id":"pn-3","producer_id":"fixture","trace_id":"progress-negative","sequence":3,"kind":"iteration.finished","payload":{"made_progress":false}}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/progress-positive.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/progress-positive.jsonl
@@ -1,0 +1,3 @@
+{"record_id":"pp-1","producer_id":"fixture","trace_id":"progress-positive","sequence":1,"kind":"iteration.finished","payload":{"made_progress":false}}
+{"record_id":"pp-2","producer_id":"fixture","trace_id":"progress-positive","sequence":2,"kind":"iteration.finished","payload":{"made_progress":false}}
+{"record_id":"pp-3","producer_id":"fixture","trace_id":"progress-positive","sequence":3,"kind":"iteration.finished","payload":{"made_progress":false}}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/repeat-negative.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/repeat-negative.jsonl
@@ -1,0 +1,2 @@
+{"record_id":"rn-1","producer_id":"fixture","trace_id":"repeat-negative","sequence":1,"kind":"tool.request","payload":{"tool":"terminal","command":"pytest"}}
+{"record_id":"rn-2","producer_id":"fixture","trace_id":"repeat-negative","sequence":2,"kind":"tool.request","payload":{"tool":"terminal","command":"ruff check"}}

--- a/tests/agent_flight_recorder/fixtures/traces/diagnostics/repeat-positive.jsonl
+++ b/tests/agent_flight_recorder/fixtures/traces/diagnostics/repeat-positive.jsonl
@@ -1,0 +1,2 @@
+{"record_id":"rp-1","producer_id":"fixture","trace_id":"repeat-positive","sequence":1,"kind":"tool.request","payload":{"tool":"terminal","command":"pytest"}}
+{"record_id":"rp-2","producer_id":"fixture","trace_id":"repeat-positive","sequence":2,"kind":"tool.request","payload":{"tool":"terminal","command":"pytest"}}

--- a/tests/agent_flight_recorder/gui/test_context_inspector.py
+++ b/tests/agent_flight_recorder/gui/test_context_inspector.py
@@ -1,0 +1,37 @@
+from flight_recorder.gui.controllers.selection import SelectionController
+from flight_recorder.gui.inspector.context import ContextInspector
+from flight_recorder.models.envelopes import Provenance, ProvenanceKind
+from flight_recorder.models.view_models import CondensationView, ContextView
+
+
+def test_context_inspector_labels_provenance_and_unresolved_events(qtbot) -> None:
+    inspector = ContextInspector()
+    qtbot.addWidget(inspector)
+    context = ContextView(
+        record_id="request",
+        messages=({"role": "user", "content": "Hello"},),
+        provenance=Provenance(
+            kind=ProvenanceKind.RECONSTRUCTED,
+            source_ids=("message",),
+            complete=False,
+        ),
+    )
+    condensation = CondensationView(
+        resolved_ids=("message",),
+        unresolved_ids=("missing",),
+        summary="Earlier work",
+    )
+
+    inspector.set_context(context)
+    inspector.set_condensation(condensation)
+
+    assert inspector.provenance.text() == "Reconstructed context"
+    assert "missing" in inspector.condensation.toPlainText()
+
+
+def test_context_source_navigation_uses_canonical_selection(qtbot) -> None:
+    controller = SelectionController()
+
+    controller.navigate_to_evidence("message")
+
+    assert controller.current_selection().record_id == "message"

--- a/tests/agent_flight_recorder/gui/test_findings.py
+++ b/tests/agent_flight_recorder/gui/test_findings.py
@@ -1,0 +1,54 @@
+from typing import Literal
+
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.gui.models.findings import FindingsModel
+from flight_recorder.models.envelopes import Finding
+
+
+def finding(
+    finding_id: str,
+    severity: Literal["info", "warning", "error"],
+    category: str,
+) -> Finding:
+    return Finding(
+        finding_id=finding_id,
+        trace_id="trace",
+        origin="rule",
+        detector_id=finding_id,
+        category=category,
+        severity=severity,
+        confidence=1,
+        title=finding_id,
+        explanation="Evidence-backed explanation",
+        recommendation="Change approach",
+        evidence_ids=(f"evidence-{finding_id}",),
+    )
+
+
+def test_findings_model_filters_severity_and_category() -> None:
+    model = FindingsModel(
+        [finding("loop", "warning", "loop"), finding("tool", "error", "tool")]
+    )
+
+    model.set_filters(severity="error", category=None)
+
+    assert model.rowCount() == 1
+    assert model.finding_at(0).finding_id == "tool"
+    assert model.data(model.index(0, 0)) == "error"
+    assert model.evidence_at(0) == ("evidence-tool",)
+
+
+def test_finding_navigation_selects_openable_evidence(qtbot) -> None:
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.set_findings([finding("loop", "warning", "loop")])
+
+    window.navigate_to_finding(0)
+
+    assert window.selection.current_selection().record_id == "evidence-loop"
+    assert "Evidence-backed explanation" in window.inspector.summary.text()
+    explanation = window.inspector.explanation.text()
+    assert "Diagnostic finding" in explanation
+    assert "deterministic recorder rule" in explanation
+    assert "Confidence: 100%" in explanation
+    assert "evidence-loop" in explanation

--- a/tests/agent_flight_recorder/gui/test_main_window.py
+++ b/tests/agent_flight_recorder/gui/test_main_window.py
@@ -1,0 +1,12 @@
+from flight_recorder.gui.main_window import MainWindow
+from PySide6.QtWidgets import QSplitter
+
+
+def test_main_window_has_three_panel_workspace(qtbot) -> None:
+    window = MainWindow()
+    qtbot.addWidget(window)
+
+    assert window.windowTitle() == "Agent Flight Recorder"
+    workspace = window.centralWidget()
+    assert isinstance(workspace, QSplitter)
+    assert workspace.count() == 3

--- a/tests/agent_flight_recorder/gui/test_orchestration.py
+++ b/tests/agent_flight_recorder/gui/test_orchestration.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+from flight_recorder.gui.inspector.widget import InspectorWidget
+from flight_recorder.gui.models.trace_tree import TraceTreeModel
+from flight_recorder.gui.timeline.items import TimelineSpanItem
+from flight_recorder.gui.timeline.layout import project_spans
+from flight_recorder.models.envelopes import (
+    Provenance,
+    RelationshipStatus,
+    Span,
+    TokenUsage,
+)
+from flight_recorder.models.view_models import (
+    AgentDetail,
+    AgentRelationship,
+    TimelineView,
+)
+
+
+def agent_span(
+    span_id: str,
+    *,
+    parent_span_id: str | None = None,
+    status: RelationshipStatus = RelationshipStatus.VERIFIED,
+) -> Span:
+    return Span(
+        span_id=span_id,
+        trace_id="trace",
+        span_type="agent",
+        name=span_id,
+        parent_span_id=parent_span_id,
+        agent_span_id=span_id,
+        relationship_status=status,
+        start_sequence=1 if parent_span_id is None else 2,
+        end_sequence=6,
+        started_at=datetime(2026, 9, 1, 12),
+        ended_at=datetime(2026, 9, 1, 12, 0, 5),
+        status="completed",
+    )
+
+
+def test_orchestration_tree_nests_agents_and_labels_lineage() -> None:
+    parent = agent_span("parent")
+    child = agent_span(
+        "child",
+        parent_span_id="parent",
+        status=RelationshipStatus.INFERRED,
+    )
+
+    model = TraceTreeModel(
+        TimelineView(trace_id="trace", records=(), spans=(parent, child))
+    )
+
+    assert model.item(0).text() == "parent"
+    assert model.item(0).child(0).text() == "child"
+    assert "inferred" in model.item(0).child(0).toolTip().lower()
+
+
+def test_timeline_and_inspector_show_lineage_and_handoff(qtbot) -> None:
+    child = agent_span(
+        "child",
+        parent_span_id="parent",
+        status=RelationshipStatus.UNRESOLVED,
+    )
+    item = TimelineSpanItem(project_spans([child], current_sequence=6)[0])
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    detail = AgentDetail(
+        relationship=AgentRelationship(
+            parent_span_id="parent",
+            child_span_id="child",
+            status=RelationshipStatus.UNRESOLVED,
+            provenance=Provenance(),
+        ),
+        handoff={"task": "Inspect failure"},
+        returned_result="Found root cause",
+        duration_seconds=5,
+        usage=TokenUsage(prompt_tokens=12),
+        cost=0.08,
+    )
+
+    inspector.show_agent(detail)
+
+    assert "unresolved" in item.toolTip().lower()
+    assert "Inspect failure" in inspector.summary.text()
+    assert "Found root cause" in inspector.summary.text()
+    assert "12" in inspector.summary.text()
+    assert inspector.tabText(inspector.indexOf(inspector.explanation)) == "Explanation"
+    explanation = inspector.explanation.text()
+    assert "Agent lifecycle" in explanation
+    assert "delegated agent" in explanation
+    assert "unresolved" in explanation
+    assert "5.000 seconds" in explanation
+    assert "Found root cause" in explanation
+    assert "Prompt tokens: 12" in explanation
+    assert "captured evidence" in explanation

--- a/tests/agent_flight_recorder/gui/test_selection.py
+++ b/tests/agent_flight_recorder/gui/test_selection.py
@@ -1,0 +1,19 @@
+from flight_recorder.gui.controllers.selection import SelectionController
+from flight_recorder.models.view_models import Selection
+
+
+def test_selection_controller_emits_only_canonical_changes(qtbot) -> None:
+    controller = SelectionController()
+    selections: list[Selection] = []
+    controller.selection_changed.connect(selections.append)
+
+    controller.select_record("record-1")
+    controller.select_record("record-1")
+    controller.select_span("span-1")
+    controller.select_span("span-1")
+
+    assert selections == [
+        Selection(record_id="record-1"),
+        Selection(span_id="span-1"),
+    ]
+    assert controller.current_selection() == Selection(span_id="span-1")

--- a/tests/agent_flight_recorder/gui/test_trace_workspace.py
+++ b/tests/agent_flight_recorder/gui/test_trace_workspace.py
@@ -4,6 +4,14 @@ from flight_recorder.gui.inspector.widget import InspectorWidget
 from flight_recorder.gui.main_window import MainWindow
 from flight_recorder.gui.models.run_table import RunTableModel
 from flight_recorder.gui.models.trace_tree import TraceTreeModel
+from flight_recorder.gui.timeline.items import (
+    HEADER_HEIGHT,
+    LANE_HEIGHT,
+    MIN_RECORD_WIDTH,
+    TimelineRecordItem,
+    TimelineSequenceArrowItem,
+    TimelineSpanItem,
+)
 from flight_recorder.gui.timeline.scene import TimelineScene
 from flight_recorder.gui.timeline.view import TimelineViewWidget
 from flight_recorder.models.envelopes import Record, Span
@@ -39,6 +47,173 @@ def test_run_table_and_trace_tree_expose_trace_data() -> None:
     assert tree_model.item(0).text() == "tool.request"
 
 
+def test_conversation_and_llm_interaction_have_two_subrows(qtbot) -> None:
+    user_message = Record(
+        record_id="user",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "source": "user",
+            "llm_message": {"role": "user"},
+        },
+    )
+    assistant_message = Record(
+        record_id="assistant",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=2,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "source": "agent",
+            "llm_message": {"role": "assistant"},
+        },
+    )
+    request = Record(
+        record_id="request",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=3,
+        kind="llm.request",
+        payload={"request": {"input": []}},
+    )
+    response = Record(
+        record_id="response",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=4,
+        kind="llm.response",
+        payload={"response": {"id": "response-1"}},
+    )
+
+    tree_model = TraceTreeModel(
+        TimelineView(
+            trace_id="trace",
+            records=(user_message, assistant_message, request, response),
+        )
+    )
+    scene = TimelineScene()
+    scene.set_timeline(
+        [],
+        [user_message, assistant_message, request, response],
+        current_sequence=4,
+    )
+
+    assert [tree_model.item(row).text() for row in range(4)] == [
+        "User prompt",
+        "Assistant message",
+        "LLM request",
+        "LLM response",
+    ]
+    assert scene.record_label("request") == "LLM request"
+    assert scene.record_label("response") == "LLM response"
+    assert scene.available_row_types == (
+        "user_conversation",
+        "llm_interaction",
+    )
+    assert scene.enabled_row_types == scene.available_row_types
+    assert scene.lane_names == (
+        "User Conversation · Session",
+        "LLM Interaction · Session",
+    )
+    record_items = {
+        str(getattr(item, "record_id")): item
+        for item in scene.items()
+        if isinstance(item, QGraphicsRectItem)
+        and isinstance(getattr(item, "record_id", None), str)
+    }
+    request_item = record_items["request"]
+    assert request_item.rect().width() == MIN_RECORD_WIDTH
+    assert request_item.rect().x() > record_items["assistant"].rect().right()
+    assert record_items["response"].rect().x() > request_item.rect().right()
+    assert record_items["user"].rect().y() < record_items["assistant"].rect().y()
+    assert request_item.rect().y() < record_items["response"].rect().y()
+    assert scene.record_at(sequence=1, lane=0) == "user"
+    assert scene.record_at(sequence=2, lane=0) == "assistant"
+    assert scene.record_at(sequence=3, lane=1) == "request"
+    assert scene.record_at(sequence=4, lane=1) == "response"
+    subrow_labels = {
+        item.toPlainText()
+        for item in scene.items()
+        if isinstance(item, QGraphicsTextItem)
+    }
+    assert {"User Input", "Agent Response", "Request", "Response"}.issubset(
+        subrow_labels
+    )
+    assert "Display-aligned start" in request_item.toolTip()
+    assistant_to_request = next(
+        item
+        for item in scene.items()
+        if isinstance(item, TimelineSequenceArrowItem)
+        and item.previous_record_id == "assistant"
+        and item.next_record_id == "request"
+    )
+    assert assistant_to_request.start.x() == record_items["assistant"].rect().right()
+    assert assistant_to_request.end.x() == request_item.rect().left()
+    assert assistant_to_request.start.y() != assistant_to_request.end.y()
+
+
+def test_conversation_messages_share_user_conversation_row(qtbot) -> None:
+    system_prompt = Record(
+        record_id="system",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="conversation.event",
+        payload={"event_type": "SystemPromptEvent", "source": "agent"},
+    )
+    user_message = Record(
+        record_id="user",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=2,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "source": "user",
+            "llm_message": {"role": "user"},
+        },
+    )
+    assistant_message = Record(
+        record_id="assistant",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=3,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "source": "agent",
+            "llm_message": {"role": "assistant"},
+        },
+    )
+    scene = TimelineScene()
+
+    scene.set_timeline(
+        [],
+        [system_prompt, user_message, assistant_message],
+        current_sequence=3,
+    )
+
+    assert scene.available_row_types == ("user_conversation",)
+    assert scene.record_at(sequence=1, lane=0) == "system"
+    assert scene.record_at(sequence=2, lane=0) == "user"
+    assert scene.record_at(sequence=3, lane=0) == "assistant"
+    assert scene.record_label("system") == "System prompt"
+    assert scene.record_label("user") == "User prompt"
+    assert scene.record_label("assistant") == "Assistant message"
+    record_items = {
+        str(getattr(item, "record_id")): item
+        for item in scene.items()
+        if isinstance(item, QGraphicsRectItem)
+        and isinstance(getattr(item, "record_id", None), str)
+    }
+    assert record_items["system"].rect().y() == record_items["user"].rect().y()
+    assert record_items["user"].rect().y() < record_items["assistant"].rect().y()
+
+
 def test_timeline_hit_testing_and_zoom(qtbot) -> None:
     span = Span(
         span_id="tool-span",
@@ -66,6 +241,71 @@ def test_timeline_hit_testing_and_zoom(qtbot) -> None:
     qtbot.keyClick(view, Qt.Key.Key_Plus)
     assert view.zoom_factor > initial_zoom
     assert isinstance(view.minimap, QGraphicsView)
+
+
+def test_minimum_record_width_stays_fixed_until_duration_requires_growth(
+    qtbot,
+) -> None:
+    started_at = datetime(2026, 9, 1, 12)
+    records = [
+        Record(
+            record_id="request",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=1,
+            source_timestamp=started_at,
+            kind="llm.request",
+        ),
+        Record(
+            record_id="action",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=2,
+            source_timestamp=started_at,
+            kind="conversation.event",
+            payload={
+                "event_type": "ActionEvent",
+                "tool_call_id": "call-1",
+            },
+        ),
+        Record(
+            record_id="result",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=3,
+            source_timestamp=started_at + timedelta(milliseconds=100),
+            kind="conversation.event",
+            payload={
+                "event_type": "ObservationEvent",
+                "tool_call_id": "call-1",
+            },
+        ),
+    ]
+    scene = TimelineScene()
+    scene.set_timeline([], records, current_sequence=3)
+    view = TimelineViewWidget(scene)
+    qtbot.addWidget(view)
+
+    def record_widths() -> dict[str, float]:
+        return {
+            str(getattr(item, "record_id")): item.rect().width()
+            for item in scene.items()
+            if isinstance(item, QGraphicsRectItem)
+            and isinstance(getattr(item, "record_id", None), str)
+        }
+
+    assert record_widths()["request"] == MIN_RECORD_WIDTH
+    assert record_widths()["action"] == MIN_RECORD_WIDTH
+
+    view.zoom_in()
+
+    assert record_widths()["request"] == MIN_RECORD_WIDTH
+    assert record_widths()["action"] > MIN_RECORD_WIDTH
+
+    for _ in range(8):
+        view.zoom_in()
+
+    assert record_widths()["request"] == MIN_RECORD_WIDTH
 
 
 def test_timeline_shows_lane_axis_and_activity_markers(qtbot) -> None:
@@ -116,12 +356,11 @@ def test_timeline_shows_lane_axis_and_activity_markers(qtbot) -> None:
     view = TimelineViewWidget(scene)
     qtbot.addWidget(view)
 
-    assert scene.available_row_types == ("lifecycle", "actions", "results")
+    assert scene.available_row_types == ("lifecycle", "tool")
     assert scene.enabled_row_types == scene.available_row_types
     assert scene.lane_names == (
         "Lifecycle · Implementation agent",
-        "Actions · Implementation agent",
-        "Results · Implementation agent",
+        "Tool · Implementation agent",
     )
     lifecycle_label = next(
         item
@@ -132,20 +371,136 @@ def test_timeline_shows_lane_axis_and_activity_markers(qtbot) -> None:
     assert "Lifecycle · Implementation agent" in lifecycle_label.toolTip()
     assert "started, remained active, and finished" in lifecycle_label.toolTip()
     assert scene.record_at(sequence=2, lane=1) == "action"
-    assert scene.record_at(sequence=3, lane=2) == "result"
+    assert scene.record_at(sequence=3, lane=1) == "result"
     assert "+0s" in scene.axis_labels
     assert "file_editor" in scene.record_label("action")
     action_interval = scene.record_interval("action")
     assert action_interval.start_seconds == 0
     assert action_interval.duration_seconds == 3.5
-    record_items = [
-        item
+    record_items = {
+        str(getattr(item, "record_id")): item
         for item in scene.items()
         if isinstance(item, QGraphicsRectItem)
-        and getattr(item, "record_id", None) == "action"
+        and isinstance(getattr(item, "record_id", None), str)
+    }
+    assert record_items["action"].rect().width() == 3.5 * scene.pixels_per_second
+    assert record_items["action"].rect().y() < record_items["result"].rect().y()
+    subrow_labels = {
+        item.toPlainText()
+        for item in scene.items()
+        if isinstance(item, QGraphicsTextItem)
+    }
+    assert {"Action", "Result"}.issubset(subrow_labels)
+
+
+def test_incomplete_lifecycle_covers_sequence_shifted_activity(qtbot) -> None:
+    observed_at = datetime(2026, 9, 1, 12)
+    span = Span(
+        span_id="agent",
+        trace_id="trace",
+        span_type="agent",
+        name="Primary agent",
+        agent_span_id="agent",
+        start_sequence=1,
+        started_at=observed_at,
+        status="incomplete",
+    )
+    records = [
+        Record(
+            record_id="agent-start",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=1,
+            source_timestamp=observed_at,
+            kind="agent.started",
+        ),
+        *[
+            Record(
+                record_id=f"activity-{index}",
+                producer_id="producer",
+                trace_id="trace",
+                span_id="agent",
+                agent_span_id="agent",
+                sequence=index + 2,
+                source_timestamp=observed_at,
+                kind="conversation.event",
+                payload={"event_type": "ActionEvent"},
+            )
+            for index in range(8)
+        ],
     ]
-    assert len(record_items) == 1
-    assert record_items[0].rect().width() == 3.5 * scene.pixels_per_second
+    scene = TimelineScene()
+
+    scene.set_timeline([span], records, current_sequence=9)
+
+    lifecycle = next(
+        item
+        for item in scene.items()
+        if isinstance(item, TimelineSpanItem) and item.span_id == "agent"
+    )
+    activity_right = max(
+        item.rect().right()
+        for item in scene.items()
+        if isinstance(item, TimelineRecordItem)
+        and item.record_id.startswith("activity-")
+    )
+    assert lifecycle.rect().right() >= activity_right
+
+
+def test_back_to_back_tool_results_use_one_row_with_arrows(qtbot) -> None:
+    started_at = datetime(2026, 9, 1, 12)
+    records = [
+        Record(
+            record_id=f"result-{index}",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=index + 1,
+            source_timestamp=started_at + timedelta(milliseconds=index),
+            kind="conversation.event",
+            payload={
+                "event_type": "ObservationEvent",
+                "tool_name": "file_editor",
+                "tool_call_id": f"call-{index}",
+            },
+        )
+        for index in range(5)
+    ]
+    scene = TimelineScene()
+
+    scene.set_timeline([], records, current_sequence=5)
+
+    result_items = {
+        str(getattr(item, "record_id")): item
+        for item in scene.items()
+        if isinstance(item, QGraphicsRectItem)
+        and isinstance(getattr(item, "record_id", None), str)
+    }
+    result_y_positions = [
+        result_items[f"result-{index}"].rect().y() for index in range(5)
+    ]
+    result_x_positions = [
+        result_items[f"result-{index}"].rect().x() for index in range(5)
+    ]
+    arrows = [
+        item for item in scene.items() if isinstance(item, TimelineSequenceArrowItem)
+    ]
+
+    assert len(set(result_y_positions)) == 1
+    for index in range(1, 5):
+        previous = result_items[f"result-{index - 1}"].rect()
+        assert result_x_positions[index] > previous.right()
+    assert len(arrows) == 4
+    for arrow in arrows:
+        previous = result_items[arrow.previous_record_id].rect()
+        following = result_items[arrow.next_record_id].rect()
+        assert arrow.start.x() == previous.right()
+        assert arrow.start.y() == previous.center().y()
+        assert arrow.end.x() == following.left()
+        assert arrow.end.y() == following.center().y()
+    assert scene.lane_names == ("Tool · Session",)
+    assert scene.sceneRect().height() > HEADER_HEIGHT + LANE_HEIGHT
 
 
 def test_timeline_activity_click_selects_record(qtbot, trace_index) -> None:
@@ -187,7 +542,22 @@ def test_timeline_activity_click_selects_record(qtbot, trace_index) -> None:
     window.timeline.record_activated.emit("tool-action")
 
     assert window.selection.current_selection().record_id == "tool-action"
+    assert window.timeline.timeline_scene.selected_record_id == "tool-action"
+    selected_item = window.timeline.timeline_scene._record_items["tool-action"]
+    assert selected_item.selected is True
+    assert selected_item.pen().width() == 3
     assert "terminal" in window.inspector.summary.text()
+
+    window.timeline.zoom_in()
+
+    rebuilt_item = window.timeline.timeline_scene._record_items["tool-action"]
+    assert rebuilt_item is not selected_item
+    assert rebuilt_item.selected is True
+
+    window.navigate_to_agent("agent")
+
+    assert window.timeline.timeline_scene.selected_record_id is None
+    assert rebuilt_item.selected is False
 
 
 def test_timeline_toolbar_controls_zoom_and_fit(qtbot) -> None:
@@ -241,6 +611,50 @@ def test_workspace_assembles_named_panels_and_inspector_tabs(qtbot) -> None:
         "Changes",
         "Evidence",
     ]
+
+
+def test_inspector_ctrl_f_searches_active_text_tab(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    inspector.summary.setText("alpha beta alpha")
+    inspector.explanation.setText("explanation alpha")
+    inspector.show()
+    qtbot.waitExposed(inspector)
+    inspector.activateWindow()
+    inspector.summary.setFocus()
+    qtbot.waitUntil(inspector.summary.hasFocus)
+
+    qtbot.keyClick(
+        inspector.summary,
+        Qt.Key.Key_F,
+        Qt.KeyboardModifier.ControlModifier,
+    )
+    qtbot.keyClicks(inspector.find_input, "alpha")
+
+    assert inspector.find_bar.isVisible()
+    assert inspector.find_status.text() == "1/2"
+    assert inspector.summary.textCursor().selectedText() == "alpha"
+    assert inspector.summary.textCursor().selectionStart() == 0
+
+    qtbot.keyPress(inspector.find_input, Qt.Key.Key_Return)
+
+    assert inspector.find_status.text() == "2/2"
+    assert inspector.summary.textCursor().selectionStart() == 11
+
+    qtbot.keyPress(
+        inspector.find_input,
+        Qt.Key.Key_Return,
+        Qt.KeyboardModifier.ShiftModifier,
+    )
+
+    assert inspector.find_status.text() == "1/2"
+    inspector.setCurrentWidget(inspector.explanation)
+    assert inspector.find_status.text() == "1/1"
+    assert inspector.explanation.textCursor().selectedText() == "alpha"
+
+    qtbot.keyPress(inspector.find_input, Qt.Key.Key_Escape)
+
+    assert not inspector.find_bar.isVisible()
 
 
 def test_run_explanation_distinguishes_trace_lifetime(qtbot) -> None:
@@ -317,6 +731,198 @@ def test_selecting_activity_shows_record_payload(qtbot, trace_index) -> None:
     assert "Recorded activity" in window.inspector.explanation.text()
     assert "immutable trace record" in window.inspector.explanation.text()
     assert "command" in window.inspector.explanation.text()
+
+
+def test_llm_response_summary_formats_chat_output(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    request = Record(
+        record_id="request",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=4,
+        kind="llm.request",
+        llm_response_id="response-1",
+        payload={
+            "filename": "completion.json",
+            "request": {
+                "instructions": "Keep changes focused.",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Fix the test"}],
+                    },
+                    {
+                        "type": "function_call",
+                        "name": "terminal",
+                        "call_id": "call-0",
+                        "arguments": '{"command":"pytest"}',
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call-0",
+                        "output": "One test failed",
+                    },
+                ],
+                "tools": [{"name": "terminal"}],
+            },
+        },
+    )
+    response = Record(
+        record_id="response",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=5,
+        kind="llm.response",
+        llm_response_id="response-1",
+        payload={
+            "filename": "completion.json",
+            "response": {
+                "id": "response-1",
+                "model": "gpt-5",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "finish_reason": "tool_calls",
+                        "message": {
+                            "role": "assistant",
+                            "content": "I found the failing assertion.",
+                            "reasoning_content": "I should inspect the fixture.",
+                            "tool_calls": [
+                                {
+                                    "id": "call-1",
+                                    "function": {
+                                        "name": "terminal",
+                                        "arguments": '{"command":"pytest -q"}',
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            "usage_summary": {
+                "prompt_tokens": 42,
+                "completion_tokens": 12,
+            },
+            "cost": 0.002,
+            "latency_sec": 0.25,
+        },
+    )
+
+    inspector.show_record(request)
+
+    request_summary = inspector.summary.text()
+    assert request_summary.startswith("LLM request\n")
+    assert "SYSTEM INSTRUCTIONS\nKeep changes focused." in request_summary
+    assert "INPUT 1: USER MESSAGE\nFix the test" in request_summary
+    assert "INPUT 2: ASSISTANT TOOL CALL\nTool: terminal" in request_summary
+    assert "INPUT 3: TOOL RESULT\nCall ID: call-0\nOne test failed" in request_summary
+    assert "AVAILABLE TOOLS (1)\n- terminal" in request_summary
+    llm_input = inspector.input.text()
+    assert llm_input.startswith("LLM REQUEST\n")
+    assert "INPUT 1: USER MESSAGE\nFix the test" in llm_input
+    assert '"role"' not in llm_input
+    assert inspector.output.text() == "This activity is not an LLM response."
+
+    inspector.show_record(response)
+
+    summary = inspector.summary.text()
+    assert summary.startswith("LLM response\n")
+    assert "MODEL OUTPUT\nI found the failing assertion." in summary
+    assert "MODEL REASONING\nI should inspect the fixture." in summary
+    assert "TOOL CALLS (1)\n1. terminal" in summary
+    assert "Command: pytest -q" in summary
+    assert "Prompt Tokens: 42" in summary
+    assert "Finish reason: tool_calls" in summary
+    assert '"choices"' not in summary
+    assert '\\"command\\"' not in summary
+    assert inspector.input.text() == "This activity is not an LLM request."
+    assert "MODEL OUTPUT\nI found the failing assertion." in inspector.output.text()
+
+
+def test_llm_response_summary_formats_responses_api_output(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    record = Record(
+        record_id="response",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=5,
+        kind="llm.response",
+        payload={
+            "completion": {
+                "response": {
+                    "id": "response-2",
+                    "model": "gpt-5-codex",
+                    "object": "response",
+                    "output": [
+                        {
+                            "type": "reasoning",
+                            "summary": [
+                                {"type": "summary_text", "text": "Check tests"}
+                            ],
+                        },
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "Tests pass."}],
+                        },
+                        {
+                            "type": "function_call",
+                            "call_id": "call-2",
+                            "name": "terminal",
+                            "arguments": '{"command":"pytest"}',
+                        },
+                    ],
+                    "usage": {"input_tokens": 20, "output_tokens": 8},
+                }
+            }
+        },
+    )
+
+    inspector.show_record(record)
+
+    summary = inspector.summary.text()
+    assert "MODEL OUTPUT\nTests pass." in summary
+    assert "MODEL REASONING\nCheck tests" in summary
+    assert "TOOL CALLS (1)\n1. terminal" in summary
+    assert "Command: pytest" in summary
+    assert "Input Tokens: 20" in summary
+
+
+def test_generic_summary_formats_nested_payload_without_json(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    record = Record(
+        record_id="action",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=6,
+        kind="conversation.event",
+        payload={
+            "event_type": "ActionEvent",
+            "source": "agent",
+            "tool_name": "terminal",
+            "action": {
+                "command": "pytest -q",
+                "env": {"CI": True},
+                "tags": ["focused", "fast"],
+            },
+        },
+    )
+
+    inspector.show_record(record)
+
+    summary = inspector.summary.text()
+    assert summary.startswith("Tool action\n")
+    assert "Tool Name: terminal" in summary
+    assert "Action:\n  Command: pytest -q" in summary
+    assert "Env:\n    CI: Yes" in summary
+    assert "Tags:\n    - focused\n    - fast" in summary
+    assert '"command"' not in summary
+    assert "{" not in summary
 
 
 def test_message_summary_formats_text_content_and_metadata(qtbot) -> None:
@@ -587,17 +1193,17 @@ def test_timeline_row_types_are_configurable_and_persisted(
     window = MainWindow(repository=repository, trace_id="trace")
     qtbot.addWidget(window)
 
-    assert window.timeline_row_actions["actions"].isChecked()
+    assert window.timeline_row_actions["tool"].isChecked()
     assert not window.timeline_row_actions["errors"].isEnabled()
     assert not window.timeline_row_actions["state"].isChecked()
     assert not window.timeline_row_actions["metrics"].isChecked()
-    window.timeline_row_actions["results"].trigger()
-    assert "Results · Primary agent" not in window.timeline.timeline_scene.lane_names
+    window.timeline_row_actions["tool"].trigger()
+    assert "Tool · Primary agent" not in window.timeline.timeline_scene.lane_names
     window.save_settings(settings)
 
     restored = MainWindow()
     qtbot.addWidget(restored)
     restored.restore_settings(settings)
     restored.set_repository(repository, "trace")
-    assert not restored.timeline_row_actions["results"].isChecked()
-    assert "Actions · Primary agent" in restored.timeline.timeline_scene.lane_names
+    assert not restored.timeline_row_actions["tool"].isChecked()
+    assert "Tool · Primary agent" not in restored.timeline.timeline_scene.lane_names

--- a/tests/agent_flight_recorder/gui/test_trace_workspace.py
+++ b/tests/agent_flight_recorder/gui/test_trace_workspace.py
@@ -1,0 +1,603 @@
+from datetime import datetime, timedelta
+
+from flight_recorder.gui.inspector.widget import InspectorWidget
+from flight_recorder.gui.main_window import MainWindow
+from flight_recorder.gui.models.run_table import RunTableModel
+from flight_recorder.gui.models.trace_tree import TraceTreeModel
+from flight_recorder.gui.timeline.scene import TimelineScene
+from flight_recorder.gui.timeline.view import TimelineViewWidget
+from flight_recorder.models.envelopes import Record, Span
+from flight_recorder.models.view_models import RunSummary, TimelineView
+from flight_recorder.services.repository import TraceRepository
+from PySide6.QtCore import QPoint, QPointF, QSettings, Qt
+from PySide6.QtGui import QWheelEvent
+from PySide6.QtWidgets import (
+    QApplication,
+    QGraphicsRectItem,
+    QGraphicsTextItem,
+    QGraphicsView,
+    QSplitter,
+)
+
+
+def test_run_table_and_trace_tree_expose_trace_data() -> None:
+    run = RunSummary(trace_id="trace", status="completed", record_count=2)
+    record = Record(
+        record_id="record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="tool.request",
+    )
+
+    run_model = RunTableModel([run])
+    tree_model = TraceTreeModel(TimelineView(trace_id="trace", records=(record,)))
+
+    assert run_model.rowCount() == 1
+    assert run_model.data(run_model.index(0, 0)) == "trace"
+    assert tree_model.rowCount() == 1
+    assert tree_model.item(0).text() == "tool.request"
+
+
+def test_timeline_hit_testing_and_zoom(qtbot) -> None:
+    span = Span(
+        span_id="tool-span",
+        trace_id="trace",
+        span_type="tool",
+        name="Run tests",
+        agent_span_id="agent",
+        start_sequence=2,
+        end_sequence=5,
+        started_at=datetime(2026, 9, 1, 12),
+        ended_at=datetime(2026, 9, 1, 12, 0, 3),
+        status="completed",
+    )
+    scene = TimelineScene()
+    scene.set_spans([span], current_sequence=5)
+    view = TimelineViewWidget(scene)
+    qtbot.addWidget(view)
+
+    assert scene.span_at(sequence=3, lane=0) == "tool-span"
+    initial_zoom = view.zoom_factor
+    view.zoom_in()
+    assert view.zoom_factor > initial_zoom
+    view.zoom_out()
+    assert view.zoom_factor == initial_zoom
+    qtbot.keyClick(view, Qt.Key.Key_Plus)
+    assert view.zoom_factor > initial_zoom
+    assert isinstance(view.minimap, QGraphicsView)
+
+
+def test_timeline_shows_lane_axis_and_activity_markers(qtbot) -> None:
+    span = Span(
+        span_id="agent-span",
+        trace_id="trace",
+        span_type="agent",
+        name="Implementation agent",
+        agent_span_id="agent-span",
+        start_sequence=1,
+        end_sequence=4,
+        started_at=datetime(2026, 9, 1, 12),
+        ended_at=datetime(2026, 9, 1, 12, 0, 4),
+        status="completed",
+    )
+    records = (
+        Record(
+            record_id="action",
+            producer_id="producer",
+            trace_id="trace",
+            agent_span_id="agent-span",
+            sequence=2,
+            source_timestamp=datetime(2026, 9, 1, 12, 0, 2),
+            kind="conversation.event",
+            payload={
+                "event_type": "ActionEvent",
+                "tool_name": "file_editor",
+                "tool_call_id": "call-1",
+            },
+        ),
+        Record(
+            record_id="result",
+            producer_id="producer",
+            trace_id="trace",
+            agent_span_id="agent-span",
+            sequence=3,
+            source_timestamp=datetime(2026, 9, 1, 12, 0, 2) + timedelta(seconds=3.5),
+            kind="conversation.event",
+            payload={
+                "event_type": "ObservationEvent",
+                "tool_name": "file_editor",
+                "tool_call_id": "call-1",
+            },
+        ),
+    )
+    scene = TimelineScene()
+    scene.set_timeline([span], records, current_sequence=4)
+    view = TimelineViewWidget(scene)
+    qtbot.addWidget(view)
+
+    assert scene.available_row_types == ("lifecycle", "actions", "results")
+    assert scene.enabled_row_types == scene.available_row_types
+    assert scene.lane_names == (
+        "Lifecycle · Implementation agent",
+        "Actions · Implementation agent",
+        "Results · Implementation agent",
+    )
+    lifecycle_label = next(
+        item
+        for item in scene.items()
+        if isinstance(item, QGraphicsTextItem)
+        and item.toPlainText() == "Lifecycle\nImplementation agent"
+    )
+    assert "Lifecycle · Implementation agent" in lifecycle_label.toolTip()
+    assert "started, remained active, and finished" in lifecycle_label.toolTip()
+    assert scene.record_at(sequence=2, lane=1) == "action"
+    assert scene.record_at(sequence=3, lane=2) == "result"
+    assert "+0s" in scene.axis_labels
+    assert "file_editor" in scene.record_label("action")
+    action_interval = scene.record_interval("action")
+    assert action_interval.start_seconds == 0
+    assert action_interval.duration_seconds == 3.5
+    record_items = [
+        item
+        for item in scene.items()
+        if isinstance(item, QGraphicsRectItem)
+        and getattr(item, "record_id", None) == "action"
+    ]
+    assert len(record_items) == 1
+    assert record_items[0].rect().width() == 3.5 * scene.pixels_per_second
+
+
+def test_timeline_activity_click_selects_record(qtbot, trace_index) -> None:
+    records = [
+        Record(
+            record_id="agent-start",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=1,
+            kind="agent.started",
+            payload={"name": "Primary agent"},
+        ),
+        Record(
+            record_id="tool-action",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=2,
+            kind="conversation.event",
+            payload={"event_type": "ActionEvent", "tool_name": "terminal"},
+        ),
+        Record(
+            record_id="agent-finish",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=3,
+            kind="agent.finished",
+        ),
+    ]
+    trace_index.add_records(records)
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+
+    window.timeline.record_activated.emit("tool-action")
+
+    assert window.selection.current_selection().record_id == "tool-action"
+    assert "terminal" in window.inspector.summary.text()
+
+
+def test_timeline_toolbar_controls_zoom_and_fit(qtbot) -> None:
+    window = MainWindow()
+    qtbot.addWidget(window)
+    initial_zoom = window.timeline.zoom_factor
+
+    window.timeline_zoom_in.click()
+    assert window.timeline.zoom_factor > initial_zoom
+    window.timeline_zoom_out.click()
+    assert window.timeline.zoom_factor == initial_zoom
+    window.timeline_zoom_in.click()
+    window.timeline_fit.click()
+    assert window.timeline.zoom_factor == 1.0
+
+
+def test_timeline_mouse_wheel_controls_zoom(qtbot) -> None:
+    view = TimelineViewWidget()
+    qtbot.addWidget(view)
+    initial_zoom = view.zoom_factor
+    event = QWheelEvent(
+        QPointF(20, 20),
+        QPointF(20, 20),
+        QPoint(),
+        QPoint(0, 120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+
+    view.wheelEvent(event)
+
+    assert view.zoom_factor > initial_zoom
+
+
+def test_workspace_assembles_named_panels_and_inspector_tabs(qtbot) -> None:
+    window = MainWindow()
+    qtbot.addWidget(window)
+
+    assert window.findChild(RunTableModel) is not None
+    assert window.findChild(TimelineViewWidget, "timeline") is not None
+    inspector = window.findChild(InspectorWidget, "inspector")
+    assert inspector is not None
+    assert [inspector.tabText(index) for index in range(inspector.count())] == [
+        "Summary",
+        "Explanation",
+        "Input",
+        "Output",
+        "Metrics",
+        "Changes",
+        "Evidence",
+    ]
+
+
+def test_run_explanation_distinguishes_trace_lifetime(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    inspector.show_run(
+        RunSummary(
+            trace_id="trace",
+            status="completed",
+            started_at=datetime(2026, 9, 1, 12),
+            completed_at=datetime(2026, 9, 1, 13),
+            record_count=42,
+        )
+    )
+
+    assert "Run overview" in inspector.explanation.text()
+    assert "3600.000 seconds" in inspector.explanation.text()
+    assert "can include idle time" in inspector.explanation.text()
+
+
+def test_workspace_restores_settings_and_detaches_on_close(tmp_path, qtbot) -> None:
+    settings = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
+    first = MainWindow()
+    qtbot.addWidget(first)
+    first.resize(940, 620)
+    first.save_settings(settings)
+
+    detached = []
+    restored = MainWindow()
+    qtbot.addWidget(restored)
+    restored.restore_settings(settings)
+    restored.add_detach_callback(lambda: detached.append(True))
+
+    assert restored.size().width() == 940
+    assert restored.size().height() == 620
+    restored.close()
+    restored.close()
+    assert detached == [True]
+
+
+def test_workspace_clamps_stale_oversized_window_settings(tmp_path, qtbot) -> None:
+    settings = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
+    settings.setValue("window/width", 81_229)
+    settings.setValue("window/height", 42_000)
+    window = MainWindow()
+    qtbot.addWidget(window)
+
+    window.restore_settings(settings)
+
+    screen = QApplication.primaryScreen()
+    assert screen is not None
+    assert window.width() <= max(1200, screen.availableGeometry().width())
+    assert window.height() <= max(760, screen.availableGeometry().height())
+
+
+def test_selecting_activity_shows_record_payload(qtbot, trace_index) -> None:
+    record = Record(
+        record_id="tool-record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="tool.request",
+        payload={"command": "make test"},
+    )
+    trace_index.add_records([record])
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+
+    window.tree.setCurrentIndex(window.tree_model.index(0, 0))
+    window._tree_item_selected(window.tree.currentIndex())
+
+    assert "tool.request" in window.inspector.summary.text()
+    assert "make test" in window.inspector.summary.text()
+    assert "Recorded activity" in window.inspector.explanation.text()
+    assert "immutable trace record" in window.inspector.explanation.text()
+    assert "command" in window.inspector.explanation.text()
+
+
+def test_message_summary_formats_text_content_and_metadata(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    record = Record(
+        record_id="message",
+        producer_id="producer",
+        trace_id="trace",
+        agent_span_id="agent",
+        sequence=4,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "id": "message-id",
+            "source": "user",
+            "sender": "developer",
+            "timestamp": "2026-09-01T12:00:00",
+            "activated_skills": ["repository-guide"],
+            "extended_content": [
+                {"type": "text", "text": "Inspect carefully\nPreserve behavior"}
+            ],
+            "llm_message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "First paragraph\n\nSecond paragraph",
+                    },
+                    {"type": "image", "image_urls": ["image-data"]},
+                ],
+            },
+        },
+    )
+
+    inspector.show_record(record)
+
+    summary = inspector.summary.text()
+    assert summary.startswith("Message\n")
+    assert "Source: user" in summary
+    assert "Role: user" in summary
+    assert "Sender: developer" in summary
+    assert "First paragraph\n\nSecond paragraph" in summary
+    assert "[Image attachment: 1 image]" in summary
+    assert "PROMPT EXTENSION\nInspect carefully\nPreserve behavior" in summary
+    assert "Activated skills: repository-guide" in summary
+    assert '"text"' not in summary
+    assert "\\n" not in summary
+    highlighted_sections = {
+        selection.cursor.selectedText().replace(
+            "\u2029", "\n"
+        ): selection.format.background().color().name()
+        for selection in inspector.summary.extraSelections()
+    }
+    user_color = next(
+        color
+        for text, color in highlighted_sections.items()
+        if text.startswith("USER PROMPT\nFirst paragraph")
+    )
+    template_color = next(
+        color
+        for text, color in highlighted_sections.items()
+        if text.startswith("OPENHANDS PROMPT EXTENSION\nInspect carefully")
+    )
+    assert user_color == "#e5f5eb"
+    assert template_color == "#e5eff8"
+    assert user_color != template_color
+
+
+def test_system_prompt_summary_formats_prompt_and_dynamic_context(qtbot) -> None:
+    inspector = InspectorWidget()
+    qtbot.addWidget(inspector)
+    record = Record(
+        record_id="system-prompt",
+        producer_id="producer",
+        trace_id="trace",
+        agent_span_id="agent",
+        sequence=3,
+        kind="conversation.event",
+        payload={
+            "event_type": "SystemPromptEvent",
+            "id": "system-prompt-id",
+            "source": "agent",
+            "timestamp": "2026-09-01T12:00:00",
+            "system_prompt": {
+                "type": "text",
+                "text": "Follow instructions.\n\nUse available tools carefully.",
+            },
+            "dynamic_context": {
+                "type": "text",
+                "text": "<SKILLS>\n  <name>code-review</name>\n</SKILLS>",
+            },
+            "tools": [
+                {"name": "terminal", "description": "Run commands"},
+                {"name": "file_editor", "description": "Edit files"},
+            ],
+        },
+    )
+
+    inspector.show_record(record)
+
+    summary = inspector.summary.text()
+    assert summary.startswith("System prompt\n")
+    assert "Follow instructions.\n\nUse available tools carefully." in summary
+    assert "DYNAMIC CONTEXT\n<SKILLS>\n  <name>code-review</name>" in summary
+    assert "AVAILABLE TOOLS (2)\n- terminal\n- file_editor" in summary
+    assert '"text"' not in summary
+    assert "\\n" not in summary
+    highlighted_text = "\n".join(
+        selection.cursor.selectedText().replace("\u2029", "\n")
+        for selection in inspector.summary.extraSelections()
+    )
+    assert "OPENHANDS TEMPLATE\nSYSTEM INSTRUCTIONS" in highlighted_text
+    assert "OPENHANDS DYNAMIC CONTEXT\n<SKILLS>" in highlighted_text
+    assert all(
+        selection.format.background().color().name() == "#e5eff8"
+        for selection in inspector.summary.extraSelections()
+    )
+
+
+def test_system_prompt_summary_includes_following_user_request(
+    qtbot, trace_index
+) -> None:
+    system_prompt = Record(
+        record_id="system-prompt",
+        producer_id="producer",
+        trace_id="trace",
+        agent_span_id="agent",
+        sequence=3,
+        kind="conversation.event",
+        payload={
+            "event_type": "SystemPromptEvent",
+            "source": "agent",
+            "system_prompt": {"type": "text", "text": "OpenHands template"},
+            "tools": [],
+        },
+    )
+    user_request = Record(
+        record_id="user-request",
+        producer_id="producer",
+        trace_id="trace",
+        agent_span_id="agent",
+        sequence=4,
+        kind="conversation.event",
+        payload={
+            "event_type": "MessageEvent",
+            "source": "user",
+            "llm_message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Implement the original requested feature.",
+                    }
+                ],
+            },
+        },
+    )
+    trace_index.add_records([system_prompt, user_request])
+    window = MainWindow(repository=TraceRepository(trace_index), trace_id="trace")
+    qtbot.addWidget(window)
+
+    window.navigate_to_record("system-prompt")
+
+    summary = window.inspector.summary.text()
+    assert "USER REQUEST (SEQUENCE 4)" in summary
+    assert "Implement the original requested feature." in summary
+    assert summary.index("USER REQUEST") < summary.index("OPENHANDS TEMPLATE")
+    user_highlight = next(
+        selection
+        for selection in window.inspector.summary.extraSelections()
+        if selection.cursor.selectedText().startswith("USER REQUEST")
+    )
+    assert user_highlight.format.background().color().name() == "#e5f5eb"
+
+
+def test_long_inspector_payload_does_not_resize_workspace_panels(qtbot) -> None:
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.show()
+    QApplication.processEvents()
+    splitter = window.findChild(QSplitter)
+    assert splitter is not None
+    initial_sizes = splitter.sizes()
+    record = Record(
+        record_id="large-record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="conversation.event",
+        payload={"content": "long payload " * 1000},
+    )
+
+    window.inspector.show_record(record)
+    QApplication.processEvents()
+
+    assert splitter.sizes() == initial_sizes
+
+
+def test_workspace_panels_are_draggable_and_persisted(tmp_path, qtbot) -> None:
+    settings = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.show()
+    QApplication.processEvents()
+    splitter = window.findChild(QSplitter)
+    assert splitter is not None
+    initial_sizes = splitter.sizes()
+    handle = splitter.handle(2)
+
+    qtbot.mousePress(handle, Qt.MouseButton.LeftButton)
+    qtbot.mouseMove(handle, handle.rect().center() + QPoint(80, 0))
+    qtbot.mouseRelease(handle, Qt.MouseButton.LeftButton)
+    QApplication.processEvents()
+
+    adjusted_sizes = splitter.sizes()
+    assert adjusted_sizes != initial_sizes
+    window.save_settings(settings)
+
+    restored = MainWindow()
+    qtbot.addWidget(restored)
+    restored.restore_settings(settings)
+    restored.show()
+    QApplication.processEvents()
+    restored_splitter = restored.findChild(QSplitter)
+    assert restored_splitter is not None
+    assert restored_splitter.sizes() == adjusted_sizes
+
+
+def test_timeline_row_types_are_configurable_and_persisted(
+    tmp_path, qtbot, trace_index
+) -> None:
+    settings = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
+    records = [
+        Record(
+            record_id="agent-start",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=1,
+            kind="agent.started",
+            payload={"name": "Primary agent"},
+        ),
+        Record(
+            record_id="action",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=2,
+            kind="conversation.event",
+            payload={"event_type": "ActionEvent", "tool_name": "terminal"},
+        ),
+        Record(
+            record_id="result",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=3,
+            kind="conversation.event",
+            payload={"event_type": "ObservationEvent", "tool_name": "terminal"},
+        ),
+    ]
+    trace_index.add_records(records)
+    repository = TraceRepository(trace_index)
+    window = MainWindow(repository=repository, trace_id="trace")
+    qtbot.addWidget(window)
+
+    assert window.timeline_row_actions["actions"].isChecked()
+    assert not window.timeline_row_actions["errors"].isEnabled()
+    assert not window.timeline_row_actions["state"].isChecked()
+    assert not window.timeline_row_actions["metrics"].isChecked()
+    window.timeline_row_actions["results"].trigger()
+    assert "Results · Primary agent" not in window.timeline.timeline_scene.lane_names
+    window.save_settings(settings)
+
+    restored = MainWindow()
+    qtbot.addWidget(restored)
+    restored.restore_settings(settings)
+    restored.set_repository(repository, "trace")
+    assert not restored.timeline_row_actions["results"].isChecked()
+    assert "Actions · Primary agent" in restored.timeline.timeline_scene.lane_names

--- a/tests/agent_flight_recorder/gui/test_workers.py
+++ b/tests/agent_flight_recorder/gui/test_workers.py
@@ -1,0 +1,33 @@
+from threading import Event
+
+from flight_recorder.gui.workers import TaskWorker
+
+
+def test_task_worker_emits_result_off_thread(qtbot) -> None:
+    worker = TaskWorker(lambda cancelled: 42)
+
+    with qtbot.waitSignal(worker.succeeded, timeout=1000) as signal:
+        worker.start()
+
+    assert signal.args == [42]
+    worker.wait()
+
+
+def test_task_worker_cancellation_suppresses_result(qtbot) -> None:
+    started = Event()
+    release = Event()
+    results = []
+
+    def work(cancelled):
+        started.set()
+        release.wait(1)
+        return "ignored"
+
+    worker = TaskWorker(work)
+    worker.succeeded.connect(results.append)
+    worker.start()
+    assert started.wait(1)
+    worker.cancel()
+    release.set()
+    assert worker.wait(1000)
+    assert results == []

--- a/tests/agent_flight_recorder/integration/test_bundle_roundtrip.py
+++ b/tests/agent_flight_recorder/integration/test_bundle_roundtrip.py
@@ -1,0 +1,145 @@
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from flight_recorder.errors import InvalidBundle
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Record
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.bundles import BundleMergeSource, BundleService
+
+
+def test_bundle_validation_and_import_are_idempotent(tmp_path: Path) -> None:
+    bundle = tmp_path / "trace.afr"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "format": "agent-flight-recorder",
+                "format_version": 1,
+                "trace_id": "trace",
+            }
+        )
+    )
+    record = Record(
+        record_id="record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="run.started",
+    )
+    (bundle / "records.jsonl").write_text(record.model_dump_json() + "\n")
+    index = TraceIndex(tmp_path / "index.db")
+    service = BundleService(index)
+
+    assert service.validate_bundle(bundle).record_count == 1
+    assert service.import_bundle(bundle) == "trace"
+    assert service.import_bundle(bundle) == "trace"
+    assert index.iter_records("trace") == [record]
+
+
+def test_export_finalizes_and_round_trips_portable_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "trace.afr"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "format": "agent-flight-recorder",
+                "format_version": 1,
+                "trace_id": "trace",
+                "created_at": "2026-09-01T12:00:00",
+                "status": "completed",
+                "completed_at": "2026-09-01T12:01:00",
+                "stop_reason": "finished",
+                "recorder_version": "0.1.0",
+                "content_encoding": "zstd",
+            }
+        )
+    )
+    records = [
+        Record(
+            record_id=f"record-{sequence}",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=sequence,
+            kind=kind,
+        )
+        for sequence, kind in ((1, "run.started"), (2, "run.finished"))
+    ]
+    (bundle / "records.jsonl").write_text(
+        "".join(record.model_dump_json() + "\n" for record in records)
+    )
+    archive = tmp_path / "trace.afr.zip"
+
+    BundleService().export_bundle(bundle, archive)
+
+    with zipfile.ZipFile(archive) as exported:
+        names = set(exported.namelist())
+        manifest = json.loads(exported.read("trace.afr/manifest.json"))
+    assert manifest["record_count"] == 2
+    assert manifest["finding_count"] == 0
+    assert "trace.afr/findings.jsonl" in names
+    assert "trace.afr/checksums.sha256" in names
+
+    replay_index = TraceIndex(tmp_path / "replay.db")
+    replay_index.add_records(
+        [
+            Record(
+                record_id="stale-record",
+                producer_id="producer",
+                trace_id="trace",
+                sequence=3,
+                kind="stale",
+            )
+        ]
+    )
+    replay_service = BundleService(replay_index)
+    assert replay_service.validate_bundle(archive).record_count == 2
+    assert replay_service.import_bundle(archive) == "trace"
+    assert replay_index.iter_records("trace") == records
+
+    exported_directory = tmp_path / "exported.afr"
+    BundleService().export_bundle(bundle, exported_directory)
+    manifest_path = exported_directory / "manifest.json"
+    manifest_path.write_text(manifest_path.read_text() + "\n")
+
+    with pytest.raises(InvalidBundle, match="checksum"):
+        BundleService().validate_bundle(exported_directory)
+
+
+def test_merge_bundles_links_child_root_agent_to_parent(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.afr"
+    child = tmp_path / "child.afr"
+    parent_index = TraceIndex(tmp_path / "parent.db")
+    child_index = TraceIndex(tmp_path / "child.db")
+    parent_recorder = Recorder(parent, parent_index)
+    child_recorder = Recorder(child, child_index)
+    parent_recorder.close()
+    child_recorder.close()
+    destination = tmp_path / "merged.afr"
+
+    merged = BundleService().merge_bundles(
+        [
+            BundleMergeSource(parent),
+            BundleMergeSource(
+                child,
+                parent_trace_id=parent_recorder.trace_id,
+                agent_name="Child implementation",
+            ),
+        ],
+        destination,
+    )
+
+    records = list(BundleService.iter_record_file(destination / "records.jsonl"))
+    child_start = next(
+        record
+        for record in records
+        if record.kind == "agent.started"
+        and record.span_id == child_recorder.agent_span_id
+    )
+    assert merged.trace_id == parent_recorder.trace_id
+    assert child_start.trace_id == parent_recorder.trace_id
+    assert child_start.parent_span_id == parent_recorder.agent_span_id
+    assert child_start.payload["name"] == "Child implementation"
+    assert BundleService().validate_bundle(destination).record_count == len(records)

--- a/tests/agent_flight_recorder/integration/test_diagnostic_quality.py
+++ b/tests/agent_flight_recorder/integration/test_diagnostic_quality.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from flight_recorder.diagnostics.rules import deterministic_findings
+from flight_recorder.models.envelopes import Record
+
+
+CORPUS = Path(__file__).parents[1] / "fixtures" / "traces" / "diagnostics"
+
+
+def test_deterministic_detector_quality_and_evidence_validity() -> None:
+    manifest = json.loads((CORPUS / "manifest.json").read_text())
+    outcomes: dict[str, list[tuple[bool, bool]]] = {}
+    for case in manifest["cases"]:
+        records = [
+            Record.model_validate_json(line)
+            for line in (CORPUS / case["file"]).read_text().splitlines()
+        ]
+        findings = deterministic_findings(records)
+        detected = any(finding.detector_id == case["detector"] for finding in findings)
+        outcomes.setdefault(case["detector"], []).append((case["positive"], detected))
+        record_ids = {record.record_id for record in records}
+        assert all(set(finding.evidence_ids) <= record_ids for finding in findings)
+
+    for results in outcomes.values():
+        true_positives = sum(expected and detected for expected, detected in results)
+        false_positives = sum(
+            not expected and detected for expected, detected in results
+        )
+        false_negatives = sum(
+            expected and not detected for expected, detected in results
+        )
+        precision = true_positives / (true_positives + false_positives)
+        recall = true_positives / (true_positives + false_negatives)
+        assert precision >= 0.9
+        assert recall >= 0.9

--- a/tests/agent_flight_recorder/integration/test_failure_isolation.py
+++ b/tests/agent_flight_recorder/integration/test_failure_isolation.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.recorder import Recorder
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.llm import Metrics
+
+
+def test_bad_callback_data_does_not_escape(tmp_path: Path) -> None:
+    recorder = Recorder(tmp_path / "trace.afr", TraceIndex(tmp_path / "index.db"))
+
+    recorder.on_event(object())
+    recorder.close()
+
+    assert recorder.errors == 1
+
+
+def test_metrics_capture_and_close_are_failure_isolated(tmp_path: Path) -> None:
+    index = TraceIndex(tmp_path / "index.db")
+    recorder = Recorder(tmp_path / "trace.afr", index)
+    stats = ConversationStats(
+        usage_to_metrics={"agent": Metrics(model_name="test-model")}
+    )
+
+    recorder.record_metrics(stats)
+    recorder.close()
+    recorder.close()
+    recorder.record_metrics(stats)
+
+    records = index.iter_records(recorder.trace_id)
+    assert [record.kind for record in records] == [
+        "run.started",
+        "agent.started",
+        "metrics.snapshot",
+        "agent.finished",
+        "run.finished",
+    ]
+    assert recorder.errors == 1
+
+
+def test_storage_failure_does_not_escape_collector_thread(
+    tmp_path: Path, monkeypatch
+) -> None:
+    index = TraceIndex(tmp_path / "index.db")
+
+    def fail_add_records(records) -> None:
+        raise OSError("injected index failure")
+
+    monkeypatch.setattr(index, "add_records", fail_add_records)
+    recorder = Recorder(tmp_path / "trace.afr", index)
+
+    recorder.close()
+
+    assert recorder.warning_counters["collector_errors"] == 1

--- a/tests/agent_flight_recorder/integration/test_failure_isolation.py
+++ b/tests/agent_flight_recorder/integration/test_failure_isolation.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from flight_recorder.models.database import TraceIndex
@@ -14,6 +15,34 @@ def test_bad_callback_data_does_not_escape(tmp_path: Path) -> None:
     recorder.close()
 
     assert recorder.errors == 1
+
+
+def test_llm_request_is_committed_without_waiting_for_completion(
+    tmp_path: Path,
+) -> None:
+    index = TraceIndex(tmp_path / "index.db")
+    recorder = Recorder(tmp_path / "trace.afr", index)
+
+    recorder.on_llm_request(
+        "call-1",
+        json.dumps(
+            {
+                "llm_call_id": "call-1",
+                "timestamp": 1_788_545_603.75,
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        ),
+    )
+    recorder.close()
+
+    requests = [
+        record
+        for record in index.iter_records(recorder.trace_id)
+        if record.kind == "llm.request"
+    ]
+    assert len(requests) == 1
+    assert requests[0].llm_call_id == "call-1"
+    assert requests[0].payload["request"]["messages"][0]["content"] == "hello"
 
 
 def test_metrics_capture_and_close_are_failure_isolated(tmp_path: Path) -> None:

--- a/tests/agent_flight_recorder/integration/test_subscriptions.py
+++ b/tests/agent_flight_recorder/integration/test_subscriptions.py
@@ -1,0 +1,61 @@
+from threading import Event
+
+from flight_recorder.models.envelopes import CommittedBatch
+from flight_recorder.services.subscriptions import TraceSubscription
+
+
+def batch(first: int, last: int) -> CommittedBatch:
+    return CommittedBatch(
+        trace_id="trace",
+        first_sequence=first,
+        last_sequence=last,
+        record_ids=tuple(str(sequence) for sequence in range(first, last + 1)),
+    )
+
+
+def test_subscription_resumes_after_sequence_and_unsubscribes() -> None:
+    subscription = TraceSubscription()
+    delivered: list[CommittedBatch] = []
+    delivery = Event()
+
+    def receive(item: CommittedBatch) -> None:
+        delivered.append(item)
+        delivery.set()
+
+    handle = subscription.subscribe(
+        "trace",
+        after_sequence=5,
+        callback=receive,
+    )
+
+    subscription.publish(batch(1, 5))
+    subscription.publish(batch(6, 7))
+
+    assert delivery.wait(1)
+    assert [(item.first_sequence, item.last_sequence) for item in delivered] == [(6, 7)]
+    handle.unsubscribe()
+    handle.unsubscribe()
+    subscription.publish(batch(8, 8))
+    assert len(delivered) == 1
+    subscription.close()
+
+
+def test_slow_subscriber_does_not_block_fast_subscriber() -> None:
+    subscription = TraceSubscription()
+    release_slow = Event()
+    slow_started = Event()
+    fast_finished = Event()
+
+    def slow_callback(item: CommittedBatch) -> None:
+        slow_started.set()
+        release_slow.wait(1)
+
+    subscription.subscribe("trace", 0, slow_callback)
+    subscription.subscribe("trace", 0, lambda item: fast_finished.set())
+
+    subscription.publish(batch(1, 1))
+
+    assert slow_started.wait(1)
+    assert fast_finished.wait(1)
+    release_slow.set()
+    subscription.close()

--- a/tests/agent_flight_recorder/performance/test_performance_targets.py
+++ b/tests/agent_flight_recorder/performance/test_performance_targets.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from statistics import quantiles
+from threading import Event
+from time import perf_counter, sleep
+
+from flight_recorder.collector.queue import RecordQueue
+from flight_recorder.gui.controllers.selection import SelectionController
+from flight_recorder.gui.timeline.layout import project_spans
+from flight_recorder.models.envelopes import CommittedBatch, Record, Span
+from flight_recorder.services.subscriptions import TraceSubscription
+
+
+def record(sequence: int) -> Record:
+    return Record(
+        record_id=f"record-{sequence}",
+        producer_id="benchmark",
+        trace_id="trace",
+        sequence=sequence,
+        observed_at=datetime(2026, 9, 1, 12),
+        kind="llm.stream_delta",
+    )
+
+
+def test_callback_latency_and_observed_run_overhead() -> None:
+    queue = RecordQueue(maxsize=256)
+    latencies = []
+    observed_work_seconds = 0.5
+    for sequence in range(1, 51):
+        sleep(0.01)
+        callback_started = perf_counter()
+        queue.put(record(sequence))
+        latencies.append(perf_counter() - callback_started)
+
+    assert quantiles(latencies, n=20)[-1] < 0.005
+    assert sum(latencies) / observed_work_seconds < 0.05
+
+
+def test_live_update_latency_is_below_500ms() -> None:
+    delivered = Event()
+    subscription = TraceSubscription(max_workers=1)
+    subscription.subscribe("trace", 0, lambda batch: delivered.set())
+    started = perf_counter()
+    subscription.publish(
+        CommittedBatch(
+            trace_id="trace", first_sequence=1, last_sequence=1, record_ids=("one",)
+        )
+    )
+
+    assert delivered.wait(0.5)
+    assert perf_counter() - started < 0.5
+    subscription.close()
+
+
+def test_100k_overview_and_selection_targets() -> None:
+    spans = [
+        Span(
+            span_id=f"span-{index}",
+            trace_id="trace",
+            span_type="iteration",
+            name=f"Iteration {index}",
+            agent_span_id=f"agent-{index % 8}",
+            start_sequence=index + 1,
+            end_sequence=index + 1,
+            started_at=datetime(2026, 9, 1, 12),
+            status="completed",
+        )
+        for index in range(100_000)
+    ]
+    started = perf_counter()
+    projected = project_spans(spans, current_sequence=100_000)
+    render_elapsed = perf_counter() - started
+    controller = SelectionController()
+    selection_started = perf_counter()
+    controller.select_span(projected[-1].span_id)
+    selection_elapsed = perf_counter() - selection_started
+
+    assert len(projected) == 100_000
+    assert render_elapsed < 3
+    assert selection_elapsed < 0.1

--- a/tests/agent_flight_recorder/unit/test_agent_projection.py
+++ b/tests/agent_flight_recorder/unit/test_agent_projection.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+from flight_recorder.gui.timeline.layout import project_spans
+from flight_recorder.models.envelopes import Record, Span
+from flight_recorder.services.repository import TraceRepository
+
+
+def agent_span(span_id: str, start: int, end: int) -> Span:
+    return Span(
+        span_id=span_id,
+        trace_id="trace",
+        span_type="agent",
+        name=span_id,
+        parent_span_id="parent",
+        agent_span_id=span_id,
+        start_sequence=start,
+        end_sequence=end,
+        started_at=datetime(2026, 9, 1, 12),
+        ended_at=datetime(2026, 9, 1, 12, 0, end),
+        status="completed",
+    )
+
+
+def test_parallel_agent_branches_have_stable_distinct_lanes() -> None:
+    spans = [agent_span("child-b", 2, 6), agent_span("child-a", 2, 5)]
+
+    projected = project_spans(spans, current_sequence=6)
+
+    assert [(item.span_id, item.lane) for item in projected] == [
+        ("child-a", 0),
+        ("child-b", 1),
+    ]
+
+
+def test_repository_aggregates_metrics_per_agent(trace_index) -> None:
+    def metrics(
+        record_id: str, sequence: int, agent_span_id: str, tokens: int
+    ) -> Record:
+        return Record(
+            record_id=record_id,
+            producer_id="producer",
+            trace_id="trace",
+            agent_span_id=agent_span_id,
+            sequence=sequence,
+            observed_at=datetime(2026, 9, 1, 12),
+            kind="metrics.snapshot",
+            payload={
+                "usage_to_metrics": {
+                    record_id: {
+                        "accumulated_token_usage": {"prompt_tokens": tokens},
+                        "accumulated_cost": tokens / 100,
+                    }
+                }
+            },
+        )
+
+    trace_index.add_records(
+        [
+            metrics("parent-metrics", 1, "parent", 10),
+            metrics("child-metrics", 2, "child", 4),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    usage, cost = repository.get_agent_usage("trace", "child")
+
+    assert usage.prompt_tokens == 4
+    assert cost == 0.04

--- a/tests/agent_flight_recorder/unit/test_bundle_primitives.py
+++ b/tests/agent_flight_recorder/unit/test_bundle_primitives.py
@@ -1,0 +1,60 @@
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from flight_recorder.errors import InvalidBundle, UnsupportedFormat
+from flight_recorder.models.envelopes import Record
+from flight_recorder.services.bundles import BundleService
+
+
+def bundle(tmp_path: Path, version: int = 1) -> Path:
+    root = tmp_path / "trace.afr"
+    root.mkdir()
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "format": "agent-flight-recorder",
+                "format_version": version,
+                "trace_id": "trace",
+            }
+        )
+    )
+    record = Record(
+        record_id="record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="run.started",
+    )
+    (root / "records.jsonl").write_text(record.model_dump_json() + "\n")
+    return root
+
+
+def test_rejects_unsupported_format(tmp_path: Path) -> None:
+    with pytest.raises(UnsupportedFormat):
+        BundleService().validate_bundle(bundle(tmp_path, version=2))
+
+
+def test_ignores_truncated_final_record(tmp_path: Path) -> None:
+    root = bundle(tmp_path)
+    with (root / "records.jsonl").open("a") as stream:
+        stream.write('{"incomplete":')
+
+    assert BundleService().validate_bundle(root).record_count == 1
+
+
+def test_rejects_zip_parent_traversal(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive, "w") as stream:
+        stream.writestr("../outside", "invalid")
+
+    with pytest.raises(InvalidBundle):
+        BundleService().validate_bundle(archive)
+
+
+def test_checksum_uses_file_content(tmp_path: Path) -> None:
+    content = tmp_path / "content"
+    content.write_bytes(b"flight recorder")
+
+    assert len(BundleService.checksum(content)) == 64

--- a/tests/agent_flight_recorder/unit/test_cli.py
+++ b/tests/agent_flight_recorder/unit/test_cli.py
@@ -1,0 +1,102 @@
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from flight_recorder.cli import build_parser, run_cli
+from flight_recorder.config import RecorderPaths
+from flight_recorder.models.envelopes import Record
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.bundles import BundleService
+
+
+def test_parser_accepts_record_target_and_output() -> None:
+    args = build_parser().parse_args(["record", "--output", "trace.afr", "example:run"])
+
+    assert args.command == "record"
+    assert args.output == Path("trace.afr")
+    assert args.target == "example:run"
+
+
+def test_cli_records_with_attachment_target(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    paths = RecorderPaths(
+        data=tmp_path / "data",
+        cache=tmp_path / "cache",
+        traces=tmp_path / "data" / "traces",
+        index=tmp_path / "data" / "index.db",
+    )
+    monkeypatch.setattr(RecorderPaths, "defaults", lambda: paths)
+    module = ModuleType("recording_target")
+
+    def run(recorder: Recorder) -> None:
+        recorder.on_completion_log(
+            "completion.json", json.dumps({"response_id": "response-1"})
+        )
+
+    module.__dict__["run"] = run
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    output = tmp_path / "recorded.afr"
+
+    result = run_cli(
+        build_parser().parse_args(
+            ["record", "--output", str(output), "recording_target:run"]
+        )
+    )
+
+    assert result == 0
+    assert BundleService().validate_bundle(output).record_count == 5
+    assert capsys.readouterr().out.strip()
+
+
+def test_cli_imports_and_exports_trace_by_id(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    paths = RecorderPaths(
+        data=tmp_path / "data",
+        cache=tmp_path / "cache",
+        traces=tmp_path / "data" / "traces",
+        index=tmp_path / "data" / "index.db",
+    )
+    monkeypatch.setattr(RecorderPaths, "defaults", lambda: paths)
+    bundle = tmp_path / "source.afr"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "format": "agent-flight-recorder",
+                "format_version": 1,
+                "trace_id": "trace",
+            }
+        )
+    )
+    record = Record(
+        record_id="record",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="run.started",
+    )
+    (bundle / "records.jsonl").write_text(record.model_dump_json() + "\n")
+
+    assert run_cli(build_parser().parse_args(["import", str(bundle)])) == 0
+    assert capsys.readouterr().out.strip() == "trace"
+
+    destination = tmp_path / "exported.afr.zip"
+    assert (
+        run_cli(build_parser().parse_args(["export", "trace", str(destination)])) == 0
+    )
+    assert capsys.readouterr().out.strip() == str(destination)
+    assert destination.is_file()
+
+
+def test_cli_validation_errors_go_to_stderr(tmp_path: Path, capsys) -> None:
+    result = run_cli(
+        build_parser().parse_args(["validate", str(tmp_path / "missing.afr")])
+    )
+
+    output = capsys.readouterr()
+    assert result == 1
+    assert output.out == ""
+    assert output.err

--- a/tests/agent_flight_recorder/unit/test_cli.py
+++ b/tests/agent_flight_recorder/unit/test_cli.py
@@ -31,8 +31,13 @@ def test_cli_records_with_attachment_target(
     module = ModuleType("recording_target")
 
     def run(recorder: Recorder) -> None:
+        recorder.on_llm_request(
+            "call-1",
+            json.dumps({"llm_call_id": "call-1", "messages": []}),
+        )
         recorder.on_completion_log(
-            "completion.json", json.dumps({"response_id": "response-1"})
+            "completion.json",
+            json.dumps({"llm_call_id": "call-1", "response_id": "response-1"}),
         )
 
     module.__dict__["run"] = run
@@ -46,7 +51,14 @@ def test_cli_records_with_attachment_target(
     )
 
     assert result == 0
-    assert BundleService().validate_bundle(output).record_count == 5
+    assert BundleService().validate_bundle(output).record_count == 6
+    records = [
+        json.loads(line) for line in (output / "records.jsonl").read_text().splitlines()
+    ]
+    assert [record["kind"] for record in records[2:4]] == [
+        "llm.request",
+        "llm.response",
+    ]
     assert capsys.readouterr().out.strip()
 
 

--- a/tests/agent_flight_recorder/unit/test_collector.py
+++ b/tests/agent_flight_recorder/unit/test_collector.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from flight_recorder.collector.persistence import Collector
+from flight_recorder.collector.queue import RecordQueue
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Record
+
+
+def test_collector_assigns_order_and_publishes_batch(tmp_path: Path) -> None:
+    queue = RecordQueue()
+    index = TraceIndex(tmp_path / "index.db")
+    collector = Collector(queue, tmp_path / "trace.afr", index)
+    batches = []
+    collector.subscribe(batches.append)
+    queue.put(
+        Record(
+            record_id="one",
+            producer_id="producer",
+            trace_id="trace",
+            kind="run.started",
+        )
+    )
+
+    collector.start()
+    collector.stop()
+
+    assert index.iter_records("trace")[0].sequence == 1
+    assert batches[0].record_ids == ("one",)
+
+
+def test_collector_deduplicates_record_ids_before_append(tmp_path: Path) -> None:
+    queue = RecordQueue()
+    index = TraceIndex(tmp_path / "index.db")
+    bundle = tmp_path / "trace.afr"
+    collector = Collector(queue, bundle, index)
+    batches = []
+    collector.subscribe(batches.append)
+    record = Record(
+        record_id="duplicate",
+        producer_id="producer",
+        trace_id="trace",
+        kind="run.started",
+    )
+    queue.put(record)
+    queue.put(record)
+
+    collector.start()
+    collector.stop()
+
+    assert len((bundle / "records.jsonl").read_text().splitlines()) == 1
+    assert [item.record_id for item in index.iter_records("trace")] == ["duplicate"]
+    assert batches[0].record_ids == ("duplicate",)
+
+
+def test_collector_records_queue_omissions(tmp_path: Path) -> None:
+    queue = RecordQueue(maxsize=1)
+    index = TraceIndex(tmp_path / "index.db")
+    collector = Collector(queue, tmp_path / "trace.afr", index)
+    queue.put(
+        Record(
+            record_id="stream",
+            producer_id="producer",
+            trace_id="trace",
+            kind="llm.stream_delta",
+        )
+    )
+    queue.put(
+        Record(
+            record_id="lifecycle",
+            producer_id="producer",
+            trace_id="trace",
+            kind="run.finished",
+        )
+    )
+
+    collector.start()
+    collector.stop()
+
+    records = index.iter_records("trace")
+    assert [record.kind for record in records] == ["run.finished", "recorder.warning"]
+    assert records[-1].payload == {"dropped_records": 1}

--- a/tests/agent_flight_recorder/unit/test_context_diff.py
+++ b/tests/agent_flight_recorder/unit/test_context_diff.py
@@ -1,0 +1,30 @@
+from flight_recorder.gui.inspector.diff import diff_contexts
+from flight_recorder.services.repository import resolve_condensation
+
+
+def test_context_diff_reports_added_removed_and_changed_messages() -> None:
+    previous = (
+        {"id": "one", "content": "old"},
+        {"id": "removed", "content": "gone"},
+    )
+    current = (
+        {"id": "one", "content": "new"},
+        {"id": "added", "content": "here"},
+    )
+
+    difference = diff_contexts(previous, current)
+
+    assert difference.added == ("added",)
+    assert difference.removed == ("removed",)
+    assert difference.changed == ("one",)
+
+
+def test_condensation_retains_unresolved_event_ids() -> None:
+    result = resolve_condensation(
+        {"forgotten_event_ids": ["known", "missing"], "summary": "Earlier work"},
+        known_record_ids={"known"},
+    )
+
+    assert result.resolved_ids == ("known",)
+    assert result.unresolved_ids == ("missing",)
+    assert result.summary == "Earlier work"

--- a/tests/agent_flight_recorder/unit/test_context_projection.py
+++ b/tests/agent_flight_recorder/unit/test_context_projection.py
@@ -1,0 +1,57 @@
+from flight_recorder.models.envelopes import ProvenanceKind, Record
+from flight_recorder.services.repository import TraceRepository
+
+
+def test_context_prefers_authoritative_completion_log(trace_index) -> None:
+    trace_index.add_records(
+        [
+            Record(
+                record_id="request",
+                producer_id="producer",
+                trace_id="trace",
+                sequence=1,
+                kind="llm.response",
+                payload={
+                    "completion": {
+                        "messages": [{"role": "user", "content": "Exact input"}]
+                    }
+                },
+            )
+        ]
+    )
+
+    context = TraceRepository(trace_index).get_model_context("trace", "request")
+
+    assert context.provenance.kind == ProvenanceKind.CAPTURED
+    assert context.messages[0]["content"] == "Exact input"
+
+
+def test_context_reconstructs_from_conversation_events(trace_index) -> None:
+    trace_index.add_records(
+        [
+            Record(
+                record_id="message",
+                producer_id="producer",
+                trace_id="trace",
+                sequence=1,
+                kind="conversation.event",
+                payload={
+                    "event_type": "MessageEvent",
+                    "llm_message": {"role": "user", "content": [{"text": "Hello"}]},
+                },
+            ),
+            Record(
+                record_id="request",
+                producer_id="producer",
+                trace_id="trace",
+                sequence=2,
+                kind="llm.response",
+            ),
+        ]
+    )
+
+    context = TraceRepository(trace_index).get_model_context("trace", "request")
+
+    assert context.provenance.kind == ProvenanceKind.RECONSTRUCTED
+    assert context.provenance.source_ids == ("message",)
+    assert context.messages[0]["role"] == "user"

--- a/tests/agent_flight_recorder/unit/test_context_projection.py
+++ b/tests/agent_flight_recorder/unit/test_context_projection.py
@@ -2,7 +2,7 @@ from flight_recorder.models.envelopes import ProvenanceKind, Record
 from flight_recorder.services.repository import TraceRepository
 
 
-def test_context_prefers_authoritative_completion_log(trace_index) -> None:
+def test_context_prefers_authoritative_llm_request(trace_index) -> None:
     trace_index.add_records(
         [
             Record(
@@ -10,11 +10,9 @@ def test_context_prefers_authoritative_completion_log(trace_index) -> None:
                 producer_id="producer",
                 trace_id="trace",
                 sequence=1,
-                kind="llm.response",
+                kind="llm.request",
                 payload={
-                    "completion": {
-                        "messages": [{"role": "user", "content": "Exact input"}]
-                    }
+                    "request": {"input": [{"role": "user", "content": "Exact input"}]}
                 },
             )
         ]

--- a/tests/agent_flight_recorder/unit/test_database.py
+++ b/tests/agent_flight_recorder/unit/test_database.py
@@ -1,0 +1,37 @@
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Record
+
+
+def test_index_orders_and_deduplicates_records(trace_index: TraceIndex) -> None:
+    record = Record(
+        record_id="one",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=1,
+        kind="run.started",
+    )
+    trace_index.add_records([record, record])
+
+    assert trace_index.iter_records("trace") == [record]
+
+
+def test_index_creates_every_rebuildable_projection_table(
+    trace_index: TraceIndex,
+) -> None:
+    with trace_index.connect() as connection:
+        names = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+
+    assert {
+        "runs",
+        "spans",
+        "records",
+        "llm_calls",
+        "artifacts",
+        "findings",
+        "content_blobs",
+    } <= names

--- a/tests/agent_flight_recorder/unit/test_diagnostics.py
+++ b/tests/agent_flight_recorder/unit/test_diagnostics.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+import pytest
+from flight_recorder.diagnostics.analyzer import AnalyzerFailure, InterpretiveAnalyzer
+from flight_recorder.diagnostics.rules import repeated_tool_calls
+from flight_recorder.diagnostics.schemas import EvidencePacket
+from flight_recorder.models.envelopes import Finding, Record
+from flight_recorder.services.diagnostics import DiagnosticService
+
+
+def test_repeated_tool_call_finding_links_evidence() -> None:
+    records = [
+        Record(
+            record_id=f"record-{index}",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=index,
+            kind="tool.request",
+            payload={"tool": "terminal", "command": "pytest"},
+        )
+        for index in (1, 2)
+    ]
+
+    findings = repeated_tool_calls(records)
+
+    assert len(findings) == 1
+    assert findings[0].evidence_ids == ("record-1", "record-2")
+
+
+def test_evidence_packet_rejects_cross_trace_records() -> None:
+    record = Record(
+        record_id="record",
+        producer_id="producer",
+        trace_id="other",
+        sequence=1,
+        kind="tool.request",
+    )
+
+    with pytest.raises(ValueError, match="same trace"):
+        EvidencePacket(trace_id="trace", records=(record,))
+
+
+def test_service_rejects_missing_evidence_and_keeps_rules_on_analyzer_failure(
+    trace_index,
+) -> None:
+    records = [
+        Record(
+            record_id=f"record-{index}",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=index,
+            observed_at=datetime(2026, 9, 1, 12),
+            kind="tool.request",
+            payload={"tool": "terminal", "command": "pytest"},
+        )
+        for index in (1, 2)
+    ]
+    trace_index.add_records(records)
+
+    class FailingAnalyzer(InterpretiveAnalyzer):
+        def analyze(self, packet: EvidencePacket):
+            raise AnalyzerFailure("offline")
+
+    service = DiagnosticService(trace_index, analyzer=FailingAnalyzer())
+
+    findings = service.analyze("trace", include_interpretive=True)
+
+    assert [finding.detector_id for finding in findings] == ["repeated-tool-call"]
+    assert service.analyzer_failure is not None
+
+    class UnsupportedAnalyzer(InterpretiveAnalyzer):
+        def analyze(self, packet: EvidencePacket):
+            return [
+                Finding(
+                    finding_id="unsupported",
+                    trace_id=packet.trace_id,
+                    origin="model",
+                    detector_id="interpretive",
+                    category="loop",
+                    severity="warning",
+                    confidence=0.5,
+                    title="Unsupported claim",
+                    explanation="No matching evidence exists.",
+                    recommendation="Do not display this.",
+                    evidence_ids=("missing",),
+                )
+            ]
+
+    service = DiagnosticService(trace_index, analyzer=UnsupportedAnalyzer())
+
+    findings = service.analyze("trace", include_interpretive=True)
+
+    assert [finding.detector_id for finding in findings] == ["repeated-tool-call"]

--- a/tests/agent_flight_recorder/unit/test_envelopes.py
+++ b/tests/agent_flight_recorder/unit/test_envelopes.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import pytest
+from flight_recorder.models.envelopes import Record, RunStatus, Trace
+from pydantic import ValidationError
+
+
+def test_terminal_trace_requires_completion_fields() -> None:
+    with pytest.raises(ValidationError):
+        Trace(trace_id="trace", status=RunStatus.COMPLETED)
+
+    trace = Trace(
+        trace_id="trace",
+        status=RunStatus.COMPLETED,
+        completed_at=datetime.now(),
+        stop_reason="agent_finished",
+    )
+    assert trace.stop_reason == "agent_finished"
+
+
+def test_record_rejects_invalid_content_reference() -> None:
+    with pytest.raises(ValidationError):
+        Record(
+            record_id="record",
+            producer_id="producer",
+            trace_id="trace",
+            kind="run.started",
+            content_ref="not-a-digest",
+        )

--- a/tests/agent_flight_recorder/unit/test_lineage.py
+++ b/tests/agent_flight_recorder/unit/test_lineage.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+
+from flight_recorder.adapter.propagation import AgentTraceContext
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.models.envelopes import Provenance, ProvenanceKind, Record
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.repository import TraceRepository
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.llm import Metrics
+
+
+def lineage_record(
+    record_id: str,
+    sequence: int,
+    span_id: str,
+    *,
+    parent_span_id: str | None = None,
+    provenance: Provenance | None = None,
+) -> Record:
+    return Record(
+        record_id=record_id,
+        producer_id="producer",
+        trace_id="trace",
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        agent_span_id=span_id,
+        sequence=sequence,
+        observed_at=datetime(2026, 9, 1, 12),
+        kind="agent.started",
+        provenance=provenance or Provenance(),
+    )
+
+
+def test_child_trace_context_preserves_trace_and_parent_agent() -> None:
+    parent = AgentTraceContext(trace_id="trace", agent_span_id="parent")
+
+    child = parent.child("child")
+
+    assert child.trace_id == "trace"
+    assert child.agent_span_id == "child"
+    assert child.parent_agent_span_id == "parent"
+
+
+def test_repository_labels_verified_inferred_and_unresolved_lineage(
+    trace_index,
+) -> None:
+    trace_index.add_records(
+        [
+            lineage_record("parent", 1, "parent"),
+            lineage_record("verified", 2, "verified", parent_span_id="parent"),
+            lineage_record(
+                "inferred",
+                3,
+                "inferred",
+                parent_span_id="parent",
+                provenance=Provenance(
+                    kind=ProvenanceKind.DERIVED,
+                    source_ids=("parent",),
+                ),
+            ),
+            lineage_record("unresolved", 4, "unresolved", parent_span_id="missing"),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    relationships = repository.get_agent_relationships("trace")
+
+    assert [(item.child_span_id, item.status.value) for item in relationships] == [
+        ("verified", "verified"),
+        ("inferred", "inferred"),
+        ("unresolved", "unresolved"),
+    ]
+
+
+def test_nested_recorder_callbacks_use_unique_spans_and_capture_usage(tmp_path) -> None:
+    index = TraceIndex(tmp_path / "trace.db")
+    recorder = Recorder(tmp_path / "nested.afr", index)
+    child = recorder.for_subagent(
+        task_id="task_00000001",
+        subagent_type="general-purpose",
+        description="First level",
+    )
+    nested = child.for_subagent(
+        task_id="task_00000001",
+        subagent_type="general-purpose",
+        description="Second level",
+    )
+    metrics = Metrics(model_name="test-model")
+    metrics.add_cost(0.03)
+    metrics.add_token_usage(7, 2, 0, 0, 64, "child-response")
+    stats = ConversationStats(usage_to_metrics={"child": metrics})
+
+    nested.finish_subagent(status="completed", result="done", error=None, stats=stats)
+    child.finish_subagent(status="completed", result="done", error=None, stats=stats)
+    recorder.close()
+
+    starts = [
+        record
+        for record in index.iter_records(recorder.trace_id)
+        if record.kind == "agent.started" and record.parent_span_id is not None
+    ]
+    assert len({record.span_id for record in starts}) == 2
+    assert starts[1].parent_span_id == starts[0].span_id
+    usage, cost = TraceRepository(index).get_agent_usage(
+        recorder.trace_id, starts[1].span_id or ""
+    )
+    assert usage.prompt_tokens == 7
+    assert cost == 0.03

--- a/tests/agent_flight_recorder/unit/test_normalize.py
+++ b/tests/agent_flight_recorder/unit/test_normalize.py
@@ -1,0 +1,75 @@
+import json
+
+from flight_recorder.adapter.conversation import normalize_event
+from flight_recorder.adapter.llm import normalize_completion_log, normalize_metrics
+from flight_recorder.collector.normalize import make_record
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.llm import Metrics
+
+
+def test_completion_log_preserves_response_correlation() -> None:
+    record = normalize_completion_log(
+        "completion.json",
+        json.dumps({"response_id": "response-1", "model": "test"}),
+        producer_id="producer",
+        trace_id="trace",
+    )
+
+    assert record.kind == "llm.response"
+    assert record.llm_response_id == "response-1"
+
+
+def test_condensation_preserves_response_correlation() -> None:
+    event = Condensation(
+        id="condensation-1",
+        timestamp="2026-09-01T12:00:00",
+        forgotten_event_ids={"event-2", "event-1"},
+        summary="Earlier work",
+        summary_offset=1,
+        llm_response_id="response-1",
+    )
+
+    record = normalize_event(event, producer_id="producer", trace_id="trace")
+
+    assert record.kind == "context.condensed"
+    assert record.openhands_event_id == "condensation-1"
+    assert record.llm_response_id == "response-1"
+    assert record.payload["forgotten_event_ids"] == ["event-1", "event-2"]
+
+
+def test_metrics_normalization_uses_bounded_snapshots() -> None:
+    metrics = Metrics(model_name="test-model")
+    metrics.add_cost(0.25)
+    metrics.add_token_usage(
+        prompt_tokens=10,
+        completion_tokens=4,
+        cache_read_tokens=2,
+        cache_write_tokens=1,
+        context_window=128,
+        response_id="response-1",
+    )
+    stats = ConversationStats(usage_to_metrics={"agent": metrics})
+
+    record = normalize_metrics(stats, producer_id="producer", trace_id="trace")
+
+    assert record.kind == "metrics.snapshot"
+    snapshot = record.payload["usage_to_metrics"]["agent"]
+    assert snapshot["accumulated_cost"] == 0.25
+    assert snapshot["accumulated_token_usage"]["prompt_tokens"] == 10
+    assert "costs" not in snapshot
+    assert "token_usages" not in snapshot
+
+
+def test_make_record_assigns_stable_source_fields() -> None:
+    record = make_record(
+        producer_id="producer",
+        trace_id="trace",
+        kind="run.started",
+        payload={},
+    )
+
+    assert record.producer_id == "producer"
+    assert record.trace_id == "trace"
+    assert record.record_id

--- a/tests/agent_flight_recorder/unit/test_normalize.py
+++ b/tests/agent_flight_recorder/unit/test_normalize.py
@@ -1,7 +1,11 @@
 import json
 
 from flight_recorder.adapter.conversation import normalize_event
-from flight_recorder.adapter.llm import normalize_completion_log, normalize_metrics
+from flight_recorder.adapter.llm import (
+    normalize_completion_log,
+    normalize_metrics,
+    normalize_request_log,
+)
 from flight_recorder.collector.normalize import make_record
 
 from openhands.sdk.conversation.conversation_stats import ConversationStats
@@ -10,15 +14,53 @@ from openhands.sdk.llm import Metrics
 
 
 def test_completion_log_preserves_response_correlation() -> None:
-    record = normalize_completion_log(
+    request = normalize_request_log(
+        "call-1",
+        json.dumps(
+            {
+                "llm_call_id": "call-1",
+                "input": [{"type": "message", "role": "user"}],
+                "tools": [{"name": "terminal"}],
+                "timestamp": 1_788_545_603.75,
+            }
+        ),
+        producer_id="producer",
+        trace_id="trace",
+    )
+    response = normalize_completion_log(
         "completion.json",
-        json.dumps({"response_id": "response-1", "model": "test"}),
+        json.dumps(
+            {
+                "llm_call_id": "call-1",
+                "response": {"id": "response-1", "model": "test"},
+                "timestamp": 1_788_545_605.25,
+                "latency_sec": 1.5,
+            }
+        ),
         producer_id="producer",
         trace_id="trace",
     )
 
-    assert record.kind == "llm.response"
-    assert record.llm_response_id == "response-1"
+    assert request.kind == "llm.request"
+    assert response.kind == "llm.response"
+    assert request.llm_call_id == response.llm_call_id == "call-1"
+    assert request.llm_response_id is None
+    assert response.llm_response_id == "response-1"
+    assert request.payload == {
+        "request": {
+            "input": [{"type": "message", "role": "user"}],
+            "tools": [{"name": "terminal"}],
+        },
+    }
+    assert response.payload == {
+        "filename": "completion.json",
+        "response": {"id": "response-1", "model": "test"},
+        "timestamp": 1_788_545_605.25,
+        "latency_sec": 1.5,
+    }
+    assert request.source_timestamp is not None
+    assert response.source_timestamp is not None
+    assert (response.source_timestamp - request.source_timestamp).total_seconds() == 1.5
 
 
 def test_condensation_preserves_response_correlation() -> None:

--- a/tests/agent_flight_recorder/unit/test_progress_rules.py
+++ b/tests/agent_flight_recorder/unit/test_progress_rules.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from flight_recorder.diagnostics.rules import no_progress_iterations, recurring_failures
+from flight_recorder.models.envelopes import Record
+
+
+def diagnostic_record(
+    record_id: str, sequence: int, kind: str, payload: dict
+) -> Record:
+    return Record(
+        record_id=record_id,
+        producer_id="producer",
+        trace_id="trace",
+        sequence=sequence,
+        observed_at=datetime(2026, 9, 1, 12),
+        kind=kind,
+        payload=payload,
+    )
+
+
+def test_recurring_failure_requires_matching_failures_at_threshold() -> None:
+    failures = [
+        diagnostic_record(
+            f"error-{index}", index, "tool.error", {"error": "command failed"}
+        )
+        for index in (1, 2)
+    ]
+
+    assert recurring_failures(failures, threshold=2)[0].evidence_ids == (
+        "error-1",
+        "error-2",
+    )
+    assert recurring_failures(failures, threshold=3) == []
+
+
+def test_no_progress_requires_consecutive_unchanged_iterations() -> None:
+    records = [
+        diagnostic_record(
+            f"iteration-{index}",
+            index,
+            "iteration.finished",
+            {"made_progress": made_progress},
+        )
+        for index, made_progress in enumerate((False, False, True, False), start=1)
+    ]
+
+    findings = no_progress_iterations(records, threshold=2)
+
+    assert len(findings) == 1
+    assert findings[0].evidence_ids == ("iteration-1", "iteration-2")

--- a/tests/agent_flight_recorder/unit/test_queue.py
+++ b/tests/agent_flight_recorder/unit/test_queue.py
@@ -1,0 +1,26 @@
+from flight_recorder.collector.queue import RecordQueue
+from flight_recorder.models.envelopes import Record
+
+
+def record(kind: str, identity: str) -> Record:
+    return Record(
+        record_id=identity,
+        producer_id="producer",
+        trace_id="trace",
+        kind=kind,
+    )
+
+
+def test_queue_discards_stream_delta_before_lifecycle_record() -> None:
+    queue = RecordQueue(maxsize=1)
+    assert queue.put(record("llm.stream_delta", "delta"))
+    assert queue.put(record("run.finished", "finish"))
+
+    assert [item.record_id for item in queue.drain()] == ["finish"]
+    assert queue.dropped == 1
+
+
+def test_queue_never_blocks_when_full() -> None:
+    queue = RecordQueue(maxsize=1)
+    assert queue.put(record("run.started", "start"))
+    assert not queue.put(record("llm.stream_delta", "delta"))

--- a/tests/agent_flight_recorder/unit/test_queue.py
+++ b/tests/agent_flight_recorder/unit/test_queue.py
@@ -24,3 +24,15 @@ def test_queue_never_blocks_when_full() -> None:
     queue = RecordQueue(maxsize=1)
     assert queue.put(record("run.started", "start"))
     assert not queue.put(record("llm.stream_delta", "delta"))
+
+
+def test_queue_never_partially_enqueues_llm_exchange() -> None:
+    queue = RecordQueue(maxsize=1)
+    exchange = (
+        record("llm.request", "request"),
+        record("llm.response", "response"),
+    )
+
+    assert not queue.put_many(exchange)
+    assert queue.drain() == []
+    assert queue.dropped == 2

--- a/tests/agent_flight_recorder/unit/test_repeated_tool_rule.py
+++ b/tests/agent_flight_recorder/unit/test_repeated_tool_rule.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+from flight_recorder.diagnostics.rules import fingerprint, repeated_tool_calls
+from flight_recorder.models.envelopes import Record
+
+
+def tool_record(record_id: str, sequence: int, command: str) -> Record:
+    return Record(
+        record_id=record_id,
+        producer_id="producer",
+        trace_id="trace",
+        sequence=sequence,
+        observed_at=datetime(2026, 9, 1, 12) + timedelta(seconds=sequence),
+        kind="tool.request",
+        payload={"tool": "terminal", "command": command, "id": record_id},
+    )
+
+
+def test_fingerprint_ignores_volatile_identity_but_preserves_arguments() -> None:
+    first = tool_record("first", 1, "pytest")
+    repeated = tool_record("second", 2, "pytest")
+    different = tool_record("third", 3, "ruff check")
+
+    assert fingerprint(first) == fingerprint(repeated)
+    assert fingerprint(first) != fingerprint(different)
+
+
+def test_repeated_tool_call_threshold_is_inclusive() -> None:
+    records = [tool_record("first", 1, "pytest"), tool_record("second", 2, "pytest")]
+
+    assert repeated_tool_calls(records, threshold=2)
+    assert repeated_tool_calls(records, threshold=3) == []

--- a/tests/agent_flight_recorder/unit/test_repository.py
+++ b/tests/agent_flight_recorder/unit/test_repository.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from flight_recorder.models.envelopes import Record
+from flight_recorder.models.envelopes import ProvenanceKind, Record
 from flight_recorder.models.view_models import RunQuery
 from flight_recorder.services.repository import TraceRepository
 
@@ -83,6 +83,100 @@ def test_repository_projects_span_detail_and_workspace_changes(trace_index) -> N
     assert [(item.path, item.created_sequence) for item in changes] == [
         ("src/app.py", 2)
     ]
+
+
+def test_agent_span_requires_explicit_finish_record(trace_index) -> None:
+    trace_index.add_records(
+        [
+            record(
+                "start",
+                "trace",
+                1,
+                "agent.started",
+                span_id="agent",
+                agent_span_id="agent",
+            ),
+            record(
+                "activity",
+                "trace",
+                2,
+                "conversation.event",
+                span_id="agent",
+                agent_span_id="agent",
+            ),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    active = repository.get_span("trace", "agent").span
+
+    assert active.status == "incomplete"
+    assert active.end_sequence is None
+    assert active.ended_at is None
+
+    trace_index.add_records(
+        [
+            record(
+                "finish",
+                "trace",
+                3,
+                "agent.finished",
+                span_id="agent",
+                agent_span_id="agent",
+            )
+        ]
+    )
+
+    finished = repository.get_span("trace", "agent").span
+
+    assert finished.status == "completed"
+    assert finished.end_sequence == 3
+    assert finished.ended_at == datetime(2026, 9, 1, 12, 0, 3)
+
+
+def test_repository_projects_legacy_llm_exchange_without_mutating_index(
+    trace_index,
+) -> None:
+    legacy = record(
+        "completion",
+        "trace",
+        1,
+        "llm.response",
+        payload={
+            "filename": "completion.json",
+            "completion": {
+                "input": [{"type": "message", "role": "user"}],
+                "response": {"id": "response-1"},
+                "timestamp": datetime(2026, 9, 1, 12, 0, 5).timestamp(),
+                "latency_sec": 1.5,
+            },
+        },
+    )
+    trace_index.add_records([legacy])
+    repository = TraceRepository(trace_index)
+
+    timeline = repository.get_timeline("trace")
+
+    assert [item.kind for item in timeline.records] == [
+        "llm.request",
+        "llm.response",
+    ]
+    assert [item.record_id for item in timeline.records] == [
+        "completion/request",
+        "completion/response",
+    ]
+    assert {item.llm_call_id for item in timeline.records} == {"completion"}
+    assert timeline.records[0].payload["request"]["input"][0]["role"] == "user"
+    assert timeline.records[1].payload["response"]["id"] == "response-1"
+    assert timeline.records[0].source_timestamp == datetime(
+        2026, 9, 1, 12, 0, 3, 500000
+    )
+    assert timeline.records[1].source_timestamp == datetime(2026, 9, 1, 12, 0, 5)
+    assert all(
+        item.provenance.kind is ProvenanceKind.DERIVED for item in timeline.records
+    )
+    assert repository.get_record("trace", "completion/request") == timeline.records[0]
+    assert trace_index.iter_records("trace") == [legacy]
 
 
 def test_primary_agent_duration_excludes_recorder_shutdown_idle_time(

--- a/tests/agent_flight_recorder/unit/test_repository.py
+++ b/tests/agent_flight_recorder/unit/test_repository.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timedelta
+
+from flight_recorder.models.envelopes import Record
+from flight_recorder.models.view_models import RunQuery
+from flight_recorder.services.repository import TraceRepository
+
+
+def record(
+    record_id: str,
+    trace_id: str,
+    sequence: int,
+    kind: str,
+    *,
+    span_id: str | None = None,
+    parent_span_id: str | None = None,
+    agent_span_id: str | None = None,
+    observed_seconds: float | None = None,
+    payload: dict | None = None,
+) -> Record:
+    return Record(
+        record_id=record_id,
+        producer_id="producer",
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        agent_span_id=agent_span_id,
+        sequence=sequence,
+        observed_at=datetime(2026, 9, 1, 12)
+        + timedelta(
+            seconds=observed_seconds if observed_seconds is not None else sequence
+        ),
+        kind=kind,
+        payload=payload or {},
+    )
+
+
+def test_repository_filters_runs_and_preserves_generic_records(trace_index) -> None:
+    trace_index.add_records(
+        [
+            record(
+                "a-start",
+                "trace-a",
+                1,
+                "run.started",
+                payload={"repository": "sdk", "model": "test-model"},
+            ),
+            record("future", "trace-a", 2, "future.activity"),
+            record("a-finish", "trace-a", 3, "run.finished"),
+            record("b-start", "trace-b", 1, "run.started"),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    completed = repository.list_runs(RunQuery(status="completed", repository="sdk"))
+
+    assert [run.trace_id for run in completed] == ["trace-a"]
+    assert repository.get_timeline("trace-a").records[1].kind == "future.activity"
+
+
+def test_repository_projects_span_detail_and_workspace_changes(trace_index) -> None:
+    trace_index.add_records(
+        [
+            record("start", "trace", 1, "tool.request", span_id="tool-span"),
+            record(
+                "change",
+                "trace",
+                2,
+                "workspace.diff",
+                span_id="tool-span",
+                payload={"path": "src/app.py", "content_hash": "abc", "size": 12},
+            ),
+            record("finish", "trace", 3, "tool.result", span_id="tool-span"),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    detail = repository.get_span("trace", "tool-span")
+    changes = repository.get_workspace_changes("trace", "tool-span")
+
+    assert detail.span.start_sequence == 1
+    assert detail.span.end_sequence == 3
+    assert [item.record_id for item in detail.records] == ["start", "change", "finish"]
+    assert [(item.path, item.created_sequence) for item in changes] == [
+        ("src/app.py", 2)
+    ]
+
+
+def test_primary_agent_duration_excludes_recorder_shutdown_idle_time(
+    trace_index,
+) -> None:
+    trace_index.add_records(
+        [
+            record("run-start", "trace", 1, "run.started", observed_seconds=0),
+            record(
+                "root-start",
+                "trace",
+                2,
+                "agent.started",
+                span_id="root",
+                agent_span_id="root",
+                observed_seconds=0,
+                payload={"name": "Primary agent"},
+            ),
+            record(
+                "child-start",
+                "trace",
+                3,
+                "agent.started",
+                span_id="child",
+                parent_span_id="root",
+                agent_span_id="child",
+                observed_seconds=5,
+            ),
+            record(
+                "child-finish",
+                "trace",
+                4,
+                "agent.finished",
+                span_id="child",
+                parent_span_id="root",
+                agent_span_id="child",
+                observed_seconds=20,
+            ),
+            record(
+                "root-activity",
+                "trace",
+                5,
+                "conversation.event",
+                span_id="root",
+                agent_span_id="root",
+                observed_seconds=30,
+            ),
+            record(
+                "root-finish",
+                "trace",
+                6,
+                "agent.finished",
+                span_id="root",
+                agent_span_id="root",
+                observed_seconds=3600,
+            ),
+            record(
+                "run-finish",
+                "trace",
+                7,
+                "run.finished",
+                observed_seconds=3600,
+                payload={"stop_reason": "recorder_closed"},
+            ),
+        ]
+    )
+    repository = TraceRepository(trace_index)
+
+    assert repository.get_agent_detail("trace", "root").duration_seconds == 30
+    assert repository.get_agent_detail("trace", "child").duration_seconds == 15

--- a/tests/agent_flight_recorder/unit/test_timeline_projection.py
+++ b/tests/agent_flight_recorder/unit/test_timeline_projection.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from flight_recorder.gui.timeline.layout import project_spans
+from flight_recorder.models.envelopes import Span
+
+
+def make_span(
+    span_id: str,
+    agent_span_id: str,
+    start: int,
+    end: int | None,
+) -> Span:
+    return Span(
+        span_id=span_id,
+        trace_id="trace",
+        span_type="tool",
+        name=span_id,
+        agent_span_id=agent_span_id,
+        start_sequence=start,
+        end_sequence=end,
+        started_at=datetime(2026, 9, 1, 12),
+        status="completed" if end is not None else "incomplete",
+    )
+
+
+def test_projection_assigns_stable_lanes_and_incomplete_bounds() -> None:
+    spans = [
+        make_span("late", "agent-b", 4, 6),
+        make_span("early", "agent-a", 1, 3),
+        make_span("active", "agent-a", 7, None),
+    ]
+
+    layout = project_spans(spans, current_sequence=10)
+
+    assert [(item.span_id, item.lane) for item in layout] == [
+        ("early", 0),
+        ("late", 1),
+        ("active", 0),
+    ]
+    assert layout[-1].start == 7
+    assert layout[-1].end == 10
+    assert layout[-1].incomplete is True
+
+
+def test_projection_filters_to_visible_sequence_range() -> None:
+    spans = [
+        make_span("before", "agent-a", 1, 2),
+        make_span("visible", "agent-b", 3, 8),
+        make_span("after", "agent-c", 9, 10),
+    ]
+
+    layout = project_spans(
+        spans,
+        current_sequence=10,
+        visible_range=(4, 7),
+    )
+
+    assert [item.span_id for item in layout] == ["visible"]

--- a/tests/agent_flight_recorder/unit/test_timeline_time.py
+++ b/tests/agent_flight_recorder/unit/test_timeline_time.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta
+
+from flight_recorder.gui.timeline.time import project_record_intervals
+from flight_recorder.models.envelopes import Record
+
+
+BASE = datetime(2026, 9, 2, 10, 0, 0)
+
+
+def timed_record(
+    record_id: str,
+    sequence: int,
+    event_type: str,
+    seconds: float,
+    *,
+    tool_call_id: str | None = None,
+    observed_offset: float = 0,
+) -> Record:
+    payload = {"event_type": event_type}
+    if tool_call_id is not None:
+        payload["tool_call_id"] = tool_call_id
+    return Record(
+        record_id=record_id,
+        producer_id="producer",
+        trace_id="trace",
+        sequence=sequence,
+        observed_at=BASE + timedelta(seconds=seconds + observed_offset),
+        source_timestamp=BASE + timedelta(seconds=seconds),
+        kind="conversation.event",
+        payload=payload,
+    )
+
+
+def test_action_interval_uses_source_time_until_correlated_result() -> None:
+    records = [
+        timed_record("message", 1, "MessageEvent", 0),
+        timed_record("action", 2, "ActionEvent", 2, tool_call_id="call-1"),
+        timed_record("result", 3, "ObservationEvent", 5.5, tool_call_id="call-1"),
+    ]
+
+    projection = project_record_intervals(records)
+
+    assert projection.elapsed_seconds == 5.5
+    assert projection.intervals["action"].start_seconds == 2
+    assert projection.intervals["action"].end_seconds == 5.5
+    assert projection.intervals["action"].duration_seconds == 3.5
+    assert projection.intervals["result"].duration_seconds == 0
+
+
+def test_timing_prefers_source_timestamp_and_falls_back_to_observed() -> None:
+    source_timed = timed_record("source", 1, "MessageEvent", 1, observed_offset=20)
+    observed_timed = Record(
+        record_id="observed",
+        producer_id="producer",
+        trace_id="trace",
+        sequence=2,
+        observed_at=BASE + timedelta(seconds=4),
+        kind="conversation.event",
+        payload={"event_type": "MessageEvent"},
+    )
+
+    projection = project_record_intervals([source_timed, observed_timed])
+
+    assert projection.intervals["source"].start_seconds == 0
+    assert projection.intervals["observed"].start_seconds == 3
+
+
+def test_recorder_shutdown_idle_time_does_not_extend_timeline() -> None:
+    records = [
+        Record(
+            record_id="run-start",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=1,
+            observed_at=BASE,
+            kind="run.started",
+        ),
+        Record(
+            record_id="agent-start",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=2,
+            observed_at=BASE,
+            kind="agent.started",
+        ),
+        timed_record("activity", 3, "MessageEvent", 30),
+        Record(
+            record_id="agent-finish",
+            producer_id="producer",
+            trace_id="trace",
+            span_id="agent",
+            agent_span_id="agent",
+            sequence=4,
+            observed_at=BASE + timedelta(hours=1),
+            kind="agent.finished",
+        ),
+        Record(
+            record_id="run-finish",
+            producer_id="producer",
+            trace_id="trace",
+            sequence=5,
+            observed_at=BASE + timedelta(hours=1),
+            kind="run.finished",
+            payload={"stop_reason": "recorder_closed"},
+        ),
+    ]
+
+    projection = project_record_intervals(records)
+
+    assert projection.elapsed_seconds == 30
+    assert projection.intervals["agent-finish"].start_seconds == 30
+    assert projection.intervals["run-finish"].start_seconds == 30

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -48,6 +48,13 @@ def test_load_config_reads_telemetry_deployment_kind_from_env(monkeypatch, tmp_p
     assert load_config().telemetry.deployment_kind == "remote"
 
 
+def test_load_config_enables_flight_recorder_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv(CONFIG_PATH_ENV, str(tmp_path / "missing.json"))
+    monkeypatch.setenv("OH_ENABLE_FLIGHT_RECORDER", "true")
+
+    assert load_config().enable_flight_recorder is True
+
+
 def test_conversation_idle_ttl_defaults_to_twenty_minutes():
     assert DEFAULT_CONVERSATION_IDLE_TTL_SECONDS == 1200.0
     assert Config().conversation_idle_ttl_seconds == 1200.0

--- a/tests/agent_server/test_event_router_websocket.py
+++ b/tests/agent_server/test_event_router_websocket.py
@@ -272,11 +272,14 @@ async def test_websocket_general_exception_continues_loop(
 
 @pytest.mark.asyncio
 async def test_websocket_successful_message_processing(
-    mock_websocket, mock_event_service, sample_conversation_id
+    mock_websocket, mock_event_service, sample_conversation_id, caplog
 ):
     """Test successful message processing before disconnect."""
-    message_data = {"role": "user", "content": "Hello"}
+    secret = "ghp_" + "m" * 36
+    message_data = {"role": "user", "content": secret}
     call_count = 0
+
+    caplog.set_level(logging.INFO, logger="openhands.agent_server.sockets")
 
     def side_effect():
         nonlocal call_count
@@ -305,6 +308,11 @@ async def test_websocket_successful_message_processing(
 
     mock_event_service.send_message.assert_called_once()
     assert mock_websocket.receive_json.call_count == 2
+    assert "websocket_message_received" in caplog.text
+    assert f"conversation_id={sample_conversation_id}" in caplog.text
+    assert "role=user" in caplog.text
+    assert "content_part_count=1" in caplog.text
+    assert secret not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -3456,6 +3456,7 @@ def test_llm_io_logging_is_disabled_by_default(event_service: EventService) -> N
 
     event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
 
+    llm.telemetry.set_log_requests_callback.assert_not_called()
     llm.telemetry.set_log_completions_callback.assert_not_called()
 
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -3377,12 +3377,13 @@ def test_llm_log_callback_swallows_emit_failures(
 
 
 def test_llm_io_logging_emits_paired_records_without_transport_kwargs(
-    event_service: EventService, caplog, monkeypatch
+    event_service: EventService, caplog, monkeypatch, tmp_path
 ) -> None:
     callbacks = []
     llm = MagicMock(log_completions=False, usage_id="test-usage", model="gpt-4o")
     llm.telemetry.set_log_completions_callback.side_effect = callbacks.append
     monkeypatch.setenv("OH_LOG_LLM_IO", "true")
+    monkeypatch.setattr("openhands.agent_server.event_service.ENV_LOG_DIR", tmp_path)
 
     event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
     log_data = json.dumps(
@@ -3403,13 +3404,51 @@ def test_llm_io_logging_emits_paired_records_without_transport_kwargs(
     with caplog.at_level("INFO", logger="openhands.agent_server.event_service"):
         callbacks[0]("completion.json", log_data)
 
-    assert "llm_input" in caplog.text
-    assert "llm_output" in caplog.text
-    assert '"content":"hello"' in caplog.text
-    assert '"content":"hello back"' in caplog.text
-    assert '"tool_names":["terminal"]' in caplog.text
+    input_record = next(
+        record for record in caplog.records if record.event == "llm_input"
+    )
+    output_record = next(
+        record for record in caplog.records if record.event == "llm_output"
+    )
+    assert input_record.llm_io["messages"][0]["content"] == "hello"
+    assert input_record.llm_io["tool_names"] == ["terminal"]
+    assert output_record.llm_io["response"]["choices"][0]["message"]["content"] == (
+        "hello back"
+    )
     assert "must-not-be-logged" not in caplog.text
     assert llm.telemetry.log_enabled is True
+
+    exchanges = [
+        json.loads(line)
+        for line in (tmp_path / "llm-io.jsonl").read_text().splitlines()
+    ]
+    assert exchanges == [
+        {
+            "event": "llm_exchange",
+            "conversation_id": str(event_service.stored.id),
+            "usage_id": "test-usage",
+            "model": "gpt-4o",
+            "completion_id": "completion.json",
+            "api": "chat_completions",
+            "request": {
+                "messages": [{"role": "user", "content": "hello"}],
+                "instructions": None,
+                "input": None,
+                "tools": [{"name": "terminal", "description": "large schema"}],
+                "tool_names": ["terminal"],
+            },
+            "result": {
+                "response": {
+                    "id": "response-1",
+                    "choices": [{"message": {"content": "hello back"}}],
+                },
+                "raw_response": None,
+                "usage": {"prompt_tokens": 2, "completion_tokens": 2},
+                "cost": 0.01,
+                "latency_sec": 0.5,
+            },
+        }
+    ]
 
 
 def test_llm_io_logging_is_disabled_by_default(event_service: EventService) -> None:
@@ -3421,12 +3460,13 @@ def test_llm_io_logging_is_disabled_by_default(event_service: EventService) -> N
 
 
 def test_llm_io_logging_emits_error_record(
-    event_service: EventService, caplog, monkeypatch
+    event_service: EventService, caplog, monkeypatch, tmp_path
 ) -> None:
     callbacks = []
     llm = MagicMock(log_completions=False, usage_id="test-usage", model="gpt-4o")
     llm.telemetry.set_log_completions_callback.side_effect = callbacks.append
     monkeypatch.setenv("OH_LOG_LLM_IO", "true")
+    monkeypatch.setattr("openhands.agent_server.event_service.ENV_LOG_DIR", tmp_path)
     event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
 
     log_data = json.dumps(
@@ -3441,8 +3481,19 @@ def test_llm_io_logging_emits_error_record(
 
     assert "llm_input" in caplog.text
     assert "llm_error" in caplog.text
-    assert "provider failed" in caplog.text
     assert "llm_output" not in caplog.text
+    error_record = next(
+        record for record in caplog.records if record.event == "llm_error"
+    )
+    assert error_record.llm_io["error"] == {
+        "type": "RuntimeError",
+        "message": "provider failed",
+    }
+    exchange = json.loads((tmp_path / "llm-io.jsonl").read_text())
+    assert exchange["error"] == {
+        "type": "RuntimeError",
+        "message": "provider failed",
+    }
 
 
 def _make_stored(tmp_path: Path) -> StoredConversation:

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -3376,6 +3376,75 @@ def test_llm_log_callback_swallows_emit_failures(
     assert "Failed to emit LLM completion log event" in caplog.text
 
 
+def test_llm_io_logging_emits_paired_records_without_transport_kwargs(
+    event_service: EventService, caplog, monkeypatch
+) -> None:
+    callbacks = []
+    llm = MagicMock(log_completions=False, usage_id="test-usage", model="gpt-4o")
+    llm.telemetry.set_log_completions_callback.side_effect = callbacks.append
+    monkeypatch.setenv("OH_LOG_LLM_IO", "true")
+
+    event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
+    log_data = json.dumps(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{"name": "terminal", "description": "large schema"}],
+            "kwargs": {"api_key": "must-not-be-logged"},
+            "response": {
+                "id": "response-1",
+                "choices": [{"message": {"content": "hello back"}}],
+            },
+            "usage_summary": {"prompt_tokens": 2, "completion_tokens": 2},
+            "cost": 0.01,
+            "latency_sec": 0.5,
+        }
+    )
+
+    with caplog.at_level("INFO", logger="openhands.agent_server.event_service"):
+        callbacks[0]("completion.json", log_data)
+
+    assert "llm_input" in caplog.text
+    assert "llm_output" in caplog.text
+    assert '"content":"hello"' in caplog.text
+    assert '"content":"hello back"' in caplog.text
+    assert '"tool_names":["terminal"]' in caplog.text
+    assert "must-not-be-logged" not in caplog.text
+    assert llm.telemetry.log_enabled is True
+
+
+def test_llm_io_logging_is_disabled_by_default(event_service: EventService) -> None:
+    llm = MagicMock(log_completions=False, usage_id="test-usage", model="gpt-4o")
+
+    event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
+
+    llm.telemetry.set_log_completions_callback.assert_not_called()
+
+
+def test_llm_io_logging_emits_error_record(
+    event_service: EventService, caplog, monkeypatch
+) -> None:
+    callbacks = []
+    llm = MagicMock(log_completions=False, usage_id="test-usage", model="gpt-4o")
+    llm.telemetry.set_log_completions_callback.side_effect = callbacks.append
+    monkeypatch.setenv("OH_LOG_LLM_IO", "true")
+    event_service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
+
+    log_data = json.dumps(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "error": {"type": "RuntimeError", "message": "provider failed"},
+            "latency_sec": 0.25,
+        }
+    )
+    with caplog.at_level("INFO", logger="openhands.agent_server.event_service"):
+        callbacks[0]("completion-error.json", log_data)
+
+    assert "llm_input" in caplog.text
+    assert "llm_error" in caplog.text
+    assert "provider failed" in caplog.text
+    assert "llm_output" not in caplog.text
+
+
 def _make_stored(tmp_path: Path) -> StoredConversation:
     return StoredConversation(
         id=uuid4(),

--- a/tests/agent_server/test_execution_environment.py
+++ b/tests/agent_server/test_execution_environment.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+import threading
+
+from openhands.agent_server.execution_environment import (
+    ExecutionEnvironmentTracker,
+)
+
+
+def _events(log_path):
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+async def test_execution_environment_logs_startup_async_context_and_threads(tmp_path):
+    tracker = ExecutionEnvironmentTracker(tmp_path)
+    original_thread_start = threading.Thread.start
+    tracker.start()
+    try:
+        tracker.log_async_environment(max_concurrent_runs=3)
+        await asyncio.to_thread(lambda: None)
+    finally:
+        tracker.stop()
+
+    assert threading.Thread.start is original_thread_start
+    events = _events(tmp_path / "execution-env.log")
+    event_names = [event["event"] for event in events]
+    assert event_names[0] == "execution_environment_started"
+    assert "async_execution_environment_initialized" in event_names
+    assert "thread_started" in event_names
+    assert event_names[-1] == "execution_environment_stopped"
+
+    async_event = next(
+        event
+        for event in events
+        if event["event"] == "async_execution_environment_initialized"
+    )
+    assert async_event["conversation_run_max_workers"] == 3
+    assert isinstance(async_event["event_loop_id"], int)
+
+    thread_event = next(event for event in events if event["event"] == "thread_started")
+    assert thread_event["created_thread"]["thread_name"].startswith("asyncio_")
+    assert isinstance(thread_event["created_thread"]["thread_id"], int)
+    assert thread_event["creation_stack"]
+    assert all("filename" in frame for frame in thread_event["creation_stack"])

--- a/tests/agent_server/test_flight_recorder.py
+++ b/tests/agent_server/test_flight_recorder.py
@@ -1,0 +1,194 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from flight_recorder.models.database import TraceIndex
+from flight_recorder.recorder import Recorder
+from flight_recorder.services.bundles import BundleService
+
+from openhands.agent_server.conversation_router import conversation_router
+from openhands.agent_server.conversation_service import (
+    ConversationService,
+    _ConversationRecord,
+)
+from openhands.agent_server.dependencies import get_conversation_service
+from openhands.agent_server.event_service import EventService
+from openhands.agent_server.models import FlightRecorderTraceInfo, StoredConversation
+from openhands.sdk import Agent, Message
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.llm import TextContent
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.testing import TestLLM
+from openhands.sdk.workspace import LocalWorkspace
+
+
+@pytest.mark.asyncio
+async def test_event_service_records_web_run_and_finalizes_trace(
+    tmp_path: Path,
+) -> None:
+    conversation_id = uuid4()
+    llm = TestLLM.from_messages(
+        [Message(role="assistant", content=[TextContent(text="Implemented")])]
+    )
+    stored = StoredConversation(
+        id=conversation_id,
+        workspace=LocalWorkspace(working_dir=str(tmp_path / "workspace")),
+        confirmation_policy=NeverConfirm(),
+        initial_message=None,
+        metrics=None,
+    )
+    service = EventService(
+        stored=stored,
+        conversations_dir=tmp_path / "conversations",
+        agent=Agent(llm=llm, tools=[]),
+        enable_flight_recorder=True,
+    )
+
+    await service.start()
+    await service.send_message(
+        Message(role="user", content=[TextContent(text="Implement a helper")]),
+        run=True,
+    )
+    assert service._run_task is not None
+    await service._run_task
+    active = service.get_flight_recorder_info()
+    assert active is not None
+    assert active.conversation_id == conversation_id
+    assert active.active is True
+
+    await service.close()
+    await service.save_meta()
+
+    finished = service.get_flight_recorder_info()
+    assert finished is not None
+    assert finished.active is False
+    validation = BundleService().validate_bundle(Path(finished.bundle_path))
+    assert validation.trace_id == finished.trace_id
+    assert validation.record_count > 4
+
+    trace_dir = service.conversation_dir / "flight-recorder"
+    bundles_before = list(trace_dir.glob("*.afr"))
+    async with ConversationService(
+        conversations_dir=service.conversations_dir
+    ) as restarted:
+        cold = await restarted.get_flight_recorder_info(conversation_id)
+    assert cold == finished
+    assert list(trace_dir.glob("*.afr")) == bundles_before
+
+
+def test_flight_recorder_endpoint_returns_latest_trace(tmp_path: Path) -> None:
+    conversation_id = uuid4()
+    info = FlightRecorderTraceInfo(
+        conversation_id=conversation_id,
+        trace_id="trace-id",
+        bundle_path=str(tmp_path / "trace.afr"),
+        active=False,
+    )
+    conversation_service = AsyncMock(spec=ConversationService)
+    conversation_service.get_flight_recorder_info.return_value = info
+    app = FastAPI()
+    app.include_router(conversation_router, prefix="/api")
+    app.dependency_overrides[get_conversation_service] = lambda: conversation_service
+
+    response = TestClient(app).get(
+        f"/api/conversations/{conversation_id}/flight-recorder"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == info.model_dump(mode="json")
+    conversation_service.get_flight_recorder_info.assert_awaited_once_with(
+        conversation_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_parent_trace_merges_server_native_child_conversation(
+    tmp_path: Path,
+) -> None:
+    conversations_dir = tmp_path / "conversations"
+    parent_id = uuid4()
+    child_id = uuid4()
+    parent_stored = _stored(parent_id, tmp_path / "workspace")
+    child_stored = _stored(
+        child_id,
+        tmp_path / "workspace",
+        parent_conversation_id=parent_id,
+    )
+    parent_bundle, parent_recorder = _record_bundle(
+        conversations_dir, parent_id, "parent"
+    )
+    child_bundle, child_recorder = _record_bundle(conversations_dir, child_id, "child")
+    _write_latest(parent_id, parent_recorder, parent_bundle, conversations_dir)
+    _write_latest(child_id, child_recorder, child_bundle, conversations_dir)
+    service = ConversationService(conversations_dir=conversations_dir)
+    service._conversation_records = {
+        parent_id: _ConversationRecord(
+            stored=parent_stored,
+            execution_status=ConversationExecutionStatus.FINISHED,
+        ),
+        child_id: _ConversationRecord(
+            stored=child_stored,
+            execution_status=ConversationExecutionStatus.FINISHED,
+        ),
+    }
+
+    info = await service.get_flight_recorder_info(parent_id)
+
+    assert info is not None
+    assert Path(info.bundle_path).name == "orchestration.afr"
+    records = list(
+        BundleService.iter_record_file(Path(info.bundle_path) / "records.jsonl")
+    )
+    child_start = next(
+        record
+        for record in records
+        if record.kind == "agent.started"
+        and record.span_id == child_recorder.agent_span_id
+    )
+    assert child_start.trace_id == parent_recorder.trace_id
+    assert child_start.parent_span_id == parent_recorder.agent_span_id
+
+
+def _stored(
+    conversation_id: UUID,
+    workspace: Path,
+    *,
+    parent_conversation_id: UUID | None = None,
+) -> StoredConversation:
+    return StoredConversation(
+        id=conversation_id,
+        workspace=LocalWorkspace(working_dir=str(workspace)),
+        confirmation_policy=NeverConfirm(),
+        initial_message=None,
+        metrics=None,
+        parent_conversation_id=parent_conversation_id,
+    )
+
+
+def _record_bundle(
+    conversations_dir: Path, conversation_id: UUID, label: str
+) -> tuple[Path, Recorder]:
+    trace_dir = conversations_dir / conversation_id.hex / "flight-recorder"
+    bundle = trace_dir / f"{label}.afr"
+    recorder = Recorder(bundle, TraceIndex(trace_dir / f"{label}.db"))
+    recorder.close()
+    return bundle, recorder
+
+
+def _write_latest(
+    conversation_id: UUID,
+    recorder: Recorder,
+    bundle: Path,
+    conversations_dir: Path,
+) -> None:
+    info = FlightRecorderTraceInfo(
+        conversation_id=conversation_id,
+        trace_id=recorder.trace_id,
+        bundle_path=str(bundle),
+        active=False,
+    )
+    path = conversations_dir / conversation_id.hex / "flight-recorder" / "latest.json"
+    path.write_text(info.model_dump_json())

--- a/tests/agent_server/test_flight_recorder.py
+++ b/tests/agent_server/test_flight_recorder.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -23,6 +23,36 @@ from openhands.sdk.llm import TextContent
 from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.workspace import LocalWorkspace
+
+
+def test_flight_recorder_captures_llm_completion_log(tmp_path: Path) -> None:
+    service = EventService(
+        stored=_stored(uuid4(), tmp_path / "workspace"),
+        conversations_dir=tmp_path / "conversations",
+    )
+    recorder = MagicMock(spec=Recorder)
+    service._flight_recorder = recorder
+    request_callbacks = []
+    completion_callbacks = []
+    llm = MagicMock(log_completions=False, usage_id="agent", model="gpt-4o")
+    llm.telemetry.set_log_requests_callback.side_effect = request_callbacks.append
+    llm.telemetry.set_log_completions_callback.side_effect = completion_callbacks.append
+
+    service._setup_llm_log_streaming(MagicMock(get_all_llms=lambda: [llm]))
+    request_callbacks[0]("call-1", '{"llm_call_id":"call-1"}')
+    completion_callbacks[0](
+        "completion.json",
+        '{"llm_call_id":"call-1","response":{"id":"response-1"}}',
+    )
+
+    assert llm.telemetry.log_enabled is True
+    recorder.on_llm_request.assert_called_once_with(
+        "call-1", '{"llm_call_id":"call-1"}'
+    )
+    recorder.on_completion_log.assert_called_once_with(
+        "completion.json",
+        '{"llm_call_id":"call-1","response":{"id":"response-1"}}',
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_logging_config.py
+++ b/tests/agent_server/test_logging_config.py
@@ -1,0 +1,27 @@
+import json
+import logging
+
+from openhands.agent_server.logging_config import UvicornAccessJsonFormatter
+
+
+def test_uvicorn_access_formatter_adds_execution_and_http_fields():
+    formatter = UvicornAccessJsonFormatter("%(message)s")
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "test.py",
+        1,
+        '%s - "%s %s HTTP/%s" %d',
+        ("127.0.0.1", "GET", "/api/settings", "1.1", 200),
+        None,
+    )
+
+    data = json.loads(formatter.format(record))
+
+    assert isinstance(data["process_id"], int)
+    assert isinstance(data["thread_id"], int)
+    assert data["http.client_ip"] == "127.0.0.1"
+    assert data["http.method"] == "GET"
+    assert data["http.url"] == "/api/settings"
+    assert data["http.version"] == "1.1"
+    assert data["http.status_code"] == 200

--- a/tests/agent_server/test_websocket_first_message_auth.py
+++ b/tests/agent_server/test_websocket_first_message_auth.py
@@ -383,6 +383,11 @@ async def test_bash_socket_ignores_redundant_auth_before_command(
     request = mock_bash_service.start_bash_command.await_args.args[0]
     assert request.command == "printf queued-command"
     ws.send_json.assert_not_called()
+    assert "bash_websocket_request_received" in caplog.text
+    assert "command_length=21" in caplog.text
+    assert "has_cwd=False" in caplog.text
+    assert "timeout=300" in caplog.text
+    assert request.command not in caplog.text
     assert secret not in caplog.text
 
 

--- a/tests/sdk/agent/test_parallel_execution_integration.py
+++ b/tests/sdk/agent/test_parallel_execution_integration.py
@@ -16,7 +16,12 @@ from pydantic import Field, ValidationError
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event import ActionEvent, AgentErrorEvent, ObservationEvent
+from openhands.sdk.event import (
+    ActionEvent,
+    AgentErrorEvent,
+    ObservationEvent,
+    UserRejectObservation,
+)
 from openhands.sdk.llm import Message, MessageToolCall, TextContent
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
@@ -217,6 +222,116 @@ def test_sequential_execution_with_default_limit():
     assert len(obs_events) == 2
     assert obs_events[0].tool_call_id == "call_0"
     assert obs_events[1].tool_call_id == "call_1"
+    tool_events = [
+        event
+        for event in collected
+        if isinstance(event, (ActionEvent, ObservationEvent))
+    ]
+    assert [type(event) for event in tool_events] == [
+        ActionEvent,
+        ObservationEvent,
+        ActionEvent,
+        ObservationEvent,
+    ]
+    assert [event.tool_call_id for event in tool_events] == [
+        "call_0",
+        "call_0",
+        "call_1",
+        "call_1",
+    ]
+    assert tool_events[0].timestamp <= tool_events[1].timestamp
+    assert tool_events[1].timestamp <= tool_events[2].timestamp
+
+
+async def test_async_sequential_execution_emits_each_action_with_its_result():
+    llm = TestLLM.from_messages(
+        [
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[
+                    _tool_call("call_0", "slow_tool", '{"delay": 0.0, "label": "a"}'),
+                    _tool_call("call_1", "slow_tool", '{"delay": 0.0, "label": "b"}'),
+                ],
+            ),
+            Message(role="assistant", content=[TextContent(text="Done")]),
+        ]
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="SlowTool")])
+    collected = []
+    conversation = Conversation(agent=agent, callbacks=[collected.append])
+    conversation.send_message(Message(role="user", content=[TextContent(text="Go")]))
+
+    await agent.astep(conversation, on_event=collected.append)
+
+    tool_events = [
+        event
+        for event in collected
+        if isinstance(event, (ActionEvent, ObservationEvent))
+    ]
+    assert [type(event) for event in tool_events] == [
+        ActionEvent,
+        ObservationEvent,
+        ActionEvent,
+        ObservationEvent,
+    ]
+    assert [event.tool_call_id for event in tool_events] == [
+        "call_0",
+        "call_0",
+        "call_1",
+        "call_1",
+    ]
+    assert tool_events[0].timestamp <= tool_events[1].timestamp
+    assert tool_events[1].timestamp <= tool_events[2].timestamp
+
+
+def test_sequential_action_hook_blocks_before_execution() -> None:
+    llm = TestLLM.from_messages(
+        [
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[
+                    _tool_call(
+                        "call_0", "slow_tool", '{"delay": 0.0, "label": "blocked"}'
+                    ),
+                    _tool_call(
+                        "call_1", "slow_tool", '{"delay": 0.0, "label": "runs"}'
+                    ),
+                ],
+            ),
+            Message(role="assistant", content=[TextContent(text="Done")]),
+        ]
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="SlowTool")])
+    collected = []
+    conversation = Conversation(agent=agent, callbacks=[])
+    conversation.send_message(Message(role="user", content=[TextContent(text="Go")]))
+
+    def on_event(event) -> None:
+        collected.append(event)
+        if isinstance(event, ActionEvent) and event.tool_call_id == "call_0":
+            conversation.state.block_action(event.id, "blocked by hook")
+
+    agent.step(conversation, on_event=on_event)
+
+    tool_events = [
+        event
+        for event in collected
+        if isinstance(event, (ActionEvent, ObservationEvent, UserRejectObservation))
+    ]
+    assert [type(event) for event in tool_events] == [
+        ActionEvent,
+        UserRejectObservation,
+        ActionEvent,
+        ObservationEvent,
+    ]
+    assert [event.tool_call_id for event in tool_events] == [
+        "call_0",
+        "call_0",
+        "call_1",
+        "call_1",
+    ]
 
 
 def test_limit_one_preserves_sequential_semantics():

--- a/tests/sdk/agent/test_response_dispatch.py
+++ b/tests/sdk/agent/test_response_dispatch.py
@@ -357,16 +357,8 @@ def test_tool_calls_response_executes_actions():
     assert convo.state.execution_status == ConversationExecutionStatus.FINISHED
 
 
-def test_batch_action_events_are_emitted_consecutively():
-    """Pin the invariant the metrics visualizer relies on (#4189).
-
-    Parallel tool calls from one LLM response are emitted as a consecutive run
-    of ActionEvents that share one llm_response_id, in tool-call order, and only
-    the first carries the turn's thought. ``DefaultConversationVisualizer.
-    _claim_batch_primary`` tracks only the *previous* response id to spot batch
-    siblings in O(1); if emission ever stops being consecutive, that shortcut
-    would silently mislabel metrics -- this test should catch it first.
-    """
+def test_sequential_batch_emits_each_action_with_its_result():
+    """Sequential tool events reflect execution order without duplicating metrics."""
     tool_calls = [
         MessageToolCall(
             id="tc-1",
@@ -388,12 +380,23 @@ def test_batch_action_events_are_emitted_consecutively():
     )
     events, _ = _run_single_step(_make_llm_response(msg))
 
-    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    tool_events = [
+        event for event in events if isinstance(event, (ActionEvent, ObservationEvent))
+    ]
+    action_events = [event for event in tool_events if isinstance(event, ActionEvent)]
     assert len(action_events) == 2
-    # One LLM response -> one shared llm_response_id for the whole batch.
     assert len({a.llm_response_id for a in action_events}) == 1
-    # Emitted as a consecutive run (nothing of another response interleaves),
-    # in tool-call order.
     assert [a.tool_call_id for a in action_events] == ["tc-1", "tc-2"]
-    # Only the first event of the batch carries the turn's thought.
     assert action_events[0].thought and not action_events[1].thought
+    assert [type(event) for event in tool_events] == [
+        ActionEvent,
+        ObservationEvent,
+        ActionEvent,
+        ObservationEvent,
+    ]
+    assert [event.tool_call_id for event in tool_events] == [
+        "tc-1",
+        "tc-1",
+        "tc-2",
+        "tc-2",
+    ]

--- a/tests/sdk/conversation/local/test_subagent_callbacks.py
+++ b/tests/sdk/conversation/local/test_subagent_callbacks.py
@@ -1,0 +1,67 @@
+from openhands.sdk import Agent, Conversation
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.event import Event
+from openhands.sdk.testing import TestLLM
+
+
+class ChildObserver:
+    def __init__(self) -> None:
+        self.contexts: list[tuple[str, str, str | None]] = []
+
+    def __call__(self, event: Event) -> None:
+        pass
+
+    def for_subagent(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> "ChildObserver":
+        child = ChildObserver()
+        child.contexts.append((task_id, subagent_type, description))
+        return child
+
+    def finish_subagent(
+        self,
+        *,
+        status: str,
+        result: str | None,
+        error: str | None,
+        stats: ConversationStats,
+    ) -> None:
+        pass
+
+
+class FailingObserver(ChildObserver):
+    def for_subagent(
+        self,
+        *,
+        task_id: str,
+        subagent_type: str,
+        description: str | None,
+    ) -> ChildObserver:
+        raise RuntimeError("observer unavailable")
+
+
+def test_subagent_callbacks_are_opt_in_and_failure_isolated() -> None:
+    ordinary_events = []
+    observer = ChildObserver()
+    conversation = Conversation(
+        agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+        callbacks=[ordinary_events.append, observer, FailingObserver()],
+        visualizer=None,
+    )
+    try:
+        callbacks = conversation.create_subagent_callbacks(
+            task_id="task-1",
+            subagent_type="implementer",
+            description="Implement helper",
+        )
+    finally:
+        conversation.close()
+
+    assert len(callbacks) == 1
+    assert isinstance(callbacks[0], ChildObserver)
+    assert callbacks[0].contexts == [("task-1", "implementer", "Implement helper")]
+    assert ordinary_events == []

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -923,11 +923,8 @@ def _batch_action_event(call_id: str, response_id: str) -> ActionEvent:
     )
 
 
-def test_claim_batch_primary_tracks_consecutive_batches():
-    """Parallel tool calls share one llm_response_id and render consecutively;
-    only the first ActionEvent of each batch claims the per-request metrics
-    (#4189). Detection tracks just the previous response id -- O(1), no scan --
-    so it must be called once per event in render order."""
+def test_claim_batch_primary_ignores_interleaved_non_action_events():
+    """Only the first action for an LLM response claims per-request metrics."""
     visualizer = DefaultConversationVisualizer()
 
     a1 = _batch_action_event("call_1", "resp_batch")

--- a/tests/sdk/llm/test_llm_retry_telemetry.py
+++ b/tests/sdk/llm/test_llm_retry_telemetry.py
@@ -7,7 +7,7 @@ combined time of all failed attempts plus the successful one.
 """
 
 import time
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from litellm.exceptions import APIConnectionError
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
@@ -127,6 +127,68 @@ def test_telemetry_records_only_successful_attempt_latency(mock_litellm_completi
     assert recorded_latency < 0.5, (
         f"Recorded latency ({recorded_latency:.3f}s) should be < 0.5s for a mocked call"
     )
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_request_log_callback_runs_before_transport(mock_litellm_completion):
+    events = []
+    mock_response = create_mock_response()
+
+    def request_callback(llm_call_id: str, log_data: str) -> None:
+        events.append(("request", llm_call_id))
+
+    def transport(*args, **kwargs):
+        events.append(("transport", None))
+        return mock_response
+
+    mock_litellm_completion.side_effect = transport
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=0,
+        usage_id="test-service",
+    )
+    llm.telemetry.log_enabled = True
+    llm.telemetry.set_log_requests_callback(request_callback)
+
+    llm.completion(
+        messages=[Message(role="user", content=[TextContent(text="Hello!")])]
+    )
+
+    assert [event[0] for event in events] == ["request", "transport"]
+    assert events[0][1]
+
+
+@patch("openhands.sdk.llm.llm.litellm_acompletion", new_callable=AsyncMock)
+async def test_request_log_callback_runs_before_async_transport(
+    mock_litellm_acompletion,
+):
+    events = []
+    mock_response = create_mock_response()
+
+    def request_callback(llm_call_id: str, log_data: str) -> None:
+        events.append(("request", llm_call_id))
+
+    async def transport(*args, **kwargs):
+        events.append(("transport", None))
+        return mock_response
+
+    mock_litellm_acompletion.side_effect = transport
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=0,
+        usage_id="test-service",
+    )
+    llm.telemetry.log_enabled = True
+    llm.telemetry.set_log_requests_callback(request_callback)
+
+    await llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="Hello!")])]
+    )
+
+    assert [event[0] for event in events] == ["request", "transport"]
+    assert events[0][1]
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")

--- a/tests/sdk/llm/test_llm_telemetry.py
+++ b/tests/sdk/llm/test_llm_telemetry.py
@@ -485,6 +485,7 @@ class TestTelemetryLogging:
             assert data["context_window"] == 4096
             assert data["instructions"] == "test instructions"
             assert data["input"][0]["type"] == "reasoning"
+            assert data["llm_call_id"]
             assert "error" in data
             assert data["error"]["type"] == "ValueError"
             assert data["error"]["message"] == "boom"
@@ -887,6 +888,46 @@ class TestTelemetryEdgeCases:
 
 class TestTelemetryCallbacks:
     """Test callback functionality for log streaming and stats updates."""
+
+    def test_request_callback_precedes_correlated_completion(
+        self, basic_telemetry, mock_response
+    ):
+        events = []
+
+        def request_callback(llm_call_id: str, log_data: str) -> None:
+            events.append(("request", llm_call_id, json.loads(log_data)))
+
+        def completion_callback(filename: str, log_data: str) -> None:
+            events.append(("response", filename, json.loads(log_data)))
+
+        basic_telemetry.log_enabled = True
+        basic_telemetry.set_log_requests_callback(request_callback)
+        basic_telemetry.set_log_completions_callback(completion_callback)
+
+        with patch.object(basic_telemetry, "_compute_cost", return_value=None):
+            basic_telemetry.on_request(
+                {"messages": [{"role": "user", "content": "hello"}]}
+            )
+            basic_telemetry.on_response(mock_response)
+
+        assert [event[0] for event in events] == ["request", "response"]
+        request_id = events[0][1]
+        assert events[0][2]["llm_call_id"] == request_id
+        assert events[0][2]["messages"][0]["content"] == "hello"
+        assert events[1][2]["llm_call_id"] == request_id
+        assert events[1][2]["response"]["id"] == "test-response-id"
+
+    def test_request_callback_failure_does_not_escape(self, basic_telemetry):
+        def failing_callback(llm_call_id: str, log_data: str) -> None:
+            raise RuntimeError("request log failed")
+
+        basic_telemetry.set_log_requests_callback(failing_callback)
+
+        with pytest.warns(UserWarning, match="Telemetry request logging failed"):
+            basic_telemetry.on_request({"messages": []})
+
+        assert basic_telemetry._req_ctx == {"messages": []}
+        assert basic_telemetry._req_id is not None
 
     def test_set_log_callback(self, basic_telemetry):
         """Test setting log callback."""

--- a/tests/sdk/logger/test_execution_context_formatter.py
+++ b/tests/sdk/logger/test_execution_context_formatter.py
@@ -1,0 +1,53 @@
+import asyncio
+import json
+import logging
+
+from openhands.sdk.logger import ExecutionContextJsonFormatter
+
+
+def _record(message: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        "test",
+        logging.INFO,
+        "test.py",
+        1,
+        message,
+        (),
+        None,
+    )
+
+
+def test_execution_context_formatter_adds_process_and_thread_fields():
+    formatter = ExecutionContextJsonFormatter("%(message)s")
+
+    data = json.loads(formatter.format(_record("sync")))
+
+    assert isinstance(data["process_id"], int)
+    assert data["process_name"] == "MainProcess"
+    assert isinstance(data["thread_id"], int)
+    assert data["thread_name"] == "MainThread"
+    assert "task_id" not in data
+    assert "task_name" not in data
+
+
+async def test_execution_context_formatter_adds_asyncio_task_fields():
+    formatter = ExecutionContextJsonFormatter("%(message)s")
+    task = asyncio.current_task()
+    assert task is not None
+
+    data = json.loads(formatter.format(_record("async")))
+
+    assert data["task_id"] == id(task)
+    assert data["task_name"] == task.get_name()
+
+
+async def test_execution_context_formatter_identifies_worker_thread():
+    formatter = ExecutionContextJsonFormatter("%(message)s")
+
+    data = await asyncio.to_thread(
+        lambda: json.loads(formatter.format(_record("worker")))
+    )
+
+    assert data["thread_name"].startswith("asyncio_")
+    assert "task_id" not in data
+    assert "task_name" not in data

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ litellm = "2026-07-20T00:00:00Z"
 
 [manifest]
 members = [
+    "openhands-agent-flight-recorder",
     "openhands-agent-server",
     "openhands-sdk",
     "openhands-tools",
@@ -47,6 +48,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
+    { name = "pytest-qt", specifier = ">=4.5.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.12.10" },
@@ -2718,6 +2720,34 @@ wheels = [
 ]
 
 [[package]]
+name = "openhands-agent-flight-recorder"
+version = "0.1.0"
+source = { editable = "agent-flight-recorder" }
+dependencies = [
+    { name = "openhands-sdk" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyside6" },
+    { name = "zstandard" },
+]
+
+[package.optional-dependencies]
+package = [
+    { name = "pyinstaller" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "openhands-sdk", editable = "openhands-sdk" },
+    { name = "platformdirs", specifier = ">=4.2" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pyinstaller", marker = "extra == 'package'", specifier = ">=6.16" },
+    { name = "pyside6", specifier = ">=6.8" },
+    { name = "zstandard", specifier = ">=0.23" },
+]
+provides-extras = ["package"]
+
+[[package]]
 name = "openhands-agent-server"
 version = "1.42.1"
 source = { editable = "openhands-agent-server" }
@@ -2736,6 +2766,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+flight-recorder = [
+    { name = "openhands-agent-flight-recorder" },
+]
 posthog = [
     { name = "posthog" },
 ]
@@ -2747,6 +2780,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.1,<8" },
     { name = "fastapi", specifier = ">=0.104" },
     { name = "openai", specifier = ">=2.33.0,<3" },
+    { name = "openhands-agent-flight-recorder", marker = "extra == 'flight-recorder'", editable = "agent-flight-recorder" },
     { name = "openhands-sdk", editable = "openhands-sdk" },
     { name = "posthog", marker = "extra == 'posthog'", specifier = ">=6,<7" },
     { name = "pydantic", specifier = ">=2" },
@@ -2755,7 +2789,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=12" },
     { name = "wsproto", specifier = ">=1.2.0" },
 ]
-provides-extras = ["posthog"]
+provides-extras = ["flight-recorder", "posthog"]
 
 [[package]]
 name = "openhands-sdk"
@@ -6412,6 +6446,54 @@ nodejs = [
 ]
 
 [[package]]
+name = "pyside6"
+version = "6.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/b5/99ff75f604d69eda1c5d1fe85cc43fb697d95eabc30ba86af099c2ddcd96/pyside6-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:13a3c79816879d9743672a669f1988f74459a78f89a97a2624fae4fe059ffa3a", size = 571875, upload-time = "2026-08-18T06:37:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fe/968844def58150a41568b505edca0d68df6901b20ea4222ccb0c069cc703/pyside6-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:dc6d03990489a5085842770718392ef5de36352d8f608d9a9fe03e60af4d7b66", size = 572120, upload-time = "2026-08-18T06:37:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/f4ecc6defaec645e5ac3ca2f99e3da286a28d1c647c2d10b584e0392b94c/pyside6-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:57fe867a6c93821a085d74e8a26f863fc2363516848181c466032595b33b1729", size = 572121, upload-time = "2026-08-18T06:37:32.383Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fe/4aea9d30300fff4cda9bb729c1363b9e1095a8544e0d6b57065465e16599/pyside6-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:3201d67e3c10be2eaedd3910ff0f02351eca7e88c95a291cde5e7f2f55ef207f", size = 578382, upload-time = "2026-08-18T06:37:34.385Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b0/8e2fb01e9ee15ad29fe10d0dd2d37f503e4aa3714c9fbb07aca380618de7/pyside6-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:0444ac71d0791a19bded35f6d9a94515941f23a6eb7098ca45a1b64a338be697", size = 561768, upload-time = "2026-08-18T06:37:36.437Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/91/339fe9f7c94163815004ccd6b5c58b926b2dfb4e51c3b5563d412eab151f/pyside6_addons-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:354c574a839f7d0751960ba03f33bec87c95e0f2796dca3287f54d03abe97dac", size = 332047075, upload-time = "2026-08-18T06:35:33.037Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cd/ce470e20f68901f4dfa5f742d6a3a58ba865684a232e4b87d5a1a2179cc0/pyside6_addons-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a8b00956925fbdeffc7052cf933506391289f35ac4f3f71a0a167ec195cd47b4", size = 175062576, upload-time = "2026-08-18T06:35:45.583Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bd/f725a8984703612c72cd17d0871d047132bacaccc13fc0d288a5e8a37dad/pyside6_addons-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a2ca3c73e5f060d4aca49451abd9fba68dd0e1c66ff40cea3a1fe0415def579a", size = 170827254, upload-time = "2026-08-18T06:35:56.675Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/08bf6594101b42fc88834009f1dac59a983c5b6805c62c5081f077d09b4a/pyside6_addons-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:f449ea4431da20e7b86752cca8d166f93434516fe417f981c27e5f8e1b554407", size = 168208836, upload-time = "2026-08-18T06:36:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/e4b7f09343e9f29e565f488fb44c4f1fe260db481ba2c08ad8a1a7d48216/pyside6_addons-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:d5606af369484b862b4d5741cfc179e19d2b8819c3e04d210b8188e0c9f85988", size = 35807245, upload-time = "2026-08-18T06:36:12.485Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/16/0b7ecf89ebada82ed0430be33809ff325761ece83104f8635b1bd101fcd0/pyside6_essentials-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:77795c145202e65a78d88f7cd409d186e3ba23d159bdb3ba2dcd159ae5e5f0d9", size = 110800753, upload-time = "2026-08-18T06:36:33.674Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1a/84a84bbc75835ee88abdcb66eb875b8e1a21834af9b833bc1893f2c1bfaf/pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:aaf9f25f0f324874085fa5b26a610318db8a8e243cf85bb3e5400595191c7778", size = 80108947, upload-time = "2026-08-18T06:36:40.637Z" },
+    { url = "https://files.pythonhosted.org/packages/60/4c/d92b08a2151d095b9a3725fa0e71b215ec686d40bbd5d8b702d21a9b5eaa/pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:d3ec6e1885c46e57f16364f38ea8040ffc5dc0b18341058f608fede3ba930567", size = 79575497, upload-time = "2026-08-18T06:36:46.97Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/09/d2662684aee4d3f027ff9b1e965f22301bc28ffc5b7f167658508e4475dc/pyside6_essentials-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:c8a29def77032773a30879f7f24415b5395ad08592d147c170824ef4c735dfc1", size = 76913043, upload-time = "2026-08-18T06:36:54.038Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/4dd2a6468cea600da1fcf9c7f02bc248eeaa98cdc75658e48e669d95326a/pyside6_essentials-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:fadd75c5c20800d64dd0a586ea8cb337c5e630aa2246df0e5105738afa46e02c", size = 58125520, upload-time = "2026-08-18T06:36:59.073Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6465,6 +6547,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz", hash = "sha256:4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f", size = 9977, upload-time = "2023-02-12T23:22:27.544Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl", hash = "sha256:810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0", size = 4897, upload-time = "2023-02-12T23:22:26.022Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
 ]
 
 [[package]]
@@ -6936,6 +7032,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/44/11bf71c36e71936ab4e923e5dd23599dab527c4488b01860b0f689ce9947/shiboken6-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:53659683b1f7a08e9f87eff9b1065f1ceb7110cd7a4bc09fdf5efe43d286604d", size = 476674, upload-time = "2026-08-18T06:37:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9a/f41bea4316d0c1bec4800842dcb4bd8fd3e29d6a79c496bc32e1aec42583/shiboken6-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:7a7a0a72a9ed26c9bf77d42246b1c736486befb8f31aa2fb29957ea4cdd1c1c2", size = 272435, upload-time = "2026-08-18T06:37:13.397Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/79ed0697515d4fc7435459e4ed4c4a3b5621a55b7c91d0f3f2cc3d617aa0/shiboken6-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4bbbd6fa4d7cff5ec5e12bc4c10e1d845fa30c89457ecb13cc64f7bddb77f6f9", size = 270668, upload-time = "2026-08-18T06:37:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/fee1b4814317e4664e318644c9c007676c65a71e5b2b9d3ac4121a94dc0a/shiboken6-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:6ab0eba1c904455df621f9a6df3ca2bb896bab8670572d2bc4e37804ae91f19a", size = 1226578, upload-time = "2026-08-18T06:37:18.002Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b5/80c4e5aafeb8ac777cf5a1becfe87ac7197c35051df00b5f7819787e09d5/shiboken6-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:97c49432488df958f0308736f3d15b6915d8826fc380af17bb4b9ec5c4a5e81b", size = 1784669, upload-time = "2026-08-18T06:37:21.046Z" },
 ]
 
 [[package]]
@@ -7679,4 +7787,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
Azure OpenAI Responses API is enabled only for api-version 2025-03-01-preview and later. Need to update accordingly.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Updated the api-version to 2025-03-01 and tested in my local laptop that this worked to my model endpoint in azure ai foundry. 

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

When creating LLM from azure provider, the API endpoint fails with error. {"error":{"code":"BadRequest","message":"Azure OpenAI Responses API is enabled only for api-version 2025-03-01-preview and later"}}

## Summary

- The change is simple. Just changed the default API version to the latest one.

## Issue Number
[4549](https://github.com/OpenHands/software-agent-sdk/issues/4549)

## How to Test

1. Prepare Azure AI foundry based model deployment and the endpoint and the api key.
2. Create LLM using OpenHand webpage with provider Azure.
3. When trying to create the LLM, it fails with the error message above.

## Video/Screenshots
<img width="1406" height="895" alt="image" src="https://github.com/user-attachments/assets/5c854945-9a8a-4dea-9ded-eb4e4b9cc458" />



## Design Doc

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a simple API version fix which is outdated.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.55s · commit e22d599  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 11/206 hunks, 31/142 files (context budget: 11, file budget: 111, hunk budget: 195).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 7.0% | No direct hunk selected |
| Command injection | 8.0% | No direct hunk selected |
| Weakened authentication | 5.0% | No direct hunk selected |
| Weakened authorization | 9.0% | No direct hunk selected |
| Contract regression | 13.0% | No direct hunk selected |
| Data loss | 7.0% | No direct hunk selected |
| Sensitive data disclosure | 32.0% | No direct hunk selected |
| Unexpected data transfer | 5.0% | No direct hunk selected |
| Credential misuse | 9.0% | No direct hunk selected |
| Untrusted instruction authority | 8.0% | No direct hunk selected |
| Package source redirection | 5.0% | No direct hunk selected |
| Unverified remote execution | 4.0% | No direct hunk selected |
| Privileged environment access | 13.0% | No direct hunk selected |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 78.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 0f53e8a1c9d2e1abc85a60a69634bc0f1276f5d6737aeae22c49fd5abe08ca4c -->
<!-- jev-fast-audit:end -->
