### PR TITLE
fix(sdk): resolve structured builtin tool specs remotely

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -153,7 +153,12 @@ def resolve_tool(
         resolver = _REG.get(tool_spec.name)
 
     if resolver is None:
-        raise KeyError(f"ToolDefinition '{tool_spec.name}' is not registered")
+        from openhands.sdk.tool.builtins import BUILT_IN_TOOL_CLASSES
+
+        tool_class = BUILT_IN_TOOL_CLASSES.get(tool_spec.name)
+        if tool_class is None:
+            raise KeyError(f"ToolDefinition '{tool_spec.name}' is not registered")
+        resolver = _resolver_from_subclass(tool_spec.name, tool_class)
 
     params = dict(tool_spec.params)
     response_schema = params.pop("response_schema", None)

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -100,8 +100,18 @@ def test_reconciliation_targets_replaced_agent(tmp_path: Path) -> None:
 
     client._tools_reconciled_callback(cast(MCPClient, client), [replacement])
 
-    assert set(conversation.agent.tools_map) == {"replacement"}
-    assert set(old_agent.tools_map) == {"initial"}
+    updated_mcp_tools = {
+        name
+        for name, tool in conversation.agent.tools_map.items()
+        if isinstance(tool, MCPToolDefinition)
+    }
+    old_mcp_tools = {
+        name
+        for name, tool in old_agent.tools_map.items()
+        if isinstance(tool, MCPToolDefinition)
+    }
+    assert updated_mcp_tools == {"replacement"}
+    assert old_mcp_tools == {"initial"}
     conversation.close()
 
 

--- a/tests/sdk/conversation/test_utility_llm_span_metadata.py
+++ b/tests/sdk/conversation/test_utility_llm_span_metadata.py
@@ -18,26 +18,31 @@ METADATA_ATTRIBUTE_PREFIX = "lmnr.association.properties.metadata."
 
 
 def _record_observe_kwargs(unbound_method: Any) -> dict[str, Any]:
-    """Trigger the lazy ``observe`` build on a method and return the observe kwargs."""
+    """Return the ``observe`` kwargs declared on a lazily decorated method."""
     recorded: dict[str, Any] = {}
 
     def recorder(**kwargs: Any):
         recorded.update(kwargs)
-        # Identity: leaves the decorated function's cached wrapper equivalent to
-        # the undecorated function for the rest of the process.
         return lambda func: func
 
-    with (
-        patch("lmnr.observe", recorder),
-        patch(
+    with patch("lmnr.observe", recorder):
+        code = getattr(unbound_method, "__code__", None)
+        closure = getattr(unbound_method, "__closure__", None)
+        if code is not None and closure is not None:
+            freevars = dict(zip(code.co_freevars, closure, strict=False))
+            build_wrapped_cell = freevars.get("_build_wrapped")
+            if build_wrapped_cell is not None:
+                build_wrapped_cell.cell_contents(lambda: None)
+                return recorded
+
+        with patch(
             "openhands.sdk.observability.laminar.should_enable_observability",
             return_value=True,
-        ),
-    ):
-        try:
-            unbound_method(object())
-        except Exception:
-            pass
+        ):
+            try:
+                unbound_method(object())
+            except Exception:
+                pass
 
     return recorded
 

--- a/tests/sdk/tool/test_response_schema.py
+++ b/tests/sdk/tool/test_response_schema.py
@@ -12,6 +12,7 @@ from openhands.sdk.event import ActionEvent, Event
 from openhands.sdk.llm import MessageToolCall
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.tool import MCPToolDefinition
+from openhands.sdk.tool import registry
 from openhands.sdk.tool.builtins.finish import (
     FinishAction,
     FinishObservation,
@@ -74,6 +75,22 @@ def test_finish_tool_without_schema_is_unchanged():
     assert tool.response_schema is None
     schema = tool._get_tool_schema()
     assert set(schema["properties"]) == {"message", "summary"}
+
+
+def test_builtin_finish_tool_spec_resolves_without_registry_entry(monkeypatch):
+    response_schema = TaskResult.model_json_schema()
+    monkeypatch.delitem(registry._REG, FinishTool.__name__, raising=False)
+    monkeypatch.delitem(registry._USABILITY_REG, FinishTool.__name__, raising=False)
+
+    [tool] = resolve_tool(
+        Tool(name=FinishTool.__name__, params={"response_schema": response_schema}),
+        conv_state=MagicMock(),
+    )
+
+    assert isinstance(tool, FinishTool)
+    assert tool.name == "finish"
+    assert tool.response_schema == response_schema
+    assert "success" in tool._get_tool_schema()["properties"]
 
 
 def test_response_schema_extends_action_schema():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
This PR was created by an AI agent (OpenHands) on behalf of the user.

## Why

Automation preset runs can send an explicit structured `FinishTool` spec through a remote conversation. The client-side preset helper registers `FinishTool` locally, but the serialized tool spec is resolved in the agent-server process. If that server process has not registered the SDK built-in in the global tool registry, remote initialization fails with `ToolDefinition 'FinishTool' is not registered`.

## Summary

- Fall back to SDK built-in tool classes when resolving explicit `Tool(...)` specs that are not present in the process-local registry.
- Add a regression test proving structured `FinishTool` specs resolve without a registry entry.
- Make two existing SDK tests robust to environment/order-sensitive behavior discovered during the full SDK run.

## Issue Number

N/A

## How to Test

Commands run locally:

```bash
uv run pytest tests/sdk/tool/test_response_schema.py tests/sdk/tool/test_registry.py tests/tools/test_preset_default.py -q
uv run pytest tests/sdk/conversation/test_local_conversation_mcp.py -q
uv run pytest tests/sdk/conversation/test_utility_llm_span_metadata.py -q
uv run pytest $(cat /tmp/sdk-tail-files.txt) -q
uv run pre-commit run --files openhands-sdk/openhands/sdk/tool/registry.py tests/sdk/tool/test_response_schema.py tests/sdk/conversation/test_local_conversation_mcp.py tests/sdk/conversation/test_utility_llm_span_metadata.py
```

Results:

- Response schema / registry / preset tests: 42 passed.
- MCP conversation tests: 4 passed.
- Utility LLM span metadata tests: 4 passed.
- SDK tail from `tests/sdk/conversation/test_utility_llm_span_metadata.py` onward: 3928 passed, 7 skipped, 10 xfailed.
- Pre-commit passed for all changed files.

A full `uv run pytest tests/sdk -q` was also started after the MCP fix. It progressed past the original MCP failure and later exposed the utility span metadata order-sensitivity fixed in this PR.

## Video/Screenshots

N/A — backend SDK behavior covered by unit tests.

## Design Doc

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes


Structured response note: the fallback does not switch `FinishTool` back to unstructured mode. Remote conversations already serialize `response_schema` on the explicit `Tool(name="FinishTool", ...)` spec; this change only lets the server resolve that built-in spec before applying the schema.
Opened as draft because the PR template requires the human-only `HUMAN` section to be filled by a human before marking ready for review.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/325f68c0-761a-4144-bd1c-eb65f2d96f3b)
<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:da3389c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-da3389c-python \
  ghcr.io/openhands/agent-server:da3389c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:da3389c-golang-amd64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-golang-amd64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-golang-amd64
ghcr.io/openhands/agent-server:da3389c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:da3389c-golang-arm64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-golang-arm64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-golang-arm64
ghcr.io/openhands/agent-server:da3389c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:da3389c-java-amd64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-java-amd64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-java-amd64
ghcr.io/openhands/agent-server:da3389c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:da3389c-java-arm64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-java-arm64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-java-arm64
ghcr.io/openhands/agent-server:da3389c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:da3389c-python-amd64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-python-amd64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-python-amd64
ghcr.io/openhands/agent-server:da3389c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:da3389c-python-arm64
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-python-arm64
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-python-arm64
ghcr.io/openhands/agent-server:da3389c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:da3389c-golang
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-golang
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-golang
ghcr.io/openhands/agent-server:da3389c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:da3389c-java
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-java
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-java
ghcr.io/openhands/agent-server:da3389c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:da3389c-python
ghcr.io/openhands/agent-server:da3389c8b4864316152f06fef6fbe193ffd95492-python
ghcr.io/openhands/agent-server:fix-remote-structured-finish-tool-python
ghcr.io/openhands/agent-server:da3389c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `da3389c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `da3389c-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->