### PR TITLE
test(integration): cover triggered skill and path-rule content across condensation

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -17,6 +17,7 @@ from openhands.sdk import (
     Message,
     TextContent,
 )
+from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.context.condenser import CondenserBase
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.visualizer import DefaultConversationVisualizer
@@ -135,7 +136,10 @@ class BaseIntegrationTest(ABC):
 
         self.llm: LLM = LLM(**llm_kwargs, usage_id="test-llm")
         self.agent: Agent = Agent(
-            llm=self.llm, tools=self.tools, condenser=self.condenser
+            llm=self.llm,
+            tools=self.tools,
+            condenser=self.condenser,
+            agent_context=self.agent_context,
         )
         self.collected_events: list[Event] = []
         self.llm_messages: list[dict[str, Any]] = []
@@ -268,6 +272,16 @@ class BaseIntegrationTest(ABC):
         return get_tools_for_preset(
             self.tool_preset, enable_browser=self.enable_browser
         )
+
+    @property
+    def agent_context(self) -> AgentContext | None:
+        """Optional agent context for the agent. Override to provide skills,
+        path rules, or other context the scenario needs.
+
+        Returns:
+            AgentContext instance or None (default)
+        """
+        return None
 
     @property
     def condenser(self) -> CondenserBase | None:

--- a/tests/integration/tests/c06_triggered_skill_survives_condensation.py
+++ b/tests/integration/tests/c06_triggered_skill_survives_condensation.py
@@ -1,0 +1,311 @@
+"""Keyword-triggered skill content across condensation (issue #4544).
+
+Scenario, end to end against a real LLM:
+
+1. A keyword-triggered skill is installed on the agent.
+2. Filler turns push the activating turn outside the condenser's protected
+   ``keep_first`` prefix.
+3. A user message containing the keyword activates the skill, which injects the
+   body into the conversation and records the name in
+   ``state.activated_knowledge_skills``.
+4. The agent does real work, then a real summarizing condensation runs.
+5. The keyword is sent again.
+
+The invariant asserted is the one the issue asks the maintainers to confirm:
+**after condensation, triggered content is either still present in the active
+view, or recoverable when the trigger fires again.** Any of the three candidate
+mechanisms (preserve, reconstruct, reactivate) satisfies it.
+
+On current main it does not hold, so this test FAILS by design and its failure
+message is the diagnosis. That is deliberate: the ``c*`` suite is optional and
+non-blocking, and a maintainer asked for a live run of the whole scenario to
+settle whether re-inclusion on a fresh trigger is the intended contract.
+
+The sentinel sits deliberately PAST ``N_CHAR_PREVIEW`` (500) inside the skill
+body. ``MessageEvent.__str__()`` truncates the TAIL, so a marker near the front
+survives truncation, reaches the summarizer, and a capable model will carry a
+distinctive token into its summary. An earlier draft did exactly that and passed
+against a real model while the bug was live. Beyond the cap the marker provably
+never reaches the summarizer, so the scenario stays deterministic with a real
+model in the loop.
+"""
+
+from openhands.sdk import Tool
+from openhands.sdk.context.agent_context import AgentContext
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.skills import KeywordTrigger, Skill
+from openhands.sdk.tool import register_tool
+from openhands.tools.terminal import TerminalTool
+from tests.integration.base import BaseIntegrationTest, TestResult
+
+
+SENTINEL = "PRESERVE_EXACT_SENTINEL_7F3A"
+
+# The sentinel must sit PAST N_CHAR_PREVIEW (500), not merely inside a body
+# longer than it. __str__ truncates the TAIL, so a front-loaded marker survives
+# and reaches the summarizer -- see the module docstring.
+_PREAMBLE = (
+    "Project convention for Python work in this repository. "
+    "Always wrap repository access in try-finally and release the handle in "
+    "the finally block, even on the error path. Prefer explicit resource "
+    "lifetimes over context managers when the handle outlives the block. "
+) * 4
+SKILL_BODY = f"{_PREAMBLE}\n\nSpecific rule marker: {SENTINEL}\n"
+
+
+INSTRUCTION: str = "This test defines its own instructions in run_instructions()."
+
+
+class TriggeredSkillCondensationTest(BaseIntegrationTest):
+    """Keyword-skill content must survive condensation or come back on retrigger."""
+
+    INSTRUCTION: str = INSTRUCTION
+
+    def __init__(self, *args, **kwargs):
+        self.condensations: list[Condensation] = []
+        # Facts recorded as the scenario runs, so verify_result can tell a
+        # genuine reproduction apart from a scenario that never set itself up.
+        self.activated_before: list[str] = []
+        self.sentinel_in_view_before: bool = False
+        self.skill_index_before: int | None = None
+        self.skill_event_id: str | None = None
+        self.carrier_forgotten: bool = False
+        self.view_map_after: list[str] = []
+        self.sentinel_echoed_after: bool = False
+        self.keep_first: int = 4
+        self.activated_after: list[str] = []
+        self.sentinel_in_view_after: bool = False
+        self.retrigger_activated_skills: list[str] = []
+        self.retrigger_extended_content: list[str] = []
+        super().__init__(*args, **kwargs)
+
+    @property
+    def tools(self) -> list[Tool]:
+        register_tool("TerminalTool", TerminalTool)
+        return [Tool(name="TerminalTool")]
+
+    @property
+    def agent_context(self) -> AgentContext:
+        return AgentContext(
+            skills=[
+                Skill(
+                    name="python_tips",
+                    content=SKILL_BODY,
+                    source="python-tips.md",
+                    trigger=KeywordTrigger(keywords=["python"]),
+                )
+            ]
+        )
+
+    @property
+    def condenser(self) -> LLMSummarizingCondenser:
+        condenser_llm = self.create_llm_copy("test-condenser-llm")
+        return LLMSummarizingCondenser(
+            llm=condenser_llm,
+            # High enough that condensation only happens where the scenario
+            # asks for it explicitly, never mid-scenario by surprise.
+            max_size=100,
+            keep_first=self.keep_first,
+        )
+
+    @property
+    def max_iteration_per_run(self) -> int:
+        return 30
+
+    def conversation_callback(self, event):
+        super().conversation_callback(event)
+        if isinstance(event, Condensation):
+            self.condensations.append(event)
+
+    @staticmethod
+    def _sentinel_in_injection_channel(conversation: LocalConversation) -> bool:
+        """Is the skill text still present through the MECHANISM that delivers it?
+
+        Only ``extended_content`` counts, because only that is deterministic.
+        A summarizer may happen to echo the text into its summary when the agent
+        quoted it back, which reads as survival but is a coin flip: strong models
+        do it, weaker ones do not, and the same model does not do it every run.
+        Observed directly here, as a real intermittent PASS on Opus 5.
+
+        This matches what the issue asks for: the active context should retain or
+        recover triggered content *deterministically*. Counting an echo would let
+        the test agree that a maybe is a contract.
+        """
+        for event in conversation.state.view.events:
+            extended = getattr(event, "extended_content", None) or []
+            if any(SENTINEL in c.text for c in extended):
+                return True
+        return False
+
+    @staticmethod
+    def _sentinel_echoed_only(conversation: LocalConversation) -> bool:
+        """Marker present in rendered text but NOT in the injection channel."""
+        for event in conversation.state.view.events:
+            if SENTINEL in str(event):
+                return True
+        return False
+
+    @staticmethod
+    def _view_map(conversation: LocalConversation) -> list[str]:
+        """Per-event map of where the marker survives, for the verdict message.
+
+        A verdict that says only "present" or "absent" leaves the reader
+        guessing which channel carried it. ``ext`` = the injection channel
+        (``extended_content``, what actually reaches the model); ``str`` = the
+        rendered text, which is what the summarizer is fed.
+        """
+        out = []
+        for event in conversation.state.view.events:
+            extended = getattr(event, "extended_content", None) or []
+            tags = ""
+            if any(SENTINEL in c.text for c in extended):
+                tags += "+ext"
+            if SENTINEL in str(event):
+                tags += "+str"
+            out.append(f"{type(event).__name__}{tags}")
+        return out
+
+    def run_instructions(self, conversation: LocalConversation) -> None:
+        # 1. Filler ahead of the activating turn, so the skill-bearing event
+        #    lands outside the protected prefix and the failure cannot be
+        #    written off as a keep_first artifact.
+        for i in range(self.keep_first):
+            conversation.send_message(f"Noting context item {i}; no action needed yet.")
+
+        # 2. Activate the skill and have the agent do real work with it present.
+        conversation.send_message(
+            "Using python, print the numbers 1 through 3 with three separate "
+            "echo commands."
+        )
+        conversation.run()
+
+        self.activated_before = list(conversation.state.activated_knowledge_skills)
+        self.sentinel_in_view_before = self._sentinel_in_injection_channel(conversation)
+        for idx, event in enumerate(conversation.state.view.events):
+            carries = any(
+                SENTINEL in c.text for c in getattr(event, "extended_content", []) or []
+            ) or SENTINEL in str(event)
+            if isinstance(event, MessageEvent) and carries:
+                self.skill_index_before = idx
+                self.skill_event_id = event.id
+                break
+
+        # 3. Trailing turns so the activating event sits well inside the
+        #    condensable range. Without these the explicit condensation can
+        #    summarize a window that never includes it, the content stays in
+        #    view for a reason that has nothing to do with the contract, and
+        #    the test passes while the bug is live. Found exactly that way.
+        for i in range(10):
+            conversation.send_message(f"Follow-up note {i}; still no action needed.")
+
+        # 4. Real summarizing condensation through the public API.
+        conversation.condense()
+
+        self.activated_after = list(conversation.state.activated_knowledge_skills)
+        self.sentinel_in_view_after = self._sentinel_in_injection_channel(conversation)
+        self.view_map_after = self._view_map(conversation)
+        self.sentinel_echoed_after = self._sentinel_echoed_only(conversation)
+        self.carrier_forgotten = not any(
+            e.id == self.skill_event_id for e in conversation.state.view.events
+        )
+
+        # 5. Fire the same trigger again and look at what the new turn carries.
+        conversation.send_message("One more python question, same conventions apply.")
+        last = conversation.state.events[-1]
+        if isinstance(last, MessageEvent):
+            self.retrigger_activated_skills = list(last.activated_skills)
+            self.retrigger_extended_content = [c.text for c in last.extended_content]
+
+    def verify_result(self) -> TestResult:
+        # --- preconditions: did the scenario actually happen? ---
+        # A precondition failure is a broken test, not a reproduction, and the
+        # reason string has to say so or the two become indistinguishable.
+        if "python_tips" not in self.activated_before:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: the skill never activated "
+                    f"(activated_knowledge_skills={self.activated_before}). "
+                    "Nothing about #4544 was exercised."
+                ),
+            )
+        if not self.sentinel_in_view_before:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: skill activated but its body was not "
+                    "in the view before condensation, so there was nothing to lose."
+                ),
+            )
+        skill_idx = self.skill_index_before
+        if skill_idx is not None and skill_idx < self.keep_first:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: the skill-bearing event landed at view "
+                    f"index {skill_idx}, inside the protected "
+                    f"keep_first={self.keep_first} prefix. Add filler turns."
+                ),
+            )
+        if not self.condensations:
+            return TestResult(
+                success=False,
+                reason="SCENARIO NOT SET UP: no Condensation event was produced.",
+            )
+        if not self.carrier_forgotten:
+            # The decisive guard. If condensation never dropped the event that
+            # carried the skill, nothing was ever at risk, and "content is
+            # still in view" says nothing about the lifecycle contract.
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: condensation did not forget the "
+                    "skill-bearing event, so the content was never at risk. "
+                    "Add trailing turns or lower the condenser's max_size until "
+                    "the carrying event falls inside the condensable range."
+                ),
+            )
+
+        # --- the invariant ---
+        still_present = self.sentinel_in_view_after
+        recovered = any(SENTINEL in text for text in self.retrigger_extended_content)
+        if still_present or recovered:
+            return TestResult(
+                success=True,
+                reason=(
+                    f"view={self.view_map_after} "
+                    f"Skill content survived through the injection "
+                    f"channel (present_in_view={still_present}, "
+                    f"recovered_on_retrigger={recovered})."
+                ),
+            )
+        if self.sentinel_echoed_after:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SUMMARY-ECHO ONLY, not a contract: the marker appears in "
+                    "rendered text but NOT in the injection channel. The agent "
+                    "quoted the guidance back, that message reached the "
+                    "summarizer, and the summary carried it. This is exactly the "
+                    '"permitted, not guaranteed" behavior the issue describes, '
+                    "and it varies run to run on the same model. "
+                    f"view={self.view_map_after}"
+                ),
+            )
+        return TestResult(
+            success=False,
+            reason=(
+                "#4544 REPRODUCED: after condensation the skill body is absent "
+                "from the active view and a fresh trigger does not bring it back, "
+                "while conversation state still reports the skill as activated. "
+                f"activated_knowledge_skills={self.activated_after}, "
+                f"sentinel_in_view={self.sentinel_in_view_after}, "
+                f"retrigger_activated_skills={self.retrigger_activated_skills}, "
+                f"retrigger_extended_content={self.retrigger_extended_content}. "
+                "The guidance is silently inapplicable for the rest of the "
+                "conversation."
+            ),
+        )

--- a/tests/integration/tests/c07_path_rule_survives_condensation.py
+++ b/tests/integration/tests/c07_path_rule_survives_condensation.py
@@ -1,0 +1,303 @@
+"""Path-triggered rule content across condensation (issue #4544).
+
+The path-rule half of the same question, and the deterministic half. Two
+properties of path rules make the loss unconditional rather than probabilistic:
+
+- ``ObservationEvent.__str__()`` is built from ``observation.to_llm_content``
+  and omits ``extended_content`` entirely, so a rule body never reaches the
+  summarizer at all. It cannot be preserved by a summary that never saw it.
+- The ``Skill`` validator forces ``disable_model_invocation=True`` on path
+  rules, so there is no ``invoke_skill`` route to fetch the guidance back.
+
+Scenario, end to end against a real LLM: the agent edits a file matching the
+rule's glob (a real tool call, so the rule is injected by the production
+callback), filler turns push that observation outside ``keep_first``, a real
+summarizing condensation runs, and then the agent edits the same file again.
+
+Asserted invariant, same as c06: after condensation the rule text is either
+still in the active view or comes back when the path is touched again. This
+FAILS on current main by design; see c06's docstring for why a red test is the
+requested artifact here.
+"""
+
+from openhands.sdk.context.agent_context import AgentContext
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.event.llm_convertible import ObservationEvent
+from openhands.sdk.skills import PathTrigger, Skill
+from tests.integration.base import BaseIntegrationTest, TestResult
+
+
+SENTINEL = "PATH_RULE_SENTINEL_9C4E"
+
+RULE_BODY = (
+    f"{SENTINEL}\n\n"
+    "Repository convention for files under src/: always wrap repository access "
+    "in try-finally and release the handle in the finally block."
+)
+
+TARGET_REL_PATH = "src/pkg/app.py"
+
+INSTRUCTION: str = "This test defines its own instructions in run_instructions()."
+
+
+class PathRuleCondensationTest(BaseIntegrationTest):
+    """Path-rule content must survive condensation or come back on a fresh touch."""
+
+    INSTRUCTION: str = INSTRUCTION
+
+    def __init__(self, *args, **kwargs):
+        self.condensations: list[Condensation] = []
+        self.activated_before: list[str] = []
+        self.injected_on_first_touch: bool = False
+        self.carrier_event_id: str | None = None
+        self.carrier_forgotten: bool = False
+        self.view_map_after: list[str] = []
+        self.sentinel_echoed_after: bool = False
+        self.sentinel_in_view_before: bool = False
+        self.activated_after: list[str] = []
+        self.sentinel_in_view_after: bool = False
+        self.second_touch_seen: bool = False
+        self.second_touch_extended: list[str] = []
+        self.keep_first: int = 4
+        super().__init__(*args, **kwargs)
+
+    @property
+    def agent_context(self) -> AgentContext:
+        return AgentContext(
+            skills=[
+                Skill(
+                    name="style_rule",
+                    content=RULE_BODY,
+                    source="rules/style.md",
+                    trigger=PathTrigger(paths=["src/**/*.py"]),
+                )
+            ]
+        )
+
+    @property
+    def condenser(self) -> LLMSummarizingCondenser:
+        condenser_llm = self.create_llm_copy("test-condenser-llm")
+        return LLMSummarizingCondenser(
+            llm=condenser_llm,
+            max_size=100,  # condensation happens only where asked for, explicitly
+            keep_first=self.keep_first,
+        )
+
+    @property
+    def max_iteration_per_run(self) -> int:
+        return 30
+
+    def conversation_callback(self, event):
+        super().conversation_callback(event)
+        if isinstance(event, Condensation):
+            self.condensations.append(event)
+
+    def setup(self) -> None:
+        """Create the file the rule's glob matches."""
+        import os
+
+        target = os.path.join(self.workspace, TARGET_REL_PATH)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w") as f:
+            f.write("def load():\n    return 1\n")
+
+    @staticmethod
+    def _sentinel_in_injection_channel(conversation: LocalConversation) -> bool:
+        """Is the rule text still present through the MECHANISM that delivers it?
+
+        Only ``extended_content`` counts, because only that is deterministic.
+        A summarizer may happen to echo the text into its summary when the agent
+        quoted it back, which reads as survival but is a coin flip: strong models
+        do it, weaker ones do not, and the same model does not do it every run.
+        Observed directly here, as a real intermittent PASS on Opus 5.
+
+        This matches what the issue asks for: the active context should retain or
+        recover triggered content *deterministically*. Counting an echo would let
+        the test agree that a maybe is a contract.
+        """
+        for event in conversation.state.view.events:
+            extended = getattr(event, "extended_content", None) or []
+            if any(SENTINEL in c.text for c in extended):
+                return True
+        return False
+
+    @staticmethod
+    def _sentinel_echoed_only(conversation: LocalConversation) -> bool:
+        """Marker present in rendered text but NOT in the injection channel."""
+        for event in conversation.state.view.events:
+            if SENTINEL in str(event):
+                return True
+        return False
+
+    @staticmethod
+    def _rule_carrying_observations(
+        conversation: LocalConversation, start_index: int = 0
+    ) -> list[ObservationEvent]:
+        """Observations at or after ``start_index`` carrying injected rule text."""
+        found = []
+        for event in list(conversation.state.events)[start_index:]:
+            if isinstance(event, ObservationEvent) and event.extended_content:
+                found.append(event)
+        return found
+
+    @staticmethod
+    def _view_map(conversation: LocalConversation) -> list[str]:
+        """Per-event map of where the marker survives, for the verdict message.
+
+        A verdict that says only "present" or "absent" leaves the reader
+        guessing which channel carried it. ``ext`` = the injection channel
+        (``extended_content``, what actually reaches the model); ``str`` = the
+        rendered text, which is what the summarizer is fed.
+        """
+        out = []
+        for event in conversation.state.view.events:
+            extended = getattr(event, "extended_content", None) or []
+            tags = ""
+            if any(SENTINEL in c.text for c in extended):
+                tags += "+ext"
+            if SENTINEL in str(event):
+                tags += "+str"
+            out.append(f"{type(event).__name__}{tags}")
+        return out
+
+    def run_instructions(self, conversation: LocalConversation) -> None:
+        # 1. Filler FIRST. The rule-carrying observation must land outside the
+        #    protected keep_first prefix; an earlier draft touched the file on
+        #    turn one, so the carrier sat at a protected index, condensation
+        #    never reached it, and nothing was ever at risk.
+        for i in range(self.keep_first):
+            conversation.send_message(f"Noting context item {i}; no action needed yet.")
+
+        # 2. Touch the matching path. A real edit through a real tool, so the
+        #    rule is injected by the production callback rather than a stub.
+        conversation.send_message(
+            f"Add a docstring to the load() function in {TARGET_REL_PATH}. "
+            "Edit the file directly."
+        )
+        conversation.run()
+
+        first_touch = self._rule_carrying_observations(conversation)
+        self.injected_on_first_touch = any(
+            SENTINEL in c.text for obs in first_touch for c in obs.extended_content
+        )
+        for obs in first_touch:
+            if any(SENTINEL in c.text for c in obs.extended_content):
+                self.carrier_event_id = obs.id
+                break
+        self.activated_before = list(conversation.state.activated_path_rules)
+        self.sentinel_in_view_before = self._sentinel_in_injection_channel(conversation)
+
+        # 3. Trailing turns so the carrier sits well inside the condensable
+        #    range rather than at its edge.
+        for i in range(10):
+            conversation.send_message(f"Follow-up note {i}; still no action needed.")
+
+        # 4. Real summarizing condensation through the public API.
+        conversation.condense()
+
+        self.activated_after = list(conversation.state.activated_path_rules)
+        self.sentinel_in_view_after = self._sentinel_in_injection_channel(conversation)
+        self.view_map_after = self._view_map(conversation)
+        self.sentinel_echoed_after = self._sentinel_echoed_only(conversation)
+        self.carrier_forgotten = not any(
+            e.id == self.carrier_event_id for e in conversation.state.view.events
+        )
+
+        # 5. Touch the same path again and inspect what the new observation carries.
+        mark = len(list(conversation.state.events))
+        conversation.send_message(
+            f"Now also add a trailing comment to {TARGET_REL_PATH}. Edit the file."
+        )
+        conversation.run()
+
+        second_touch = self._rule_carrying_observations(conversation, start_index=mark)
+        # Did the agent actually touch a matching file again? Look for any
+        # observation past the mark, injected or not.
+        self.second_touch_seen = any(
+            isinstance(e, ObservationEvent)
+            for e in list(conversation.state.events)[mark:]
+        )
+        self.second_touch_extended = [
+            c.text for obs in second_touch for c in obs.extended_content
+        ]
+
+    def verify_result(self) -> TestResult:
+        # --- preconditions ---
+        if not self.injected_on_first_touch:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: the path rule never injected on the first "
+                    f"touch (activated_path_rules={self.activated_before}). The "
+                    "agent likely did not edit "
+                    f"{TARGET_REL_PATH} through a path-bearing tool."
+                ),
+            )
+        if not self.condensations:
+            return TestResult(
+                success=False,
+                reason="SCENARIO NOT SET UP: no Condensation event was produced.",
+            )
+        if not self.carrier_forgotten:
+            # See c06: without this, "content still in view" can mean the
+            # condensation simply never reached the carrying event, and the
+            # test passes while the bug is live.
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: condensation did not forget the "
+                    "rule-carrying observation, so the content was never at risk."
+                ),
+            )
+        if not self.second_touch_seen:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SCENARIO NOT SET UP: the agent did not touch the file again "
+                    "after condensation, so re-injection was never exercised."
+                ),
+            )
+
+        # --- the invariant ---
+        still_present = self.sentinel_in_view_after
+        recovered = any(SENTINEL in text for text in self.second_touch_extended)
+        if still_present or recovered:
+            return TestResult(
+                success=True,
+                reason=(
+                    f"view={self.view_map_after} "
+                    f"Rule content survived through the injection "
+                    f"channel (present_in_view={still_present}, "
+                    f"recovered_on_retouch={recovered})."
+                ),
+            )
+        if self.sentinel_echoed_after:
+            return TestResult(
+                success=False,
+                reason=(
+                    "SUMMARY-ECHO ONLY, not a contract: the marker appears in "
+                    "rendered text but NOT in the injection channel. The agent "
+                    "quoted the guidance back, that message reached the "
+                    "summarizer, and the summary carried it. This is exactly the "
+                    '"permitted, not guaranteed" behavior the issue describes, '
+                    "and it varies run to run on the same model. "
+                    f"view={self.view_map_after}"
+                ),
+            )
+        return TestResult(
+            success=False,
+            reason=(
+                "#4544 REPRODUCED: after condensation the rule body is absent from "
+                "the active view and touching the matching path again re-injects "
+                "nothing, while conversation state still reports the rule as "
+                f"activated. activated_path_rules={self.activated_after}, "
+                f"sentinel_in_view={self.sentinel_in_view_after}, "
+                f"second_touch_extended={self.second_touch_extended}. "
+                "The rule body never reached the summarizer either "
+                "(ObservationEvent.__str__ omits extended_content), so no summary "
+                "could have preserved it, and disable_model_invocation=True leaves "
+                "no invoke_skill route back."
+            ),
+        )


### PR DESCRIPTION
HUMAN:

Human reviewed. These tests should help make the skill condensation behavior known

---

AGENT:

## Why

#4544 reports that keyword-triggered skills and path-triggered rules are injected once per conversation, on an event condensation is allowed to forget, while the "already activated" marker lives in persistent state and is never cleared. After a condensation the guidance can be gone from everything the model sees while state still reports it as active.

The issue deliberately did not prescribe a mechanism, and asked maintainers to confirm the intended lifecycle instead. These tests run the whole scenario end to end so that question can be settled against observed behavior rather than against a reading of the code.

#4552 proposes a fix for the same issue at the session level. These tests sit a layer above it, in the live `c*` integration suite it does not touch, so they are complementary rather than competing.

## Summary

- `c06_triggered_skill_survives_condensation.py`: keyword-triggered skill, activated outside `keep_first`, real work, real summarizing condensation, then the keyword again.
- `c07_path_rule_survives_condensation.py`: the same shape for a `PathTrigger` rule, driven by real file edits through the file editor so injection happens in the production callback.
- `BaseIntegrationTest` gains an overridable `agent_context` property defaulting to `None`, mirroring the existing `tools` and `condenser` hooks. Without it the harness builds `Agent()` with no context and no skill can be installed.

Both assert one invariant: after condensation, triggered content is either still in the active view or recoverable when the trigger fires again. Preserve, reconstruct and reactivate all satisfy it, so neither test prejudges the fix.

They fail on current main by design, and the failure message is the diagnosis. The `c*` suite is optional and non-blocking, so a red case here does not gate anything.

## Issue Number

#4544

## How to Test

Run against any OpenAI-compatible endpoint:

```
export LLM_API_KEY=... LLM_BASE_URL=...
uv run python tests/integration/run_infer.py \
  --llm-config '{"model":"openai/<model>","max_output_tokens":8192,"native_tool_calling":true}' \
  --test-type condenser \
  --eval-ids c06_triggered_skill_survives_condensation,c07_path_rule_survives_condensation
```

Observed on `anthropic/claude-opus-5`, against `1de2e6d1b`:

```
c06_triggered_skill_survives_condensation -> FAIL
  #4544 REPRODUCED: after condensation the skill body is absent from the
  active view and a fresh trigger does not bring it back, while conversation
  state still reports the skill as activated.
  activated_knowledge_skills=['python_tips'], sentinel_in_view=False,
  retrigger_activated_skills=[], retrigger_extended_content=[]
```

`c07` fails on every run, but lands on either of two verdicts. Across six runs on the same model it gave `SUMMARY-ECHO ONLY` four times and `#4544 REPRODUCED` twice:

```
c07_path_rule_survives_condensation -> FAIL
  SUMMARY-ECHO ONLY, not a contract: the marker appears in rendered text but
  NOT in the injection channel. The agent quoted the guidance back, that
  message reached the summarizer, and the summary carried it.

c07_path_rule_survives_condensation -> FAIL
  #4544 REPRODUCED: after condensation the rule body is absent from the active
  view and touching the matching path again re-injects nothing, while
  conversation state still reports the rule as activated.
  activated_path_rules=['style_rule'], sentinel_in_view=False,
  second_touch_extended=[]
```

Both verdicts are the same failure. The injection channel is empty either way, so the contract fails; which one you land on depends on whether the model happened to quote the guidance back before condensation. Expect either when running it.

Also run on `glm-5.3`.

Local checks on the committed tree: `ruff check` and `ruff format --check` clean, `pyright` clean, `pytest tests/integration/` 27 passed and 1 skipped.

## Video/Screenshots

<img width="1120" height="697" alt="c0607-run" src="https://github.com/user-attachments/assets/185bc8c7-1930-4422-a02f-76aa50883b4a" />

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Three things in the tests are deliberate and easy to undo by accident.

**Verdicts are three-way, not two.** A marker found only in rendered text gets its own `SUMMARY-ECHO ONLY` verdict, which is a failure. Injected guidance sits in the agent's context by design, so a capable model quotes it back, that message reaches the summarizer, and the summary carries the marker through. It reads as survival but is a coin flip: before this distinction existed, `c07` went 2 pass / 4 fail across six identical runs on the same model. Presence is therefore measured only in the injection channel (`extended_content`), which matches the issue's ask that content be retained or recovered deterministically.

**`c06`'s sentinel sits past `N_CHAR_PREVIEW` (500), not merely inside a longer body.** `__str__` truncates the tail, so a front-loaded marker survives, reaches the summarizer, and gets preserved. An earlier draft did that and passed while the bug was live.

**Presence is never measured with `str(event)`.** `ObservationEvent.__str__` omits `extended_content` entirely, so that string can never contain path-rule text and would report "gone" regardless of truth. The rendered string is what the summarizer is fed; it is not what the agent sees.

`verify_result` also checks preconditions first and reports `SCENARIO NOT SET UP` separately from any verdict. In particular the carrying event must actually be absent from the view after condensation. If it survived, nothing was at risk and the run says so rather than pronouncing on the contract.
