### PR TITLE
feat(tools): add factory_spawn server tool + attach client tools to resolved agents

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -68,7 +68,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.observability import OPERATION_METADATA_KEY, observe
-from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
+from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable, resolve_tool
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
@@ -1592,6 +1592,51 @@ class ConversationService:
                     "Dynamically registered %d tools for conversation %s",
                     len(request.tool_module_qualnames),
                     conversation_id,
+                )
+
+            # Attach the named tools to the resolved agent (both the inline
+            # agent-settings and the agent-profile launch paths) so the agent
+            # can actually call them. Registration alone only makes them
+            # resolvable by name; without this, profile-launched agents never
+            # see the client's custom tools. Only tools that resolve as a bare
+            # ``Tool(name=...)`` spec are attached — a qualname key whose tool
+            # needs constructor params (e.g. the low-level ``task`` tool) must
+            # not be force-added, or the conversation crashes at run time. Two
+            # qualname keys can also resolve to the same effective tool name
+            # (``workflow_tool_set`` and ``workflow`` both yield a ``workflow``
+            # tool), so the effective names are deduped as well.
+            existing_names = {t.name for t in request.agent.tools}
+            covered_names = set(existing_names)
+            new_tools: list[Tool] = []
+            for tool_name in request.tool_module_qualnames:
+                if tool_name in covered_names:
+                    continue
+                try:
+                    resolved = resolve_tool(Tool(name=tool_name), None)
+                except Exception:  # noqa: BLE001 — skip tools that can't be
+                    # constructed from a bare spec; they aren't callable anyway
+                    logger.debug(
+                        "Skipping tool '%s' for conversation %s: not resolvable "
+                        "as a bare spec",
+                        tool_name,
+                        conversation_id,
+                    )
+                    continue
+                effective_names = {t.name for t in resolved}
+                if effective_names & covered_names:
+                    logger.debug(
+                        "Skipping tool '%s' for conversation %s: effective "
+                        "names %s already covered",
+                        tool_name,
+                        conversation_id,
+                        effective_names,
+                    )
+                    continue
+                covered_names |= effective_names
+                new_tools.append(Tool(name=tool_name))
+            if new_tools:
+                request.agent = request.agent.model_copy(
+                    update={"tools": [*request.agent.tools, *new_tools]}
                 )
 
         # Register client-defined tools (JSON specs, no Python code). The

--- a/openhands-sdk/openhands/sdk/tool/builtins/finish.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/finish.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Self
 from pydantic import Field
 from rich.text import Text
 
+from openhands.sdk.tool.registry import register_tool
 from openhands.sdk.tool.tool import (
     Action,
     Observation,
@@ -104,3 +105,12 @@ class FinishTool(ToolDefinition[FinishAction, FinishObservation]):
                 ),
             )
         ]
+
+
+# Self-register so `tool_module_qualnames` can resolve FinishTool on a remote
+# agent-server: clients (e.g. automation presets) put `Tool(name="FinishTool")`
+# in the agent's toolset (to attach a response schema), and the server imports
+# this module expecting it to register the tool, like every other tool module.
+# Registered under the class name (`FinishTool.__name__`) to match how
+# `openhands.tools.preset.default.get_default_agent` names the tool spec.
+register_tool(FinishTool.__name__, FinishTool)

--- a/openhands-tools/openhands/tools/factory/__init__.py
+++ b/openhands-tools/openhands/tools/factory/__init__.py
@@ -1,0 +1,32 @@
+"""Factory tools for OpenHands agents.
+
+This package provides a ``factory_spawn`` tool that routes sub-work into the
+factory as child conversations (parent-child linked, same workspace) or as new
+roots (different workspace).
+
+Usage:
+    from openhands.tools.factory import FactorySpawnTool
+
+    agent = Agent(
+        llm=llm,
+        tools=[
+            Tool(name=TerminalTool.name),
+            Tool(name=FactorySpawnTool.name),
+        ],
+    )
+"""
+
+from openhands.tools.factory.definition import (
+    FactorySpawnAction,
+    FactorySpawnObservation,
+    FactorySpawnTool,
+)
+from openhands.tools.factory.impl import FactorySpawnExecutor
+
+
+__all__ = [
+    "FactorySpawnAction",
+    "FactorySpawnExecutor",
+    "FactorySpawnObservation",
+    "FactorySpawnTool",
+]

--- a/openhands-tools/openhands/tools/factory/definition.py
+++ b/openhands-tools/openhands/tools/factory/definition.py
@@ -1,0 +1,135 @@
+"""Factory spawn tool — route sub-work into the factory as child conversations.
+
+This module defines the schema and tool class for spawning a factory child
+conversation. It mirrors the wire payload proven by the openhands-factory-ctl
+chassis (``build_start_payload``) so child conversations carry the factory tags
+the canvas tree / run-graph / trace chips key off (``factory``/``runid``/
+``workstreamid``).
+
+Semantics:
+- Same workspace as the caller -> child is linked via ``parent_conversation_id``
+  (deep tree; the agent-server requires parent and child to share a workspace).
+- Different ``target_workspace`` -> child is a NEW ROOT (no parent link); it
+  still renders in the canvas tree as its own root and traces to Laminar.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Final
+
+from pydantic import Field
+from rich.text import Text
+
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    register_tool,
+)
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+    from openhands.tools.factory.impl import FactorySpawnExecutor
+
+
+class FactorySpawnAction(Action):
+    """Schema for spawning a factory child conversation."""
+
+    prompt: str = Field(
+        description="The sub-task for the child agent to perform.",
+    )
+    workstream_label: str | None = Field(
+        default=None,
+        description="Short label for the child workstream (e.g. ws-search).",
+    )
+    target_workspace: str | None = Field(
+        default=None,
+        description="Working directory for the child. Defaults to this "
+        "conversation's workspace. If it differs, the child becomes a NEW "
+        "ROOT (no parent link) because the agent-server requires parent and "
+        "child to share a workspace.",
+    )
+
+
+class FactorySpawnObservation(Observation):
+    """Observation from a factory spawn."""
+
+    conversation_id: str = Field(description="The child conversation id.")
+    workspace: str = Field(description="The child's working directory.")
+    parent_conversation_id: str | None = Field(
+        default=None,
+        description="The parent conversation id, when the child is linked.",
+    )
+    run_id: str = Field(description="The factory run id the child belongs to.")
+
+    def _get_factory_info(self) -> str:
+        parent = self.parent_conversation_id or "none (new root)"
+        return (
+            f"Conversation ID: {self.conversation_id}\n"
+            f"Workspace: {self.workspace}\n"
+            f"Run ID: {self.run_id}\n"
+            f"Parent: {parent}"
+        )
+
+    @property
+    def visualize(self) -> Text:
+        text = Text()
+        text.append(self._get_factory_info(), style="cyan")
+        text.append("\n")
+        if self.is_error:
+            text.append("❌ ", style="red bold")
+            text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
+        text.append(self.text)
+        return text
+
+
+FACTORY_SPAWN_DESCRIPTION: Final[
+    str
+] = """Spawn a child conversation for a sub-task and link it as a child of this conversation (factory fan-out).
+
+The child is a real, independent conversation that executes its own prompt. It
+is linked as a parent-child node (visible in the canvas tree view and run-graph)
+and traces to Laminar under the same factory run.
+
+Use this tool when the work decomposes into independent, parallel streams that
+should run as separate agents: several independent features, isolated
+experiments, or long-running async work you will collect later. Each spawn
+returns the child conversation id.
+
+Do NOT use it for linear, quick, single-threaded work — keep that in this
+conversation. Only spawn children for work that genuinely benefits from a
+separate agent.
+"""
+
+
+class FactorySpawnTool(ToolDefinition[FactorySpawnAction, FactorySpawnObservation]):
+    """Tool for spawning a factory child conversation."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState",  # noqa: ARG003
+    ) -> Sequence["FactorySpawnTool"]:
+        from openhands.tools.factory.impl import FactorySpawnExecutor
+
+        return [
+            cls(
+                action_type=FactorySpawnAction,
+                observation_type=FactorySpawnObservation,
+                description=FACTORY_SPAWN_DESCRIPTION,
+                annotations=ToolAnnotations(
+                    title="factory_spawn",
+                    readOnlyHint=False,
+                    destructiveHint=True,
+                    idempotentHint=False,
+                    openWorldHint=True,
+                ),
+                executor=FactorySpawnExecutor(),
+            )
+        ]
+
+
+register_tool(FactorySpawnTool.name, FactorySpawnTool)

--- a/openhands-tools/openhands/tools/factory/impl.py
+++ b/openhands-tools/openhands/tools/factory/impl.py
@@ -1,0 +1,168 @@
+"""Factory spawn tool executor — creates the child conversation on the agent-server."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.logger import get_logger
+from openhands.sdk.tool.tool import ToolExecutor
+from openhands.tools.factory.definition import (
+    FactorySpawnAction,
+    FactorySpawnObservation,
+)
+
+logger = get_logger(__name__)
+
+DEFAULT_BASE_URL = "http://127.0.0.1:18000"
+SESSION_KEY_ENV_VARS = ("OH_SESSION_API_KEYS_0", "SESSION_API_KEY")
+
+
+def _server_config() -> tuple[str, str | None]:
+    base_url = os.environ.get("AGENT_SERVER_URL") or DEFAULT_BASE_URL
+    api_key = None
+    for var in SESSION_KEY_ENV_VARS:
+        if os.environ.get(var):
+            api_key = os.environ[var]
+            break
+    return base_url.rstrip("/"), api_key
+
+
+class FactorySpawnExecutor(ToolExecutor):
+    """Executes a factory spawn by POSTing a child conversation to the agent-server."""
+
+    def __call__(
+        self,
+        action: FactorySpawnAction,
+        conversation: LocalConversation | None = None,
+    ) -> FactorySpawnObservation:
+        try:
+            return self._spawn(action, conversation)
+        except Exception as e:  # noqa: BLE001 — surface any failure to the agent
+            logger.error(f"factory_spawn failed: {e}", exc_info=True)
+            return FactorySpawnObservation.from_text(
+                text=f"Failed to spawn factory child: {e}",
+                conversation_id="unknown",
+                workspace="",
+                run_id="",
+                is_error=True,
+            )
+
+    def _spawn(
+        self,
+        action: FactorySpawnAction,
+        conversation: LocalConversation | None,
+    ) -> FactorySpawnObservation:
+        parent_id = str(conversation.id) if conversation is not None else None
+        current_workspace = (
+            str(conversation.state.workspace.working_dir)
+            if conversation is not None
+            else None
+        )
+        target_workspace = action.target_workspace or current_workspace
+        if not target_workspace:
+            raise ValueError("no workspace available on this conversation")
+
+        base_url, api_key = _server_config()
+        headers = {}
+        if api_key:
+            headers["X-Session-API-Key"] = api_key
+
+        with httpx.Client(base_url=base_url, headers=headers, timeout=30.0) as client:
+            parent_run_id = self._parent_run_id(client, parent_id)
+            linked = bool(parent_id) and target_workspace == current_workspace
+            run_id = parent_run_id or f"tree-{uuid.uuid4().hex[:8]}"
+            workstream_id = (
+                action.workstream_label or f"child-{uuid.uuid4().hex[:6]}"
+            )
+
+            profile_id = self._active_agent_profile_id(client)
+            if not profile_id:
+                raise RuntimeError(
+                    "no active agent profile; configure one on the agent-server "
+                    "before using factory_spawn"
+                )
+
+            payload: dict = {
+                "workspace": {"working_dir": target_workspace},
+                "worktree": False,
+                "confirmation_policy": {"kind": "NeverConfirm"},
+                "agent_profile_id": profile_id,
+                "max_iterations": 500,
+                "stuck_detection": True,
+                "autotitle": True,
+                "tags": {
+                    "factory": "1",
+                    "runid": run_id,
+                    "workstreamid": workstream_id,
+                },
+                "observability_span_name": "factory_workstream",
+                "observability_metadata": {
+                    "factory.run_id": run_id,
+                    "factory.workstream_id": workstream_id,
+                },
+                "initial_message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": action.prompt}],
+                    "run": True,
+                },
+            }
+            if linked:
+                payload["parent_conversation_id"] = parent_id
+
+            data = self._post(client, "/api/conversations", payload)
+            child_id = data.get("conversation_id") or data.get("id")
+            if not child_id:
+                raise RuntimeError(f"no conversation id in response: {data}")
+
+            logger.info(
+                "factory_spawn -> child %s (parent %s, run %s, workspace %s)",
+                child_id,
+                parent_id if linked else None,
+                run_id,
+                target_workspace,
+            )
+            return FactorySpawnObservation.from_text(
+                text="Factory child spawned.",
+                conversation_id=str(child_id),
+                workspace=target_workspace,
+                parent_conversation_id=str(parent_id) if linked else None,
+                run_id=run_id,
+            )
+
+    def _post(self, client: httpx.Client, path: str, payload: dict) -> dict:
+        resp = client.post(path, json=payload)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"{path} -> {resp.status_code}: {resp.text[:300]}")
+        if not resp.text:
+            return {}
+        return resp.json()
+
+    def _get(self, client: httpx.Client, path: str) -> dict:
+        resp = client.get(path)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"{path} -> {resp.status_code}: {resp.text[:300]}")
+        if not resp.text:
+            return {}
+        return resp.json()
+
+    def _parent_run_id(self, client: httpx.Client, parent_id: str | None) -> str | None:
+        if not parent_id:
+            return None
+        try:
+            conv = self._get(client, f"/api/conversations/{parent_id}")
+            return (conv.get("tags") or {}).get("runid")
+        except Exception:  # noqa: BLE001 — inheritance is best-effort
+            logger.warning("could not read parent run id for %s", parent_id)
+            return None
+
+    def _active_agent_profile_id(self, client: httpx.Client) -> str | None:
+        try:
+            data = self._get(client, "/api/agent-profiles")
+        except Exception:  # noqa: BLE001
+            return None
+        pid = (data or {}).get("active_agent_profile_id")
+        return str(pid) if pid else None

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -6,6 +6,7 @@ description = "OpenHands Tools - Runtime tools for AI agents"
 requires-python = ">=3.12"
 dependencies = [
     "openhands-sdk",
+    "httpx>=0.27.0",
     "tree-sitter>=0.24",
     "tree-sitter-bash>=0.23",
     "binaryornot>=0.4.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1256,11 +1256,11 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
+    { name = "google-auth", marker = "python_full_version < '3.13'" },
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
+    { name = "proto-plus", marker = "python_full_version < '3.13'" },
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ea/e7b6ac3c7b557b728c2d0181010548cbbdd338e9002513420c5a354fa8df/google_api_core-2.26.0.tar.gz", hash = "sha256:e6e6d78bd6cf757f4aee41dcc85b07f485fbb069d5daa3afb126defba1e91a62", size = 166369, upload-time = "2025-10-08T21:37:38.39Z" }
 wheels = [
@@ -1269,8 +1269,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio" },
-    { name = "grpcio-status" },
+    { name = "grpcio", marker = "python_full_version < '3.13'" },
+    { name = "grpcio-status", marker = "python_full_version < '3.13'" },
 ]
 
 [[package]]
@@ -1282,11 +1282,11 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
 ]
 dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
+    { name = "google-auth", marker = "python_full_version >= '3.13'" },
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.13'" },
+    { name = "proto-plus", marker = "python_full_version >= '3.13'" },
+    { name = "protobuf", marker = "python_full_version >= '3.13'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
@@ -1295,8 +1295,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio" },
-    { name = "grpcio-status" },
+    { name = "grpcio", marker = "python_full_version >= '3.13'" },
+    { name = "grpcio-status", marker = "python_full_version >= '3.13'" },
 ]
 
 [[package]]
@@ -1445,12 +1445,12 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "google-api-core", version = "2.26.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "google-api-core", version = "2.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "google-auth", marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version < '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/ef/7cefdca67a6c8b3af0ec38612f9e78e5a9f6179dd91352772ae1a9849246/google_cloud_storage-3.4.1.tar.gz", hash = "sha256:6f041a297e23a4b485fad8c305a7a6e6831855c208bcbe74d00332a909f82268", size = 17238203, upload-time = "2025-10-08T18:43:39.665Z" }
 wheels = [
@@ -1466,12 +1466,12 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
 ]
 dependencies = [
-    { name = "google-api-core", version = "2.31.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "google-api-core", version = "2.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "google-auth", marker = "python_full_version >= '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version >= '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version >= '3.13'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
@@ -2828,6 +2828,7 @@ dependencies = [
     { name = "browser-use" },
     { name = "cachetools" },
     { name = "func-timeout" },
+    { name = "httpx" },
     { name = "libtmux" },
     { name = "openhands-sdk" },
     { name = "pydantic" },
@@ -2842,6 +2843,7 @@ requires-dist = [
     { name = "browser-use", specifier = ">=0.8.0" },
     { name = "cachetools" },
     { name = "func-timeout", specifier = ">=4.3.5" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "libtmux", specifier = ">=0.53.0" },
     { name = "openhands-sdk", editable = "openhands-sdk" },
     { name = "pydantic", specifier = ">=2.11.7" },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

Factory-capable conversations (fan-out into real parent-child conversations that
render in the canvas tree view / run-graph and trace to Laminar) need a native
server-side `factory_spawn` tool, and the agent-server must attach client-registered
custom tools to the resolved agent — registration alone (via `tool_module_qualnames`)
only imports the module; it does not put the tool in the agent's toolset. Without
this, profile-launched agents never receive `factory_spawn`, and automation-born
conversations can't fan out.

## Summary

- Add `openhands/tools/factory/` — `FactorySpawnTool` (`definition.py` + `impl.py`),
  auto-registered at import (qualname `openhands.tools.factory.definition`). The
  executor reads `AGENT_SERVER_URL` + `OH_SESSION_API_KEYS_0` from the agent-server
  env, resolves the active agent profile, and POSTs `/api/conversations` with
  `parent_conversation_id` (same workspace → deep tree; different
  `target_workspace` → new root), factory tags (`factory`/`runid`/`workstreamid`),
  `observability_metadata`, and `initial_message`. Add `httpx>=0.27.0` to
  `openhands-tools` deps (+ lock update).
- `conversation_service.py`: after the dynamic `tool_module_qualnames` import block,
  attach `Tool(name=...)` for each qualname key to the resolved agent (dedup vs
  `agent.tools`) — but only when the tool resolves as a bare spec (the low-level
  `task` tool takes `executor`/`description`, not `conv_state`), and dedupe by the
  resolved **effective** name (`workflow_tool_set` + `workflow` both yield a
  `workflow`-named tool).
- `finish.py`: self-register `FinishTool` at module import (under the class name,
  matching `get_default_agent`). Clients that put `Tool(name="FinishTool")` in the
  agent's toolset to attach a response schema (e.g. automation presets) were failing
  on the server with `ToolDefinition 'FinishTool' is not registered`, because builtins
  are normally resolved via `include_default_tools` → `BUILT_IN_TOOL_CLASSES`, never
  registered. The `tool_module_qualnames` contract is "import the module → it
  self-registers", so `finish.py` now follows it.

## Issue Number

No tracked issue. Part of the factory effort (see the agent-canvas frontend PR
`OpenHands/OpenHands#16859` for the tree view / run-graph / trace chips that consume
the factory tags this tool emits).

## How to Test

Live end-to-end on the agent-canvas dev stack (`npm run dev` in the OpenHands
frontend with `OH_AGENT_SERVER_LOCAL_PATH` pointing at this checkout, automation
backend run from `OH_AUTOMATION_LOCAL_PATH`):

1. Dispatch a prompt automation. Server log shows
   `Dynamically registered 9 tools for conversation <id>` and
   `GET /api/conversations/{id}` lists `factory_spawn` in the agent's tools
   alongside `terminal`, `file_editor`, `task_tracker`, `FinishTool`.
2. Fan-out prompt ("two independent workstreams, use factory_spawn"): log shows
   `factory_spawn -> child <id> (parent <root>, run tree-…, workspace <run-ws>)`
   twice; the run-graph at `/conversations/<root>/graph` renders **PARENT** + 2
   **WORKSTREAM** nodes, all Finished; children wrote their files in the shared
   workspace. Run COMPLETED.
3. Linear prompt: zero `factory_spawn` calls; single conversation, no children.
4. `nested-tree-builder` regression (3-level parent-child tree via raw curl) still
   builds a valid tree.

Full log evidence, conversation ids, and the run-graph screenshot are recorded in
`~/src/openhands-factory-ctl/docs/session-checkpoint-2026-08-24-factory-spawn-automations.md`
and the Phase 1 checkpoint
`docs/session-checkpoint-2026-08-24-factory-spawn-tool.md` (local factory-ctl docs).

## Video/Screenshots

Run-graph of a live automation fan-out (PARENT + 2 WORKSTREAM nodes, Finished):
`docs/fanout-run-graph-2026-08-24.png` in `~/src/openhands-factory-ctl` (local).

## Design Doc

N/A.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `uv.lock` diff adds `httpx` to `openhands-tools` (required) and also carries
  version-marker normalization produced by a newer `uv`; benign.
- The attach filter intentionally only force-attaches tools that are constructible
  from a bare `Tool(name=...)` spec — a qualname key whose tool needs constructor
  params is skipped rather than crashing the conversation at run time.
