### PR TITLE
fix(sdk): tolerate orphaned tool results in view indices

### DIFF
--- a/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
+++ b/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
@@ -84,13 +84,10 @@ class ToolCallMatchingProperty(ViewPropertyBase):
                 case ActionEvent():
                     pending_tool_call_ids.add(event.tool_call_id)
                 case ObservationBaseEvent():
-                    # Intentionally use remove(), not discard(): a second
-                    # observation-like event for the same tool_call_id means the
-                    # view has already violated the 1 action -> 1 result
-                    # invariant that downstream LLM APIs expect. That case must
-                    # be fixed by de-duplicating the view before serialization,
-                    # not by silently tolerating it here.
-                    pending_tool_call_ids.remove(event.tool_call_id)
+                    # This method can run before enforce() repairs a persisted view.
+                    # Tolerate invalid observations here; enforce() and the
+                    # uniqueness property own removing them from the view.
+                    pending_tool_call_ids.discard(event.tool_call_id)
 
             if pending_tool_call_ids:
                 # The enumeration index corresponds to the position of the event, but we

--- a/tests/sdk/context/view/properties/test_tool_call_matching.py
+++ b/tests/sdk/context/view/properties/test_tool_call_matching.py
@@ -10,6 +10,7 @@ from openhands.sdk.context.view.manipulation_indices import ManipulationIndices
 from openhands.sdk.context.view.properties.tool_call_matching import (
     ToolCallMatchingProperty,
 )
+from openhands.sdk.context.view.view import View
 from openhands.sdk.event.base import LLMConvertibleEvent
 from openhands.sdk.event.llm_convertible import (
     ActionEvent,
@@ -429,3 +430,47 @@ class TestToolCallMatchingPropertyManipulationIndices(TestToolCallMatchingBase):
 
         result = self.property.manipulation_indices(events)
         assert result == ManipulationIndices.complete(events)
+
+    def test_orphaned_agent_error_does_not_crash_before_enforcement(self) -> None:
+        """A restart-recovery result can outlive its matching action in a view."""
+        orphaned_error = AgentErrorEvent(
+            error="Tool execution was interrupted by a restart.",
+            tool_name="task",
+            tool_call_id="call_interrupted",
+        )
+        user_message = message_event("Continue")
+        events: list[LLMConvertibleEvent] = [orphaned_error, user_message]
+
+        assert self.property.manipulation_indices(
+            events
+        ) == ManipulationIndices.complete(events)
+        assert View(events=list(events)).manipulation_indices == (
+            ManipulationIndices.complete(events)
+        )
+
+        repaired_view = View(events=list(events))
+        repaired_view.enforce_properties(events)
+        assert repaired_view.events == [user_message]
+
+    def test_duplicate_observation_does_not_crash_before_enforcement(self) -> None:
+        """ObservationUniquenessProperty owns duplicate-result cleanup."""
+        action = create_action_event_with_none_action(
+            "action_1", "response_1", "call_1"
+        )
+        first_error = AgentErrorEvent(
+            error="Tool execution was interrupted by a restart.",
+            tool_name="task",
+            tool_call_id="call_1",
+        )
+        late_error = AgentErrorEvent(
+            error="Late result for the same tool call.",
+            tool_name="task",
+            tool_call_id="call_1",
+        )
+        events: list[LLMConvertibleEvent] = [action, first_error, late_error]
+
+        result = self.property.manipulation_indices(events)
+
+        assert 1 not in result
+        assert 2 in result
+        assert 3 in result


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

After an agent-server restart, crash recovery can persist an `AgentErrorEvent` for an interrupted tool call whose matching `ActionEvent` is later absent from the active view. `ToolCallMatchingProperty.enforce()` can already repair this orphaned result, but `manipulation_indices()` called `set.remove()` first and raised `KeyError`.

Because every later turn reloads the same persisted history, the exception was non-retryable and permanently bricked the conversation before the LLM could be called. The failure was observed in a real 408-event conversation and is reproducible without credentials or network access.

The invariant is that boundary analysis must remain total over states the enforcement layer can repair. This follows the same durable-recovery principle used by [DeepSeek Harness session repair](https://github.com/deepseek-ai/deepseek-harness/blob/main/packages/core/session/src/repair.ts): persisted tool-call anomalies are made replay-safe at recovery boundaries instead of making recovery itself fail.

## Summary

- tolerate orphaned or duplicate observations while calculating manipulation indices
- preserve cleanup ownership in `ToolCallMatchingProperty.enforce()` and `ObservationUniquenessProperty`
- cover restart-recovery orphans, duplicate results, top-level `View.manipulation_indices`, and post-enforcement repair

## Issue Number

Fixes #4591

## How to Test

Directly exercised the production event and view path without a model or mocks:

```bash
uv run python - <<PY
from openhands.sdk.context.view.properties.tool_call_matching import ToolCallMatchingProperty
from openhands.sdk.context.view.view import View
from openhands.sdk.event import AgentErrorEvent, MessageEvent
from openhands.sdk.llm import Message, TextContent

orphan = AgentErrorEvent(
    source="agent",
    error="tool execution was interrupted by restart",
    tool_name="task",
    tool_call_id="restart-interrupted-call",
)
message = MessageEvent(
    source="user",
    llm_message=Message(
        role="user",
        content=[TextContent(text="continue")],
    ),
)
events = [orphan, message]

print(ToolCallMatchingProperty().manipulation_indices(events))
print(View(events=list(events)).manipulation_indices)
view = View(events=list(events))
view.enforce_properties(events)
print([type(event).__name__ for event in view.events])
PY
```

Observed:

```text
ManipulationIndices({0, 1, 2})
ManipulationIndices({0, 1, 2})
[MessageEvent]
```

Automated validation:

- `uv run pytest -q tests/sdk/context` -> `435 passed`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py tests/sdk/context/view/properties/test_tool_call_matching.py` -> all hooks passed, including Ruff, Pyright, import rules, and tool registration
- `uv run pytest -q tests/sdk` -> `5961 passed, 9 skipped, 10 xfailed`; the only failure was an unrelated localhost MCP negative test because the host proxy converted connection refusal into HTTP 502
- `NO_PROXY=127.0.0.1,localhost uv run pytest -q tests/sdk/mcp/test_create_mcp_tool.py::test_create_mcp_tools_connection_to_nonexistent_server` -> `1 passed`

## Video/Screenshots

Not applicable. This is a non-visual SDK recovery-path bug; the direct terminal reproduction and outputs are included above.

## Design Doc

Not applicable. The production change is one line and does not alter a public API or serialized event shape.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Well-formed action/result histories keep identical manipulation boundaries.
- No provider-specific branch, prompt, tool scheduling, or public schema changes were introduced.
- No live-model eval was run because the defect occurs before any LLM request; the full SDK suite covers unchanged valid-history behavior.
