### PR TITLE
fix(sdk): reject provider-only and whitespace model IDs

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -714,7 +714,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
 
         model_val = d.get("model")
-        if not model_val:
+        if isinstance(model_val, str):
+            stripped = model_val.strip()
+            # Whitespace-only values, and provider-only IDs like "openai/" or
+            # "openhands/", parse through LiteLLM to an empty model name and
+            # 400 upstream. Reject them the same way as a missing model.
+            if not stripped or stripped.endswith("/"):
+                raise ValueError("model must be specified in LLM")
+        elif not model_val:
             raise ValueError("model must be specified in LLM")
 
         # Azure default version

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -44,6 +44,30 @@ def test_llm_init_with_default_config(default_llm):
     assert default_llm.metrics.model_name == "gpt-4o"
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "",
+        "   ",
+        "openai/",
+        "openhands/",
+        "azure/",
+        "litellm_proxy/",
+        "openrouter/",
+        " openai/ ",
+    ],
+)
+def test_llm_rejects_empty_or_provider_only_model(model: str):
+    """Empty, whitespace, and provider-only IDs must fail at construction.
+
+    LiteLLM parses ``openai/`` / ``openhands/`` as provider + empty model
+    name, which then 400s upstream. The existing empty-string guard did not
+    catch whitespace or a trailing provider slash.
+    """
+    with pytest.raises(ValueError, match="model must be specified"):
+        LLM(model=model, api_key=SecretStr("test_key"), usage_id="empty-model")
+
+
 @patch("openhands.sdk.llm.utils.model_info.httpx.get")
 def test_base_url_for_openhands_provider(mock_get):
     """Test that openhands/ remains public while transport uses the proxy."""


### PR DESCRIPTION
HUMAN:

Santhi Prakash — reproduced on current main that LLM() accepts provider-only IDs like openai/ and openhands/; LiteLLM parses them as an empty model name. See AGENT for before/after construction output and tests.

---

AGENT:

## Why

Fixes an issue where users (or a provider-prefixed form) supplying a model ID that is only a provider prefix plus a slash — `openai/`, `openhands/`, `azure/`, `litellm_proxy/`, `openrouter/` — or a whitespace-only string would get past `LLM()` construction. `_coerce_inputs` only rejected a falsey model, so `"   "` and `"openai/"` were accepted. LiteLLM then parsed them as `provider=<name>, model=\"\"`, which 400s upstream instead of failing at config time.

This is independent of #4438 (double prefix strip on namespaced IDs like `openai/openai/example-model`). That path is about a *non-empty* inner model being stripped twice; this path is empty input after the provider prefix.

## Summary

- Reject whitespace-only model strings.
- Reject model IDs that end with `/` after strip (provider-only / empty nested name).
- Keep real IDs such as `openai/gpt-4o` unchanged.

## Issue Number

Self-sourced; no existing issue. Related model-ID work: #4438 / #4613 (different bug: double prefix strip).

## How to Test

Before (current `main`):

```
''                   REJECTED ValidationError: model must be specified in LLM
'   '                ACCEPTED provider=LLMProvider(model='   ', name=None, api_base=None)
'openhands/'         ACCEPTED provider=LLMProvider(model='', name='litellm_proxy', api_base='https://llm-proxy.app.all-hands.dev')
'openai/'            ACCEPTED provider=LLMProvider(model='', name='openai', api_base=None)
'azure/'             ACCEPTED provider=LLMProvider(model='', name='azure', api_base=None)
'litellm_proxy/'     ACCEPTED provider=LLMProvider(model='', name='litellm_proxy', api_base=None)
'openrouter/'        ACCEPTED provider=LLMProvider(model='', name='openrouter', api_base=None)
```

After:

```
''                   REJECTED ValidationError: model must be specified in LLM
'   '                REJECTED ValidationError: model must be specified in LLM
'openhands/'         REJECTED ValidationError: model must be specified in LLM
'openai/'            REJECTED ValidationError: model must be specified in LLM
'azure/'             REJECTED ValidationError: model must be specified in LLM
'litellm_proxy/'     REJECTED ValidationError: model must be specified in LLM
'openrouter/'        REJECTED ValidationError: model must be specified in LLM
'openai/gpt-4o'      ACCEPTED model='openai/gpt-4o' provider=LLMProvider(model='gpt-4o', name='openai', api_base=None)
```

```bash
uv run pytest tests/sdk/llm/test_llm.py::test_llm_rejects_empty_or_provider_only_model tests/sdk/llm/test_llm.py::test_llm_init_with_default_config tests/sdk/conversation/local/test_state_serialization.py::test_agent_pydantic_validation_on_creation tests/sdk/llm/test_litellm_provider.py -v
```

21 passed.

Pre-commit on the touched files passed (Ruff format/lint, PEP8, pyright, import dependency rules, tool subclass registration).

## Video/Screenshots

N/A — construction-time validation; no visual surface.

## Design Doc

Not added — small construction guard with regression tests, not a new API or agent-loop change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Public construction now fails closed on provider-only IDs. Callers that previously passed `openai/` and caught the later LiteLLM 400 will now get a Pydantic `ValidationError` at `LLM()` instead.
- Does not change #4438 / `as_litellm_call_kwargs` double-strip behavior.