### PR TITLE
fix(acp): never inject workspace project skills into an ACP agent (#4019)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -514,13 +514,17 @@ async def materialize_agent_profile(
     mcp_config = settings.agent_settings.mcp_config
 
     # Discover skills off the event loop so the dry-run can report which skills
-    # (catalog minus ``disabled_skills``) resolve. Only OpenHands profiles carry
-    # user/public skills; ACP profiles do not. A discovery failure must not 500
+    # (catalog minus ``disabled_skills``) resolve. Mirrors the launch rule in
+    # ``conversation_service._resolve_agent_from_profile`` so the preview matches
+    # a real launch: an ACP profile is only given a catalog where the CLI cannot
+    # read the user's own configuration (#4019). A discovery failure must not 500
     # the preview: pass ``available_skills=None`` and surface the failure as its
     # own diagnostic below.
     discovery_error: str | None = None
     available_skills = None
-    if profile.agent_kind == "openhands":
+    if profile.agent_kind == "openhands" or (
+        config.acp_skill_sourcing == "openhands_managed"
+    ):
         try:
             available_skills = await asyncio.to_thread(discover_profile_skills)
         except Exception as exc:

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -27,6 +27,7 @@ CONFIG_PATH_ENV = "OPENHANDS_AGENT_SERVER_CONFIG_PATH"
 DEFAULT_CONFIG_PATH = Path("workspace/openhands_agent_server_config.json")
 # 20 minutes, matching the idle timeout used by OpenHands Cloud.
 DEFAULT_CONVERSATION_IDLE_TTL_SECONDS: Final[float] = 20 * 60.0
+ACPSkillSourcing = Literal["native", "openhands_managed"]
 _logger = logging.getLogger(__name__)
 
 
@@ -347,6 +348,20 @@ class Config(BaseModel):
         default_factory=_default_web_url,
         description=(
             "The URL where this agent server instance is available externally"
+        ),
+    )
+    acp_skill_sourcing: ACPSkillSourcing = Field(
+        default="native",
+        description=(
+            "Who supplies an ACP agent's skills. 'native' (the default, for a "
+            "host-local agent-server): nobody but the ACP CLI — it reads the "
+            "user's own home configuration and the repository, so OpenHands "
+            "injects none of its managed skills. 'openhands_managed' (for "
+            "container runtimes, where that host configuration is absent): also "
+            "inject the user/org/public/marketplace skills the server "
+            "discovers. Project/repository skills are never injected either way "
+            "— the CLI reads AGENTS.md itself (#4019). Set explicitly per "
+            "deployment; the agent-server image sets 'openhands_managed'."
         ),
     )
     registered_marketplaces: list[MarketplaceRegistration] = Field(

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -15,7 +15,7 @@ from weakref import WeakValueDictionary
 import httpx
 from pydantic import BaseModel
 
-from openhands.agent_server.config import Config, WebhookSpec
+from openhands.agent_server.config import ACPSkillSourcing, Config, WebhookSpec
 from openhands.agent_server.conversation_lease import (
     DEFAULT_LEASE_TTL_SECONDS,
     ConversationLeaseHeldError,
@@ -290,11 +290,53 @@ def _same_workspace(a: LocalWorkspace, b: LocalWorkspace) -> bool:
     return Path(a.working_dir).resolve() == Path(b.working_dir).resolve()
 
 
+def _apply_acp_skill_sourcing(
+    agent: "AgentBase", sourcing: ACPSkillSourcing
+) -> "AgentBase":
+    """Strip OpenHands-managed skills from an ACP agent under ``native`` sourcing.
+
+    A host-local ACP CLI reads the user's own skills from its home directory, so
+    a second, OpenHands-managed set injected into its prompt is at best noise —
+    and the catalog listing tells it to call ``invoke_skill``, a tool no ACP
+    agent has. Container runtimes set ``openhands_managed`` because that home
+    configuration is absent there. Project skills are excluded either way, by
+    ``ACPAgent`` itself (#4019).
+
+    A caller that sends ``agent`` / ``agent_settings`` puts its own skills on the
+    context, so the strip happens here rather than at profile resolution.
+    """
+    if sourcing != "native" or not isinstance(agent, ACPAgent):
+        return agent
+    context = agent.agent_context
+    if context is None:
+        return agent
+    if not (
+        context.skills
+        or context.load_user_skills
+        or context.load_public_skills
+        or context.registered_marketplaces
+    ):
+        return agent
+    return agent.model_copy(
+        update={
+            "agent_context": context.model_copy(
+                update={
+                    "skills": [],
+                    "load_user_skills": False,
+                    "load_public_skills": False,
+                    "registered_marketplaces": [],
+                }
+            )
+        }
+    )
+
+
 def _resolve_agent_from_profile(
     profile_id: "UUID",
     cipher: "Cipher | None",
     mcp_config: "dict[str, MCPServer]",
     load_memory: bool = False,
+    acp_skill_sourcing: ACPSkillSourcing = "native",
 ) -> "tuple[AgentBase, LaunchedAgentProfile]":
     """Load and resolve an agent profile by id, returning the built agent + provenance.
 
@@ -310,6 +352,9 @@ def _resolve_agent_from_profile(
             has no ``agent_context`` field, so the preference cannot ride the
             profile — it is stamped onto the resolved agent below, else a
             profile-launched conversation would silently ignore the setting.
+        acp_skill_sourcing: This deployment's ACP skill policy
+            (``Config.acp_skill_sourcing``).  Decides whether an ACP profile is
+            resolved with the server's managed skill catalog or with none.
 
     Raises:
         ProfileNotFound: No stored profile has ``profile_id``.
@@ -340,11 +385,15 @@ def _resolve_agent_from_profile(
         ) from exc
 
     # OpenHands profiles get the discovered catalog minus their ``disabled_skills``
-    # deny-list; ACP profiles carry no user/public skills so discovery is skipped.
-    # A genuine discovery failure fails the launch loudly rather than silently
-    # producing a zero-skill agent.
+    # deny-list. An ACP profile gets it only where the CLI cannot reach the user's
+    # own configuration (``openhands_managed``); under ``native`` it sources its
+    # own skills and OpenHands injects none (#4019). A genuine discovery failure
+    # fails the launch loudly rather than silently producing a zero-skill agent.
     available_skills = None
-    if profile.agent_kind == "openhands":
+    wants_skills = profile.agent_kind == "openhands" or (
+        acp_skill_sourcing == "openhands_managed"
+    )
+    if wants_skills:
         try:
             available_skills = discover_profile_skills()
         except Exception as exc:
@@ -641,6 +690,7 @@ class ConversationService:
     conversation_worktree_root: Path = field(
         default=Path("/tmp/conversation-worktrees")
     )
+    acp_skill_sourcing: ACPSkillSourcing = "native"
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_records: dict[UUID, _ConversationRecord] = field(
         default_factory=dict, init=False
@@ -1533,8 +1583,17 @@ class ConversationService:
                 self.cipher,
                 mcp_config,
                 load_memory=bool(stored_context and stored_context.load_memory),
+                acp_skill_sourcing=self.acp_skill_sourcing,
             )
             request = request.model_copy(update={"agent": resolved_agent})
+
+        request = request.model_copy(
+            update={
+                "agent": _apply_acp_skill_sourcing(
+                    request.agent, self.acp_skill_sourcing
+                )
+            }
+        )
 
         additions = request.agent_launch_additions
         suffix = (
@@ -2238,6 +2297,7 @@ class ConversationService:
             lease_ttl_seconds=config.lease_ttl_seconds,
             conversation_idle_ttl_seconds=config.conversation_idle_ttl_seconds,
             conversation_worktree_root=config.conversation_worktree_root,
+            acp_skill_sourcing=config.acp_skill_sourcing,
         )
 
     async def _start_event_service(

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -266,6 +266,9 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV OH_ENABLE_VNC=false
 ENV LOG_JSON=true
+# The ACP CLIs run without the user's host home here, so OpenHands supplies the
+# managed skill catalog they cannot read for themselves (#4019).
+ENV OH_ACP_SKILL_SOURCING=openhands_managed
 EXPOSE ${PORT}
 
 ####################################################################################
@@ -378,6 +381,9 @@ USER ${USERNAME}
 WORKDIR /
 ENV OH_ENABLE_VNC=false
 ENV LOG_JSON=true
+# The ACP CLIs run without the user's host home here, so OpenHands supplies the
+# managed skill catalog they cannot read for themselves (#4019).
+ENV OH_ACP_SKILL_SOURCING=openhands_managed
 EXPOSE ${PORT} ${NOVNC_PORT}
 
 

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1699,6 +1699,21 @@ class ACPAgent(AgentBase):
         ),
     )
 
+    @field_validator("agent_context")
+    @classmethod
+    def _drop_project_skills(cls, value: AgentContext | None) -> AgentContext | None:
+        """Clear ``load_project_skills`` — ACP CLIs read the repo themselves.
+
+        Claude Code, Codex and Gemini already ingest ``AGENTS.md`` / ``CLAUDE.md``
+        and their own project skills from the session cwd, so loading them here
+        too would put that content in the prompt twice. Normalised rather than
+        rejected: callers legitimately set the flag on a shared context they also
+        use for OpenHands agents (#4019).
+        """
+        if value is None or not value.load_project_skills:
+            return value
+        return value.model_copy(update={"load_project_skills": False})
+
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
         # Propagate the actual model name to the sentinel LLM and its

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -224,9 +224,9 @@ class ACPAgentProfile(AgentProfileBase):
         ),
     )
     # No skill-selection field: ACP agents own their tooling and prompt
-    # construction, so no user/public discovered skills are injected. (Only
-    # repo-scoped project skills reach an ACP agent, via the resolver's
-    # ``load_project_skills`` — see #4019 for whether even those should.)
+    # construction. Project skills never reach one (the CLI reads the repo
+    # itself, #4019); whether any managed skill does is a deployment choice the
+    # caller expresses through ``resolve_agent_profile``'s ``available_skills``.
     acp_server: ACPServerKind = Field(
         default="claude-code",
         description=(

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -261,18 +261,21 @@ def _build_openhands_settings(
 def _build_acp_settings(
     profile: ACPAgentProfile,
     mcp_config: dict[str, MCPServer],
+    managed_skills: list[Skill],
 ) -> AgentSettingsConfig:
     """Compose the resolved ``ACPAgentSettings`` from a profile.
 
     ``acp_command`` is stored as a shell string and split into the settings'
     token list. No credential is set — provider creds ride
-    ``state.secret_registry``. ACP profiles carry no user/public skills (the ACP
-    subprocess owns its context), so ``agent_context`` has no discovered skills;
-    it is always built (never ``None``) only so ``load_project_skills=True``
-    reaches ``LocalConversation``'s lazy load (``current_datetime=None`` matches
-    ACP's no-timestamp convention). Caveat: an ACP CLI that already ingests repo
-    files (e.g. AGENTS.md) may then see that content twice (#4019). A ``custom``
-    server has no default command, so one must be supplied.
+    ``state.secret_registry``.
+
+    ``load_project_skills`` stays ``False``: an ACP CLI reads ``AGENTS.md`` /
+    ``CLAUDE.md`` and its own project skills from the session cwd, so loading
+    them here would duplicate that content in the prompt (#4019).
+    ``managed_skills`` is what the *deployment* chose to inject — empty when the
+    ACP CLI can reach its own host configuration, non-empty in a container where
+    it cannot. ``current_datetime=None`` matches ACP's no-timestamp convention.
+    A ``custom`` server has no default command, so one must be supplied.
     """
     command = shlex.split(profile.acp_command) if profile.acp_command else []
     if profile.acp_server == "custom" and not command:
@@ -281,7 +284,7 @@ def _build_acp_settings(
             "default launch command to fall back to"
         )
     agent_context = AgentContext(
-        skills=[], current_datetime=None, load_project_skills=True
+        skills=managed_skills, current_datetime=None, load_project_skills=False
     )
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
@@ -313,10 +316,10 @@ def resolve_agent_profile(
     decrypted by the caller (the agent-server runs settings decryption
     before calling). ``available_skills`` is the server-discovered skill catalog
     (the agent-server caller passes the result of ``load_all_skills``); an
-    OpenHands profile keeps all of it except the names in ``disabled_skills``.
-    ``None`` means discovery was not run or failed: no catalog, so the resolved
-    agent gets no user/public skills (project skills, loaded separately by
-    ``LocalConversation``, are unaffected). Unlike the ``mcp_server_refs``
+    OpenHands profile keeps all of it except the names in ``disabled_skills``,
+    and an ACP profile keeps all of it (it has no deny-list). ``None`` means the
+    caller injected no catalog — discovery was not run, failed, or, for ACP, the
+    deployment leaves skill sourcing to the CLI. Unlike the ``mcp_server_refs``
     allow-list, the ``disabled_skills`` deny-list can never dangle, so this
     never raises for skills. ``cipher`` decrypts the referenced LLM profile.
 
@@ -340,7 +343,9 @@ def resolve_agent_profile(
             ) from e
         return _build_openhands_settings(profile, llm, filtered_mcp, filtered_skills)
 
-    return _build_acp_settings(profile, filtered_mcp)
+    return _build_acp_settings(
+        profile, filtered_mcp, _apply_disabled_skills(available_skills, [])
+    )
 
 
 def resolve_agent_profile_dry_run(
@@ -375,15 +380,17 @@ def resolve_agent_profile_dry_run(
             "MCP server(s) not configured: " + ", ".join(dangling)
         )
 
-    # Skill selection report (OpenHands only; ACP injects no user/public skills).
-    # Deny-list semantics: the catalog minus disabled names, never dangling.
+    # Skill selection report. Deny-list semantics: the catalog minus disabled
+    # names, never dangling. An ACP profile has no deny-list of its own — its
+    # catalog is whatever the deployment injects (empty unless the caller passes
+    # one), and never includes project skills (#4019).
     if isinstance(profile, OpenHandsAgentProfile):
         filtered_skills = _apply_disabled_skills(
             available_skills, profile.disabled_skills
         )
         diagnostics.disabled_skills = profile.disabled_skills
     else:
-        filtered_skills = []
+        filtered_skills = _apply_disabled_skills(available_skills, [])
     diagnostics.resolved_skills = [s.name for s in filtered_skills]
 
     llm: LLM | None = None
@@ -431,7 +438,7 @@ def resolve_agent_profile_dry_run(
                     profile, llm, filtered_mcp, filtered_skills
                 )
             else:
-                settings = _build_acp_settings(profile, filtered_mcp)
+                settings = _build_acp_settings(profile, filtered_mcp, filtered_skills)
             # No expose context => secrets redacted (mcp env/headers, llm api_key).
             diagnostics.resolved_settings = settings.model_dump(mode="json")
         except Exception as e:

--- a/tests/agent_server/test_acp_skill_sourcing.py
+++ b/tests/agent_server/test_acp_skill_sourcing.py
@@ -14,10 +14,10 @@ from unittest.mock import patch
 
 import pytest
 
-from openhands.agent_server.config import Config
+from openhands.agent_server.config import ACPSkillSourcing, Config
 from openhands.agent_server.conversation_service import _apply_acp_skill_sourcing
 from openhands.sdk import LLM, Agent, Conversation
-from openhands.sdk.agent import ACPAgent
+from openhands.sdk.agent import ACPAgent, AgentBase
 from openhands.sdk.context import AgentContext
 from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.settings.model import validate_agent_settings
@@ -63,7 +63,7 @@ def _workspace(root: Path) -> Path:
     return project
 
 
-def _installed_suffix(agent: ACPAgent, project: Path) -> str:
+def _installed_suffix(agent: AgentBase, project: Path) -> str:
     """The suffix ``init_state`` renders into the ACP subprocess's prompt.
 
     Only the subprocess spawn is stubbed; the render is the production one.
@@ -99,7 +99,7 @@ def test_openhands_agent_keeps_load_project_skills() -> None:
 
 @pytest.mark.parametrize("sourcing", ["native", "openhands_managed"])
 def test_repo_context_never_reaches_the_acp_prompt(
-    tmp_path: Path, sourcing: str
+    tmp_path: Path, sourcing: ACPSkillSourcing
 ) -> None:
     project = _workspace(tmp_path)
     agent = _apply_acp_skill_sourcing(

--- a/tests/agent_server/test_acp_skill_sourcing.py
+++ b/tests/agent_server/test_acp_skill_sourcing.py
@@ -1,0 +1,167 @@
+"""ACP skill sourcing: who supplies an ACP agent's skills (#4019).
+
+An ACP CLI reads ``AGENTS.md`` / ``CLAUDE.md`` and its own project skills from
+the session cwd, so OpenHands never injects those. Whether it injects its
+*managed* catalog is a per-deployment choice (``Config.acp_skill_sourcing``):
+a host-local CLI reaches the user's own configuration, one in a container
+cannot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openhands.agent_server.config import Config
+from openhands.agent_server.conversation_service import _apply_acp_skill_sourcing
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.agent import ACPAgent
+from openhands.sdk.context import AgentContext
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
+from openhands.sdk.settings.model import validate_agent_settings
+from openhands.sdk.skills import Skill
+
+
+AGENTS_MD_BODY = "sentinel-agents-md-body"
+MANAGED_SKILL = "managed-catalog-skill"
+
+
+def _managed_skill() -> Skill:
+    return Skill(
+        name=MANAGED_SKILL,
+        content="managed content",
+        description="from the server catalog",
+        source="public",
+        is_agentskills_format=True,
+    )
+
+
+def _acp_agent(**context_kwargs) -> ACPAgent:
+    settings = validate_agent_settings(
+        {
+            "agent_kind": "acp",
+            "acp_server": "claude-code",
+            "agent_context": AgentContext(**context_kwargs).model_dump(),
+        }
+    )
+    agent = settings.create_agent()
+    assert isinstance(agent, ACPAgent)
+    return agent
+
+
+def _workspace(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text(f"# Repo\n\n{AGENTS_MD_BODY}\n")
+    skill_dir = project / ".agents" / "skills" / "project-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: project-skill\ndescription: local\n---\n\nbody\n"
+    )
+    return project
+
+
+def _installed_suffix(agent: ACPAgent, project: Path) -> str:
+    """The suffix ``init_state`` renders into the ACP subprocess's prompt.
+
+    Only the subprocess spawn is stubbed; the render is the production one.
+    """
+    with patch.object(ACPAgent, "_start_acp_server", lambda self, state: None):
+        conversation = Conversation(agent=agent, workspace=str(project))
+        conversation._ensure_agent_ready()
+        agent_after_load = conversation.agent
+        assert isinstance(agent_after_load, ACPAgent)
+        return agent_after_load._installed_suffix or ""
+
+
+def test_config_defaults_to_native_sourcing() -> None:
+    assert Config().acp_skill_sourcing == "native"
+
+
+def test_acp_agent_clears_load_project_skills() -> None:
+    agent = _acp_agent(load_project_skills=True)
+    assert agent.agent_context is not None
+    assert agent.agent_context.load_project_skills is False
+
+
+def test_openhands_agent_keeps_load_project_skills() -> None:
+    """The guard is ACP-only — a regular agent still loads project skills."""
+    agent = Agent(
+        llm=LLM(model="gpt-4o", usage_id="agent"),
+        tools=[],
+        agent_context=AgentContext(load_project_skills=True),
+    )
+    assert agent.agent_context is not None
+    assert agent.agent_context.load_project_skills is True
+
+
+@pytest.mark.parametrize("sourcing", ["native", "openhands_managed"])
+def test_repo_context_never_reaches_the_acp_prompt(
+    tmp_path: Path, sourcing: str
+) -> None:
+    project = _workspace(tmp_path)
+    agent = _apply_acp_skill_sourcing(
+        _acp_agent(skills=[_managed_skill()], load_project_skills=True), sourcing
+    )
+    suffix = _installed_suffix(agent, project)
+    assert AGENTS_MD_BODY not in suffix
+    assert "project-skill" not in suffix
+
+
+def test_native_sourcing_strips_managed_skills(tmp_path: Path) -> None:
+    project = _workspace(tmp_path)
+    agent = _apply_acp_skill_sourcing(
+        _acp_agent(skills=[_managed_skill()], load_project_skills=True), "native"
+    )
+    assert agent.agent_context is not None
+    assert agent.agent_context.skills == []
+    assert MANAGED_SKILL not in _installed_suffix(agent, project)
+
+
+def test_managed_sourcing_keeps_managed_skills(tmp_path: Path) -> None:
+    project = _workspace(tmp_path)
+    agent = _apply_acp_skill_sourcing(
+        _acp_agent(skills=[_managed_skill()], load_project_skills=True),
+        "openhands_managed",
+    )
+    assert agent.agent_context is not None
+    assert [s.name for s in agent.agent_context.skills] == [MANAGED_SKILL]
+    assert MANAGED_SKILL in _installed_suffix(agent, project)
+
+
+def test_native_sourcing_clears_lazy_skill_sources() -> None:
+    """Flags and marketplace registrations resolve to skills later, so a strip
+    that only emptied ``skills`` would let them back in."""
+    agent = _apply_acp_skill_sourcing(
+        _acp_agent(
+            load_user_skills=True,
+            load_public_skills=True,
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="mkt", source="https://example.invalid/mkt.git"
+                )
+            ],
+        ),
+        "native",
+    )
+    context = agent.agent_context
+    assert context is not None
+    assert context.load_user_skills is False
+    assert context.load_public_skills is False
+    assert context.registered_marketplaces == []
+
+
+def test_native_sourcing_leaves_a_non_acp_agent_alone() -> None:
+    agent = Agent(
+        llm=LLM(model="gpt-4o", usage_id="agent"),
+        tools=[],
+        agent_context=AgentContext(skills=[_managed_skill()]),
+    )
+    assert _apply_acp_skill_sourcing(agent, "native") is agent
+
+
+def test_native_sourcing_is_a_no_op_without_skills() -> None:
+    agent = _acp_agent()
+    assert _apply_acp_skill_sourcing(agent, "native") is agent

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -45,6 +45,7 @@ from openhands.sdk.profiles.resolver import (
     ProfileNotFound,
 )
 from openhands.sdk.settings.model import ACPAgentSettings, OpenHandsAgentSettings
+from openhands.sdk.skills import Skill
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -288,6 +289,65 @@ class TestResolveAgentFromProfile:
         # No model_copy/mutation attempted on an ACP (non-OpenHandsAgentSettings)
         # resolved settings object.
         mock_config.model_copy.assert_not_called()
+
+    def test_acp_profile_skips_discovery_under_native_sourcing(self):
+        """A host-local ACP CLI reads the user's own skills from its home
+        directory, so the server injects none and skips discovery entirely
+        (#4019)."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_acp_profile()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(_DISCOVER_PATH, return_value=[Skill(name="a", content="x")]) as Disc,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            MockResolve.return_value = MagicMock()
+
+            _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config={}, acp_skill_sourcing="native"
+            )
+
+        Disc.assert_not_called()
+        assert MockResolve.call_args.kwargs["available_skills"] is None
+
+    def test_acp_profile_gets_catalog_under_managed_sourcing(self):
+        """In a container the CLI has no host home to read skills from, so the
+        server supplies its discovered catalog instead (#4019)."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_acp_profile()
+        catalog = [Skill(name="a", content="x")]
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(_DISCOVER_PATH, return_value=catalog) as Disc,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            MockResolve.return_value = MagicMock()
+
+            _resolve_agent_from_profile(
+                profile.id,
+                cipher=None,
+                mcp_config={},
+                acp_skill_sourcing="openhands_managed",
+            )
+
+        Disc.assert_called_once()
+        assert MockResolve.call_args.kwargs["available_skills"] == catalog
 
     def test_openhands_default_tools_get_browser_when_usable(self):
         """A default-toolset (tools=None) OpenHands profile launch injects the

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -372,11 +372,11 @@ def test_duplicate_named_catalog_is_deduped(
     assert skills == {"alpha": "second"}  # de-duped (last wins); beta disabled
 
 
-def test_acp_profile_gets_no_user_public_skills(
+def test_acp_profile_has_no_skill_selection_field(
     llm_store: LLMProfileStore,
 ) -> None:
-    # ACP profiles carry no skill field — the subprocess owns its context, so no
-    # user/public discovered skills are injected regardless of the catalog.
+    # An ACP profile selects no skills of its own: the catalog the caller passes
+    # is taken whole, since there is no deny-list to apply.
     acp = ACPAgentProfile(name="acp", acp_server="claude-code")
     assert not hasattr(acp, "skill_refs")
     assert not hasattr(acp, "disabled_skills")
@@ -385,6 +385,27 @@ def test_acp_profile_gets_no_user_public_skills(
         llm_store=llm_store,
         mcp_config={},
         available_skills=_discovered_skills(),
+        cipher=None,
+    )
+    assert isinstance(acp_settings, ACPAgentSettings)
+    assert acp_settings.agent_context is not None
+    assert {s.name for s in acp_settings.agent_context.skills} == {
+        "alpha",
+        "beta",
+        "gamma",
+    }
+
+
+def test_acp_profile_gets_no_skills_without_a_catalog(
+    llm_store: LLMProfileStore,
+) -> None:
+    # available_skills=None is how a deployment says "the ACP CLI sources its
+    # own skills" (#4019) — nothing is injected.
+    acp_settings = resolve_agent_profile(
+        ACPAgentProfile(name="acp", acp_server="claude-code"),
+        llm_store=llm_store,
+        mcp_config={},
+        available_skills=None,
         cipher=None,
     )
     assert isinstance(acp_settings, ACPAgentSettings)
@@ -590,13 +611,12 @@ def test_acp_blank_command_resolves_empty_list(
     assert settings.acp_args == []
 
 
-def test_acp_carries_no_user_public_skills_but_keeps_load_project_skills(
+def test_acp_never_loads_project_skills(
     llm_store: LLMProfileStore,
 ) -> None:
-    """ACP profiles inject no user/public discovered skills (the subprocess owns
-    its context), but ``agent_context`` is still constructed (never ``None``) so
-    ``load_project_skills=True`` reaches ``LocalConversation``'s lazy
-    project-skill load (#4016). ACP convention: no injected datetime."""
+    """An ACP CLI reads ``AGENTS.md`` and its own project skills from the session
+    cwd, so loading them here would duplicate that content in the prompt
+    (#4019). ACP convention: no injected datetime."""
     profile = ACPAgentProfile(name="acp", acp_server="claude-code")
     settings = resolve_agent_profile(
         profile,
@@ -607,8 +627,7 @@ def test_acp_carries_no_user_public_skills_but_keeps_load_project_skills(
     )
     assert isinstance(settings, ACPAgentSettings)
     assert settings.agent_context is not None
-    assert settings.agent_context.skills == []
-    assert settings.agent_context.load_project_skills is True
+    assert settings.agent_context.load_project_skills is False
     assert settings.agent_context.current_datetime is None
 
 
@@ -778,11 +797,11 @@ def test_dry_run_acp_reports_credential_channels_by_role(
     assert diag.resolved_settings is not None
 
 
-def test_dry_run_acp_reports_no_skills(
+def test_dry_run_acp_reports_the_injected_catalog(
     llm_store: LLMProfileStore,
 ) -> None:
-    # ACP profiles carry no skill field, so the dry-run reports no resolved
-    # skills regardless of the catalog, and stays valid.
+    # An ACP profile has no deny-list, so the dry-run reports whatever catalog
+    # the caller injected — and none when the caller injects nothing.
     profile = ACPAgentProfile(name="acp", acp_server="codex")
     diag = resolve_agent_profile_dry_run(
         profile,
@@ -792,8 +811,18 @@ def test_dry_run_acp_reports_no_skills(
         cipher=None,
     )
     assert diag.disabled_skills == []
-    assert diag.resolved_skills == []
+    assert set(diag.resolved_skills) == {"alpha", "beta", "gamma"}
     assert diag.valid is True
+
+    bare = resolve_agent_profile_dry_run(
+        profile,
+        llm_store=llm_store,
+        mcp_config={},
+        available_skills=None,
+        cipher=None,
+    )
+    assert bare.resolved_skills == []
+    assert bare.valid is True
 
 
 def test_dry_run_skill_verdict_matches_real_resolve(


### PR DESCRIPTION
HUMAN:

Implements the serving-mode direction I settled on in #4019 after the discussion with @enyst: ACP CLIs are full applications and OpenHands should not re-inject the repository context they already read for themselves.

---

AGENT:

## Why

`_build_acp_settings` set `load_project_skills=True` for ACP profiles, and clients (canvas/cloud) set the same flag on the `agent_settings` path. `LocalConversation` therefore loaded workspace project skills — `AGENTS.md`, `CLAUDE.md`, `.agents/skills/` — and `ACPAgent` rendered them into the subprocess's system-message suffix. Claude Code, Codex and Gemini already ingest those files natively from the session cwd, so the ACP agent saw the same content **twice**.

Reproducing it surfaced a second defect the issue did not name: the injected catalog emits
`To use a skill, call the invoke_skill(name="<skill-name>") tool` — and an ACP agent has **no tools at all** (`agent.tools == []`; `ACPAgent.init_state` raises if any are set). The prompt was instructing the CLI to call a tool that does not exist.

Both defects reproduce on the profile path *and* the `agent_settings` path, so a resolver-only fix would have left production untouched (the default canvas launch goes through `agent_settings`, not a profile).

## Summary

- `ACPAgent` clears `load_project_skills` on its `agent_context`. One guard at the ACP boundary covers every launch path — profile, `agent_settings`, and direct construction. Normalised rather than rejected, because callers legitimately set the flag on a context they also use for OpenHands agents.
- `Config.acp_skill_sourcing` (`native` | `openhands_managed`, default `native`) makes *managed*-skill injection explicit deployment configuration, per the design in #4019 — not a profile field, and not inferred from container detection. The agent-server image sets `OH_ACP_SKILL_SOURCING=openhands_managed`, since an ACP CLI in a container has no host home to read the user's own skills from.
- The resolver takes the injected catalog as a parameter instead of hard-coding `skills=[]`, so it stays policy-free; `conversation_service` and the `/materialize` preview apply the deployment's rule identically.

| Environment | Repo instructions (`AGENTS.md`) | OpenHands managed skills |
|---|---|---|
| Host-local agent-server | ACP CLI only | not injected |
| Agent Canvas Docker / SaaS | ACP CLI only | injected |

## Issue Number

Closes #4019

## How to Test

The suffix `ACPAgent` installs into the subprocess is readable without a live CLI — only `_start_acp_server` needs stubbing, so the render itself is the production one. Both scripts below are checked in as tests (`tests/agent_server/test_acp_skill_sourcing.py`), but they were first run standalone against a temp workspace containing `AGENTS.md`, `CLAUDE.md` and `.agents/skills/deploy-guide/SKILL.md`.

**Before** (`git stash` the change, then run the repro):

```
===== profile launch (resolve_agent_profile) =====
  agent.tools (ACP has none): []
  installed suffix bytes     : 1244
  LEAKED  AGENTS.md body
  LEAKED  CLAUDE.md body
  LEAKED  project skill 'deploy-guide'
  LEAKED  invoke_skill instruction
===== agent_settings launch (canvas/cloud shape) =====
  installed suffix bytes     : 1331
  LEAKED  AGENTS.md body
  LEAKED  CLAUDE.md body
  LEAKED  project skill 'deploy-guide'
  LEAKED  invoke_skill instruction
RESULT: REPRODUCED (duplication present)
```

The leaked suffix, verbatim:

```
<REPO_CONTEXT>
...
[BEGIN context from [agents]]
# Repo instructions
SENTINEL-AGENTS-MD-XYZZY
[END Context]
[BEGIN context from [claude]]
...
<SKILLS>
To use a skill, call the `invoke_skill(name="<skill-name>")` tool ...
<available_skills>
  <skill><name>deploy-guide</name><description>How to deploy</description></skill>
</available_skills>
</SKILLS>
```

**After**, same script:

```
===== profile launch (resolve_agent_profile) =====
  clean   AGENTS.md body
  clean   CLAUDE.md body
  clean   project skill 'deploy-guide'
  clean   invoke_skill instruction
===== agent_settings launch (canvas/cloud shape) =====
  clean   AGENTS.md body / CLAUDE.md body / project skill / invoke_skill
RESULT: FIXED (no duplication)
```

**Both modes × both launch paths**, driving the real `_resolve_agent_from_profile` and `_apply_acp_skill_sourcing`:

```
Config default acp_skill_sourcing: native
native (host-local agent-server):
  [PASS] agent_settings launch   repo_dup=False project_skill=False managed=False
openhands_managed (container runtime):
  [PASS] agent_settings launch   repo_dup=False project_skill=False managed=True
native (profile launch):
  [PASS] profile launch          repo_dup=False project_skill=False managed=False
openhands_managed (profile launch):
  [PASS] profile launch          repo_dup=False project_skill=False managed=True
RESULT: ALL PASS
```

**Env wiring** (`LiteralEnvParser`, so an invalid value falls back to the default):

```
$ OH_ACP_SKILL_SOURCING=openhands_managed python -c "...load_config().acp_skill_sourcing"
openhands_managed
$ OH_ACP_SKILL_SOURCING=bogus python -c "..."
native
```

**Suites** — `uv run pytest tests/agent_server tests/sdk -q`: `8062 passed`. The 2 failures in that run (`test_openapi_discriminator`, `test_conversation_large_event_handling`) are pre-existing and order-dependent: unmodified `origin/main` fails the identical two (`8049 passed`), and both pass in isolation with and without this change. `uv run pre-commit run --all-files`: all hooks pass (ruff, pycodestyle, pyright, import rules).

## Type

- [x] Bug fix

## Notes

- **Behaviour change for host-local deployments.** Under the default `native` sourcing, a host-local agent-server no longer injects OpenHands-managed skills into an ACP prompt — the CLI reads the user's own home configuration instead. That is the intended design (#4019); container runtimes keep today's behaviour through the image's `OH_ACP_SKILL_SOURCING=openhands_managed`. Any deployment that runs the agent-server outside this image and wants managed skills must set the variable.
- Clients still sending `load_project_skills: true` on an ACP `agent_context` (e.g. `buildAgentContext` in OpenHands/OpenHands) are now a harmless no-op. Cleaning that up client-side is a follow-up, not a prerequisite.
- Conversations already persisted with project skills merged into `agent_context.skills` keep them on resume; the suffix is installed once per session, so nothing new is injected. New conversations are clean.


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:16860c4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-16860c4-python \
  ghcr.io/openhands/agent-server:16860c4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:16860c4-golang-amd64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-golang-amd64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-golang-amd64
ghcr.io/openhands/agent-server:16860c4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:16860c4-golang-arm64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-golang-arm64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-golang-arm64
ghcr.io/openhands/agent-server:16860c4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:16860c4-java-amd64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-java-amd64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-java-amd64
ghcr.io/openhands/agent-server:16860c4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:16860c4-java-arm64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-java-arm64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-java-arm64
ghcr.io/openhands/agent-server:16860c4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:16860c4-python-amd64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-python-amd64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-python-amd64
ghcr.io/openhands/agent-server:16860c4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:16860c4-python-arm64
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-python-arm64
ghcr.io/openhands/agent-server:acp-skill-serving-mode-python-arm64
ghcr.io/openhands/agent-server:16860c4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:16860c4-golang
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-golang
ghcr.io/openhands/agent-server:acp-skill-serving-mode-golang
ghcr.io/openhands/agent-server:16860c4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:16860c4-java
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-java
ghcr.io/openhands/agent-server:acp-skill-serving-mode-java
ghcr.io/openhands/agent-server:16860c4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:16860c4-python
ghcr.io/openhands/agent-server:16860c4e836bd30a34fa123d92582469a8699109-python
ghcr.io/openhands/agent-server:acp-skill-serving-mode-python
ghcr.io/openhands/agent-server:16860c4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `16860c4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `16860c4-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->