### PR TITLE
fix(sdk): mask registered secrets at the tool chokepoint

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -344,6 +344,45 @@ class ExecutableTool(Protocol):
         ...
 
 
+def mask_observation_secrets(
+    observation: Observation, conversation: "LocalConversation | None"
+) -> Observation:
+    """Replace registered secret values in an observation's text content.
+
+    Every tool that declares an executor returns through
+    :meth:`ToolDefinition.__call__`, so masking here covers the whole tool
+    surface rather than the tools that remembered to call the registry. A tool
+    added later is covered without touching it.
+
+    Observations are immutable once built, so a masked one is a copy; an
+    observation with nothing to mask is returned unchanged.
+    """
+    if conversation is None:
+        return observation
+
+    state = getattr(conversation, "state", None)
+    registry = getattr(state, "secret_registry", None)
+    if registry is None:
+        return observation
+
+    masked_content = []
+    changed = False
+    for block in observation.content:
+        text = getattr(block, "text", None)
+        if not text:
+            masked_content.append(block)
+            continue
+        masked_text = registry.mask_secrets_in_output(text)
+        if masked_text != text:
+            block = block.model_copy(update={"text": masked_text})
+            changed = True
+        masked_content.append(block)
+
+    if not changed:
+        return observation
+    return observation.model_copy(update={"content": masked_content})
+
+
 class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
     """Base class for all tool implementations.
 
@@ -621,19 +660,23 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         # Coerce output only if we declared a model; else wrap in base Observation
         if self.observation_type:
             if isinstance(result, self.observation_type):
-                return result
-            return self.observation_type.model_validate(result)
+                observation = result
+            else:
+                observation = self.observation_type.model_validate(result)
         else:
             # When no output schema is defined, wrap the result in Observation
             if isinstance(result, Observation):
-                return result
+                observation = result
             elif isinstance(result, BaseModel):
-                return Observation.model_validate(result.model_dump())
+                observation = Observation.model_validate(result.model_dump())
             elif isinstance(result, dict):
-                return Observation.model_validate(result)
-            raise TypeError(
-                "Output must be dict or BaseModel when no output schema is defined"
-            )
+                observation = Observation.model_validate(result)
+            else:
+                raise TypeError(
+                    "Output must be dict or BaseModel when no output schema is defined"
+                )
+
+        return mask_observation_secrets(observation, conversation)
 
     async def acall(
         self, action: ActionT, conversation: "LocalConversation | None" = None

--- a/tests/sdk/tool/test_secret_masking_chokepoint.py
+++ b/tests/sdk/tool/test_secret_masking_chokepoint.py
@@ -1,0 +1,98 @@
+"""Registered secrets must be masked for every tool, not tool by tool.
+
+`ToolDefinition.__call__` is the single place every tool with an executor returns
+through, so masking there covers the whole tool surface. Masking inside individual
+tools is what left 12 of 13 packages handing raw secrets to the model.
+"""
+
+import os
+import tempfile
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.llm import LLM
+from openhands.sdk.tool.tool import ToolDefinition
+
+
+SECRET = "sk-test-secret-value-abcdef123456"
+
+# MCPToolDefinition overrides __call__ and masks on its own path
+# (openhands-sdk/openhands/sdk/mcp/tool.py). Anything else that overrides it
+# leaves the chokepoint and has to say how it masks instead.
+_OVERRIDES_ALLOWED_TO_BYPASS = {"MCPToolDefinition"}
+
+
+def _all_subclasses(cls):
+    for sub in cls.__subclasses__():
+        yield sub
+        yield from _all_subclasses(sub)
+
+
+@pytest.fixture
+def conversation():
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, ".env"), "w") as handle:
+            handle.write(f"API_KEY={SECRET}\n")
+        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test")
+        yield Conversation(
+            agent=Agent(llm=llm, tools=[]),
+            workspace=tmp,
+            persistence_dir=tmp,
+            secrets={"API_KEY": SECRET},
+        )
+
+
+def _observation_text(observation) -> str:
+    return " ".join(
+        block.text for block in observation.content if hasattr(block, "text")
+    )
+
+
+def test_file_editor_does_not_hand_the_model_a_raw_secret(conversation):
+    from openhands.tools.file_editor import FileEditorTool
+
+    tool = FileEditorTool.create(conv_state=conversation.state)[0]
+    target = os.path.join(conversation.state.workspace.working_dir, ".env")
+
+    observation = tool(tool.action_type(command="view", path=target), conversation)
+
+    text = _observation_text(observation)
+    assert SECRET not in text
+    assert "<secret-hidden>" in text
+
+
+def test_masking_is_skipped_without_a_conversation(conversation):
+    """A direct call with no conversation has no registry to mask against."""
+    from openhands.tools.file_editor import FileEditorTool
+
+    tool = FileEditorTool.create(conv_state=conversation.state)[0]
+    target = os.path.join(conversation.state.workspace.working_dir, ".env")
+
+    observation = tool(tool.action_type(command="view", path=target), None)
+
+    assert SECRET in _observation_text(observation)
+
+
+def test_no_tool_leaves_the_masking_chokepoint_unannounced():
+    """Fails when a tool starts overriding __call__ without arranging its own masking.
+
+    This is the property the per-tool approach could not give: a tool added later
+    is covered by default, and one that opts out of the chokepoint has to be named
+    here deliberately.
+    """
+    import openhands.tools  # noqa: F401  - import for subclass registration
+
+    overriding = {
+        sub.__name__
+        for sub in _all_subclasses(ToolDefinition)
+        if "__call__" in sub.__dict__
+    }
+
+    assert overriding <= _OVERRIDES_ALLOWED_TO_BYPASS, (
+        f"{sorted(overriding - _OVERRIDES_ALLOWED_TO_BYPASS)} override "
+        "ToolDefinition.__call__ and so bypass secret masking; mask on that path "
+        "or add the class here with a reason."
+    )


### PR DESCRIPTION
HUMAN:

Ran the new masking tests plus the existing tool suite; checked a registered secret is masked in the observation content and that an unregistered string is left alone.

---

AGENT:

## Why

Sweeping the tools package for masking call sites returns one file:

```
$ grep -rln "mask_secrets_in_output\|secret_registry" openhands-tools/openhands/tools/
openhands-tools/openhands/tools/terminal/impl.py
```

Twelve other tool packages hand their output to the model unmasked, so whether a registered secret is masked depends on which tool the model happened to pick.

`ToolDefinition.__call__` is the one place every tool with an executor returns through, and it already receives `conversation`. Masking there covers the whole tool surface instead of the tools that remembered — the property #4677 asks for, so tool #14 is covered by default rather than by remembering.

## Summary

- Mask registered secrets in `ToolDefinition.__call__`, against `Observation.content` — the base field every tool's text lands in, so the masking is not tool-specific. `acall` delegates to `__call__`, so the async path is covered.
- `terminal/impl.py` keeps its own masking: `TerminalExecutor` is also called directly, without going through `ToolDefinition`, and `test_terminal_executor_with_conversation_secrets` covers exactly that path. Masking twice is idempotent.
- Add `tests/sdk/tool/test_secret_masking_chokepoint.py`, including a structural test that fails when a class starts overriding `ToolDefinition.__call__` without arranging its own masking.

## Issue Number

Closes #4677

## How to Test

End-to-end against a real `Conversation` with a registered secret, no mocks:

```bash
cat > /tmp/repro.py <<'EOF'
import os, tempfile
from pydantic import SecretStr
from openhands.sdk.agent import Agent
from openhands.sdk.conversation import Conversation
from openhands.sdk.llm import LLM
from openhands.tools.file_editor import FileEditorTool

SECRET = "sk-super-secret-value-123456"
tmp = tempfile.mkdtemp()
env = os.path.join(tmp, ".env")
open(env, "w").write(f"API_KEY={SECRET}\n")

llm = LLM(model="gpt-4o-mini", api_key=SecretStr("k"), usage_id="t")
conv = Conversation(agent=Agent(llm=llm, tools=[]), workspace=tmp,
                    persistence_dir=tmp, secrets={"API_KEY": SECRET})
tool = FileEditorTool.create(conv_state=conv.state)[0]
obs = tool(tool.action_type(command="view", path=env), conv)
text = " ".join(c.text for c in obs.content if hasattr(c, "text"))
print("raw secret present:", SECRET in text)
print("mask marker present:", "<secret-hidden>" in text)
EOF
uv run python /tmp/repro.py
```

On `main`:

```
raw secret present: True
mask marker present: False
```

On this branch:

```
raw secret present: False
mask marker present: True
```

Same harness across the tools named in the acceptance criteria, and a call with `conversation=None` to confirm behaviour is unchanged when there is no registry:

```
file_editor    raw=False  masked_marker=True
grep(content)  raw=False
apply_patch    raw=False
no conversation -> raw retained: True
```

Note on the issue text: `grep` and `glob` are listed there next to `file_editor`, but both return only file paths, never matched line content —

```
Found 1 file(s) containing pattern 'token' in '/tmp/...'
/tmp/.../cfg.txt
```

so they are covered by construction rather than because they were leaking. `file_editor` is the reproducible leak.

Suites:

```bash
uv run pytest tests/sdk/tool/ tests/cross/test_agent_secrets_integration.py \
              tests/tools/terminal/test_secrets_masking.py -q
# 221 passed

uv run ruff check && uv run ruff format --check
# clean
```

The new `test_file_editor_does_not_hand_the_model_a_raw_secret` fails on `main` with

```
assert 'sk-test-sec...abcdef123456' not in "Here's the ...\n     2\t\n"
```

## Video/Screenshots

Not applicable — no GUI surface; the console transcripts above are the evidence.

## Design Doc

Not added; the change is one function and one call site.

