### PR TITLE
fix(sdk): resolve custom OpenAI-compatible endpoints when model id lacks a recognized provider prefix

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
@@ -33,25 +33,48 @@ class LLMProvider:
 
     @classmethod
     def from_model(cls, *, model: str, api_base: str | None) -> LLMProvider:
-        """Parse a model string using LiteLLM's provider inference logic."""
-        try:
-            get_llm_provider = cast(Any, litellm).get_llm_provider
-            parsed_model, provider_name, _dynamic_key, _resolved_api_base = (
-                get_llm_provider(
-                    model=model,
-                    custom_llm_provider=None,
-                    api_base=api_base,
-                    api_key=None,
+        """Parse a model string using LiteLLM's provider inference logic.
+
+        LiteLLM infers the provider from the model string's first ``/``
+        segment. When ``api_base`` points at a custom endpoint (a
+        self-hosted server such as LM Studio, or a third-party router) and
+        that segment isn't a LiteLLM-recognized provider name, inference
+        raises instead of falling back to the custom base — so a model id
+        like ``auto/coding`` configured against a personal OpenAI-compatible
+        router fails with "LLM Provider NOT provided" deep inside the actual
+        completion call, not here. Retry once with
+        ``custom_llm_provider="openai"`` in that case: a caller-supplied
+        ``api_base`` already implies an OpenAI-compatible endpoint, and
+        LiteLLM only strips a *recognized* provider prefix, so an
+        unrecognized one like ``auto/`` reaches the endpoint unchanged.
+        """
+        get_llm_provider = cast(Any, litellm).get_llm_provider
+        custom_llm_providers: tuple[str | None, ...] = (
+            (None,) if api_base is None else (None, "openai")
+        )
+
+        parsed_model, provider_name = model, None
+        for custom_llm_provider in custom_llm_providers:
+            try:
+                parsed_model, provider_name, _dynamic_key, _resolved_api_base = (
+                    get_llm_provider(
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                        api_base=api_base,
+                        api_key=None,
+                    )
                 )
-            )
-        except Exception as exc:
-            logger.debug(
-                "Failed to parse LiteLLM provider for model=%s: %s",
-                model,
-                exc,
-            )
-            parsed_model = model
-            provider_name = None
+            except Exception as exc:
+                logger.debug(
+                    "Failed to parse LiteLLM provider for model=%s "
+                    "(custom_llm_provider=%s): %s",
+                    model,
+                    custom_llm_provider,
+                    exc,
+                )
+                parsed_model, provider_name = model, None
+            if provider_name is not None:
+                break
 
         return cls(
             model=parsed_model,

--- a/tests/sdk/llm/test_litellm_provider.py
+++ b/tests/sdk/llm/test_litellm_provider.py
@@ -49,6 +49,38 @@ def test_llm_provider_handles_unknown_model_without_provider():
     assert provider.as_litellm_call_kwargs() == {"model": "unknown-model"}
 
 
+def test_llm_provider_resolves_unrecognized_model_against_custom_api_base():
+    # A custom router/self-hosted endpoint (e.g. LM Studio, a personal
+    # OpenAI-compatible gateway) whose model id's first "/" segment isn't a
+    # LiteLLM-recognized provider (e.g. "auto/coding") must still resolve to
+    # the "openai" custom_llm_provider, and the model id must survive intact
+    # since "auto/" is not a prefix LiteLLM strips. See regression: without
+    # this fallback, this raises "LLM Provider NOT provided" deep inside the
+    # actual completion call instead of resolving here.
+    provider = LLMProvider.from_model(
+        model="auto/coding",
+        api_base="https://omniroute.example.com/v1",
+    )
+
+    assert provider.name == "openai"
+    assert provider.model == "auto/coding"
+    assert provider.as_litellm_call_kwargs() == {
+        "model": "auto/coding",
+        "custom_llm_provider": "openai",
+    }
+
+
+def test_llm_provider_does_not_force_openai_without_api_base():
+    # Without a custom api_base there is no OpenAI-compatible endpoint to
+    # infer, so an unrecognized model id must stay unresolved exactly as
+    # before this fix (matches test_llm_provider_handles_unknown_model_
+    # without_provider).
+    provider = LLMProvider.from_model(model="auto/coding", api_base=None)
+
+    assert provider.name is None
+    assert provider.model == "auto/coding"
+
+
 def test_llm_provider_keeps_requested_api_base_verbatim():
     # LiteLLM's own resolution appends "/v1" to a custom mistral base; the
     # helper must not leak that mutated value back into the forwarded kwargs.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

My own OpenAI-compatible endpoint kept throwing this error until I traced it to how LiteLLM resolves the provider prefix.

---

AGENT:

## Why

`LLMProvider.from_model()` only ever calls LiteLLM's `get_llm_provider()` with
`custom_llm_provider=None`. When `api_base` points at a custom endpoint (a
self-hosted server such as LM Studio, or a third-party OpenAI-compatible
router) and the model id's first `/` segment isn't a LiteLLM-recognized
provider name (e.g. `auto/coding`, `qwen/qwen3-coder-30b-a3b-instruct`), that
call raises instead of falling back to the custom base. `from_model()`
swallows the exception and returns `name=None`, so `as_litellm_call_kwargs()`
omits `custom_llm_provider` entirely — the later, unguarded
`litellm.completion()` call then hits the same resolution failure and raises
to the user:

```
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider
you are trying to call. You passed model=auto/coding
```

This reproduces with a real personal OpenAI-compatible router (Custom Model
`auto/coding`, a live `api_base`) and matches the exact symptom in the linked
issue and in prior reports (#11608, #11632, #14323 in `OpenHands/OpenHands`).

## Summary

- `LLMProvider.from_model()` retries once with `custom_llm_provider="openai"`
  when `api_base` is set and the first attempt doesn't resolve a provider. A
  caller-supplied `api_base` already implies an OpenAI-compatible endpoint,
  and LiteLLM only strips a *recognized* provider prefix, so an unrecognized
  one (`auto/`, `qwen/`, etc.) reaches the endpoint unchanged.
- Without `api_base`, behavior is unchanged — there's no custom endpoint to
  infer, so an unresolved model id stays unresolved exactly as before.
- Added 2 regression tests to `tests/sdk/llm/test_litellm_provider.py`
  covering the fix and the no-`api_base` non-regression case.

## Issue Number

Fixes #4247

## How to Test

Reproduced and verified live against the real `litellm` package (not mocked),
via `uv run python` in this repo:

```python
import litellm
litellm.get_llm_provider(
    model="auto/coding", custom_llm_provider=None,
    api_base="https://example-router.test/v1", api_key=None,
)
# -> raises litellm.BadRequestError: LLM Provider NOT provided ... model=auto/coding
# (confirmed this is the exact error from the linked issue before writing the fix)

litellm.get_llm_provider(
    model="auto/coding", custom_llm_provider="openai",
    api_base="https://example-router.test/v1", api_key=None,
)
# -> ('auto/coding', 'openai', None, 'https://example-router.test/v1')
# model id preserved verbatim, provider resolved -- this is the fix's fallback path

# Sanity checks confirming no regression for normal cases:
litellm.get_llm_provider(model="gpt-4o", custom_llm_provider=None, api_base=None, api_key=None)
# -> ('gpt-4o', 'openai', None, None)  -- unchanged
litellm.get_llm_provider(model="anthropic/claude-opus-4-5", custom_llm_provider=None, api_base=None, api_key=None)
# -> ('claude-opus-4-5', 'anthropic', None, None)  -- unchanged, prefix still stripped normally
```

Automated:

```bash
uv run pytest tests/sdk/llm/test_litellm_provider.py -v
# 13 passed (11 existing + 2 new), 1.19s

uv run pytest tests/sdk/llm/ -q
# 981 passed, 48 warnings (all pre-existing, unrelated to this change) in 62.32s

uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py tests/sdk/llm/test_litellm_provider.py
# Ruff format: Passed | Ruff lint: Passed | PEP8: Passed | pyright: Passed
# import dependency rules: Passed | Tool subclass registration: Passed
```

## Video/Screenshots

N/A — backend-only correctness fix, no visual surface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Credit to @moorsecopers99, whose prior PR `OpenHands/OpenHands#14043` diagnosed
this exact class of bug (LM Studio namespaced model ids hitting the same
LiteLLM provider-resolution failure) and validated the same auto-prefix
approach — that PR went stale before review and targeted the pre-split
monorepo's app-server settings router, which no longer exists in this repo
layout. This reimplements the fix at the SDK's LiteLLM boundary
(`LLMProvider.from_model`) instead of an app-server-specific code path, per
this repo's "prefer interfaces over special cases" principle in
`CONTRIBUTING.md` — it applies uniformly to every consumer (CLI, agent-server,
SaaS) rather than only wherever a settings endpoint happens to intercept it.
