### PR TITLE
test(agent-server): isolate MCP OAuth settings persistence

### DIFF
--- a/tests/agent_server/test_mcp_oauth_store.py
+++ b/tests/agent_server/test_mcp_oauth_store.py
@@ -124,9 +124,11 @@ def protected_oauth_mcp_server():
 @pytest.mark.asyncio
 async def test_mcp_oauth_token_store_persists_values_in_settings(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     reset_stores()
     try:
+        monkeypatch.setenv("OH_PERSISTENCE_DIR", str(tmp_path))
         config = Config(
             session_api_keys=[],
             conversations_path=tmp_path / "conversations",
@@ -152,6 +154,7 @@ async def test_mcp_oauth_token_store_persists_values_in_settings(
             }
         )
         settings_store = get_settings_store(config)
+        assert settings_store.persistence_dir == tmp_path
         settings_store.save(settings)
         create_settings_backed_mcp_tool_provider(config)
 
@@ -245,6 +248,7 @@ def test_oauth_mcp_connection_persists_and_reuses_settings_state(
     _HeadlessOAuth.reject_redirects = False
     monkeypatch.setattr(mcp_utils, "OAuth", _HeadlessOAuth)
     try:
+        monkeypatch.setenv("OH_PERSISTENCE_DIR", str(tmp_path))
         config = Config(
             session_api_keys=[],
             conversations_path=tmp_path / "conversations",
@@ -271,6 +275,7 @@ def test_oauth_mcp_connection_persists_and_reuses_settings_state(
             update={"mcp_config": mcp_config}
         )
         settings_store = get_settings_store(config)
+        assert settings_store.persistence_dir == tmp_path
         settings_store.save(settings)
         tool_provider = create_settings_backed_mcp_tool_provider(config)
 
@@ -330,9 +335,11 @@ def test_oauth_mcp_connection_persists_and_reuses_settings_state(
 @pytest.mark.asyncio
 async def test_mcp_oauth_token_storage_does_not_attach_to_non_oauth_server(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     reset_stores()
     try:
+        monkeypatch.setenv("OH_PERSISTENCE_DIR", str(tmp_path))
         config = Config(
             session_api_keys=[],
             conversations_path=tmp_path / "conversations",
@@ -347,6 +354,7 @@ async def test_mcp_oauth_token_storage_does_not_attach_to_non_oauth_server(
             }
         )
         settings_store = get_settings_store(config)
+        assert settings_store.persistence_dir == tmp_path
         settings_store.save(settings)
 
         create_settings_backed_mcp_tool_provider(config)


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The MCP OAuth settings-store tests initialize the global profile store without setting `OH_PERSISTENCE_DIR`. The store therefore falls back to the user profile directory, allowing encrypted OAuth test state to escape pytest's `tmp_path`.

## Summary

- Set `OH_PERSISTENCE_DIR` to each test's `tmp_path` before initializing the settings store.
- Assert that the store uses the temporary persistence directory in each affected OAuth test.

## Issue Number

Fixes #4604.

## How to Test

- `uv run pytest tests/agent_server/test_mcp_oauth_store.py -q`
  - 4 passed. The tests exercise persisted OAuth token, client-info, and non-OAuth server behavior, and each asserts `settings_store.persistence_dir == tmp_path`.
- `uv run pre-commit run --all-files`
  - formatting, Ruff, pycodestyle, pyright, import rules, and tool-registration checks passed.
- `uv run pytest tests/agent_server -q`
  - the focused OAuth tests passed. Five unrelated baseline failures in conversation worktree setup and file-router git-delta status handling reproduce unchanged on the unmodified base revision.

## Video/Screenshots

Not applicable for test isolation.

## Design Doc

Not needed for this focused test-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally remains a draft until a human contributor completes the `HUMAN` section.