### PR TITLE
fix(sdk): respect disabled prompt caching

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/message.py
+++ b/openhands-sdk/openhands/sdk/llm/message.py
@@ -300,7 +300,10 @@ class Message(BaseModel):
         if not force_string_serializer and (
             cache_enabled or vision_enabled or function_calling_enabled
         ):
-            message_dict = self._list_serializer(vision_enabled=vision_enabled)
+            message_dict = self._list_serializer(
+                vision_enabled=vision_enabled,
+                cache_enabled=cache_enabled,
+            )
         else:
             # some providers, like HF and Groq/llama, don't support a list here, but a
             # single string
@@ -339,7 +342,9 @@ class Message(BaseModel):
         # tool call keys are added in to_chat_dict to centralize behavior
         return message_dict
 
-    def _list_serializer(self, *, vision_enabled: bool) -> dict[str, Any]:
+    def _list_serializer(
+        self, *, vision_enabled: bool, cache_enabled: bool = True
+    ) -> dict[str, Any]:
         content: list[dict[str, Any]] = []
         role_tool_with_prompt_caching = False
 
@@ -367,7 +372,10 @@ class Message(BaseModel):
             # We have to remove cache_prompt for tool content and move it up to the
             # message level
             # See discussion here for details: https://github.com/BerriAI/litellm/issues/6422#issuecomment-2438765472
-            if self.role == "tool" and item.cache_prompt:
+            if not cache_enabled:
+                for d in item_dicts:
+                    d.pop("cache_control", None)
+            elif self.role == "tool" and item.cache_prompt:
                 role_tool_with_prompt_caching = True
                 for d in item_dicts:
                     d.pop("cache_control", None)

--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -99,6 +99,49 @@ def test_message_tool_role_with_cache_prompt():
     assert "cache_control" not in result["content"][0]
 
 
+def test_message_tool_role_omits_cache_prompt_when_cache_disabled():
+    """Tool messages should respect disabled prompt caching."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    message = Message(
+        role="tool",
+        content=[TextContent(text="Tool response", cache_prompt=True)],
+        tool_call_id="call_123",
+        name="test_tool",
+    )
+
+    result = message.to_chat_dict(
+        **{
+            **DEFAULT_SERIALIZATION_OPTS,
+            "cache_enabled": False,
+            "function_calling_enabled": True,
+        }
+    )
+
+    assert "cache_control" not in result
+    assert "cache_control" not in result["content"][0]
+
+
+def test_message_user_role_omits_cache_prompt_when_cache_disabled():
+    """User content should respect disabled prompt caching."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    message = Message(
+        role="user",
+        content=[TextContent(text="User request", cache_prompt=True)],
+    )
+
+    result = message.to_chat_dict(
+        **{
+            **DEFAULT_SERIALIZATION_OPTS,
+            "cache_enabled": False,
+            "function_calling_enabled": True,
+        }
+    )
+
+    assert "cache_control" not in result["content"][0]
+
+
 def test_message_tool_role_with_image_cache_prompt():
     """Test Message with tool role and ImageContent with cache_prompt."""
     from openhands.sdk.llm.message import ImageContent, Message


### PR DESCRIPTION
HUMAN:

I reviewed the changes and test results, and confirmed that disabled prompt caching no longer emits cache_control markers in tool-call messages.

---

AGENT:

This draft was prepared with AI assistance. The human author reviewed the code changes and verification results before submission.

## Why

`Message.to_chat_dict()` selects list serialization when function calling is enabled. That path previously did not pass `cache_enabled` to `_list_serializer()`, so content marked with `cache_prompt=True` could still emit `cache_control` even when the call-level caching switch was disabled.

## Summary

- Pass the call-level `cache_enabled` setting into list serialization.
- Remove content-level cache markers when prompt caching is disabled.
- Add regression coverage for both tool and user messages with function calling enabled.

## Issue Number

#4511

## How to Test

Run the focused message serialization tests:

```bash
uv run pytest tests/sdk/llm/test_message.py -q
```

Result on this branch:

```text
32 passed in 0.05s
```

I also invoked the public `Message.to_chat_dict()` API for tool and user messages with `cache_prompt=True`, `cache_enabled=False`, and `function_calling_enabled=True`. The serialized output was:

```text
{"content": [{"text": "Tool response", "type": "text"}], "name": "test_tool", "role": "tool", "tool_call_id": "call_123"}
{"content": [{"text": "User request", "type": "text"}], "role": "user"}
PASS: cache_control is absent when prompt caching is disabled
```

## Video/Screenshots

Not applicable; this is a message serialization fix. The end-to-end serialized output is included above.

## Design Doc

Not needed for this focused bug fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

PR #4512 already addresses the same issue. This draft is intentionally transparent about that overlap and is being submitted to validate this independently tested implementation through the project's CI and review workflow. It adds regression coverage for both tool-role and user-role messages.
