### PR TITLE
fix(critic): default CriticResult.message to None for exclude_none round-trip

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/result.py
+++ b/openhands-sdk/openhands/sdk/critic/result.py
@@ -15,7 +15,10 @@ class CriticResult(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    message: str | None = Field(description="An optional message explaining the score.")
+    message: str | None = Field(
+        default=None,
+        description="An optional message explaining the score.",
+    )
     metadata: dict[str, Any] | None = Field(
         default=None,
         description=(

--- a/tests/sdk/critic/test_critic.py
+++ b/tests/sdk/critic/test_critic.py
@@ -53,6 +53,35 @@ def test_critic_result_validation():
         CriticResult(score=1.1, message="Above max")
 
 
+def test_critic_result_message_defaults_to_none():
+    """message is optional; omitting it must yield None, not a required-field error.
+
+    Regression: the event store persists events with ``model_dump_json(
+    exclude_none=True)``, which drops ``message: null``.  On resume the event is
+    validated from ``{"score": 1.0}``; if ``message`` is a required field that
+    reload fails (``critic_result.message Field required``) and the session
+    cannot be resumed.
+    """
+    # Direct construction without message.
+    result = CriticResult(score=1.0)
+    assert result.message is None
+
+    # Round-trip through the exact persistence shape: exclude_none drops the
+    # null message, then validation must accept the message-less payload.
+    dumped = result.model_dump_json(exclude_none=True)
+    assert json.loads(dumped) == {"score": 1.0}
+    reloaded = CriticResult.model_validate_json(dumped)
+    assert reloaded.score == 1.0
+    assert reloaded.message is None
+
+    # A non-null message still round-trips unchanged.
+    msg = CriticResult(score=0.0, message="blocker")
+    assert json.loads(msg.model_dump_json(exclude_none=True))["message"] == "blocker"
+    assert CriticResult.model_validate_json(
+        msg.model_dump_json(exclude_none=True)
+    ).message == "blocker"
+
+
 def test_pass_critic_always_succeeds():
     """Test that PassCritic always returns success."""
     critic = PassCritic()


### PR DESCRIPTION
## Problem

`CriticResult.message` is typed `str | None` but declared without `default=None`, so Pydantic treats it as a **required** field. This breaks session resume:

1. The event store persists events with `model_dump_json(exclude_none=True)` (`conversation/event_store.py:217`), which drops `message: null` from the JSON — leaving `{"score": 1.0}`.
2. On resume, `Event.model_validate_json` rebuilds the `CriticResult` from `{"score": 1.0}` and fails: `critic_result.message Field required`.
3. The session cannot be resumed (surfaces as a JSON-RPC `-32602 Invalid params` error to ACP clients).

Any critic that returns a passing result with `message=None` (the common case — e.g. `PassCritic`, `EmptyPatchCritic`, and the non-blocking paths of `APIBasedCritic` / custom diff-review critics) triggers this.

## Reproduce

```python
from openhands.sdk.critic import CriticResult
CriticResult(score=1.0)  # ValidationError: message Field required
```

The exact shape the event store writes:
```python
r = CriticResult(score=1.0, message=None)
r.model_dump_json(exclude_none=True)  # '{"score":1.0}'
CriticResult.model_validate_json('{"score":1.0}')  # ValidationError
```

## Fix

Add `default=None` so the omitted key round-trips back to `None`. `metadata` already had `default=None`; `message` was the only field of `CriticResult` that combined an optional type with a missing default.

```diff
-    message: str | None = Field(description="An optional message explaining the score.")
+    message: str | None = Field(
+        default=None,
+        description="An optional message explaining the score.",
+    )
```

This is a one-line behavior change (relaxing validation), so it's backward-compatible: every existing caller already passes `message=` explicitly or relies on the field being optional at the type level.

## Testing

- Added `test_critic_result_message_defaults_to_none` — fails before the fix (exact `Field required` error), passes after. Covers both the direct construction and the `exclude_none` persistence round-trip (including a non-null message to guard against regressions on the other direction).
- `tests/sdk/critic/` — 48 passed.
- `tests/sdk/conversation/` — 786 passed, 1 skipped.