### PR TITLE
ci(release): block publication on agent-server stress regressions

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -38,17 +38,15 @@ The created PR will include a checklist. Complete the following:
 - [ ] Confirm any merged `release-note-required` PRs are accurately called out in the final release notes
 - [ ] Review and approve the PR
 
-### Step 3: Create the GitHub Release
+### Step 3: Merge the Release PR
 
-1. Go to [Releases](https://github.com/OpenHands/software-agent-sdk/releases/new)
-2. Click **"Draft a new release"**
-3. Configure the release:
-   - **Tag**: `vX.Y.Z` (must match the version)
-   - **Branch**: `rel-X.Y.Z` (the branch created by the workflow)
-   - **Previous tag**: Select the previous release version
-4. Click **"Generate release notes"** to auto-generate the changelog
-5. Review and edit the release notes as needed
-6. Click **"Publish release"**
+When the release PR is merged, `create-release.yml` first checks out that exact
+merge commit and runs the complete agent-server stress suite. The release job
+depends on this gate, so a timeout, deadlock, or resource-budget regression
+prevents the GitHub tag/release and all PyPI, image, and binary dispatches.
+
+Only after the gate succeeds does the workflow create the `vX.Y.Z` tag and
+GitHub Release, generate release notes, and dispatch the package/image builds.
 
 ### Step 4: PyPI Publication (Automated)
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,11 +11,43 @@ on:
         branches: [main]
 
 jobs:
+    pre-release-stress-tests:
+        # Validate the exact merge commit before creating any release artifact.
+        if: >
+            github.event.pull_request.merged == true &&
+            startsWith(github.event.pull_request.head.ref, 'rel-')
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 10
+        steps:
+            - name: Checkout release merge commit
+              uses: actions/checkout@v7
+              with:
+                  ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  enable-cache: true
+                  python-version: '3.13'
+
+            - name: Install deps
+              run: uv sync --frozen --group dev
+
+            - name: Run Agent Server stress tests
+              run: |
+                  # Do not use xdist: these tests assert process-wide resource
+                  # and timing budgets that parallel collection would invalidate.
+                  CI=true uv run python -m pytest -vvs \
+                    -m stress \
+                    --durations=10 \
+                    tests/agent_server/stress
+
     create-release:
         # Only run when a release PR is merged (not just closed)
         if: >
             github.event.pull_request.merged == true &&
             startsWith(github.event.pull_request.head.ref, 'rel-')
+        needs: pre-release-stress-tests
         runs-on: ubuntu-24.04
         permissions:
             actions: write

--- a/tests/agent_server/stress/budgets.py
+++ b/tests/agent_server/stress/budgets.py
@@ -135,6 +135,16 @@ class LeaseContentionBudget:
     settle_timeout_s: float = 5.0
 
 
+@dataclass(frozen=True, slots=True)
+class LifecycleIsolationBudget:
+    # Enough simultaneous operations to expose a process-wide lifecycle lock
+    # without making teardown expensive on shared CI runners.
+    n_unrelated_conversations: int = 4
+    # A blocked close is intentionally unbounded. Unrelated lifecycle work must
+    # still finish within this deliberately loose CI-tolerant deadline.
+    unrelated_operations_timeout_s: float = 5.0
+
+
 PARALLEL_SUBAGENTS = ParallelSubagentBudget()
 CONVERSATION_LISTING = ConversationListingBudget()
 CONCURRENT_CONVERSATIONS = ConcurrentConversationsBudget()
@@ -145,3 +155,4 @@ SLOW_WEBSOCKET_CONSUMER = SlowWebsocketConsumerBudget()
 WEBSOCKET_RECONNECT_STORM = WebsocketReconnectStormBudget()
 HIGH_VOLUME_BASH_OUTPUT = HighVolumeBashOutputBudget()
 LEASE_CONTENTION = LeaseContentionBudget()
+LIFECYCLE_ISOLATION = LifecycleIsolationBudget()

--- a/tests/agent_server/stress/test_lifecycle_isolation.py
+++ b/tests/agent_server/stress/test_lifecycle_isolation.py
@@ -1,0 +1,152 @@
+"""Stress test: one stuck close must not wedge unrelated conversations.
+
+Bug class this catches:
+    - A process-wide lifecycle lock held across ``EventService.close()``.
+      If one close hangs, create, load, and delete operations for every other
+      conversation queue behind it indefinitely (#4514, fixed by #4570).
+
+The blocking subscriber delays a real EventService close at its normal pub/sub
+teardown boundary. All operations under test still use the production
+ConversationService and persistence paths with credential-free TestLLMs.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.pub_sub import Subscriber
+from openhands.sdk.event import Event
+from tests.agent_server.stress.budgets import LIFECYCLE_ISOLATION
+from tests.agent_server.stress.scripts import (
+    SlowTestLLM,
+    start_conversation_with_test_llm,
+    text_message,
+)
+
+
+pytestmark = [pytest.mark.stress, pytest.mark.timeout(30)]
+
+
+@dataclass(slots=True)
+class _BlockingCloseSubscriber(Subscriber[Event]):
+    close_entered: asyncio.Event = field(default_factory=asyncio.Event)
+    release_close: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def __call__(self, event: Event) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.close_entered.set()
+        await self.release_close.wait()
+
+
+def _idle_test_llm() -> SlowTestLLM:
+    llm = SlowTestLLM.from_messages([text_message("done")], latency_s=0.0)
+    assert isinstance(llm, SlowTestLLM)
+    return llm
+
+
+async def _create_idle_conversation(
+    conversation_service: ConversationService,
+    *,
+    workspace_dir: str,
+    usage_id: str,
+):
+    return await start_conversation_with_test_llm(
+        conversation_service,
+        parent_llm=_idle_test_llm(),
+        workspace_dir=workspace_dir,
+        usage_id=usage_id,
+        initial_text=None,
+    )
+
+
+async def test_stuck_close_does_not_block_unrelated_lifecycle_operations(
+    conversation_service: ConversationService,
+    tmp_path,
+):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    blocked = await _create_idle_conversation(
+        conversation_service,
+        workspace_dir=str(workspace),
+        usage_id="lifecycle-blocked",
+    )
+    unrelated = await asyncio.gather(
+        *[
+            _create_idle_conversation(
+                conversation_service,
+                workspace_dir=str(workspace),
+                usage_id=f"lifecycle-unrelated-{i}",
+            )
+            for i in range(LIFECYCLE_ISOLATION.n_unrelated_conversations)
+        ]
+    )
+
+    blocked_service = await conversation_service.get_event_service(blocked.id)
+    assert blocked_service is not None
+    blocker = _BlockingCloseSubscriber()
+    blocked_service._pub_sub.subscribe(blocker)
+
+    blocked_delete = asyncio.create_task(
+        conversation_service.delete_conversation(blocked.id)
+    )
+    try:
+        await asyncio.wait_for(
+            blocker.close_entered.wait(),
+            timeout=LIFECYCLE_ISOLATION.unrelated_operations_timeout_s,
+        )
+
+        started_at = time.monotonic()
+        load_task = asyncio.create_task(
+            conversation_service.get_event_service(unrelated[0].id)
+        )
+        delete_tasks = [
+            asyncio.create_task(conversation_service.delete_conversation(info.id))
+            for info in unrelated[1:]
+        ]
+        create_task = asyncio.create_task(
+            _create_idle_conversation(
+                conversation_service,
+                workspace_dir=str(workspace),
+                usage_id="lifecycle-created-during-close",
+            )
+        )
+        operations: list[asyncio.Task[Any]] = [
+            load_task,
+            *delete_tasks,
+            create_task,
+        ]
+        _done, pending = await asyncio.wait(
+            operations,
+            timeout=LIFECYCLE_ISOLATION.unrelated_operations_timeout_s,
+        )
+        if pending:
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            raise AssertionError(
+                "unrelated conversation create/load/delete operations blocked "
+                "behind a stuck close; lifecycle work may be globally serialized"
+            )
+        elapsed = time.monotonic() - started_at
+
+        assert load_task.result() is not None
+        assert all(task.result() for task in delete_tasks)
+        created = create_task.result()
+        assert await conversation_service.get_event_service(created.id) is not None
+        assert elapsed < LIFECYCLE_ISOLATION.unrelated_operations_timeout_s
+        assert not blocked_delete.done(), (
+            "blocked close unexpectedly completed before its subscriber was released"
+        )
+    finally:
+        blocker.release_close.set()
+        assert await asyncio.wait_for(
+            blocked_delete,
+            timeout=LIFECYCLE_ISOLATION.unrelated_operations_timeout_s,
+        )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I authorized this contribution and will take responsibility for reviewing it and responding to maintainer feedback.
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The existing stress suite runs on relevant PRs, but release publication does not
depend on it. If a release PR is merged with checks bypassed or against a bad
merge result, `create-release.yml` immediately creates the tag and GitHub Release
and dispatches PyPI, image, and binary publication.

That gap is high impact because the regressions this suite targets are
process-wide: before #4570, one conversation stuck in `close()` held a global
lifecycle lock, so create, load, and delete for every unrelated conversation
wedged even while `/health` remained responsive. A package release can therefore
look healthy and still make the agent server unusable for all active users.

This follows the same principle as production agent harnesses such as
[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): inject a
controlled failure into the real execution path, assert a deterministic
invariant, and make that invariant a release boundary rather than advisory CI.

## Summary

- Add a credential-free stress regression that stalls one real
  `EventService.close()` and proves unrelated conversation create/load/delete
  operations still finish within a documented five-second CI budget.
- Run the complete agent-server stress suite against the exact release PR merge
  commit before `create-release` can create any tag or dispatch publication.
- Update the release runbook to document the blocking gate and the actual
  automated release flow.

## Issue Number

Fixes #4588

## How to Test

Focused reviewer command:

```bash
uv run pytest -q -m stress \
  tests/agent_server/stress/test_lifecycle_isolation.py --no-cov
```

The equivalent local command executed in this macOS workspace was
`.venv/bin/python -m pytest` with the same arguments. Observed:

```text
1 passed, 40 warnings in 0.19s
```

Full reviewer/release-gate command:

```bash
CI=true uv run python -m pytest -vvs \
  -m stress \
  --durations=10 \
  tests/agent_server/stress
```

The equivalent full local run used `.venv/bin/python -m pytest` with the same
arguments. Observed:

```text
14 passed, 17012 warnings in 69.77s
```

Historical fail-before/pass-after proof:

- Loaded the production packages from `611629e6`, the first parent of the
  #4570 merge and therefore the last tree with the process-wide lifecycle lock.
- Ran the exact new stress test without changing its test or budget code.
- It failed after 5.26 seconds with:

```text
AssertionError: unrelated conversation create/load/delete operations blocked
behind a stuck close; lifecycle work may be globally serialized
```

Static validation:

```bash
uv run pre-commit run --files \
  .github/workflows/create-release.yml \
  .github/workflows/README-RELEASE.md \
  tests/agent_server/stress/budgets.py \
  tests/agent_server/stress/test_lifecycle_isolation.py
```

All hooks passed, including YAML formatting, Ruff, Pyright, import rules, and
tool registration.

## Video/Screenshots

Not applicable. This is a backend lifecycle regression and release workflow;
the direct pass/fail terminal evidence is included above.

## Design Doc

Not applicable. The change is test/workflow-only and does not alter a public API
or production runtime behavior.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- The PR-time stress job remains path-filtered. The new release gate is
  unconditional for merged `rel-*` PRs and is a hard `needs` dependency of the
  publication job.
- Tests use the existing in-process FastAPI/ConversationService harness and
  fake LLMs; no paid model credentials or external services are required.
- No agent prompts, tool behavior, model routing, or benchmark-sensitive
  production code changes.
