### PR TITLE
fix(mcp): map mcp SDK McpError to connection failure in probe

### DIFF
--- a/openhands-agent-server/openhands/agent_server/mcp_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_router.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 import anyio
 import httpx
+import mcp
 import mcp.types
 from fastapi import APIRouter, HTTPException, Request
 from fastmcp.client.auth.oauth import ClientNotFoundError, OAuth
@@ -611,6 +612,18 @@ def _probe_mcp_server(
         # denied") because the wrapper alone isn't useful.
         cause = exc.__cause__ or exc.__context__
         detail = str(cause) if cause else str(exc) or "Failed to connect to MCP server"
+        logger.info(
+            "MCP test connection failed for server %r: %s", request.name, detail
+        )
+        return MCPTestFailure(error=detail, error_kind="connection")
+    except mcp.McpError as exc:
+        # The ``mcp`` SDK raises ``McpError`` for transport-level failures that
+        # aren't OpenHands' own ``MCPError`` -- e.g. a Streamable HTTP server
+        # returning 404 for a request carrying an established session id, which
+        # the SDK surfaces as code 32600 "Session terminated". These are
+        # connection failures, not unexpected bugs, so classify them as such
+        # instead of leaking the raw type name through error_kind="unknown".
+        detail = str(exc) or "Failed to connect to MCP server"
         logger.info(
             "MCP test connection failed for server %r: %s", request.name, detail
         )

--- a/tests/agent_server/test_mcp_router.py
+++ b/tests/agent_server/test_mcp_router.py
@@ -10,6 +10,7 @@ from collections.abc import Generator
 from types import SimpleNamespace
 
 import anyio
+import mcp
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
@@ -409,6 +410,45 @@ def test_mcp_test_remote_unreachable(client: TestClient):
     body = response.json()
     assert body["ok"] is False
     assert body["error_kind"] in {"connection", "timeout"}
+
+
+def test_mcp_test_mcp_sdk_error_maps_to_connection_failure(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    """An ``mcp.McpError`` (e.g. Streamable HTTP "Session terminated") should
+    be reported as a connection failure, not as an unexpected error.
+
+    The ``mcp`` SDK raises ``McpError`` for transport-level failures such as a
+    server returning 404 for a request carrying an established session id
+    (surfaced as code 32600 "Session terminated"). These are ordinary
+    connection failures and should not fall through to ``error_kind="unknown"``.
+    """
+
+    def fake_create_mcp_tools(config, timeout=30.0, **kwargs):
+        raise mcp.McpError(mcp.ErrorData(code=32600, message="Session terminated"))
+
+    monkeypatch.setattr(
+        "openhands.agent_server.mcp_router.create_mcp_tools",
+        fake_create_mcp_tools,
+    )
+
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "name": "gitlab",
+            "server": {
+                "transport": "http",
+                "url": "https://gitlab.com/api/v4/mcp",
+            },
+            "timeout": 5.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error_kind"] == "connection"
+    assert "Session terminated" in body["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When testing an MCP server connection in Agent Canvas, an unauthenticated/terminated Streamable HTTP session surfaces as `McpError: Session terminated`, and the UI shows the unhelpful `Connection failed: McpError: Session terminated`.

The `mcp` Python SDK raises `mcp.McpError` for transport-level failures — e.g. a server returning **HTTP 404** for a request carrying an established `Mcp-Session-Id`, which the SDK translates to JSON-RPC code `32600` "Session terminated".

In `_probe_mcp_server()` the router only caught:
- `MCPTimeoutError` → `error_kind="timeout"`
- OpenHands' own `MCPError` → `error_kind="connection"`

An `mcp.McpError` is neither of those, so it fell through to the generic `except Exception` handler and got `error_kind="unknown"` with the raw `f"{type(exc).__name__}: {exc}"` message — which the frontend renders as `Connection failed: McpError: Session terminated`.

## Fix

Add a dedicated `except mcp.McpError` branch that returns `error_kind="connection"` with the underlying message, so a session/transport failure during the probe is reported as a normal connection failure instead of leaking the SDK exception type as an "unknown" error.

## Why this path specifically

This is the exact path taken when adding a GitLab (or any OAuth/SHTTP) MCP server in Agent Canvas: the OAuth handshake completes, but the subsequent MCP-session POST to the protected resource hits a 404/terminated state, and the probe returns the misleading `McpError: Session terminated`. It's a connection-level failure, not an unexpected internal error.

## Testing

Added `test_mcp_test_mcp_sdk_error_maps_to_connection_failure`, which mocks `create_mcp_tools` to raise `mcp.McpError(ErrorData(code=32600, message="Session terminated"))` and asserts the endpoint returns `error_kind="connection"` with `"Session terminated"` in the error. Full `tests/agent_server/test_mcp_router.py`: **25 passed**.

This PR was created by an AI agent (OpenHands) on behalf of jpelletier1.