### PR TITLE
fix(agent-server): stop fanning streaming deltas out to every subscriber

### DIFF
--- a/openhands-agent-server/openhands/agent_server/pub_sub.py
+++ b/openhands-agent-server/openhands/agent_server/pub_sub.py
@@ -14,11 +14,7 @@ T = TypeVar("T")
 
 
 class Subscriber[T](ABC):
-    # Streaming deltas arrive at token rate and are transport-only: they are
-    # published straight to the bus and never persisted to
-    # ConversationState.events. Consumers sized for conversation events opt in
-    # explicitly, so a subscriber added later cannot inherit that traffic --
-    # and the content it carries -- by default.
+    # Deltas arrive at token rate; consumers opt in rather than inherit them.
     receives_streaming_deltas: ClassVar[bool] = False
 
     @abstractmethod
@@ -91,17 +87,12 @@ class PubSub[T]:
         Subscribers are notified concurrently so a slow client cannot
         block delivery to others.  Each callback runs in its own
         error-handling wrapper to preserve fault isolation.
-        Streaming deltas go only to subscribers that set
-        ``receives_streaming_deltas``; see :class:`Subscriber`.
         Args:
             event: The event to pass to all callbacks
         """
-        is_delta = isinstance(event, StreamingDeltaEvent)
-        subscribers = [
-            (subscriber_id, subscriber)
-            for subscriber_id, subscriber in self._subscribers.items()
-            if subscriber.receives_streaming_deltas or not is_delta
-        ]
+        subscribers = list(self._subscribers.items())
+        if isinstance(event, StreamingDeltaEvent):
+            subscribers = [s for s in subscribers if s[1].receives_streaming_deltas]
         if not subscribers:
             return
 

--- a/openhands-agent-server/openhands/agent_server/pub_sub.py
+++ b/openhands-agent-server/openhands/agent_server/pub_sub.py
@@ -1,9 +1,10 @@
 import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import ClassVar, TypeVar
 from uuid import UUID, uuid4
 
+from openhands.sdk.event import StreamingDeltaEvent
 from openhands.sdk.logger import get_logger
 
 
@@ -13,6 +14,13 @@ T = TypeVar("T")
 
 
 class Subscriber[T](ABC):
+    # Streaming deltas arrive at token rate and are transport-only: they are
+    # published straight to the bus and never persisted to
+    # ConversationState.events. Consumers sized for conversation events opt in
+    # explicitly, so a subscriber added later cannot inherit that traffic --
+    # and the content it carries -- by default.
+    receives_streaming_deltas: ClassVar[bool] = False
+
     @abstractmethod
     async def __call__(self, event: T):
         """Invoke this subscriber"""
@@ -83,10 +91,17 @@ class PubSub[T]:
         Subscribers are notified concurrently so a slow client cannot
         block delivery to others.  Each callback runs in its own
         error-handling wrapper to preserve fault isolation.
+        Streaming deltas go only to subscribers that set
+        ``receives_streaming_deltas``; see :class:`Subscriber`.
         Args:
             event: The event to pass to all callbacks
         """
-        subscribers = list(self._subscribers.items())
+        is_delta = isinstance(event, StreamingDeltaEvent)
+        subscribers = [
+            (subscriber_id, subscriber)
+            for subscriber_id, subscriber in self._subscribers.items()
+            if subscriber.receives_streaming_deltas or not is_delta
+        ]
         if not subscribers:
             return
 

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -539,6 +539,10 @@ def _is_websocket_connected(websocket: WebSocket) -> bool:
 class _WebSocketSubscriber(Subscriber):
     """WebSocket subscriber for conversation events."""
 
+    # The live socket is what token streaming is for: this is the one consumer
+    # that wants deltas.
+    receives_streaming_deltas = True
+
     websocket: WebSocket
 
     async def __call__(self, event: Event):

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -539,8 +539,7 @@ def _is_websocket_connected(websocket: WebSocket) -> bool:
 class _WebSocketSubscriber(Subscriber):
     """WebSocket subscriber for conversation events."""
 
-    # The live socket is what token streaming is for: this is the one consumer
-    # that wants deltas.
+    # The live socket is what token streaming is for.
     receives_streaming_deltas = True
 
     websocket: WebSocket

--- a/tests/agent_server/telemetry/test_telemetry_subscriber.py
+++ b/tests/agent_server/telemetry/test_telemetry_subscriber.py
@@ -667,13 +667,7 @@ def test_is_automation_is_derived_from_allowlisted_tags(tags, is_automation):
 
 
 async def test_event_count_ignores_streaming_deltas(factory):
-    """``event_count_bucket`` must mean the same thing with streaming on or off.
-
-    The counter is incremented for every event the subscriber sees, and the
-    subscriber shares the bus that carries token deltas -- so the bucket used to
-    scale with model verbosity rather than conversation activity, making a
-    streamed and a non-streamed conversation incomparable.
-    """
+    """Deltas must not inflate event_count_bucket (regression for #4673)."""
     sink = CollectingSink()
     sub = make_subscriber(sink, factory)
     pub_sub: PubSub = PubSub()

--- a/tests/agent_server/telemetry/test_telemetry_subscriber.py
+++ b/tests/agent_server/telemetry/test_telemetry_subscriber.py
@@ -13,7 +13,11 @@ from openhands.agent_server.telemetry.subscriber import (
     ConversationTelemetryContext,
     TelemetrySubscriber,
 )
-from openhands.sdk.event import AgentErrorEvent, ConversationStateUpdateEvent
+from openhands.sdk.event import (
+    AgentErrorEvent,
+    ConversationStateUpdateEvent,
+    StreamingDeltaEvent,
+)
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.event.error_classification import ErrorClassification, FailureKind
 
@@ -660,3 +664,22 @@ def test_is_automation_is_derived_from_allowlisted_tags(tags, is_automation):
     )
 
     assert context.is_automation is is_automation
+
+
+async def test_event_count_ignores_streaming_deltas(factory):
+    """``event_count_bucket`` must mean the same thing with streaming on or off.
+
+    The counter is incremented for every event the subscriber sees, and the
+    subscriber shares the bus that carries token deltas -- so the bucket used to
+    scale with model verbosity rather than conversation activity, making a
+    streamed and a non-streamed conversation incomparable.
+    """
+    sink = CollectingSink()
+    sub = make_subscriber(sink, factory)
+    pub_sub: PubSub = PubSub()
+    pub_sub.subscribe(sub)
+
+    for _ in range(50):
+        await pub_sub(StreamingDeltaEvent(content="tok"))
+
+    assert sub._event_count == 0

--- a/tests/agent_server/test_event_streaming.py
+++ b/tests/agent_server/test_event_streaming.py
@@ -47,17 +47,10 @@ class _CollectorSubscriber(Subscriber):
         pass
 
 
-class _PlainSubscriber(Subscriber):
-    """Subscriber that keeps the default: it must never observe a delta."""
+class _PlainSubscriber(_CollectorSubscriber):
+    """Collector that keeps the default: it must never observe a delta."""
 
-    def __init__(self):
-        self.events: list[Event] = []
-
-    async def __call__(self, event: Event):
-        self.events.append(event)
-
-    async def close(self):
-        pass
+    receives_streaming_deltas = False
 
 
 @pytest.fixture
@@ -311,14 +304,7 @@ async def test_multiple_chunks_produce_multiple_events(event_service, tmp_path):
 
 @pytest.mark.asyncio
 async def test_deltas_only_reach_subscribers_that_opted_in(event_service, tmp_path):
-    """Deltas are transport-only, so the bus must not fan them out by default.
-
-    ``StreamingDeltaEvent`` is published straight to the shared ``PubSub``, which
-    used to notify every subscriber with no kind filter. That handed token-rate
-    traffic to consumers sized for conversation events -- webhooks POSTed each
-    delta and telemetry counted it. Delivery is opt-in so a subscriber added
-    later cannot inherit the behaviour by accident.
-    """
+    """Deltas reach only subscribers that opted in, never the rest of the bus."""
     streaming = _CollectorSubscriber()
     plain = _PlainSubscriber()
     event_service._pub_sub.subscribe(streaming)

--- a/tests/agent_server/test_event_streaming.py
+++ b/tests/agent_server/test_event_streaming.py
@@ -33,7 +33,22 @@ def _make_chunk(
 
 
 class _CollectorSubscriber(Subscriber):
-    """Subscriber that collects events for assertions."""
+    """Subscriber that opts into deltas and collects events for assertions."""
+
+    receives_streaming_deltas = True
+
+    def __init__(self):
+        self.events: list[Event] = []
+
+    async def __call__(self, event: Event):
+        self.events.append(event)
+
+    async def close(self):
+        pass
+
+
+class _PlainSubscriber(Subscriber):
+    """Subscriber that keeps the default: it must never observe a delta."""
 
     def __init__(self):
         self.events: list[Event] = []
@@ -292,3 +307,26 @@ async def test_multiple_chunks_produce_multiple_events(event_service, tmp_path):
     delta_events = [e for e in collector.events if isinstance(e, StreamingDeltaEvent)]
     assert len(delta_events) == 4
     assert [e.content for e in delta_events] == words
+
+
+@pytest.mark.asyncio
+async def test_deltas_only_reach_subscribers_that_opted_in(event_service, tmp_path):
+    """Deltas are transport-only, so the bus must not fan them out by default.
+
+    ``StreamingDeltaEvent`` is published straight to the shared ``PubSub``, which
+    used to notify every subscriber with no kind filter. That handed token-rate
+    traffic to consumers sized for conversation events -- webhooks POSTed each
+    delta and telemetry counted it. Delivery is opt-in so a subscriber added
+    later cannot inherit the behaviour by accident.
+    """
+    streaming = _CollectorSubscriber()
+    plain = _PlainSubscriber()
+    event_service._pub_sub.subscribe(streaming)
+    event_service._pub_sub.subscribe(plain)
+
+    callback = await _start_and_capture_callback(event_service, tmp_path)
+    callback(_make_chunk(content="Hello"))
+    await asyncio.sleep(0.05)
+
+    assert [e for e in streaming.events if isinstance(e, StreamingDeltaEvent)]
+    assert not [e for e in plain.events if isinstance(e, StreamingDeltaEvent)]

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -1565,13 +1565,7 @@ async def test_webhook_subscribe_errors_surface(tmp_path, monkeypatch):
 async def test_streaming_deltas_never_reach_webhook(
     mock_event_service, webhook_spec, sample_conversation_id
 ):
-    """A streamed response must not add a single POST over a non-streamed one.
-
-    Webhooks subscribe to the same bus that carries ``StreamingDeltaEvent``, so
-    before delivery became opt-in every token was enqueued and shipped -- a
-    continuous POST loop for the duration of each streamed response, carrying
-    unmasked model text to a configured endpoint.
-    """
+    """No StreamingDeltaEvent is enqueued or POSTed (regression for #4672)."""
     subscriber = WebhookSubscriber(
         conversation_id=sample_conversation_id,
         service=mock_event_service,
@@ -1581,8 +1575,7 @@ async def test_streaming_deltas_never_reach_webhook(
     pub_sub.subscribe(subscriber)
 
     with patch.object(subscriber, "_post_events", new_callable=AsyncMock) as post:
-        # Comfortably past event_buffer_size: a filter that only trimmed the
-        # batch would still flush here.
+        # Past event_buffer_size: an unfiltered queue would flush here.
         for _ in range(webhook_spec.event_buffer_size + 2):
             await pub_sub(StreamingDeltaEvent(content="tok"))
 

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -23,8 +23,10 @@ from openhands.agent_server.conversation_service import (
 )
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import StoredConversation
+from openhands.agent_server.pub_sub import PubSub
 from openhands.agent_server.utils import utc_now
-from openhands.sdk import LLM, Agent
+from openhands.sdk import LLM, Agent, Event
+from openhands.sdk.event import StreamingDeltaEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm.message import Message, TextContent
 from openhands.sdk.workspace import LocalWorkspace
@@ -1557,3 +1559,34 @@ async def test_webhook_subscribe_errors_surface(tmp_path, monkeypatch):
                 usage_id="webhook-error",
                 initial_text=None,
             )
+
+
+@pytest.mark.asyncio
+async def test_streaming_deltas_never_reach_webhook(
+    mock_event_service, webhook_spec, sample_conversation_id
+):
+    """A streamed response must not add a single POST over a non-streamed one.
+
+    Webhooks subscribe to the same bus that carries ``StreamingDeltaEvent``, so
+    before delivery became opt-in every token was enqueued and shipped -- a
+    continuous POST loop for the duration of each streamed response, carrying
+    unmasked model text to a configured endpoint.
+    """
+    subscriber = WebhookSubscriber(
+        conversation_id=sample_conversation_id,
+        service=mock_event_service,
+        spec=webhook_spec,
+    )
+    pub_sub: PubSub[Event] = PubSub()
+    pub_sub.subscribe(subscriber)
+
+    with patch.object(subscriber, "_post_events", new_callable=AsyncMock) as post:
+        # Comfortably past event_buffer_size: a filter that only trimmed the
+        # batch would still flush here.
+        for _ in range(webhook_spec.event_buffer_size + 2):
+            await pub_sub(StreamingDeltaEvent(content="tok"))
+
+        assert subscriber.queue == []
+        post.assert_not_called()
+
+    subscriber._cancel_flush_timer()


### PR DESCRIPTION
HUMAN:

Fixing a bug where we were publishing every delta instead of just the event.

---

AGENT:

## Why

`StreamingDeltaEvent` is published straight to the conversation `PubSub` (`event_service.py:1061`), and `PubSub.__call__` notified **every** registered subscriber with no kind filter. Making the delta an `Event` opted it into every consumer of the bus by default, so consumers sized for *conversation* events started receiving traffic proportional to *tokens*:

- **#4672** — `WebhookSubscriber.__call__` enqueues unconditionally, and `event_buffer_size` defaults to 5, so a streamed response became a continuous POST loop to the configured endpoint for its whole duration. Model output is not masked on the standard `Agent` path, so that text was leaving the process one fragment at a time.
- **#4673** — `TelemetrySubscriber._handle` increments `_event_count` *before* its `match`, so `event_count_bucket` scaled with model verbosity instead of conversation activity, making streamed and non-streamed conversations incomparable.

Same root cause, so one fix closes both.

## Summary

- Add `Subscriber.receives_streaming_deltas` (`ClassVar`, defaults to `False`) and consult it in `PubSub.__call__`: deltas are delivered only to subscribers that opt in.
- `_WebSocketSubscriber` opts in — the live socket is the one consumer token streaming exists for.
- Regression tests for both acceptance criteria, plus one for the central bus behaviour.

Delivery is **opt-in rather than opt-out** so a subscriber added later cannot inherit token-rate traffic — and the content it carries — by accident. This is option 2 from #4672 ("interim: a kind filter"); it does not preclude the epic's structural direction of taking deltas off the bus entirely.

## Issue Number

Fixes #4672
Fixes #4673

## How to Test

**End-to-end — real HTTP egress.** The script below runs a real HTTP receiver, a real `PubSub` and a real `WebhookSubscriber`, then publishes one streamed response (3 conversation events + 200 token deltas) with the production default `event_buffer_size=5`. It uses no new API, so it runs unchanged on `main`:

<details>
<summary><code>webhook_delta_e2e.py</code></summary>

```python
import asyncio, json, threading
from http.server import BaseHTTPRequestHandler, HTTPServer
from unittest.mock import MagicMock
from uuid import uuid4

from openhands.agent_server.config import WebhookSpec
from openhands.agent_server.conversation_service import WebhookSubscriber
from openhands.agent_server.pub_sub import PubSub
from openhands.sdk.event import StreamingDeltaEvent
from openhands.sdk.event.llm_convertible import MessageEvent
from openhands.sdk.llm.message import Message, TextContent

POSTS: list[list[dict]] = []

class Handler(BaseHTTPRequestHandler):
    def do_POST(self):
        n = int(self.headers.get("Content-Length", 0))
        POSTS.append(json.loads(self.rfile.read(n)))
        self.send_response(200); self.end_headers(); self.wfile.write(b"{}")
    def log_message(self, *a): pass

async def main():
    server = HTTPServer(("127.0.0.1", 0), Handler)
    port = server.server_address[1]
    threading.Thread(target=server.serve_forever, daemon=True).start()

    subscriber = WebhookSubscriber(
        conversation_id=uuid4(), service=MagicMock(),
        spec=WebhookSpec(base_url=f"http://127.0.0.1:{port}",
                         event_buffer_size=5, num_retries=0, flush_delay=0.05),
    )
    pub_sub = PubSub()
    pub_sub.subscribe(subscriber)

    def msg(i):
        return MessageEvent(source="user",
            llm_message=Message(role="user", content=[TextContent(text=f"turn {i}")]))

    n_conv, n_delta = 3, 200
    for i in range(n_conv):
        await pub_sub(msg(i))
        for _ in range(n_delta // n_conv):
            await pub_sub(StreamingDeltaEvent(content="tok "))

    await asyncio.sleep(0.4); await subscriber.close(); await asyncio.sleep(0.2)
    server.shutdown()

    delivered = [e for batch in POSTS for e in batch]
    deltas = [e for e in delivered if e.get("kind") == "StreamingDeltaEvent"]
    print(f"  HTTP POSTs sent  : {len(POSTS)}")
    print(f"  events delivered : {len(delivered)}")
    print(f"  DELTAS DELIVERED : {len(deltas)}")

asyncio.run(main())
```

</details>

```
$ uv run python webhook_delta_e2e.py     # on main (before)
  published        : 3 conversation events + ~200 deltas
  HTTP POSTs sent  : 41
  events delivered : 201
  DELTAS DELIVERED : 198

$ uv run python webhook_delta_e2e.py     # on this branch (after)
  published        : 3 conversation events + ~200 deltas
  HTTP POSTs sent  : 1
  events delivered : 3
  DELTAS DELIVERED : 0
```

`41 POSTs → 1`, and that single POST is exactly what the equivalent non-streamed response sends — which is acceptance criterion 1 of #4672.

**Unit tests.** Each fails on `main` and passes here:

```
$ uv run pytest \
    tests/agent_server/test_event_streaming.py::test_deltas_only_reach_subscribers_that_opted_in \
    tests/agent_server/test_webhook_subscriber.py::test_streaming_deltas_never_reach_webhook \
    tests/agent_server/telemetry/test_telemetry_subscriber.py::test_event_count_ignores_streaming_deltas -q

# on main:        3 failed
#   queue == []            -> AssertionError: Left contains 5 more items ...
#   sub._event_count == 0  -> AssertionError: assert 50 == 0
# on this branch: 3 passed
```

**Regression sweep.** Full agent-server suite plus pre-commit:

```
$ uv run pytest tests/agent_server/ -q
  2073 passed, 13 deselected in 269.61s

$ uv run pre-commit run --files <changed files>
  Ruff format / Ruff lint / pycodestyle / pyright /
  Check import dependency rules / Check Tool subclass registration ... Passed
```

## Video/Screenshots

Terminal output inline above — the before/after POST counts are the observable behaviour of this change.

## Design Doc

n/a — the change is 11 added lines of source across two files.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Metric discontinuity (#4673).** `event_count_bucket` will step down for streamed conversations once this lands. That is the correction, but it is still a break in the series — worth a heads-up to whoever consumes the dashboard rather than a silent change.
- **Why opt-in and not two `isinstance` guards.** #4672 offers either. Two guards fix today's two subscribers; the flag also protects the next one. There are currently five subscribers on this bus (`_EventSubscriber`, `AutoTitleSubscriber`, `WebhookSubscriber`, `TelemetrySubscriber`, `_WebSocketSubscriber`) and only the last wants deltas.
- **Idle eviction is unaffected.** `_EventSubscriber` calls `service.touch()` on every event, so it no longer sees deltas — but `is_idle_evictable()` already returns `False` whenever `_run_task` is active, and a streamed response is by definition an active run. Dropping deltas there also removes a `stored.updated_at` write per token.
- **`PubSub` stays generic.** The `isinstance` check is a no-op for `PubSub[BashEventBase]`; the pre-commit import-dependency rule passes.
- Does not close the epic's structural item (deltas off the bus entirely) or the unmasked-model-output issue #4678, which is a separate path.


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1f2aef9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1f2aef9-python \
  ghcr.io/openhands/agent-server:1f2aef9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1f2aef9-golang-amd64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-golang-amd64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-golang-amd64
ghcr.io/openhands/agent-server:1f2aef9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1f2aef9-golang-arm64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-golang-arm64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-golang-arm64
ghcr.io/openhands/agent-server:1f2aef9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1f2aef9-java-amd64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-java-amd64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-java-amd64
ghcr.io/openhands/agent-server:1f2aef9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1f2aef9-java-arm64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-java-arm64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-java-arm64
ghcr.io/openhands/agent-server:1f2aef9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1f2aef9-python-amd64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-python-amd64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-python-amd64
ghcr.io/openhands/agent-server:1f2aef9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1f2aef9-python-arm64
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-python-arm64
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-python-arm64
ghcr.io/openhands/agent-server:1f2aef9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1f2aef9-golang
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-golang
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-golang
ghcr.io/openhands/agent-server:1f2aef9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1f2aef9-java
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-java
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-java
ghcr.io/openhands/agent-server:1f2aef9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1f2aef9-python
ghcr.io/openhands/agent-server:1f2aef96cf7f7f20dacb79bf887a75c4792a6ed3-python
ghcr.io/openhands/agent-server:vasco-filter-streaming-deltas-from-subscribers-python
ghcr.io/openhands/agent-server:1f2aef9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1f2aef9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1f2aef9-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->