### PR TITLE
docs: document SDK repository boundaries

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -9,6 +9,12 @@ triggers:
 
 You are an expert code reviewer for the **OpenHands/software-agent-sdk** repository. This skill provides repo-specific review guidelines. Be direct but constructive.
 
+## Repository Boundaries
+
+This repository owns the Python SDK and Agent Server: agent/tool behavior, conversations, workspaces, events, and the canonical REST/WebSocket API. [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors the API for browser-compatible clients, [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas, and [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox orchestration.
+
+The normal flow is SDK/Agent Server → OpenAPI contract → `typescript-client` → Agent Canvas. Review whether each change is in the repository that owns it. If a PR is opened in the wrong repository, explicitly recommend that it may need to be closed and moved to the owning repository instead of merged here.
+
 ## Review Decisions
 
 You have permission to **APPROVE** or **COMMENT** on PRs. Do not use REQUEST_CHANGES.

--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -11,7 +11,7 @@ You are an expert code reviewer for the **OpenHands/software-agent-sdk** reposit
 
 ## Repository Boundaries
 
-This repository owns the Python SDK and Agent Server: agent/tool behavior, conversations, workspaces, events, and the canonical REST/WebSocket API. [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors the API for browser-compatible clients, [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas, and [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox orchestration.
+This repository owns the Python SDK and Agent Server: agent/tool behavior, conversations, workspaces, events, and the canonical REST/WebSocket API. [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors the API for browser-compatible clients, [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas, and [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations; [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox orchestration.
 
 The normal flow is SDK/Agent Server → OpenAPI contract → `typescript-client` → Agent Canvas. Review whether each change is in the repository that owns it. If a PR is opened in the wrong repository, explicitly recommend that it may need to be closed and moved to the owning repository instead of merged here.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,18 @@ strong bias toward simplicity and maintainable code.
   matters, and what to do instead.
 </ROLE>
 
+## Cross-Repository Boundaries
+
+This repository owns the Python SDK and Agent Server: agent and tool behavior, conversations, workspaces, events, and the canonical REST/WebSocket API. Related responsibilities live elsewhere:
+
+- [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas UI, frontend state, backend selection, and local-stack orchestration.
+- [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors this repository's Agent Server API for browser-compatible TypeScript clients.
+- [`OpenHands/automation`](https://github.com/OpenHands/automation) owns automation definitions, scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration; this repository executes the dispatched conversations.
+
+The usual flow is SDK/Agent Server → OpenAPI contract → `typescript-client` → Agent Canvas. Implement backend behavior and endpoints here first, then update the typed client and downstream applications as needed. If a PR is opened in the wrong repository, explicitly recommend closing and moving it to the repository that owns the change rather than merging it here.
+
+All pull requests must comply with [`.agents/skills/custom-codereview-guide.md`](.agents/skills/custom-codereview-guide.md), in addition to the repository's contribution requirements and CI checks.
+
 ## Repository Memory
 - Async LLM completions propagate through the full call chain: `LLM.acompletion()`/`LLM.aresponses()` → `_atransport_call()` (litellm `acompletion`/`aresponses`) → `RetryMixin.retry_decorator()` (tenacity `retry`, which wraps coroutines natively — there is no separate async retry path) → condenser `acondense()` → `Agent.astep()` → `LocalConversation.arun()` → `EventService.run()`. Every async method has a sync counterpart; base classes provide default delegations to sync so custom subclasses work without changes. Token callbacks use `AnyTokenCallbackType` (union of sync/async) with `_invoke_token_callback()` for transparent dispatch.
 - `conversation.interrupt()` cancels in-flight `arun()` by cancelling the tracked `_arun_task`. `asyncio.CancelledError` propagates through all layers (LLM HTTP stream → agent step → conversation loop) without needing per-layer interrupt APIs, because LLM and Agent are frozen/stateless Pydantic models that may be shared across conversations. `arun()` catches `CancelledError`, sets status to `PAUSED`, and emits `InterruptEvent`. The agent-server exposes this via `EventService.interrupt()` → `ConversationService.interrupt_conversation()` → `POST /{conversation_id}/interrupt`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ This repository owns the Python SDK and Agent Server: agent and tool behavior, c
 
 - [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas UI, frontend state, backend selection, and local-stack orchestration.
 - [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors this repository's Agent Server API for browser-compatible TypeScript clients.
-- [`OpenHands/automation`](https://github.com/OpenHands/automation) owns automation definitions, scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration; this repository executes the dispatched conversations.
+- [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations.
+- [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations; [`OpenHands/automation`](https://github.com/OpenHands/automation) owns automation definitions, scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration; this repository executes the dispatched conversations.
 
 The usual flow is SDK/Agent Server → OpenAPI contract → `typescript-client` → Agent Canvas. Implement backend behavior and endpoints here first, then update the typed client and downstream applications as needed. If a PR is opened in the wrong repository, explicitly recommend closing and moving it to the repository that owns the change rather than merging it here.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,10 @@ cd software-agent-sdk
 make build
 ```
 
+## Repository boundaries
+
+This repository owns the Python SDK and Agent Server. Put agent/tool behavior, conversations, workspaces, events, and new REST/WebSocket endpoints here. The API contract flows through [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) to Agent Canvas in [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands); automation scheduling, webhooks, run history, and dispatch belong in [`OpenHands/automation`](https://github.com/OpenHands/automation). If a PR is opened in the wrong repository, recommend closing and moving it to the owning repository. Follow [`.agents/skills/custom-codereview-guide.md`](.agents/skills/custom-codereview-guide.md) for every PR.
+
 ## Code Quality
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ print("All done!")
 For installation instructions and detailed setup, see the [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started).
 For local development from this repository, run `make build` to install the workspace dependencies and pre-commit hooks.
 
+## Repository boundaries
+
+The Software Agent SDK is the canonical Python SDK and Agent Server implementation. It owns agents, tools, conversations, workspaces, events, and the REST/WebSocket API. [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) mirrors that API for browser-compatible clients, [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) consumes it as Agent Canvas, and [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, and dispatching. The SDK/Agent Server executes the conversations dispatched by automation.
+
+The normal flow is SDK/Agent Server → OpenAPI contract → `typescript-client` → Agent Canvas. Backend behavior and endpoints belong here; client access belongs in `typescript-client`, UI in Agent Canvas, and automation lifecycle behavior in `automation`.
+
 ## Documentation
 
 For detailed documentation, tutorials, and API reference, visit:


### PR DESCRIPTION
HUMAN:

I reviewed the SDK architecture and contributor guidance, then documented its ownership boundaries and cross-repository workflow.

AGENT:

This pull request was created by an AI agent (OpenHands) on behalf of the user.

## Why

Contributors need to know which changes belong in the SDK/Agent Server versus Agent Canvas, the TypeScript client, or the automation service. Reviewers also need explicit guidance to identify PRs opened in the wrong repository.

## Summary

- Document repository ownership in `AGENTS.md`, `README.md`, and `DEVELOPMENT.md`.
- Add the SDK → OpenAPI → TypeScript client → Canvas dependency flow.
- Add cross-repository placement guidance to the custom review guide.
- State that PRs opened in the wrong repository may need to be closed and moved.
- Require PRs to follow the custom review guide.

## Issue Number

Fixes #4586

## How to Test

Review the four changed Markdown files for accurate repository links, ownership descriptions, and review guidance.

## Video/Screenshots

Not applicable: documentation-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:67a3b47-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-67a3b47-python \
  ghcr.io/openhands/agent-server:67a3b47-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:67a3b47-golang-amd64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-golang-amd64
ghcr.io/openhands/agent-server:docs-repository-boundaries-golang-amd64
ghcr.io/openhands/agent-server:67a3b47-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:67a3b47-golang-arm64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-golang-arm64
ghcr.io/openhands/agent-server:docs-repository-boundaries-golang-arm64
ghcr.io/openhands/agent-server:67a3b47-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:67a3b47-java-amd64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-java-amd64
ghcr.io/openhands/agent-server:docs-repository-boundaries-java-amd64
ghcr.io/openhands/agent-server:67a3b47-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:67a3b47-java-arm64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-java-arm64
ghcr.io/openhands/agent-server:docs-repository-boundaries-java-arm64
ghcr.io/openhands/agent-server:67a3b47-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:67a3b47-python-amd64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-python-amd64
ghcr.io/openhands/agent-server:docs-repository-boundaries-python-amd64
ghcr.io/openhands/agent-server:67a3b47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:67a3b47-python-arm64
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-python-arm64
ghcr.io/openhands/agent-server:docs-repository-boundaries-python-arm64
ghcr.io/openhands/agent-server:67a3b47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:67a3b47-golang
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-golang
ghcr.io/openhands/agent-server:docs-repository-boundaries-golang
ghcr.io/openhands/agent-server:67a3b47-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:67a3b47-java
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-java
ghcr.io/openhands/agent-server:docs-repository-boundaries-java
ghcr.io/openhands/agent-server:67a3b47-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:67a3b47-python
ghcr.io/openhands/agent-server:67a3b4798e7685111516ca3ccb77d7658f8ccb18-python
ghcr.io/openhands/agent-server:docs-repository-boundaries-python
ghcr.io/openhands/agent-server:67a3b47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `67a3b47-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `67a3b47-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->