### PR TITLE
fix(file_editor): insert at EOF of file without trailing newline concatenates onto last line

### DIFF
--- a/openhands-tools/openhands/tools/file_editor/editor.py
+++ b/openhands-tools/openhands/tools/file_editor/editor.py
@@ -574,6 +574,13 @@ class FileEditor:
                 new_lines.append(line)
                 history_lines.append(line)
 
+        # If we are inserting after the last line (insert_line == num_lines)
+        # and the file does not end with a newline, the retained last line
+        # lacks "\n". Without it the inserted content is concatenated onto
+        # the last line instead of starting a new one.
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] = new_lines[-1] + "\n"
+
         # Insert new content
         for line in new_str_lines:
             new_lines.append(line + "\n")

--- a/tests/tools/file_editor/test_basic_operations.py
+++ b/tests/tools/file_editor/test_basic_operations.py
@@ -897,3 +897,87 @@ def test_str_replace_and_insert_snippet_output_on_a_large_file(editor):
         new_str="Inserted line at 500",
     )
     assert "   500\tInserted line at 500" in result.text
+
+
+def test_insert_at_eof_without_trailing_newline(editor):
+    """Inserting after the last line of a file without a trailing newline
+    should start the inserted content on its own line, not concatenate it
+    onto the last line.
+    """
+    editor, test_file = editor
+    # The fixture's test file has 2 lines and no trailing newline
+    # ("This is a test file.\nThis file is for testing purposes.")
+    result = editor(
+        command="insert",
+        path=str(test_file),
+        insert_line=2,
+        new_str="New line at the end",
+    )
+
+    content = test_file.read_text()
+    assert content == (
+        "This is a test file.\n"
+        "This file is for testing purposes.\n"
+        "New line at the end\n"
+    )
+    # The inserted line must not be concatenated onto the previous last line
+    assert "testing purposes.New line" not in content
+    # The observation should show the new content as a separate line
+    assert "New line at the end" in result.text
+
+
+def test_insert_multiple_lines_at_eof_without_trailing_newline(editor, tmp_path):
+    """Multi-line inserts at EOF of a file without a trailing newline should
+    each land on their own lines, without merging into the original last line.
+    """
+    editor, _ = editor
+
+    no_newline_file = tmp_path / "no_trailing_newline.txt"
+    no_newline_file.write_text("a\nb\nc")  # no trailing newline
+    result = editor(
+        command="insert",
+        path=str(no_newline_file),
+        insert_line=3,
+        new_str="X\nY",
+    )
+
+    content = no_newline_file.read_text()
+    assert content == "a\nb\nc\nX\nY\n"
+    assert "cX" not in content
+    assert "X" in result.text and "Y" in result.text
+
+
+def test_insert_at_eof_with_trailing_newline_unchanged(editor, tmp_path):
+    """Inserting at EOF of a file that already ends with a newline keeps the
+    existing behavior: no extra blank line is introduced.
+    """
+    editor, _ = editor
+
+    with_newline_file = tmp_path / "trailing_newline.txt"
+    with_newline_file.write_text("a\nb\nc\n")  # trailing newline present
+    result = editor(
+        command="insert",
+        path=str(with_newline_file),
+        insert_line=3,
+        new_str="Z",
+    )
+
+    content = with_newline_file.read_text()
+    assert content == "a\nb\nc\nZ\n"
+
+
+def test_insert_in_middle_unaffected_by_eof_fix(editor, tmp_path):
+    """Inserting in the middle of a file still behaves as before."""
+    editor, _ = editor
+
+    mid_file = tmp_path / "middle.txt"
+    mid_file.write_text("a\nb\nc")  # no trailing newline, but insert mid-file
+    editor(
+        command="insert",
+        path=str(mid_file),
+        insert_line=1,
+        new_str="MID",
+    )
+
+    content = mid_file.read_text()
+    assert content == "a\nMID\nb\nc"


### PR DESCRIPTION
HUMAN:

I manually reproduced the bug on the current main, applied the fix, and ran the file_editor test suite: my four new regression tests fail on main and all pass with the fix, with no new failures versus the baseline.

AGENT:

## Issue Number

Fixes #4583

## Why

`FileEditor.insert` silently corrupts a file when asked to insert after the last line of a file that does not end with a newline: the inserted content is concatenated onto the last line instead of starting on its own line. This is a real data-corruption path for agent-driven edits, and the bug was inherited from the original Anthropic computer-use-demo implementation this editor derives from.

## Summary

In `_execute_insert()`, the file is read line-by-line and retained lines are collected up to `insert_line`. Python's line iterator omits the trailing `\n` from the last line when the file has no final newline, so `new_lines[-1]` is e.g. `"c"`, and the new content is appended directly, producing `cX\n`.

The fix adds a guard right before appending the inserted lines:

```python
if new_lines and not new_lines[-1].endswith("\n"):
    new_lines[-1] = new_lines[-1] + "\n"
```

Reproducer:

```python
editor = FileEditor()
# file contains "a\nb\nc" (no trailing newline)
editor(command="insert", path=p, insert_line=3, new_str="X")
# Before: "a\nb\ncX\n"   After: "a\nb\nc\nX\n"
```

## How to Test

Added 4 regression tests to `tests/tools/file_editor/test_basic_operations.py`:

- `test_insert_at_eof_without_trailing_newline` — single-line insert at EOF (fails on `main`, passes with fix)
- `test_insert_multiple_lines_at_eof_without_trailing_newline` — multi-line insert at EOF (fails on `main`, passes with fix)
- `test_insert_at_eof_with_trailing_newline_unchanged` — files already ending with `\n` keep existing behavior (no extra blank line)
- `test_insert_in_middle_unaffected_by_eof_fix` — middle-of-file inserts unchanged

Verified on `main`: `2 failed, 2 passed` → with fix: `4 passed`. The full file_editor suite shows no new failures compared to baseline (the 9 pre-existing failures on `main` under Windows — including `test_insert_non_utf8_file`, which fails identically without this change — are unrelated environment/encoding issues).

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.31s · commit 7ef0be7  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 8.0% | No direct hunk selected |
| Data loss | 6.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 4.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 90.0% | No primary concern to locate |

</details>


<!-- jev-input-signature d7da818471843075429b51106c828af04e9467235b3ad82addac69a9d3dad52a -->
<!-- jev-fast-audit:end -->
