### PR TITLE
fix(sdk): route async completions through RouterLLM.select_llm

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/router/base.py
+++ b/openhands-sdk/openhands/sdk/llm/router/base.py
@@ -13,7 +13,7 @@ from pydantic import (
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.llm.message import Message
-from openhands.sdk.llm.streaming import TokenCallbackType
+from openhands.sdk.llm.streaming import AnyTokenCallbackType, TokenCallbackType
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.tool import ToolDefinition
 
@@ -78,14 +78,7 @@ class RouterLLM(LLM):
             Summary field is always added to tool schemas for transparency and
             explainability of agent actions.
         """
-        # Select appropriate LLM
-        selected_model = self.select_llm(messages)
-        self.active_llm = self.llms_for_routing[selected_model]
-
-        logger.info(f"RouterLLM routing to {selected_model}...")
-
-        # Delegate to selected LLM.
-        return self.active_llm.completion(
+        return self._select_llm_for_request(messages).completion(
             messages=messages,
             tools=tools,
             add_security_risk_prediction=add_security_risk_prediction,
@@ -93,6 +86,47 @@ class RouterLLM(LLM):
             call_context=call_context,
             **kwargs,
         )
+
+    async def acompletion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: AnyTokenCallbackType | None = None,
+        call_context: LLMCallContext | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        """Async variant of :meth:`completion`, routed identically."""
+        return await self._select_llm_for_request(messages).acompletion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            call_context=call_context,
+            **kwargs,
+        )
+
+    def _select_llm_for_request(self, messages: list[Message]) -> LLM:
+        """Resolve the child LLM serving one request.
+
+        The selection is returned to the caller instead of being read back from
+        ``active_llm``, so concurrent calls choosing different children cannot
+        dispatch to each other's model.
+        """
+        selected_model = self.select_llm(messages)
+        if selected_model not in self.llms_for_routing:
+            raise ValueError(
+                f"{type(self).__name__}.select_llm() returned "
+                f"{selected_model!r}, which is not a key in llms_for_routing "
+                f"({sorted(self.llms_for_routing)})"
+            )
+        selected_llm = self.llms_for_routing[selected_model]
+
+        logger.info(f"RouterLLM routing to {selected_model}...")
+
+        # Kept in sync for backwards compatibility only; dispatch never reads it.
+        self.active_llm = selected_llm
+        return selected_llm
 
     @abstractmethod
     def select_llm(self, messages: list[Message]) -> str:

--- a/tests/sdk/llm/router/test_base.py
+++ b/tests/sdk/llm/router/test_base.py
@@ -1,0 +1,242 @@
+"""Routing behavior shared by the sync and async RouterLLM entry points."""
+
+import asyncio
+from collections.abc import Sequence
+
+import pytest
+from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse
+from pydantic import Field
+
+from openhands.sdk.llm import LLM, LLMResponse, Message, TextContent
+from openhands.sdk.llm.llm import LLMCallContext
+from openhands.sdk.llm.router import RouterLLM
+from openhands.sdk.llm.streaming import AnyTokenCallbackType, TokenCallbackType
+from openhands.sdk.llm.utils.metrics import MetricsSnapshot, TokenUsage
+from openhands.sdk.tool import Action, ToolDefinition
+
+
+class _RouterStubAction(Action):
+    text: str
+
+
+class _RouterStubTool(ToolDefinition):
+    @classmethod
+    def create(cls, *args, **kwargs) -> Sequence["_RouterStubTool"]:
+        return [cls(description="stub", action_type=_RouterStubAction)]
+
+
+def _response(model: str) -> LLMResponse:
+    return LLMResponse(
+        message=Message(role="assistant", content=[TextContent(text=model)]),
+        metrics=MetricsSnapshot(
+            model_name=model,
+            accumulated_cost=0.0,
+            max_budget_per_task=None,
+            accumulated_token_usage=TokenUsage(model=model),
+        ),
+        raw_response=ModelResponse(
+            id=f"{model}-id",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=LiteLLMMessage(content=model, role="assistant"),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion",
+        ),
+    )
+
+
+class _RecordingLLM(LLM):
+    """Child LLM that records its calls instead of contacting a provider."""
+
+    calls: list[dict] = Field(default_factory=list)
+    barrier: asyncio.Barrier | None = None
+
+    def completion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: TokenCallbackType | None = None,
+        call_context: LLMCallContext | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        self.calls.append(
+            {
+                "kind": "completion",
+                "messages": messages,
+                "tools": tools,
+                "add_security_risk_prediction": add_security_risk_prediction,
+                "on_token": on_token,
+                "call_context": call_context,
+                **kwargs,
+            }
+        )
+        return _response(self.model)
+
+    async def acompletion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: AnyTokenCallbackType | None = None,
+        call_context: LLMCallContext | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        if self.barrier is not None:
+            # Hold every caller here until all of them have been dispatched, so
+            # the assertions below run with both requests genuinely in flight.
+            await self.barrier.wait()
+        self.calls.append(
+            {
+                "kind": "acompletion",
+                "messages": messages,
+                "tools": tools,
+                "add_security_risk_prediction": add_security_risk_prediction,
+                "on_token": on_token,
+                "call_context": call_context,
+                **kwargs,
+            }
+        )
+        return _response(self.model)
+
+
+class _KeyedRouter(RouterLLM):
+    """Routes to the child named by the first message's text."""
+
+    def select_llm(self, messages: list[Message]) -> str:
+        content = messages[0].content[0]
+        assert isinstance(content, TextContent)
+        return content.text
+
+
+def _message(text: str) -> Message:
+    return Message(role="user", content=[TextContent(text=text)])
+
+
+def _router(**children: LLM) -> _KeyedRouter:
+    return _KeyedRouter(usage_id="router", llms_for_routing=dict(children))
+
+
+@pytest.fixture
+def children() -> dict[str, _RecordingLLM]:
+    return {
+        "primary": _RecordingLLM(model="primary-model", usage_id="primary"),
+        "secondary": _RecordingLLM(model="secondary-model", usage_id="secondary"),
+    }
+
+
+async def test_acompletion_routes_to_the_selected_child(children):
+    router = _router(**children)
+
+    result = await router.acompletion(messages=[_message("secondary")])
+
+    assert result.raw_response.model == "secondary-model"
+    assert [call["kind"] for call in children["secondary"].calls] == ["acompletion"]
+    assert children["primary"].calls == []
+
+
+def test_completion_routes_to_the_selected_child(children):
+    router = _router(**children)
+
+    result = router.completion(messages=[_message("secondary")])
+
+    assert result.raw_response.model == "secondary-model"
+    assert [call["kind"] for call in children["secondary"].calls] == ["completion"]
+    assert children["primary"].calls == []
+
+
+async def test_sync_and_async_reach_the_same_child(children):
+    router = _router(**children)
+
+    sync_result = router.completion(messages=[_message("primary")])
+    async_result = await router.acompletion(messages=[_message("primary")])
+
+    assert sync_result.raw_response.model == async_result.raw_response.model
+    assert [call["kind"] for call in children["primary"].calls] == [
+        "completion",
+        "acompletion",
+    ]
+
+
+async def test_concurrent_async_calls_do_not_cross_dispatch():
+    barrier = asyncio.Barrier(2)
+    router = _router(
+        primary=_RecordingLLM(
+            model="primary-model", usage_id="primary", barrier=barrier
+        ),
+        secondary=_RecordingLLM(
+            model="secondary-model", usage_id="secondary", barrier=barrier
+        ),
+    )
+
+    primary, secondary = await asyncio.gather(
+        router.acompletion(messages=[_message("primary")]),
+        router.acompletion(messages=[_message("secondary")]),
+    )
+
+    assert primary.raw_response.model == "primary-model"
+    assert secondary.raw_response.model == "secondary-model"
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_unknown_selector_key_fails_deterministically(children, is_async):
+    router = _router(**children)
+
+    with pytest.raises(ValueError, match="not a key in llms_for_routing"):
+        if is_async:
+            await router.acompletion(messages=[_message("missing")])
+        else:
+            router.completion(messages=[_message("missing")])
+
+    assert children["primary"].calls == []
+    assert children["secondary"].calls == []
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_call_arguments_reach_the_selected_child(children, is_async):
+    router = _router(**children)
+    tools = _RouterStubTool.create()
+    context = LLMCallContext()
+
+    def on_token(chunk):
+        return None
+
+    messages = [_message("primary")]
+    if is_async:
+        await router.acompletion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=True,
+            on_token=on_token,
+            call_context=context,
+            temperature=0.25,
+        )
+    else:
+        router.completion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=True,
+            on_token=on_token,
+            call_context=context,
+            temperature=0.25,
+        )
+
+    (call,) = children["primary"].calls
+    assert call["tools"] is tools
+    assert call["add_security_risk_prediction"] is True
+    assert call["on_token"] is on_token
+    assert call["call_context"] is context
+    assert call["temperature"] == 0.25
+
+
+async def test_active_llm_still_tracks_the_last_selection(children):
+    router = _router(**children)
+
+    await router.acompletion(messages=[_message("secondary")])
+
+    assert router.active_llm is children["secondary"]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
This is a fix on #4660 
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`RouterLLM` overrode only the synchronous `completion()`. `acompletion()` was
inherited from `LLM` unchanged, so normal async agent execution
(`Agent.astep()` → `LLM.acompletion()`) never routed at all: `select_llm()` was
never called and the request was issued against the router's own placeholder
model (`router_name`, e.g. `"router"`), which is not a real provider.

Two smaller problems came with it:

- Dispatch went through the shared Pydantic field `active_llm`
  (`self.active_llm = ...` immediately followed by `self.active_llm.completion(...)`),
  so concurrent calls could overwrite each other's selection between selection
  and use.
- An unknown key returned by a subclass's `select_llm()` surfaced as a bare
  `KeyError`.

## Summary

- `acompletion()` is now overridden on `RouterLLM` and routes identically to
  `completion()`, forwarding `tools`, `add_security_risk_prediction`,
  `on_token`, `call_context` and `**kwargs` unchanged (async uses
  `AnyTokenCallbackType`, matching `LLM.acompletion`).
- Both paths resolve the child through one `_select_llm_for_request()` helper
  that **returns** the selection, so dispatch never reads it back from
  `active_llm` and concurrent calls cannot cross-dispatch. `active_llm` is still
  written, purely for backwards compatibility.
- An unknown `select_llm()` key now raises a `ValueError` naming the key and the
  valid ones, instead of `KeyError`.
- Adds `tests/sdk/llm/router/test_base.py` — the router had no tests before.

Deliberately **not** changed, to keep this scoped to the reported bug:

- `__getattr__` still delegates to the first configured child rather than to
  `active_llm`. Making attribute access depend on that mutable field would
  reintroduce exactly the shared-state coupling this PR removes; the issue's
  suggested implementation keeps `active_llm` as a compatibility field only.
- `responses()` / `aresponses()` have the same missing-override shape and are
  still unrouted. Happy to fix here or in a follow-up — reviewer's call.

## Issue Number

Fixes #4660

## How to Test

**1. Standalone reproduction (no network, no API key).** Save as `repro_4660.py`:

```python
"""Reproduction for #4660: RouterLLM never routes on the async path."""

import asyncio

from openhands.sdk.llm import LLM, Message, TextContent
from openhands.sdk.llm.router import RouterLLM


class ProbeChild(LLM):
    """Child LLM that records that it was reached, without calling a provider."""

    reached: list[str] = []

    def completion(self, messages, **kwargs):
        self.reached.append(self.model)
        raise SystemExit(f"dispatched to {self.model}")

    async def acompletion(self, messages, **kwargs):
        self.reached.append(self.model)
        raise SystemExit(f"dispatched to {self.model}")


selections: list[str] = []


class ProbeRouter(RouterLLM):
    def select_llm(self, messages) -> str:
        selections.append("select_llm() ran")
        return "child"


child = ProbeChild(model="child-model", usage_id="child")
router = ProbeRouter(usage_id="router", llms_for_routing={"child": child})

print("RouterLLM overrides acompletion:", "acompletion" in vars(RouterLLM))

messages = [Message(role="user", content=[TextContent(text="hi")])]

selections.clear()
child.reached.clear()
try:
    router.completion(messages=messages)
except SystemExit:
    print(f"sync  -> select_llm calls={len(selections)}, child reached={child.reached}")

selections.clear()
child.reached.clear()
try:
    asyncio.run(router.acompletion(messages=messages))
except SystemExit:
    print(f"async -> select_llm calls={len(selections)}, child reached={child.reached}")
except Exception as exc:
    print(
        f"async -> select_llm calls={len(selections)}, child reached={child.reached}, "
        f"escaped to {type(exc).__name__}: {str(exc)[:90]}"
    )
```

Run `uv run python repro_4660.py`.

Before (at `9d143aac`, the merge-base):

```
RouterLLM overrides acompletion: False
sync  -> select_llm calls=1, child reached=['child-model']
async -> select_llm calls=0, child reached=[], escaped to LLMBadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are tryin
```

`select_llm` ran **zero** times on the async path, the configured child was
never reached, and the call went to the placeholder model `router` — hence
"LLM Provider NOT provided".

After (this branch):

```
RouterLLM overrides acompletion: True
sync  -> select_llm calls=1, child reached=['child-model']
async -> select_llm calls=1, child reached=['child-model']
```

**2. New unit tests.**

```
uv run pytest tests/sdk/llm/router/test_base.py -q
```

→ `9 passed in 0.08s`.

Reverting only `openhands-sdk/openhands/sdk/llm/router/base.py` and rerunning
gives `7 failed, 2 passed` — the 2 that still pass are the sync-only cases that
already worked. The 7 failures cover async routing, sync/async parity,
concurrent dispatch, deterministic failure on an unknown key, async argument
forwarding, and the `active_llm` compatibility assertion.

**3. Regression runs.**

```
uv run pytest tests/sdk -q            # 5980 passed, 7 skipped, 10 xfailed
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/router/base.py \
    tests/sdk/llm/router/test_base.py tests/sdk/llm/router/__init__.py
                                      # ruff-format, ruff-check, pycodestyle,
                                      # pyright, import rules, tool registration — all pass
uv run python .github/scripts/check_sdk_api_breakage.py
                                      # No breaking changes detected (all 3 packages)
```

## Video/Screenshots

N/A — SDK-internal change; console output above is the evidence.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **The `check_pr_description.py` gate will fail on this PR until a maintainer
  acts on #4660.** That issue was opened 2026-08-27 (after the
  `READY_FOR_DEV_ROLLOUT_ISO` cutoff of 2026-08-13) and does not carry
  `ready-for-dev`; the readiness bot asked for an `### Actual Behavior` section
  with a runnable reproduction. The bot parses the issue *body*, so a comment
  cannot clear it. I've posted the reproduction above on the issue for a
  maintainer to fold into the body.
- No public symbol is added or removed — `acompletion` is an override of an
  existing `LLM` method and `_select_llm_for_request` is private — so there is
  no deprecation-runway or version-bump implication.
- This touches model-selection behavior, so maintainers may want the
  `integration-test` label applied.
