### PR TITLE
docs(examples): align Ask Oracle conventions

### DIFF
--- a/examples/01_standalone_sdk/58_ask_oracle_tool/main.py
+++ b/examples/01_standalone_sdk/58_ask_oracle_tool/main.py
@@ -22,7 +22,7 @@ from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent, LocalConversation, Tool
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.tools.ask_oracle import ORACLE_PROFILE_NAME
+from openhands.tools.ask_oracle import ORACLE_PROFILE_NAME, AskOracleTool
 
 
 DEFAULT_BASE_URL = "https://llm-proxy.app.all-hands.dev"
@@ -40,7 +40,6 @@ base_url = os.getenv("LLM_BASE_URL", DEFAULT_BASE_URL)
 
 with tempfile.TemporaryDirectory() as profile_store_dir:
     store = LLMProfileStore(profile_store_dir)
-    # The Oracle model is saved under the conventional profile name "oracle".
     store.save(
         ORACLE_PROFILE_NAME,
         LLM(
@@ -58,7 +57,7 @@ with tempfile.TemporaryDirectory() as profile_store_dir:
         base_url=base_url,
         usage_id="primary",
     )
-    agent = Agent(llm=primary_llm, tools=[Tool(name="ask_oracle")])
+    agent = Agent(llm=primary_llm, tools=[Tool(name=AskOracleTool.name)])
     conversation = LocalConversation(
         agent=agent,
         workspace=os.getcwd(),
@@ -73,6 +72,6 @@ with tempfile.TemporaryDirectory() as profile_store_dir:
     )
     conversation.run()
 
-    combined = conversation.state.stats.get_combined_metrics()
-    print(f"Total cost: ${combined.accumulated_cost:.6f}")
-    print(f"EXAMPLE_COST: {combined.accumulated_cost}")
+    cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
+    print(f"Total cost: ${cost:.6f}")
+    print(f"EXAMPLE_COST: {cost}")


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
This PR tweaks a bit the Ask Oracle tool example, to be consistent with the patterns in other examples in the codebase.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Keep the checked-in Ask Oracle example aligned with established SDK usage patterns and the synchronized documentation.

## Summary

- Reference the registered tool through `AskOracleTool.name`.
- Use the public `conversation_stats` metrics accessor.
- Remove a redundant comment.

## Issue Number

Follow-up to [SDK PR #3673](https://github.com/OpenHands/software-agent-sdk/pull/3673). Documentation: [OpenHands/docs PR #566](https://github.com/OpenHands/docs/pull/566).

## How to Test

```console
LLM_API_KEY=... \
LLM_BASE_URL=https://llm-proxy.eval.all-hands.dev \
LLM_MODEL=openai/gpt-5.1 \
ASK_ORACLE_PRIMARY_MODEL=openai/gpt-5.1 \
ASK_ORACLE_MODEL=openai/gpt-5-mini \
OPENHANDS_SUPPRESS_BANNER=1 \
uv run pytest tests/examples/test_examples.py --run-examples -k 58_ask_oracle_tool
```

Result: `1 passed, 69 deselected`.

Also ran:

```console
uv run pre-commit run --files examples/01_standalone_sdk/58_ask_oracle_tool/main.py
```

All hooks passed.

## Video/Screenshots

Not applicable; this is a small example-code consistency change.

## Design Doc

Not applicable.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was created by an AI agent (OpenAI Codex) on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:41bb901-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-41bb901-python \
  ghcr.io/openhands/agent-server:41bb901-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:41bb901-golang-amd64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-golang-amd64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-golang-amd64
ghcr.io/openhands/agent-server:41bb901-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:41bb901-golang-arm64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-golang-arm64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-golang-arm64
ghcr.io/openhands/agent-server:41bb901-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:41bb901-java-amd64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-java-amd64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-java-amd64
ghcr.io/openhands/agent-server:41bb901-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:41bb901-java-arm64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-java-arm64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-java-arm64
ghcr.io/openhands/agent-server:41bb901-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:41bb901-python-amd64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-python-amd64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-python-amd64
ghcr.io/openhands/agent-server:41bb901-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:41bb901-python-arm64
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-python-arm64
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-python-arm64
ghcr.io/openhands/agent-server:41bb901-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:41bb901-golang
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-golang
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-golang
ghcr.io/openhands/agent-server:41bb901-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:41bb901-java
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-java
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-java
ghcr.io/openhands/agent-server:41bb901-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:41bb901-python
ghcr.io/openhands/agent-server:41bb901cab640f85d1c4b7e216bbfc96eb163ab0-python
ghcr.io/openhands/agent-server:gpt-ask-oracle-example-conventions-python
ghcr.io/openhands/agent-server:41bb901-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `41bb901-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `41bb901-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->