### PR TITLE
fix(agent-server): bypass lifecycle lock for cached event services

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1100,6 +1100,11 @@ class ConversationService:
         event_services = self._event_services
         if event_services is None:
             raise ValueError("inactive_service")
+        event_service = event_services.get(conversation_id)
+        if event_service is not None and event_service.is_open():
+            # Cached runtimes do not need lifecycle serialization or disk I/O.
+            event_service.touch()
+            return event_service
         if (
             conversation_id not in event_services
             and conversation_id not in self._conversation_records

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -86,6 +86,26 @@ def sample_stored_conversation():
 
 
 @pytest.mark.asyncio
+async def test_cached_event_service_bypasses_lifecycle_lock(tmp_path):
+    service = ConversationService(conversations_dir=tmp_path / "conversations")
+    conversation_id = uuid4()
+    event_service = MagicMock(spec=EventService)
+    event_service.is_open.return_value = True
+    service._event_services = {conversation_id: event_service}
+
+    await service._lifecycle_lock.acquire()
+    try:
+        result = await asyncio.wait_for(
+            service.get_event_service(conversation_id), timeout=0.1
+        )
+    finally:
+        service._lifecycle_lock.release()
+
+    assert result is event_service
+    event_service.touch.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_meta_json_has_no_agent_and_reload_uses_base_state(tmp_path):
     """End-to-end single-source-of-truth guarantee.
 


### PR DESCRIPTION
HUMAN:

<!-- Human author: replace this with a short note of at least 20 visible characters before marking ready for review. -->

---

AGENT:

## Why

`ConversationService._get_or_load_event_service` waits on the global lifecycle lock even when the requested conversation already has an open in-memory `EventService`. During a slow persistence/runtime preparation, those waits can consume the server's worker threads and block unrelated event endpoints.

## Summary

- Return an open cached `EventService` before entering lifecycle serialization or disk hydration.
- Preserve the existing activity touch used to defer idle eviction.
- Add a regression test that holds the lifecycle lock and verifies cached access completes immediately.

## Issue Number

Fixes #4514

## How to Test

- `uv run pytest -q tests/agent_server/test_conversation_service.py -k 'cached_event_service_bypasses_lifecycle_lock or get_event_service or conversation_lifecycle' --maxfail=1`
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/conversation_service.py tests/agent_server/test_conversation_service.py`
- `make build`

The focused regression/lifecycle tests pass, and the relevant pre-commit hooks pass: Ruff format/lint, pycodestyle, pyright, import rules, and tool registration. The full conversation/event service files were also run; unrelated workspace/git initialization tests fail in this local outer worktree because pytest temporary paths are detected as Git-backed and therefore use conversation worktrees. The changed code is not involved in those failures.

## Video/Screenshots

Not applicable for this backend concurrency fix; the regression is covered by an in-process async test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is an internal agent-server scheduling change with no REST/WebSocket schema changes. The cached fast path is limited to open in-memory runtimes; closed or uncached conversations retain the existing lifecycle and hydration path.
