### PR TITLE
fix(agent-server): support workspace cookies over LAN HTTP

### DIFF
--- a/openhands-agent-server/openhands/agent_server/auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/auth_router.py
@@ -7,8 +7,9 @@ frontend wants to embed workspace artifacts (HTML reports, plots, PDFs).
 
 These endpoints let a client that already has a valid session API key
 exchange it for a short-lived cookie which the browser will automatically
-attach to every workspace request — including cross-site iframes, thanks
-to ``SameSite=None; Secure; Partitioned``.
+attach to every workspace request. Secure contexts support cross-site iframes
+via ``SameSite=None; Secure; Partitioned``; plain HTTP falls back to a
+same-site ``SameSite=Lax`` cookie.
 
 The cookie is honored by ``workspace_router`` ONLY. Every other API route
 continues to require the ``X-Session-API-Key`` header. This is deliberate:
@@ -74,12 +75,10 @@ def _set_workspace_cookie(
     in third-party contexts; without it, the cookie may be silently
     dropped under third-party-cookie phase-out.
 
-    We always set ``SameSite=None`` so the same cookie works for both
-    same-site and cross-site iframes, and always set ``HttpOnly`` so JS
-    in workspace HTML can't read it back. ``Secure`` is set whenever
-    the request comes from a secure context (HTTPS or loopback) — the
-    only contexts where a ``SameSite=None`` cookie will actually be
-    stored by the browser.
+    We set ``SameSite=None`` in secure contexts so the cookie works for both
+    same-site and cross-site iframes. Plain HTTP uses ``SameSite=Lax`` because
+    browsers reject ``SameSite=None`` cookies without ``Secure``. ``HttpOnly``
+    is always set so JS in workspace HTML can't read the cookie back.
     """
     response.set_cookie(
         key=WORKSPACE_SESSION_COOKIE_NAME,
@@ -88,7 +87,7 @@ def _set_workspace_cookie(
         path=_COOKIE_PATH,
         secure=secure,
         httponly=True,
-        samesite="none",
+        samesite="none" if secure else "lax",
     )
     # Starlette plumbs ``partitioned`` through to ``http.cookies.Morsel``,
     # which only recognized the attribute starting in Python 3.14. We need

--- a/tests/agent_server/test_workspace_cookie_auth.py
+++ b/tests/agent_server/test_workspace_cookie_auth.py
@@ -175,12 +175,12 @@ def test_mint_session_marks_cookie_secure_on_loopback(client_factory, host_heade
     assert "Partitioned" in set_cookie
 
 
-def test_mint_session_over_remote_plain_http_drops_secure(client_factory):
-    """On non-HTTPS to a non-loopback host we don't claim Secure — the
-    browser would reject a Secure cookie over plain HTTP anyway. The
-    cookie won't actually work for cross-site embedding in that case
-    (SameSite=None requires Secure), but emitting a Secure attribute we
-    can't honor would just make the failure mode less obvious."""
+def test_mint_session_over_remote_plain_http_uses_lax_cookie(client_factory):
+    """Remote plain HTTP needs a browser-compatible same-site cookie.
+
+    Browsers reject ``SameSite=None`` cookies without ``Secure``, while they
+    accept ``SameSite=Lax`` cookies for same-site workspace file requests.
+    """
     client = client_factory(conversation_id=uuid4())
 
     resp = client.post(
@@ -193,7 +193,7 @@ def test_mint_session_over_remote_plain_http_drops_secure(client_factory):
     assert resp.status_code == 204
 
     set_cookie = resp.headers["set-cookie"]
-    assert "SameSite=none" in set_cookie
+    assert "SameSite=lax" in set_cookie
     assert "Secure" not in set_cookie
     assert "Partitioned" not in set_cookie
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

On non-loopback plain-HTTP origins, the Agent Server emits the workspace-session cookie with `SameSite=None` but without `Secure`. Browsers reject that combination, so same-origin private-LAN deployments lose the cookie and workspace file requests such as `README.md` return 401.

HTTPS and loopback secure contexts must retain `SameSite=None; Secure; Partitioned` for cross-site iframe support. Plain HTTP cannot support that cross-site mode, but it can support same-site workspace requests with `SameSite=Lax`.

## Summary

- Use `SameSite=Lax` for workspace-session cookies on non-loopback plain HTTP.
- Preserve `SameSite=None; Secure; Partitioned` for HTTPS and loopback secure contexts.
- Update the remote-HTTP regression test to enforce the browser-compatible cookie attributes.

## Issue Number

Fixes #4562

## How to Test

RED before the production change:

```text
uv run pytest -q tests/agent_server/test_workspace_cookie_auth.py::test_mint_session_over_remote_plain_http_uses_lax_cookie
FAILED: assert 'SameSite=lax' in '...; SameSite=none'
```

Focused workspace-cookie suite after the change:

```text
uv run pytest -q tests/agent_server/test_workspace_cookie_auth.py
15 passed
```

Cookie and CORS regression suites, rerun by an independent read-only reviewer:

```text
uv run pytest tests/agent_server/test_workspace_cookie_auth.py tests/agent_server/test_cors.py
47 passed
```

Full Agent Server suite:

```text
uv run pytest -q tests/agent_server
2032 passed, 13 deselected
```

Repository quality hooks:

```text
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/auth_router.py tests/agent_server/test_workspace_cookie_auth.py
Ruff format: Passed
Ruff lint: Passed
pycodestyle: Passed
pyright: Passed
import dependency rules: Passed
Tool registration: Passed
```

Real HTTP smoke against `uv run agent-server` from this checkout:

```text
plain_http_status=204
plain_http_cookie=oh_workspace_session_key=<redacted>; HttpOnly; Max-Age=315360000; Path=/api/conversations; SameSite=lax
https_status=204
https_cookie=oh_workspace_session_key=<redacted>; HttpOnly; Max-Age=315360000; Path=/api/conversations; SameSite=none; Secure; Partitioned
```

## Video/Screenshots

Not applicable; this is a server-side cookie-header correction. The exact end-to-end response headers are included above.

## Design Doc

Not included because this is a localized one-line behavior fix with a focused regression test and no public API shape change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Cross-site workspace embedding still requires HTTPS (or a loopback secure context), as required by browser cookie policy. The `SameSite=Lax` fallback is specifically for same-site workspace requests over remote plain HTTP.
