### PR TITLE
docs(agent): add docstrings for image helper functions

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -121,6 +121,18 @@ INIT_STATE_PREFIX_SCAN_WINDOW = 3
 
 
 def _latest_user_message_contains_image(messages: list[Message]) -> bool:
+    """Check if the most recent user message contains image content.
+
+    Scans the message list in reverse order to find the latest user message
+    and checks whether it contains any image attachments.
+
+    Args:
+        messages: List of conversation messages to search.
+
+    Returns:
+        True if the most recent user message contains images, False otherwise.
+        Returns False if no user messages are found.
+    """
     for message in reversed(messages):
         if message.role == "user":
             return message.contains_image
@@ -128,6 +140,18 @@ def _latest_user_message_contains_image(messages: list[Message]) -> bool:
 
 
 def _non_multimodal_image_message(model: str) -> Message:
+    """Create an error message for when images are sent to a non-vision model.
+
+    Constructs a user-friendly assistant message explaining that the current
+    model does not support image understanding and suggesting the user switch
+    to a multimodal model.
+
+    Args:
+        model: The name of the current model that does not support vision.
+
+    Returns:
+        A Message object containing an assistant response with the error explanation.
+    """
     return Message(
         role="assistant",
         content=[
@@ -145,6 +169,20 @@ def _non_multimodal_image_message(model: str) -> Message:
 def _replace_latest_user_images_with_references(
     messages: list[Message],
 ) -> list[Message]:
+    """Replace image content in the latest user message with textual references.
+
+    When a non-vision model receives images, this function converts the image
+    attachments into text placeholders that reference the inspect_image_with_vision
+    tool. This allows the agent to acknowledge the images and inform the user that
+    a vision-capable tool is available for inspection.
+
+    Args:
+        messages: List of conversation messages to process.
+
+    Returns:
+        A new list of messages with image content in the latest user message
+        replaced by textual references. Other messages are unchanged.
+    """
     rewritten = list(messages)
     for index in range(len(rewritten) - 1, -1, -1):
         message = rewritten[index]


### PR DESCRIPTION
HUMAN:

I added documentation for previously undocumented image helper functions.

---

AGENT:

## Why

Several image-related helper functions in `agent.py` were undocumented, making their behavior less clear to contributors.

## Summary

- Added documentation for `_latest_user_message_contains_image`.
- Added documentation for `_non_multimodal_image_message`.
- Added documentation for `_replace_latest_user_images_with_references`.

## Issue Number

Fixes #4657 

## How to Test

This is a documentation-only change.

I verified the changes by reviewing the updated docstrings and running the relevant project checks. No runtime behavior was modified.

## Video/Screenshots

Not applicable for this documentation-only change.

## Design Doc

Not applicable.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Documentation-only change; no functional behavior was modified.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.38s · commit dededea  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 3.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 1.0% | No direct hunk selected |
| Primary concern | None selected; confidence 100.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 6ebe07a656f5fd3b70d0cd6b83813f8be00dd5bc206fb5e19eeb6a8d332b2d96 -->
<!-- jev-fast-audit:end -->
