### PR TITLE
feat(agent-server): add INSTALL_ACP_PROVIDERS build arg

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -321,7 +321,11 @@ jobs:
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
             BASE_IMAGE: ${{ inputs.base_image != '' && inputs.base_image || matrix.base_image }}
-            INSTALL_ACP_PROVIDERS: ${{ inputs.install_acp_providers != '' && inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}
+            # github.event_name (not a blank-string check): a manual dispatch
+            # can legitimately pass an empty install_acp_providers ("install
+            # none"), which must be distinguishable from "no dispatch input at
+            # all" on push/pull_request events.
+            INSTALL_ACP_PROVIDERS: ${{ github.event_name == 'workflow_dispatch' && inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}
             CUSTOM_TAGS: ${{ matrix.variant }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -321,11 +321,12 @@ jobs:
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
             BASE_IMAGE: ${{ inputs.base_image != '' && inputs.base_image || matrix.base_image }}
-            # github.event_name (not a blank-string check): a manual dispatch
-            # can legitimately pass an empty install_acp_providers ("install
-            # none"), which must be distinguishable from "no dispatch input at
-            # all" on push/pull_request events.
-            INSTALL_ACP_PROVIDERS: ${{ github.event_name == 'workflow_dispatch' && inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}
+            # The maybe-empty value (inputs.install_acp_providers) must be the
+            # LAST operand: GitHub Actions' `A && B || C` collapses to C
+            # whenever B is falsy, so an explicit "" dispatch input ("install
+            # none") would silently fall through to the default if it sat in
+            # B's position instead.
+            INSTALL_ACP_PROVIDERS: ${{ github.event_name != 'workflow_dispatch' && 'claude-code,codex,gemini-cli' || inputs.install_acp_providers }}
             CUSTOM_TAGS: ${{ matrix.variant }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -22,6 +22,10 @@ on:
                 description: Target platforms
                 type: string
                 default: linux/amd64,linux/arm64
+            install_acp_providers:
+                description: Comma-separated ACP provider keys to bake into the image
+                type: string
+                default: claude-code,codex,gemini-cli
 
 permissions:
     contents: read
@@ -317,6 +321,7 @@ jobs:
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
             BASE_IMAGE: ${{ inputs.base_image != '' && inputs.base_image || matrix.base_image }}
+            INSTALL_ACP_PROVIDERS: ${{ inputs.install_acp_providers != '' && inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}
             CUSTOM_TAGS: ${{ matrix.variant }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}
@@ -402,6 +407,7 @@ jobs:
                       BASE_IMAGE=${{ env.BASE_IMAGE }}
                       OPENHANDS_BUILD_GIT_SHA=${{ env.SDK_SHA }}
                       OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}
+                      INSTALL_ACP_PROVIDERS=${{ env.INSTALL_ACP_PROVIDERS }}
 
             - name: Cleanup build context
               if: always()

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -13,6 +13,12 @@ ARG PORT=8000
 # to bundle google-cloud-aiplatform so the resulting binary supports
 # `vertex_ai/*` partner models (MiniMax, Qwen, Kimi MaaS endpoints).
 ARG ENABLE_VERTEX=0
+# Comma-separated ACP provider keys (see ACP_PROVIDERS in
+# openhands-sdk/openhands/sdk/settings/acp_providers.py) to bake into the
+# acp-providers stage below. The default reproduces the full provider set
+# shipped today; an unknown key fails the build rather than silently
+# installing nothing.
+ARG INSTALL_ACP_PROVIDERS=claude-code,codex,gemini-cli
 
 ####################################################################################
 # Builder (source mode)
@@ -92,6 +98,7 @@ RUN test -x /agent-server/dist/openhands-agent-server
 # the per-target-image fallback).
 ####################################################################################
 FROM python:3.13-bookworm AS acp-providers
+ARG INSTALL_ACP_PROVIDERS
 # A fresh top-level path, not nested under a directory (e.g. /opt) that base
 # images commonly already populate (SWE-bench images ship /opt/miniconda3):
 # COPY --from=<stage> only produces a byte-identical layer across different
@@ -100,12 +107,30 @@ FROM python:3.13-bookworm AS acp-providers
 # stage above.
 ENV ACP_NODE_DIR=/acp-node
 RUN set -eux; \
+    ACP_WRAPPER_DIR=/opt/acp-wrappers; \
+    mkdir -p "$ACP_NODE_DIR" "$ACP_WRAPPER_DIR"; \
+    PACKAGES=""; \
+    WRAPPER_BINS=""; \
+    for provider in $(echo "$INSTALL_ACP_PROVIDERS" | tr ',' ' '); do \
+      case "$provider" in \
+        claude-code) PACKAGES="$PACKAGES @agentclientprotocol/claude-agent-acp@0.63.0"; \
+          WRAPPER_BINS="$WRAPPER_BINS claude-agent-acp";; \
+        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.1.7"; \
+          WRAPPER_BINS="$WRAPPER_BINS codex-acp";; \
+        gemini-cli) PACKAGES="$PACKAGES @google/gemini-cli@0.46.0"; \
+          WRAPPER_BINS="$WRAPPER_BINS gemini";; \
+        *) echo "Unknown ACP provider '$provider' in INSTALL_ACP_PROVIDERS" \
+             "(expected one of: claude-code, codex, gemini-cli)" >&2; exit 1;; \
+      esac; \
+    done; \
+    if [ -z "$PACKAGES" ]; then \
+      echo "INSTALL_ACP_PROVIDERS is empty; no ACP providers will be installed"; \
+      exit 0; \
+    fi; \
     apt-get -o Acquire::Retries=5 update; \
     apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         ca-certificates curl xz-utils; \
     rm -rf /var/lib/apt/lists/*; \
-    ACP_WRAPPER_DIR=/opt/acp-wrappers; \
-    mkdir -p "$ACP_NODE_DIR" "$ACP_WRAPPER_DIR"; \
     ARCH=$(uname -m); \
     case "$ARCH" in \
       x86_64|amd64) NARCH=x64; NODE_SHA256=69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec;; \
@@ -119,11 +144,8 @@ RUN set -eux; \
     tar -xJ --strip-components=1 -C "$ACP_NODE_DIR" -f "$NODE_TARBALL"; \
     rm -f "$NODE_TARBALL"; \
     "$ACP_NODE_DIR/bin/node" --version; \
-    PATH="$ACP_NODE_DIR/bin:$PATH" "$ACP_NODE_DIR/bin/npm" install -g \
-        @agentclientprotocol/claude-agent-acp@0.63.0 \
-        @agentclientprotocol/codex-acp@1.1.7 \
-        @google/gemini-cli@0.46.0; \
-    for bin in claude-agent-acp codex-acp gemini; do \
+    PATH="$ACP_NODE_DIR/bin:$PATH" "$ACP_NODE_DIR/bin/npm" install -g $PACKAGES; \
+    for bin in $WRAPPER_BINS; do \
       printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
         "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \
         > "$ACP_WRAPPER_DIR/$bin"; \

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.logger import IN_CI, get_logger, rolling_log_view
+from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
 from openhands.sdk.workspace import PlatformType, TargetType
 
 
@@ -433,6 +434,27 @@ class BuildOptions(BaseModel):
             "(e.g., at each release)."
         ),
     )
+    install_acp_providers: str = Field(
+        default="claude-code,codex,gemini-cli",
+        description=(
+            "Comma-separated ACP provider keys (see ACP_PROVIDERS in "
+            "openhands-sdk/openhands/sdk/settings/acp_providers.py) to bake "
+            "into the image. Empty string installs none."
+        ),
+    )
+
+    @field_validator("install_acp_providers")
+    @classmethod
+    def _valid_install_acp_providers(cls, v: str) -> str:
+        unknown = [
+            p for p in (t.strip() for t in v.split(",")) if p and p not in ACP_PROVIDERS
+        ]
+        if unknown:
+            raise ValueError(
+                f"Unknown ACP provider(s) in install_acp_providers: "
+                f"{', '.join(unknown)}. Valid keys: {', '.join(ACP_PROVIDERS)}"
+            )
+        return v
 
     @property
     def short_sha(self) -> str:
@@ -834,6 +856,8 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
         f"OPENHANDS_BUILD_GIT_SHA={opts.git_sha}",
         "--build-arg",
         f"OPENHANDS_BUILD_GIT_REF={opts.git_ref}",
+        "--build-arg",
+        f"INSTALL_ACP_PROVIDERS={opts.install_acp_providers}",
     ]
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]
@@ -1051,6 +1075,14 @@ def main(argv: list[str]) -> int:
             "as v1 and v1.2) in output. Should only be used for release builds."
         ),
     )
+    parser.add_argument(
+        "--install-acp-providers",
+        default=_env("INSTALL_ACP_PROVIDERS", "claude-code,codex,gemini-cli"),
+        help=(
+            "Comma-separated ACP provider keys to bake into the image "
+            "(default from $INSTALL_ACP_PROVIDERS)."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -1080,6 +1112,7 @@ def main(argv: list[str]) -> int:
             prebuilt_sdist=args.prebuilt_sdist,
             arch=args.arch or None,
             include_versioned_tag=args.versioned_tag,
+            install_acp_providers=args.install_acp_providers,
         )
 
         # If running in GitHub Actions, write outputs directly to GITHUB_OUTPUT
@@ -1128,6 +1161,7 @@ def main(argv: list[str]) -> int:
         prebuilt_sdist=args.prebuilt_sdist,
         arch=args.arch or None,
         include_versioned_tag=args.versioned_tag,
+        install_acp_providers=args.install_acp_providers,
     )
     tags = build(opts)
 

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -1077,10 +1077,12 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--install-acp-providers",
-        default=_env("INSTALL_ACP_PROVIDERS", "claude-code,codex,gemini-cli"),
+        # os.environ.get, not _env(): an explicit empty string here means
+        # "install none" and must survive, but _env() treats blank as unset.
+        default=os.environ.get("INSTALL_ACP_PROVIDERS", "claude-code,codex,gemini-cli"),
         help=(
             "Comma-separated ACP provider keys to bake into the image "
-            "(default from $INSTALL_ACP_PROVIDERS)."
+            "(default from $INSTALL_ACP_PROVIDERS; empty string installs none)."
         ),
     )
 

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -572,6 +572,89 @@ def test_make_build_context_reuses_prebuilt_sdist_without_running_uv_build(
             shutil.rmtree(ctx, ignore_errors=True)
 
 
+def test_install_acp_providers_defaults_to_full_provider_set():
+    """Test that the default reproduces today's full ACP provider set."""
+    from openhands.agent_server.docker.build import BuildOptions
+
+    opts = BuildOptions()
+    assert opts.install_acp_providers == "claude-code,codex,gemini-cli"
+
+
+def test_install_acp_providers_rejects_unknown_provider():
+    """Test that an unknown provider key fails fast with a clear message."""
+    from pydantic import ValidationError
+
+    from openhands.agent_server.docker.build import BuildOptions
+
+    with pytest.raises(ValidationError, match="Unknown ACP provider.*bogus"):
+        BuildOptions(install_acp_providers="codex,bogus")
+
+
+def test_install_acp_providers_accepts_empty_list():
+    """Test that an empty provider list is valid (installs none)."""
+    from openhands.agent_server.docker.build import BuildOptions
+
+    opts = BuildOptions(install_acp_providers="")
+    assert opts.install_acp_providers == ""
+
+
+@pytest.mark.parametrize(
+    "install_acp_providers",
+    ["claude-code,codex,gemini-cli", "codex", ""],
+)
+def test_build_passes_install_acp_providers_build_arg(
+    tmp_path: Path, install_acp_providers: str
+):
+    """Test that build() forwards install_acp_providers as a --build-arg."""
+    from openhands.agent_server.docker.build import (
+        BuildOptions,
+        _default_sdk_project_root,
+        build,
+    )
+
+    ctx = tmp_path / "ctx"
+    ctx.mkdir()
+    docker_calls: list[tuple[list[str], str | None]] = []
+
+    def fake_run(cmd: list[str], cwd: str | None = None):
+        if cmd[:3] != ["docker", "buildx", "build"]:
+            raise AssertionError(f"unexpected command: {cmd}")
+        docker_calls.append((cmd, cwd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    opts = BuildOptions(
+        base_image="python:3.12",
+        custom_tags="python",
+        git_sha="abc1234567890",
+        git_ref="refs/heads/main",
+        push=False,
+        sdk_project_root=_default_sdk_project_root(),
+        install_acp_providers=install_acp_providers,
+    )
+
+    with (
+        patch(
+            "openhands.agent_server.docker.build._make_build_context",
+            return_value=ctx,
+        ),
+        patch("openhands.agent_server.docker.build._run", side_effect=fake_run),
+        patch(
+            "openhands.agent_server.docker.build._active_buildx_driver",
+            return_value="docker-container",
+        ),
+        patch(
+            "openhands.agent_server.docker.build._default_local_cache_dir",
+            return_value=tmp_path / "cache",
+        ),
+        patch("openhands.agent_server.docker.build.shutil.rmtree"),
+    ):
+        build(opts)
+
+    assert len(docker_calls) == 1
+    cmd = docker_calls[0][0]
+    assert f"INSTALL_ACP_PROVIDERS={install_acp_providers}" in cmd
+
+
 def test_build_with_prebuilt_sdist_preserves_tags_and_docker_args(tmp_path: Path):
     from openhands.agent_server.docker.build import (
         BuildOptions,

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -655,6 +655,40 @@ def test_build_passes_install_acp_providers_build_arg(
     assert f"INSTALL_ACP_PROVIDERS={install_acp_providers}" in cmd
 
 
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        (None, "claude-code,codex,gemini-cli"),
+        ("", ""),
+        ("codex", "codex"),
+    ],
+)
+def test_main_resolves_install_acp_providers_from_env(
+    monkeypatch, env_value: str | None, expected: str
+):
+    """Test that an explicit empty $INSTALL_ACP_PROVIDERS survives as empty,
+    rather than being coerced back to the default like an unset var would be.
+    """
+    from openhands.agent_server.docker import build as build_module
+
+    if env_value is None:
+        monkeypatch.delenv("INSTALL_ACP_PROVIDERS", raising=False)
+    else:
+        monkeypatch.setenv("INSTALL_ACP_PROVIDERS", env_value)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    captured = {}
+
+    def fake_build(opts):
+        captured["opts"] = opts
+        return []
+
+    monkeypatch.setattr(build_module, "build", fake_build)
+    build_module.main(["--load"])
+
+    assert captured["opts"].install_acp_providers == expected
+
+
 def test_build_with_prebuilt_sdist_preserves_tags_and_docker_args(tmp_path: Path):
     from openhands.agent_server.docker.build import (
         BuildOptions,

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -20,6 +20,19 @@ def test_server_workflow_passes_git_metadata_build_args() -> None:
     assert "OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}" in workflow_text
 
 
+def test_server_workflow_preserves_explicit_empty_install_acp_providers() -> None:
+    """An empty install_acp_providers dispatch input ("install none") must be
+    distinguishable from no dispatch input at all — a blank-string check
+    can't tell those apart, so the gate must key off the event type instead.
+    """
+    workflow_text = SERVER_WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "INSTALL_ACP_PROVIDERS: ${{ github.event_name == 'workflow_dispatch' "
+        "&& inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}"
+    ) in workflow_text
+
+
 def test_agent_server_binary_copies_openhands_distribution_metadata() -> None:
     """The frozen binary should preserve OpenHands package metadata."""
     spec_text = AGENT_SERVER_SPEC.read_text(encoding="utf-8")

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -20,17 +20,46 @@ def test_server_workflow_passes_git_metadata_build_args() -> None:
     assert "OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}" in workflow_text
 
 
-def test_server_workflow_preserves_explicit_empty_install_acp_providers() -> None:
-    """An empty install_acp_providers dispatch input ("install none") must be
-    distinguishable from no dispatch input at all — a blank-string check
-    can't tell those apart, so the gate must key off the event type instead.
+def test_server_workflow_contains_install_acp_providers_expression() -> None:
+    """Regression guard for the exact wording of the INSTALL_ACP_PROVIDERS env
+    line. This only proves the known-good string is present, not that it
+    evaluates correctly in GitHub Actions — see
+    test_and_or_shape_preserves_falsy_last_operand for the semantic proof.
     """
     workflow_text = SERVER_WORKFLOW.read_text(encoding="utf-8")
 
     assert (
-        "INSTALL_ACP_PROVIDERS: ${{ github.event_name == 'workflow_dispatch' "
-        "&& inputs.install_acp_providers || 'claude-code,codex,gemini-cli' }}"
+        "INSTALL_ACP_PROVIDERS: ${{ github.event_name != 'workflow_dispatch' "
+        "&& 'claude-code,codex,gemini-cli' || inputs.install_acp_providers }}"
     ) in workflow_text
+
+
+def test_and_or_shape_preserves_falsy_last_operand() -> None:
+    """GitHub Actions' `&&`/`||` share Python's `and`/`or` short-circuit
+    value-return semantics (return an operand, not a coerced bool), so this
+    exercises the exact `A && B || C` shape the workflow expression uses.
+
+    A prior version put the maybe-empty dispatch value in B's position:
+    `event_name == 'workflow_dispatch' && inputs.value || default`. That
+    collapses to `default` whenever `inputs.value` is falsy (e.g. an
+    intentional ""), because the trailing `|| default` fires again. Putting
+    the maybe-empty value last, gated by the negated condition, avoids the
+    second collapse since there is nothing after it to fall through to.
+    """
+
+    def resolve(is_dispatch: bool, dispatch_value: str) -> str:
+        default = "claude-code,codex,gemini-cli"
+        return (not is_dispatch and default) or dispatch_value
+
+    assert (
+        resolve(is_dispatch=False, dispatch_value="") == "claude-code,codex,gemini-cli"
+    )
+    assert resolve(is_dispatch=True, dispatch_value="") == ""
+    assert resolve(is_dispatch=True, dispatch_value="codex") == "codex"
+    assert (
+        resolve(is_dispatch=True, dispatch_value="claude-code,codex,gemini-cli")
+        == "claude-code,codex,gemini-cli"
+    )
 
 
 def test_agent_server_binary_copies_openhands_distribution_metadata() -> None:


### PR DESCRIPTION
HUMAN:

Step 2 of #4643: add a build arg that selects which ACP providers get baked into the agent-server image.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

#4651 (Steps 0–1 of #4643) moved the ACP provider payload into its own `acp-providers` stage, deduped across per-instance eval images. Today that stage always installs all three providers (Claude Code, Codex, Gemini CLI) unconditionally. Step 2 adds a single `INSTALL_ACP_PROVIDERS` build arg so a build can select a subset — without adding a boolean per provider, which is what the predecessor issue (#4067) got wrong.

## Summary

- `ARG INSTALL_ACP_PROVIDERS=claude-code,codex,gemini-cli` (global, re-declared in the `acp-providers` stage per the Dockerfile's `ENABLE_VERTEX` precedent). Comma-separated list using the SDK registry keys (`ACP_PROVIDERS` in `openhands-sdk/openhands/sdk/settings/acp_providers.py`) as the vocabulary — no second naming scheme.
- The `acp-providers` stage's install script now loops over the requested keys, mapping each to its pinned npm package + wrapper binary name (kept in sync with the registry, as documented in-file). An unrecognized key fails the build immediately with a clear message, before any network call. An empty list creates the two payload directories empty and skips the Node/npm install entirely — no conditional `COPY`, one code path.
- `openhands-agent-server/openhands/agent_server/docker/build.py`: new `--install-acp-providers` CLI flag (env fallback `$INSTALL_ACP_PROVIDERS`, same default as the Dockerfile) forwarded as a `--build-arg`, plus a `field_validator` on `BuildOptions` that checks membership against the live `ACP_PROVIDERS` registry (fails fast in Python before ever invoking `docker buildx build`).
- `.github/workflows/server.yml`: new `workflow_dispatch` input `install_acp_providers` (default matches the Dockerfile), threaded into `INSTALL_ACP_PROVIDERS` in the `build-and-push-image` job's env and its `build-args:` block.

**Note on scope:** the brief for this step asked to wire this "the same way as `ENABLE_VERTEX`," on the assumption that `ENABLE_VERTEX` is already plumbed through `build.py`'s `--build-arg` list and `server.yml`. It isn't — it's a Dockerfile-only `ARG`, unreachable from either file (verified by grepping both for `VERTEX`/`build-arg`; only `BASE_IMAGE`, `OPENHANDS_BUILD_GIT_SHA`, and `OPENHANDS_BUILD_GIT_REF` are actually wired today). Since this PR's explicit goal is "CI and local builds can both set it," I added real plumbing through both paths (mirroring how `BASE_IMAGE` is wired end-to-end) rather than leaving `INSTALL_ACP_PROVIDERS` equally unreachable. `ENABLE_VERTEX` itself is unchanged.

## Issue Number

Fixes (partially — Step 2 only) #4643

## How to Test

All builds below use `docker buildx build --target <target> -f openhands-agent-server/openhands/agent_server/docker/Dockerfile --build-arg INSTALL_ACP_PROVIDERS=<value> <context>` on a `docker-container` buildx driver. "Before" = this Dockerfile at the PR's base commit, a5d6a06d5 (#4651, unmodified); "after" = this PR.

### Default value reproduces today's image

Built the isolated `acp-providers` stage with `--output type=local` for both before and after (default `INSTALL_ACP_PROVIDERS`):

```
$ diff -rq <before>/opt/acp-wrappers <after-default>/opt/acp-wrappers
(no output — byte-identical)
$ grep version <before|after>/.../claude-agent-acp/package.json   → "0.63.0" (both)
$ grep version <before|after>/.../codex-acp/package.json          → "1.1.7" (both)
$ grep version <before|after>/.../gemini-cli/package.json         → same (both; sparse upstream file)
$ diff <(ls <before>/acp-node/bin) <(ls <after-default>/acp-node/bin)
(no output — identical: claude-agent-acp codex-acp corepack gemini node npm npx)
```

**Important finding, and why I'm not claiming a matching full-tree/layer digest:** a raw `diff -r` across the whole `/acp-node` tree between before and after-default showed hundreds of differing files, entirely inside transitive npm dependencies (e.g. `zod`). Before concluding anything, I ran a control experiment — rebuilding the literal *unchanged* pre-change Dockerfile a second time, 5 minutes later, with `--no-cache`:

```
$ diff -rq <before-run1> <before-run2> | wc -l
1264
```

Two builds of the identical, un-modified Dockerfile already diverge in 1264 files. This is pre-existing `npm install -g` non-determinism (none of the three packages' transitive dependencies are lockfile-pinned for a global install), not something this PR introduces. What this PR can and does prove unchanged at the default value: the exact npm package list/order passed to `npm install -g`, the pinned top-level versions actually resolved, and the generated wrapper scripts (byte-identical, shown above). A literal layer-digest match is not achievable for this stage today, on `main`, regardless of this PR.

### Subset (`codex` only)

```
$ docker buildx build --target acp-providers --build-arg INSTALL_ACP_PROVIDERS=codex --output type=local,dest=out .
$ ls out/acp-node/lib/node_modules/@agentclientprotocol/   → codex-acp
$ ls out/acp-node/lib/node_modules/@google/                → No such file or directory
$ ls out/opt/acp-wrappers/                                 → codex-acp
```

### Empty list

```
$ docker buildx build --target acp-providers --build-arg INSTALL_ACP_PROVIDERS= --output type=local,dest=out .
Successfully built in 0.1s (skips apt-get/curl/npm entirely)
$ find out/acp-node -mindepth 1        → (empty)
$ find out/opt/acp-wrappers -mindepth 1 → (empty)
```

Also built the full `base-image-minimal` target (not just the isolated stage) with the empty list to exercise the real compatibility-probe RUN step against real `/acp-node` content:

```
#16 RUN if ! "/acp-node/bin/node" --version ...
#16 0.056 Warning: ACP Node 22 runtime is not compatible with this base image ...
(build succeeds — probe degrades cleanly, no crash, as required)
```

### Unknown provider name

```
$ docker buildx build --target acp-providers --build-arg INSTALL_ACP_PROVIDERS=codex,bogus-provider .
#7 0.039 Unknown ACP provider 'bogus-provider' in INSTALL_ACP_PROVIDERS (expected one of: claude-code, codex, gemini-cli)
ERROR: process "..." did not complete successfully: exit code: 1
```
Fails in 39ms, before any network call.

### Full end-to-end sanity check

Built `base-image-minimal` with the default value and ran the resulting image:
```
$ docker run --rm --entrypoint sh acp-verify-default-probe -c 'which claude-agent-acp codex-acp gemini; codex-acp --version; gemini --version'
/usr/local/bin/claude-agent-acp
/usr/local/bin/codex-acp
/usr/local/bin/gemini
@agentclientprotocol/codex-acp 1.1.7
0.46.0
```

### Tests

```
$ uv run pytest tests/agent_server/test_docker_build.py tests/cross/test_agent_server_build_metadata.py -q
47 passed
$ uv run ruff check / ruff format --check   → clean
$ pre-commit (via git commit)               → all hooks passed, including pyright
```



<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:58a7435-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-58a7435-python \
  ghcr.io/openhands/agent-server:58a7435-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:58a7435-golang-amd64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-golang-amd64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-golang-amd64
ghcr.io/openhands/agent-server:58a7435-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:58a7435-golang-arm64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-golang-arm64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-golang-arm64
ghcr.io/openhands/agent-server:58a7435-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:58a7435-java-amd64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-java-amd64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-java-amd64
ghcr.io/openhands/agent-server:58a7435-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:58a7435-java-arm64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-java-arm64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-java-arm64
ghcr.io/openhands/agent-server:58a7435-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:58a7435-python-amd64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-python-amd64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-python-amd64
ghcr.io/openhands/agent-server:58a7435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:58a7435-python-arm64
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-python-arm64
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-python-arm64
ghcr.io/openhands/agent-server:58a7435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:58a7435-golang
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-golang
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-golang
ghcr.io/openhands/agent-server:58a7435-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:58a7435-java
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-java
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-java
ghcr.io/openhands/agent-server:58a7435-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:58a7435-python
ghcr.io/openhands/agent-server:58a74359d4404e8e85e96384f8fe242b71ef3805-python
ghcr.io/openhands/agent-server:acp-provider-set-build-arg-python
ghcr.io/openhands/agent-server:58a7435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `58a7435-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `58a7435-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->