### PR TITLE
fix(task): respect provider-required streaming in sub-agents

### DIFF
--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -363,7 +363,7 @@ class TaskManager:
         parent = self.parent_conversation
         parent_llm = parent.agent.llm
 
-        llm_updates: dict = {"stream": False}
+        llm_updates: dict = {"stream": parent_llm.requires_streaming}
         sub_agent_llm = parent_llm.model_copy(update=llm_updates)
         # Reset metrics such that the sub-agent has its own
         # Metrics object
@@ -371,9 +371,13 @@ class TaskManager:
 
         sub_agent = factory.factory_func(sub_agent_llm)
 
-        # ensuring that the sub-agent LLM has stream deactivated
+        # Keep streaming enabled when the selected child provider requires it.
         sub_agent = sub_agent.model_copy(
-            update={"llm": sub_agent.llm.model_copy(update={"stream": False})}
+            update={
+                "llm": sub_agent.llm.model_copy(
+                    update={"stream": sub_agent.llm.requires_streaming}
+                )
+            }
         )
         return sub_agent
 

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -302,6 +302,51 @@ class TestTaskManager:
         assert len(factory_called_with) == 1
         assert factory_called_with[0].stream is False
 
+    def test_sub_agent_preserves_parent_required_streaming(self, tmp_path):
+        """Provider-required streaming must reach the sub-agent factory."""
+        manager, parent = _manager_with_parent(tmp_path)
+        parent.agent.llm.is_subscription = True
+        factory_called_with: list[LLM] = []
+
+        def factory(llm: LLM) -> Agent:
+            factory_called_with.append(llm)
+            return Agent(llm=llm, tools=[])
+
+        register_agent(
+            name="streaming_expert",
+            factory_func=factory,
+            description="streaming expert",
+        )
+
+        agent = manager._get_sub_agent("streaming_expert")
+
+        assert factory_called_with[0].requires_streaming is True
+        assert factory_called_with[0].stream is True
+        assert agent.llm.stream is True
+
+    def test_sub_agent_preserves_child_required_streaming(self, tmp_path):
+        """A factory-selected provider's streaming requirement must be retained."""
+        manager, _ = _manager_with_parent(tmp_path)
+        child_llm = _make_llm()
+        child_llm.is_subscription = True
+        factory_called_with: list[LLM] = []
+
+        def factory(llm: LLM) -> Agent:
+            factory_called_with.append(llm)
+            return Agent(llm=child_llm, tools=[])
+
+        register_agent(
+            name="factory_streaming_expert",
+            factory_func=factory,
+            description="factory streaming expert",
+        )
+
+        agent = manager._get_sub_agent("factory_streaming_expert")
+
+        assert factory_called_with[0].stream is False
+        assert agent.llm.requires_streaming is True
+        assert agent.llm.stream is True
+
     def test_unknown_agent_type_raises(self, tmp_path):
         manager, _ = _manager_with_parent(tmp_path)
         with pytest.raises(ValueError, match="Unknown agent"):


### PR DESCRIPTION
HUMAN:

---

AGENT:

## Why

TaskManager currently forces `stream=False` both before invoking a sub-agent factory and after the factory returns. Providers whose transport requires streaming, including ChatGPT subscription-backed LLMs, then fail delegated tasks with `Stream must be set to true`.

## Summary

- Preserve `LLM.requires_streaming` when preparing the inherited LLM passed to a sub-agent factory.
- Preserve the effective child LLM's streaming requirement after the factory selects or loads its LLM.
- Add regressions for both construction points while retaining `stream=False` for ordinary providers.

## Issue Number

Fixes #4692

## How to Test

The regression tests exercise the real `TaskManager`, `LLM`, `Agent`, and registered factory paths without making an external model request:

```bash
uv run pytest tests/tools/task/test_task_manager.py -q
uv run pytest tests/tools/task tests/tools/delegate -q
make build
make pre-commit
```

All commands pass on this branch. The focused suite covers the parent-required streaming path and a factory-selected child provider that requires streaming.

## Video/Screenshots

Not applicable: this is a non-visual runtime behavior fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The existing non-streaming behavior is unchanged for providers where `requires_streaming` is false.