### PR TITLE
test(agent-server): cover conversation reads not serializing behind an unrelated start

### DIFF
--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -663,7 +663,7 @@ async def test_conversation_read_completes_while_another_conversation_starts(
                 )
             finally:
                 release_start.set()
-                await starting
+                await asyncio.wait_for(starting, timeout=5)
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -615,6 +615,58 @@ async def test_conversation_lifecycle_serializes_only_matching_ids(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_conversation_read_completes_while_another_conversation_starts(
+    tmp_path,
+):
+    """A conversation-scoped read must not queue behind an unrelated start.
+
+    Lifecycle work once ran under a single process-wide lock, so any request
+    that resolved an ``EventService`` waited for a start, fork, delete or
+    eviction happening elsewhere in the process — for an unrelated
+    conversation. Drive the public API rather than the lock helper so the
+    guarantee is checked where callers actually hit it.
+    """
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    def request() -> StartConversationRequest:
+        return StartConversationRequest(
+            agent=_sample_agent(),
+            workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+            confirmation_policy=NeverConfirm(),
+        )
+
+    async with ConversationService(conversations_dir=conversations_dir) as service:
+        live, _ = await service.start_conversation(request())
+
+        start_entered = asyncio.Event()
+        release_start = asyncio.Event()
+        start_event_service = service._start_event_service
+
+        async def blocking_start(stored: StoredConversation, **kwargs) -> EventService:
+            # Wedge the *other* conversation inside its own lifecycle section.
+            if stored.id != live.id:
+                start_entered.set()
+                await release_start.wait()
+            return await start_event_service(stored, **kwargs)
+
+        with patch.object(service, "_start_event_service", side_effect=blocking_start):
+            starting = asyncio.create_task(service.start_conversation(request()))
+            await asyncio.wait_for(start_entered.wait(), timeout=5)
+            try:
+                assert (
+                    await asyncio.wait_for(
+                        service.get_event_service(live.id), timeout=5
+                    )
+                    is not None
+                )
+            finally:
+                release_start.set()
+                await starting
+
+
+@pytest.mark.asyncio
 async def test_prepare_for_sandbox_pause_blocks_new_hydration(
     persisted_conversation,
 ):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Just adding a regression test.

---

AGENT:

## Why

#4675 reports that `ConversationService._lifecycle_lock` is a single process-wide
`asyncio.Lock` held on the read path of every conversation-scoped request, so any
request for conversation A queues behind a start/fork/delete/eviction for an
unrelated conversation B.

**That code fix already landed** in #4570 (`replace global _lifecycle_lock with
per-conversation locks`, merged 2026-08-23) — four days before #4675 was filed.
The issue quotes `conversation_service.py:647` and a `_get_or_load_event_service`
that opens with `async with self._lifecycle_lock:`; that is the pre-#4570 file.
On `main` all nine lifecycle sites already go through `_conversation_lifecycle`
(per-conversation) or `_exclusive_lifecycle` (registry-wide sweeps only).

What is **not** covered is the issue's acceptance criterion. The tests #4570 added
(`test_conversation_lifecycle_serializes_only_matching_ids`,
`test_prepare_for_sandbox_pause_blocks_new_hydration`) exercise the
`_conversation_lifecycle` helper and internals directly. Nothing drives the public
API, so the property callers actually depend on — *a conversation-scoped read
completes while another conversation is mid-start* — can regress without any test
going red. This PR closes that gap rather than re-fixing solved code.

## Summary

- Add `test_conversation_read_completes_while_another_conversation_starts` to
  `tests/agent_server/test_conversation_service.py`: wedge conversation B inside
  `_start_event_service`, then assert `get_event_service()` for an already-live
  conversation A still resolves.
- Drives the public API (`start_conversation` + `get_event_service`) instead of the
  lock helper, so it fails if the read path is ever put back behind a process-wide
  lock — regardless of how the locking is implemented internally.
- No production code changes.

## Issue Number

Fixes #4675

## How to Test

The test is only meaningful if it fails without the fix, so it was verified in both
directions using two worktrees of this repo.

**1 · It passes on `main` (fix present):**

```
$ uv run --frozen pytest tests/agent_server/test_conversation_service.py -q --no-cov
113 passed, 375 warnings in 8.24s
```

**2 · It reproduces the bug on `611629e69`** — the commit immediately before #4570,
i.e. the exact code #4675 quotes. The same test body was dropped into a worktree at
that commit:

```
$ git worktree add --detach ../sdk-prefix 942114959^     # -> 611629e69
$ grep -c "_lifecycle_lock" openhands-agent-server/openhands/agent_server/conversation_service.py
10                                                        # process-wide lock, 9 hold sites
$ uv run --frozen pytest tests/agent_server/test_issue4675_repro.py -q --no-cov
FAILED tests/agent_server/test_issue4675_repro.py::test_conversation_read_completes_while_another_conversation_starts - TimeoutError
1 failed, 12 warnings in 5.52s
```

The `TimeoutError` is exactly the reported behaviour: `get_event_service(A)` never
returns while B sits inside `_start_event_service` holding the process-wide lock.

**3 · Lint/type:**

```
$ uv run --frozen pre-commit run --files tests/agent_server/test_conversation_service.py
Ruff format ......... Passed
Ruff lint ........... Passed
PEP8 (pycodestyle) .. Passed
Type check (pyright)  Passed
```

## Video/Screenshots

Not applicable — no user-facing surface. The pass/fail transcripts above are the
evidence; the failing run against `611629e69` is what a screenshot would show.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

Test-only change. The bug fix itself shipped in #4570.

## Notes

- **#4675 can be closed by this PR.** If reviewers would rather close it as already
  fixed by #4570, this test still stands on its own as the missing guard.
- The issue notes it "does not claim to diagnose" OpenHands/OpenHands#16331
  (*file preview panel stops working during streaming*). This PR does not diagnose
  it either — if #16331 is still live on a build that contains #4570, the
  process-wide lock is not its mechanism and that investigation should continue
  separately.
- One serialization point is intentionally retained on `main`: registry-wide sweeps
  (`_evict_idle_conversations`, `prepare_for_sandbox_pause`, `__aexit__`) take
  `_exclusive_lifecycle()`, which blocks new per-conversation work while it drains.
  That matches #4675's own proposed fix ("keep a process-wide lock only for
  operations that genuinely mutate the service registry") and is not covered here.


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9523b2e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9523b2e-python \
  ghcr.io/openhands/agent-server:9523b2e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9523b2e-golang-amd64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-golang-amd64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-golang-amd64
ghcr.io/openhands/agent-server:9523b2e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9523b2e-golang-arm64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-golang-arm64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-golang-arm64
ghcr.io/openhands/agent-server:9523b2e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9523b2e-java-amd64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-java-amd64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-java-amd64
ghcr.io/openhands/agent-server:9523b2e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9523b2e-java-arm64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-java-arm64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-java-arm64
ghcr.io/openhands/agent-server:9523b2e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9523b2e-python-amd64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-python-amd64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-python-amd64
ghcr.io/openhands/agent-server:9523b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9523b2e-python-arm64
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-python-arm64
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-python-arm64
ghcr.io/openhands/agent-server:9523b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9523b2e-golang
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-golang
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-golang
ghcr.io/openhands/agent-server:9523b2e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9523b2e-java
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-java
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-java
ghcr.io/openhands/agent-server:9523b2e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9523b2e-python
ghcr.io/openhands/agent-server:9523b2e127e2847b9bb8ba985a9c263229c6b426-python
ghcr.io/openhands/agent-server:vasco-test-4675-conversation-read-not-serialized-python
ghcr.io/openhands/agent-server:9523b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9523b2e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9523b2e-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->