### PR TITLE
fix(acp): prefer GEMINI_API_KEY over leftover oauth-personal

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -291,6 +291,11 @@ _AUTH_METHOD_ENV_MAP: dict[str, str] = {
 _GEMINI_OAUTH_PATH = Path(".gemini") / "oauth_creds.json"
 
 
+def _env_has_nonempty(env: dict[str, str], name: str) -> bool:
+    """True when *name* is set to a non-whitespace value."""
+    return bool(env.get(name, "").strip())
+
+
 def _select_auth_method(
     auth_methods: list[Any],
     env: dict[str, str],
@@ -301,14 +306,21 @@ def _select_auth_method(
     supported credential source is available (the server may not require auth).
 
     File-backed subscription / SA logins are checked first so they take
-    precedence over explicit API keys, which serve as the fallback:
+    precedence over explicit API keys, which serve as the fallback — except
+    gemini-cli personal OAuth, which is ranked *below* ``GEMINI_API_KEY``.
+    Google retired consumer-tier ``oauth-personal`` on 2026-06-18, so a stale
+    ``~/.gemini/oauth_creds.json`` from ``gemini login`` must not outrank a
+    working API key (#4629).
 
     - ``chat-gpt`` (codex-acp) — ``$CODEX_HOME/auth.json`` or
       ``~/.codex/auth.json``
     - ``vertex-ai`` (gemini-cli) — service-account JSON at
       ``GOOGLE_APPLICATION_CREDENTIALS`` (the deployable Gemini path; preferred
       over personal OAuth, which is host-bound and undeployable)
-    - ``oauth-personal`` (gemini-cli) — ``~/.gemini/oauth_creds.json``
+    - ``gemini-api-key`` — non-empty ``GEMINI_API_KEY``
+    - ``oauth-personal`` (gemini-cli) — ``~/.gemini/oauth_creds.json`` (fallback
+      when no API key / Vertex SA is present; still used by Gemini Code Assist
+      Standard/Enterprise)
 
     In a server image the interactive-login files are absent, so the API-key
     fallback (e.g. ``GEMINI_API_KEY``) is used instead.
@@ -321,6 +333,10 @@ def _select_auth_method(
     gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
     if "vertex-ai" in method_ids and gac and Path(gac).is_file():
         return "vertex-ai"
+    # GEMINI_API_KEY outranks leftover personal OAuth. Empty/whitespace values
+    # must not count as a credential (``"VAR" in env`` is true for "").
+    if "gemini-api-key" in method_ids and _env_has_nonempty(env, "GEMINI_API_KEY"):
+        return "gemini-api-key"
     if "oauth-personal" in method_ids and (Path.home() / _GEMINI_OAUTH_PATH).is_file():
         return "oauth-personal"
     # The maintained Codex ACP adapter exposes one API-key method and reads
@@ -331,7 +347,7 @@ def _select_auth_method(
         return "api-key"
     # Fall back to explicit API key env vars.
     for method_id, env_var in _AUTH_METHOD_ENV_MAP.items():
-        if method_id in method_ids and env_var in env:
+        if method_id in method_ids and _env_has_nonempty(env, env_var):
             return method_id
     return None
 
@@ -349,6 +365,22 @@ def _auth_selection_failure_reason(auth_methods: list[Any], env: dict[str, str])
         env.get(name) for name in ("CODEX_API_KEY", "OPENAI_API_KEY")
     ):
         reasons.append("CODEX_API_KEY and OPENAI_API_KEY are unset")
+    if "oauth-personal" in method_ids or "gemini-api-key" in method_ids:
+        oauth_path = Path.home() / _GEMINI_OAUTH_PATH
+        if oauth_path.is_file() and not _env_has_nonempty(env, "GEMINI_API_KEY"):
+            reasons.append(
+                "gemini-cli oauth-personal login is retired for consumer Google "
+                "AI tiers; set GEMINI_API_KEY or GOOGLE_APPLICATION_CREDENTIALS"
+            )
+        elif not _env_has_nonempty(env, "GEMINI_API_KEY"):
+            reasons.append(
+                "GEMINI_API_KEY is unset and gemini-cli consumer OAuth "
+                "(oauth-personal) is retired"
+            )
+    if "vertex-ai" in method_ids:
+        gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if not gac or not Path(gac).is_file():
+            reasons.append("GOOGLE_APPLICATION_CREDENTIALS is missing or not a file")
     return "; ".join(reasons) or "no supported credential source is available"
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4877,8 +4877,13 @@ class TestSelectAuthMethod:
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, {}) == "oauth-personal"
 
-    def test_gemini_oauth_preferred_over_api_key(self, tmp_path):
-        """OAuth login takes precedence over GEMINI_API_KEY (mirrors chatgpt)."""
+    def test_gemini_api_key_preferred_over_oauth(self, tmp_path):
+        """A working GEMINI_API_KEY outranks leftover oauth_creds.json.
+
+        Consumer-tier gemini-cli OAuth was retired on 2026-06-18 (#4629).
+        The previous ranking encoded in this test (oauth-personal first)
+        caused a stale ~/.gemini/oauth_creds.json to hide a valid API key.
+        """
         methods = [
             self._make_auth_method("oauth-personal"),
             self._make_auth_method("gemini-api-key"),
@@ -4889,7 +4894,37 @@ class TestSelectAuthMethod:
 
         env = {"GEMINI_API_KEY": "g-test"}
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
-            assert _select_auth_method(methods, env) == "oauth-personal"
+            assert _select_auth_method(methods, env) == "gemini-api-key"
+
+    def test_empty_gemini_api_key_does_not_outrank_oauth(self, tmp_path):
+        """An empty or whitespace GEMINI_API_KEY is not a credential, so a
+        present oauth_creds.json is still used as the fallback."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        gem_dir = tmp_path / ".gemini"
+        gem_dir.mkdir()
+        (gem_dir / "oauth_creds.json").write_text("{}", encoding="utf-8")
+
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert (
+                _select_auth_method(methods, {"GEMINI_API_KEY": ""}) == "oauth-personal"
+            )
+            assert (
+                _select_auth_method(methods, {"GEMINI_API_KEY": "   "})
+                == "oauth-personal"
+            )
+
+    def test_empty_gemini_api_key_does_not_count_as_present(self, tmp_path):
+        """``GEMINI_API_KEY=""`` in the environment is not a usable key."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, {"GEMINI_API_KEY": ""}) is None
+            assert _select_auth_method(methods, {"GEMINI_API_KEY": "  "}) is None
 
     def test_gemini_api_key_fallback_when_no_oauth_file(self, tmp_path):
         """Falls back to GEMINI_API_KEY when oauth-personal is offered but the
@@ -4910,6 +4945,19 @@ class TestSelectAuthMethod:
         ]
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, {}) is None
+
+    def test_gemini_failure_reason_names_retired_oauth(self, tmp_path):
+        """When no usable Gemini credential exists, the warning names the
+        retired oauth-personal login instead of a generic fallback."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            reason = _auth_selection_failure_reason(methods, {})
+        assert "GEMINI_API_KEY is unset" in reason
+        assert "oauth-personal" in reason
+        assert "retired" in reason
 
     def test_empty_auth_methods(self):
         assert _select_auth_method([], {}) is None


### PR DESCRIPTION
HUMAN:

Santhi Prakash — verified on current main that leftover gemini-cli OAuth still outranks a working API key; see AGENT for the ranking change, empty-key guard, and TestSelectAuthMethod output.

---

AGENT:

## Why

Fixes an issue where users with a leftover `~/.gemini/oauth_creds.json` from `gemini login` would have gemini-cli ACP sessions authenticate with retired consumer OAuth even when a valid `GEMINI_API_KEY` was set. Google stopped serving `oauth-personal` for Google AI Pro/Ultra and free tiers on 2026-06-18, so the session fails with "This client is no longer supported for Gemini Code Assist for individuals" instead of using the working API key.

`_select_auth_method` ranked `oauth-personal` above `gemini-api-key` whenever the creds file existed. `_auth_selection_failure_reason` also had no Gemini arm, so a missing usable credential logged only "no supported credential source is available". Empty `GEMINI_API_KEY=""` was treated as present because the fallback used `env_var in env`.

The pre-existing test `test_gemini_oauth_preferred_over_api_key` encoded that retired ranking; it now asserts the API key wins, which matches the post-cutoff contract.

## Summary

- Rank a non-empty `GEMINI_API_KEY` above leftover `oauth-personal`; keep Vertex SA first and keep oauth as fallback when no API key is set.
- Treat empty/whitespace `GEMINI_API_KEY` as absent so it cannot outrank oauth or count as a credential.
- Name the retired `oauth-personal` login in the auth-selection failure warning.

## Issue Number

Fixes #4629

## How to Test

```bash
uv run pytest tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod -v
```

Result (25 passed):

```
tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod::test_gemini_api_key_preferred_over_oauth PASSED
tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod::test_empty_gemini_api_key_does_not_outrank_oauth PASSED
tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod::test_empty_gemini_api_key_does_not_count_as_present PASSED
tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod::test_gemini_failure_reason_names_retired_oauth PASSED
============================= 25 passed in 14.39s ==============================
```

Live ranking after the fix (temp HOME with `~/.gemini/oauth_creds.json` plus `GEMINI_API_KEY=g-test`):

```
with oauth file + GEMINI_API_KEY: gemini-api-key
with oauth file + empty GEMINI_API_KEY: oauth-personal
```

Pre-commit on the touched files passed (Ruff format/lint, PEP8, pyright, import dependency rules, tool subclass registration).

## Video/Screenshots

N/A — backend auth-method selection; no visual surface.

## Design Doc

Not added — small ranking/empty-input correctness fix with regression tests, not a new API or agent-loop change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Canvas onboarding (`OpenHands/OpenHands` `acp-service.api.ts` oauth-file probe) is out of this repository.
- `GEMINI_CLI_VERSION` remains `0.46.0` (Dockerfile pin is in sync). Bumping to latest stable is a separate change and was left as a follow-up.
- oauth-personal is still selected when no API key / Vertex SA is present, so Gemini Code Assist Standard/Enterprise file logins keep working.