### PR TITLE
fix(sdk): pass workspace git patch to critics

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/critic_mixin.py
+++ b/openhands-sdk/openhands/sdk/agent/critic_mixin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 from typing import TYPE_CHECKING
 
 from openhands.sdk.critic.base import CriticResult
@@ -59,10 +60,10 @@ class CriticMixin:
             llm_convertible_events = [
                 e for e in events if isinstance(e, LLMConvertibleEvent)
             ]
+            git_patch = self._build_git_patch_for_critic(conversation)
 
-            # Evaluate without git_patch for now
             critic_result = self.critic.evaluate(
-                events=llm_convertible_events, git_patch=None
+                events=llm_convertible_events, git_patch=git_patch
             )
             logger.info(
                 f"✓ Critic evaluation: score={critic_result.score:.3f}, "
@@ -72,6 +73,48 @@ class CriticMixin:
         except Exception as e:
             logger.error(f"✗ Critic evaluation failed: {e}", exc_info=True)
             return None
+
+    def _build_git_patch_for_critic(
+        self, conversation: LocalConversation
+    ) -> str | None:
+        """Build a best-effort git patch for critic evaluation."""
+        workspace = conversation.state.workspace
+        try:
+            changes = workspace.git_changes(".")
+        except Exception as e:
+            logger.debug(f"Unable to collect git changes for critic: {e}")
+            return None
+
+        if not changes:
+            return None
+
+        patch_parts: list[str] = []
+        for change in changes:
+            try:
+                diff = workspace.git_diff(change.path)
+            except Exception as e:
+                logger.debug(
+                    f"Unable to collect git diff for critic path {change.path}: {e}"
+                )
+                continue
+
+            path = str(change.path).replace("\\", "/")
+            original = diff.original or ""
+            modified = diff.modified or ""
+            file_patch = list(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    modified.splitlines(keepends=True),
+                    fromfile=f"a/{path}",
+                    tofile=f"b/{path}",
+                )
+            )
+            if file_patch and not file_patch[-1].endswith(("\n", "\r")):
+                file_patch[-1] += "\n"
+            patch_parts.extend(file_patch)
+
+        git_patch = "".join(patch_parts)
+        return git_patch or None
 
     def _check_iterative_refinement(
         self, conversation: LocalConversation, action_event: ActionEvent

--- a/tests/sdk/agent/test_iterative_refinement.py
+++ b/tests/sdk/agent/test_iterative_refinement.py
@@ -1,6 +1,7 @@
 """Tests for iterative refinement functionality in CriticMixin."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from openhands.sdk.critic.base import (
 )
 from openhands.sdk.critic.impl.api import APIBasedCritic
 from openhands.sdk.event import ActionEvent
+from openhands.sdk.git.models import GitChange, GitChangeStatus, GitDiff
 from openhands.sdk.llm import MessageToolCall, TextContent
 from openhands.sdk.tool.builtins.finish import FinishAction
 
@@ -25,6 +27,72 @@ class MockCritic(CriticBase):
 
     def evaluate(self, events, git_patch=None):
         return CriticResult(score=0.5, message="Mock evaluation")
+
+
+class PatchAwareCritic(MockCritic):
+    """Mock critic that scores based on the git patch it receives."""
+
+    def evaluate(self, events, git_patch=None):
+        expected_lines = [
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "-print('old')",
+            "+print('new')",
+        ]
+        if git_patch and all(line in git_patch for line in expected_lines):
+            return CriticResult(score=1.0, message="Patch received")
+        return CriticResult(score=0.0, message="Patch missing")
+
+
+class WorkspaceWithChange:
+    """Workspace fake with one changed file."""
+
+    def git_changes(self, path):
+        return [GitChange(status=GitChangeStatus.UPDATED, path=Path("foo.py"))]
+
+    def git_diff(self, path):
+        return GitDiff(
+            original="print('old')\n",
+            modified="print('new')\n",
+        )
+
+
+class WorkspaceWithoutChanges:
+    """Workspace fake with no git changes."""
+
+    def git_changes(self, path):
+        return []
+
+    def git_diff(self, path):
+        raise AssertionError("git_diff should not be called without changes")
+
+
+class WorkspaceFailingChanges:
+    """Workspace fake that fails while collecting git changes."""
+
+    def git_changes(self, path):
+        raise RuntimeError("not a git repository")
+
+    def git_diff(self, path):
+        raise AssertionError("git_diff should not be called after git_changes fails")
+
+
+class WorkspaceWithPartialDiffFailure:
+    """Workspace fake where one changed file cannot be diffed."""
+
+    def git_changes(self, path):
+        return [
+            GitChange(status=GitChangeStatus.UPDATED, path=Path("foo.py")),
+            GitChange(status=GitChangeStatus.UPDATED, path=Path("bar.py")),
+        ]
+
+    def git_diff(self, path):
+        if Path(path) == Path("bar.py"):
+            raise RuntimeError("cannot diff bar.py")
+        return GitDiff(
+            original="print('old')\n",
+            modified="print('new')\n",
+        )
 
 
 class MockCriticMixin(CriticMixin):
@@ -324,6 +392,62 @@ class TestCheckIterativeRefinement:
                 )
             else:
                 assert should_continue is False
+
+
+def test_evaluate_with_critic_passes_workspace_git_patch():
+    """Critic evaluation should receive a patch when workspace has changes."""
+    critic = PatchAwareCritic()
+    mixin = MockCriticMixin(critic=critic)
+    conversation = create_mock_conversation()
+    conversation.state.events = []
+
+    conversation.state.workspace = WorkspaceWithChange()
+
+    result = mixin._evaluate_with_critic(conversation, create_finish_action_event())
+
+    assert result == CriticResult(score=1.0, message="Patch received")
+
+
+def test_evaluate_with_critic_runs_without_git_changes():
+    """Critic evaluation should still run when no patch is available."""
+    critic = PatchAwareCritic()
+    mixin = MockCriticMixin(critic=critic)
+    conversation = create_mock_conversation()
+    conversation.state.events = []
+
+    conversation.state.workspace = WorkspaceWithoutChanges()
+
+    result = mixin._evaluate_with_critic(conversation, create_finish_action_event())
+
+    assert result == CriticResult(score=0.0, message="Patch missing")
+
+
+def test_evaluate_with_critic_runs_when_git_changes_fails():
+    """Critic evaluation should still run if patch collection fails."""
+    critic = PatchAwareCritic()
+    mixin = MockCriticMixin(critic=critic)
+    conversation = create_mock_conversation()
+    conversation.state.events = []
+
+    conversation.state.workspace = WorkspaceFailingChanges()
+
+    result = mixin._evaluate_with_critic(conversation, create_finish_action_event())
+
+    assert result == CriticResult(score=0.0, message="Patch missing")
+
+
+def test_evaluate_with_critic_uses_available_diffs_when_one_file_fails():
+    """Critic evaluation should receive available diffs if one file fails."""
+    critic = PatchAwareCritic()
+    mixin = MockCriticMixin(critic=critic)
+    conversation = create_mock_conversation()
+    conversation.state.events = []
+
+    conversation.state.workspace = WorkspaceWithPartialDiffFailure()
+
+    result = mixin._evaluate_with_critic(conversation, create_finish_action_event())
+
+    assert result == CriticResult(score=1.0, message="Patch received")
 
 
 class TestShouldEvaluateWithCritic:


### PR DESCRIPTION
HUMAN:

I am submitting this initial fix for #4554 and would like maintainers to confirm whether this direction is acceptable.

---

AGENT:

## Why

`CriticMixin._evaluate_with_critic()` always passed `git_patch=None` to `CriticBase.evaluate()`, which made the `git_patch` parameter unreachable in normal SDK usage.

This means patch-aware critics could not evaluate the actual workspace changes and had to rely on transcript contents instead.

## Summary

- Build a best-effort workspace git patch before critic evaluation.
- Pass the generated patch to `CriticBase.evaluate(..., git_patch=...)`.
- Fall back to `git_patch=None` when there are no changes or patch collection fails.
- Skip individual files whose diff cannot be collected while still passing available diffs.

## Issue Number

Related to #4554

## How to Test

I tested this locally with:

- `git diff --check`
- `D:\python\python.exe -m py_compile openhands-sdk/openhands/sdk/agent/critic_mixin.py tests/sdk/agent/test_iterative_refinement.py`
- `uv run --no-sync pytest tests/sdk/agent/test_iterative_refinement.py -q`
  - Result: `21 passed in 1.40s`
- `uv run --frozen pre-commit run --files openhands-sdk/openhands/sdk/agent/critic_mixin.py tests/sdk/agent/test_iterative_refinement.py`
  - Ruff format: Passed
  - Ruff lint: Passed
  - PEP8 style check: Passed
  - Pyright: Passed
  - Import dependency rules: Passed
  - Tool subclass registration: Passed

## Video/Screenshots

N/A. This is a backend SDK behavior change covered by unit tests.

## Design Doc

N/A.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR does not mutate the user's git index. It only uses the existing workspace diff APIs.

The generated patch represents the workspace diff at evaluation time. If the workspace was already dirty before the agent run, pre-existing changes may be included.

Strictly scoping the patch to only agent-authored edits would require a larger follow-up change, such as capturing a baseline at conversation start.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.43s · commit b9d61b2  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 7/7 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 7.0% | No direct hunk selected |
| Contract regression | 9.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 5.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 8.0% | No direct hunk selected |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 51.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 59a675c49b74a4938c287eb93614ab36c26ef5a06ebbd21b090e708653d00b53 -->
<!-- jev-fast-audit:end -->
