### PR TITLE
fix(sdk): strip inline reasoning from LLM-generated titles

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for generating conversation titles."""
 
+import re
 from collections.abc import Callable, Sequence
 
 from openhands.sdk.event import MessageEvent
@@ -57,6 +58,21 @@ def extract_first_user_message(events: Sequence[Event]) -> str | None:
                 return text
 
     return None
+
+
+_REASONING_BLOCK = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+_UNCLOSED_REASONING = re.compile(r"<think>.*", re.DOTALL | re.IGNORECASE)
+
+
+def strip_reasoning_blocks(text: str) -> str:
+    """Remove inline ``<think>`` reasoning from a model's text.
+
+    Providers that do not split chain-of-thought into ``reasoning_content`` return it
+    inline in ``content``. An unterminated block means the response was cut mid-thought,
+    so everything from the opening tag on is reasoning too.
+    """
+    text = _REASONING_BLOCK.sub("", text)
+    return _UNCLOSED_REASONING.sub("", text)
 
 
 def generate_title_with_llm(
@@ -132,7 +148,13 @@ def generate_title_with_llm(
         if response.message.content and isinstance(
             response.message.content[0], TextContent
         ):
-            title = response.message.content[0].text.strip()
+            title = strip_reasoning_blocks(response.message.content[0].text).strip()
+
+            if not title:
+                logger.warning(
+                    "LLM returned only reasoning content for title generation"
+                )
+                return None
 
             # Ensure the title isn't too long
             if len(title) > max_length:

--- a/tests/sdk/conversation/test_generate_title.py
+++ b/tests/sdk/conversation/test_generate_title.py
@@ -428,3 +428,45 @@ def test_title_uses_real_http_transport(title_http_server, tmp_path, mode):
     assert bool(body.get("stream")) == (mode == "subscription")
     if mode != "chat":
         assert body["store"] is False
+
+
+@patch("openhands.sdk.llm.llm.LLM.completion")
+def test_generate_title_strips_inline_reasoning(mock_completion):
+    """Guards #4530.
+
+    Providers that do not split chain-of-thought into `reasoning_content` return it
+    inline as `<think>...</think>`. The title is consumed verbatim, so without
+    stripping, truncation to `max_length` keeps the reasoning and discards the title.
+    """
+    llm = LLM(model="qwen3-32b", api_key=SecretStr("test-key"), usage_id="t")
+    mock_completion.return_value = create_mock_llm_response(
+        "<think>The user wants a CSV summary script. I will pick the features "
+        "emoji and keep it short.</think>✨ Summarise a CSV in Python"
+    )
+
+    title = generate_title_with_llm("Help me summarise a CSV", llm)
+
+    assert title == "✨ Summarise a CSV in Python"
+
+
+@patch("openhands.sdk.llm.llm.LLM.completion")
+def test_generate_title_strips_unterminated_reasoning(mock_completion):
+    """An unterminated block means the response was cut mid-thought, so there is no
+    title to salvage and the caller falls back to a truncated message title."""
+    llm = LLM(model="qwen3-32b", api_key=SecretStr("test-key"), usage_id="t")
+    mock_completion.return_value = create_mock_llm_response(
+        "<think>Let me consider what this conversation is really about"
+    )
+
+    assert generate_title_with_llm("Help me summarise a CSV", llm) is None
+
+
+@patch("openhands.sdk.llm.llm.LLM.completion")
+def test_generate_title_keeps_text_without_reasoning(mock_completion):
+    """A normal response is unaffected."""
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="t")
+    mock_completion.return_value = create_mock_llm_response("✨ Create Python Script")
+
+    assert generate_title_with_llm("Help me write a script", llm) == (
+        "✨ Create Python Script"
+    )


### PR DESCRIPTION
HUMAN:

Reproduced #4530 locally against a Qwen3 model served with mlx-lm: the autogenerated title came back as a truncated `<think>` block rather than the title the model actually produced. Fix and evidence below.

---

AGENT:

## Why

`generate_title_with_llm()` takes `response.message.content[0].text` verbatim. A reasoning model whose provider does not split chain-of-thought into `reasoning_content` returns it inline as `<think>…</think>`, so the reasoning becomes part of the title.

The truncation makes it worse than a cosmetic prefix. With the default `max_length=50`, the title is cut to the first 47 characters, which are all reasoning, so the actual title is discarded rather than merely preceded by noise.

## Summary

- Strip inline `<think>…</think>` blocks from the model's text before trimming and truncating.
- Treat an unterminated `<think>` as reasoning through to the end, since the response was cut mid-thought.
- Return `None` when nothing survives, so the caller falls back to its truncated-message title instead of storing an empty one.

## Issue Number

Fixes #4530

## Evidence

Reproduced against a real reasoning model rather than a fixture: `mlx-community/Qwen3-4B-4bit` on Metal via `mlx-lm`. It produced 1971 characters, verbatim:

```
<think>
Okay, the user wants a conversation title that starts with a message asking for
help summarizing a CSV in Python. The title needs to be concise, under 50
characters, and start with an emoji.

First, the main keywords here are "summarize CSV in Python". The emoji should
relate to coding or data. Maybe a 🧠 for thinking, but maybe a 📊 for data.
...
Help" with the emoji. So the final title would be "📊 Python CSV Summary Help".
</think>

📊 Python CSV Summary Help
```

Worth stating because it cuts against the result: MLX's own server does not exhibit this bug. It parses the thinking block into a separate field and returns clean `content`, so it is a well-behaved provider. What reproduces the bug is delivering that same model output in `content`, which is what the providers named in the issue do. The reasoning text above is real; the provider shape is the issue's.

Against `HEAD~1` of this branch, which is unmodified `main`:

```
real model output      : 1971 chars, <think> present: True
model's actual title   : '📊 Python CSV Summary Help'

title stored           : '<think>\nOkay, the user wants a conversation tit...'
length                 : 50   (max_length default 50)
leaks reasoning        : YES
matches model's title  : NO
```

Same input on this branch:

```
title stored           : '📊 Python CSV Summary Help'
length                 : 25   (max_length default 50)
leaks reasoning        : no
matches model's title  : yes
```

The model produced a perfectly good title. Before this change it was discarded, because truncation to `max_length` consumed the reasoning first and never reached it.

A second real-model observation that motivated handling unterminated blocks: asked for a title with a 220-token budget, the same model emitted `<think>` and hit the cap before closing it. A response cut mid-thought has no title to salvage, so stripping only balanced blocks would leave the opening tag and the reasoning behind it in the title.

## How to Test

```bash
uv sync
uv run pytest tests/sdk/conversation/test_generate_title.py -q
```

To see the behaviour rather than the assertions, check out `HEAD~1` of this branch (unmodified `main`), feed a response whose text is `<think>…</think>✨ Some Title` through `generate_title_with_llm`, and observe the stored title truncate to 50 characters of reasoning. On this branch the same input yields `✨ Some Title`.

Three tests added to `tests/sdk/conversation/test_generate_title.py`:

- inline reasoning is stripped and the intended title survives
- an unterminated block yields `None`, so the caller falls back
- a response with no reasoning is unchanged

Reverting only the source change turns the first two red and leaves the third green, which is the intended split: the third is a no-regression check, not a bug guard.

```
uv run pytest tests/sdk/conversation/test_generate_title.py   ->  12 passed
uv run pytest tests/sdk/conversation/                          ->  791 passed
uv run pytest tests/ -k title                                  ->  48 passed
uv run pre-commit run --files <changed>                        ->  ruff format, ruff lint,
                                                                   pycodestyle, pyright,
                                                                   import rules, tool registration
                                                                   all Passed
```

## Note on scope

`#4564` also touches `title_utils.py` but is about custom title prompts; I checked its diff for reasoning handling and there is none, so these are orthogonal beyond a possible textual conflict.





