### PR TITLE
feat(tools): add structured task outcome preset

### DIFF
--- a/openhands-tools/openhands/tools/preset/__init__.py
+++ b/openhands-tools/openhands/tools/preset/__init__.py
@@ -26,6 +26,11 @@ from .default import (
 from .gemini import get_gemini_agent, get_gemini_tools
 from .gpt5 import get_gpt5_agent
 from .planning import get_planning_agent
+from .task_outcome import (
+    TaskOutcome,
+    TaskOutcomeBlocker,
+    TaskOutcomeStatus,
+)
 
 
 __all__ = [
@@ -36,4 +41,7 @@ __all__ = [
     "get_gpt5_agent",
     "get_planning_agent",
     "register_builtins_agents",
+    "TaskOutcome",
+    "TaskOutcomeBlocker",
+    "TaskOutcomeStatus",
 ]

--- a/openhands-tools/openhands/tools/preset/default.py
+++ b/openhands-tools/openhands/tools/preset/default.py
@@ -1,6 +1,7 @@
 """Default preset configuration for OpenHands agents."""
 
 from pathlib import Path
+from typing import Any
 
 from openhands.sdk import Agent, agent_definition_to_factory, load_agents_from_dir
 from openhands.sdk.context.condenser import default_condenser
@@ -9,6 +10,8 @@ from openhands.sdk.llm.llm import LLM
 from openhands.sdk.logger import get_logger
 from openhands.sdk.subagent import AgentDefinition, register_agent_if_absent
 from openhands.sdk.tool import Tool
+from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, FinishTool
+from openhands.sdk.tool.registry import register_tool
 
 
 logger = get_logger(__name__)
@@ -73,14 +76,31 @@ def get_default_condenser(llm: LLM) -> CondenserBase:
 def get_default_agent(
     llm: LLM,
     cli_mode: bool = False,
+    finish_tool_response_schema: Any | None = None,
 ) -> Agent:
     tools = get_default_tools(
         # Disable browser tools in CLI mode
         enable_browser=not cli_mode,
     )
+    include_default_tools = [tool.__name__ for tool in BUILT_IN_TOOLS]
+    if finish_tool_response_schema is not None:
+        register_tool(FinishTool.__name__, FinishTool)
+        tools.append(
+            Tool(
+                name=FinishTool.__name__,
+                params={"response_schema": finish_tool_response_schema},
+            )
+        )
+        include_default_tools = [
+            tool_name
+            for tool_name in include_default_tools
+            if tool_name != FinishTool.__name__
+        ]
+
     agent = Agent(
         llm=llm,
         tools=tools,
+        include_default_tools=include_default_tools,
         system_prompt_kwargs={"cli_mode": cli_mode},
         condenser=get_default_condenser(
             llm=llm.model_copy(update={"usage_id": "condenser"})

--- a/openhands-tools/openhands/tools/preset/task_outcome.py
+++ b/openhands-tools/openhands/tools/preset/task_outcome.py
@@ -1,0 +1,65 @@
+"""Experimental structured task outcome models for conversation finish actions."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+TaskOutcomeStatus = Literal[
+    "success",
+    "partial_success",
+    "blocked",
+    "failed",
+    "unknown",
+]
+
+
+class TaskOutcomeBlocker(BaseModel):
+    """A blocker that prevented or limited task completion."""
+
+    type: str = Field(
+        description=(
+            "Short machine-readable blocker category, e.g. missing_secret, "
+            "permission_denied, external_service, timeout, or unclear_requirements."
+        )
+    )
+    message: str = Field(description="Human-readable blocker description.")
+    recoverable: bool | None = Field(
+        default=None,
+        description="Whether user or system action can reasonably unblock the task.",
+    )
+
+
+class TaskOutcome(BaseModel):
+    """Latest semantic outcome reported for a conversation task.
+
+    Experimental: this structured response model may change as task outcome
+    reporting is refined.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: TaskOutcomeStatus = Field(
+        description="Agent's semantic assessment of task completion."
+    )
+    # FinishTool already has a `summary` action-metadata field, so the tool
+    # schema exposes this outcome field as `outcome_summary` while preserving
+    # the semantic model attribute name.
+    summary: str = Field(
+        alias="outcome_summary",
+        description="Concise summary of the outcome.",
+    )
+    blockers: list[TaskOutcomeBlocker] = Field(
+        default_factory=list,
+        description="Blockers encountered while trying to complete the task.",
+    )
+    confidence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional confidence in the semantic outcome, from 0 to 1.",
+    )
+    needs_user_action: bool = Field(
+        default=False,
+        description="Whether the user needs to act before the task can proceed.",
+    )

--- a/tests/tools/test_preset_default.py
+++ b/tests/tools/test_preset_default.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel
+
+from openhands.sdk import LLM, Conversation
+from openhands.sdk.tool import registry as tool_registry
+from openhands.tools.preset.default import get_default_agent
+
+
+class _FinishResult(BaseModel):
+    success: bool
+    outcome_summary: str
+
+
+def test_default_agent_registers_finish_tool_for_structured_response():
+    with tool_registry._LOCK:
+        saved_resolver = tool_registry._REG.pop("FinishTool", None)
+        saved_checker = tool_registry._USABILITY_REG.pop("FinishTool", None)
+        saved_module = tool_registry._MODULE_QUALNAMES.pop("FinishTool", None)
+
+    try:
+        llm = LLM(model="test-model", usage_id="test-llm")
+        agent = get_default_agent(
+            llm=llm,
+            cli_mode=True,
+            finish_tool_response_schema=_FinishResult,
+        )
+
+        assert "FinishTool" in tool_registry.list_registered_tools()
+        assert any(
+            tool.name == "FinishTool"
+            and tool.params == {"response_schema": _FinishResult}
+            for tool in agent.tools
+        )
+        assert "FinishTool" not in agent.include_default_tools
+        assert "ThinkTool" in agent.include_default_tools
+
+        conv = Conversation(agent=agent, visualizer=None)
+        conv._ensure_agent_ready()
+
+        finish_tool = agent.tools_map["finish"]
+        assert finish_tool.response_schema is _FinishResult
+        assert "think" in agent.tools_map
+    finally:
+        with tool_registry._LOCK:
+            tool_registry._REG.pop("FinishTool", None)
+            tool_registry._USABILITY_REG.pop("FinishTool", None)
+            tool_registry._MODULE_QUALNAMES.pop("FinishTool", None)
+            if saved_resolver is not None:
+                tool_registry._REG["FinishTool"] = saved_resolver
+            if saved_checker is not None:
+                tool_registry._USABILITY_REG["FinishTool"] = saved_checker
+            if saved_module is not None:
+                tool_registry._MODULE_QUALNAMES["FinishTool"] = saved_module

--- a/tests/tools/test_task_outcome.py
+++ b/tests/tools/test_task_outcome.py
@@ -1,0 +1,39 @@
+from openhands.sdk.tool.spec import Tool
+from openhands.tools.preset import TaskOutcome, TaskOutcomeBlocker
+
+
+def test_task_outcome_accepts_outcome_summary_alias():
+    outcome = TaskOutcome(
+        status="blocked",
+        outcome_summary="Could not continue without a token.",
+        blockers=[
+            TaskOutcomeBlocker(
+                type="missing_secret",
+                message="A required API token was not configured.",
+                recoverable=True,
+            )
+        ],
+        confidence=0.7,
+        needs_user_action=True,
+    )
+
+    assert outcome.summary == "Could not continue without a token."
+    assert outcome.blockers[0].type == "missing_secret"
+    assert outcome.needs_user_action is True
+
+
+def test_task_outcome_finish_tool_schema_uses_outcome_summary():
+    schema = Tool(
+        name="FinishTool", params={"response_schema": TaskOutcome}
+    ).model_dump(mode="json")["params"]["response_schema"]
+
+    properties = schema["properties"]
+    assert "outcome_summary" in properties
+    assert "summary" not in properties
+    assert "source" not in properties
+    assert "reported_at" not in properties
+    assert "terminal_reason" not in properties
+
+    assert properties["status"]["description"] == (
+        "Agent's semantic assessment of task completion."
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

PR #4479 adds structured task-outcome support for default-agent finish responses, but it also includes SDK-level built-in resolution and resume-compatibility code. This PR keeps the task-outcome/default-preset behavior while taking the simpler approach requested: when a structured finish response schema is passed, `get_default_agent(...)` registers `FinishTool` directly and uses an explicit schema-bound finish tool.

## Summary

- Add experimental `TaskOutcome`, `TaskOutcomeBlocker`, and `TaskOutcomeStatus` models under `openhands.tools.preset`.
- Add `finish_tool_response_schema` to `get_default_agent(...)`.
- Register `FinishTool` inside `get_default_agent(...)` when a structured finish response schema is provided, then attach the schema-bound explicit finish tool without SDK registry fallback/resolution changes.

## Issue Number

N/A

## How to Test

Focused tests:

```bash
uv run pytest tests/tools/test_task_outcome.py tests/tools/test_preset_default.py tests/sdk/tool/test_response_schema.py -q
```

Result: `37 passed, 7 warnings in 0.70s`.

Pre-commit on changed files:

```bash
uv run pre-commit run --files openhands-tools/openhands/tools/preset/default.py openhands-tools/openhands/tools/preset/__init__.py openhands-tools/openhands/tools/preset/task_outcome.py tests/tools/test_preset_default.py tests/tools/test_task_outcome.py
```

Result: all hooks passed, including Ruff format/lint, pycodestyle, pyright, import rules, and tool registration.

End-to-end smoke test:

```bash
uv run python - <<'PY'
from openhands.sdk import LLM, Conversation
from openhands.tools.preset import TaskOutcome
from openhands.tools.preset.default import get_default_agent

llm = LLM(model='test-model', usage_id='smoke-test')
agent = get_default_agent(
    llm=llm,
    cli_mode=True,
    finish_tool_response_schema=TaskOutcome,
)
conversation = Conversation(agent=agent, visualizer=None)
conversation._ensure_agent_ready()
finish = agent.tools_map['finish']
schema = finish._get_tool_schema()
action = finish.action_from_arguments({
    'message': 'done',
    'status': 'success',
    'outcome_summary': 'Structured finish works.',
    'blockers': [],
    'needs_user_action': False,
})
outcome = finish.parse_response(action)
print('finish_schema_fields=', sorted(schema['properties']))
print('outcome_status=', outcome.status)
print('outcome_summary=', outcome.summary)
print('default_tools=', sorted(agent.tools_map))
PY
```

Relevant output:

```text
finish_schema_fields= ['blockers', 'confidence', 'message', 'needs_user_action', 'outcome_summary', 'status', 'summary']
outcome_status= success
outcome_summary= Structured finish works.
default_tools= ['file_editor', 'finish', 'inspect_image_with_vision', 'task_tracker', 'terminal', 'think']
```

## Video/Screenshots

N/A — no UI changes.

## Design Doc

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This intentionally does not include the SDK-level built-in fallback in `resolve_tool(...)` or the AgentBase default-tool override/resume compatibility changes from PR #4479.

_AI disclosure: This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/764afda4-0a58-4911-9a08-ced7e405401e)
<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3b44370-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3b44370-python \
  ghcr.io/openhands/agent-server:3b44370-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3b44370-golang-amd64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-golang-amd64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-golang-amd64
ghcr.io/openhands/agent-server:3b44370-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3b44370-golang-arm64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-golang-arm64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-golang-arm64
ghcr.io/openhands/agent-server:3b44370-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3b44370-java-amd64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-java-amd64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-java-amd64
ghcr.io/openhands/agent-server:3b44370-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3b44370-java-arm64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-java-arm64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-java-arm64
ghcr.io/openhands/agent-server:3b44370-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3b44370-python-amd64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-python-amd64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-python-amd64
ghcr.io/openhands/agent-server:3b44370-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3b44370-python-arm64
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-python-arm64
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-python-arm64
ghcr.io/openhands/agent-server:3b44370-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3b44370-golang
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-golang
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-golang
ghcr.io/openhands/agent-server:3b44370-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3b44370-java
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-java
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-java
ghcr.io/openhands/agent-server:3b44370-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3b44370-python
ghcr.io/openhands/agent-server:3b443704d73f6a290ac3b912e0a6fe446dab2cc2-python
ghcr.io/openhands/agent-server:structured-finish-task-outcome-simple-python
ghcr.io/openhands/agent-server:3b44370-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3b44370-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3b44370-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->