### PR TITLE
fix(sdk): match nested repo paths by ancestry, not string prefix

### DIFF
--- a/openhands-sdk/openhands/sdk/git/git_changes.py
+++ b/openhands-sdk/openhands/sdk/git/git_changes.py
@@ -224,17 +224,15 @@ def get_git_changes(cwd: str | Path, ref: str | None = None) -> list[GitChange]:
     # First try the workspace directory
     changes = get_changes_in_repo(cwd, ref=ref)
 
-    # Filter out any changes which are in one of the git directories
+    # Filter out any changes which are inside one of the nested repositories.
+    # This compares path ancestry rather than string prefixes: a nested
+    # repository named "foo" must not swallow a root-repository change to
+    # "foobar/file.py" or "foo-config.yaml", which merely share its name as a
+    # prefix.
     changes = [
         change
         for change in changes
-        if next(
-            iter(
-                git_dir for git_dir in git_dirs if str(change.path).startswith(git_dir)
-            ),
-            None,
-        )
-        is None
+        if not any(Path(change.path).is_relative_to(git_dir) for git_dir in git_dirs)
     ]
 
     # Add changes from git directories

--- a/tests/sdk/git/test_git_changes.py
+++ b/tests/sdk/git/test_git_changes.py
@@ -718,3 +718,55 @@ def test_get_changes_in_repo_no_remote_worktree_shows_committed_changes():
         assert changes == [
             GitChange(status=GitChangeStatus.UPDATED, path=Path("app.txt"))
         ]
+
+
+def test_get_git_changes_keeps_paths_that_merely_share_a_nested_repo_prefix():
+    """A nested repository named "foo" must not swallow "foobar/" or "foo-config".
+
+    The nested-repository filter compares path ancestry; matching on the string
+    prefix instead drops root-repository changes whose names start with the
+    nested repository's name, and they disappear from the result silently.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "README.md").write_text("base\n")
+        run_bash_command("git add -A && git commit -m init", temp_dir)
+
+        nested = Path(temp_dir) / "foo"
+        nested.mkdir()
+        setup_git_repo(str(nested))
+        (nested / "nested.txt").write_text("nested\n")
+        run_bash_command("git add -A && git commit -m init", str(nested))
+
+        # Root-repository changes that share "foo" as a prefix but are not in it
+        (Path(temp_dir) / "foobar").mkdir()
+        (Path(temp_dir) / "foobar" / "file.py").write_text("changed\n")
+        (Path(temp_dir) / "foo-config.yaml").write_text("changed\n")
+        (Path(temp_dir) / "README.md").write_text("changed\n")
+
+        paths = {str(change.path) for change in get_git_changes(temp_dir)}
+
+        assert "foobar/file.py" in paths
+        assert "foo-config.yaml" in paths
+        assert "README.md" in paths
+
+
+def test_get_git_changes_still_excludes_paths_inside_a_nested_repo():
+    """The filter must keep doing its job: real nested changes stay out."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "README.md").write_text("base\n")
+        run_bash_command("git add -A && git commit -m init", temp_dir)
+
+        nested = Path(temp_dir) / "foo"
+        nested.mkdir()
+        setup_git_repo(str(nested))
+        (nested / "nested.txt").write_text("nested\n")
+        run_bash_command("git add -A && git commit -m init", str(nested))
+        (nested / "nested.txt").write_text("changed in nested\n")
+
+        changes = get_git_changes(temp_dir)
+        nested_entries = [c for c in changes if str(c.path) == "foo/nested.txt"]
+
+        # Reported once, by the nested repository, not by the parent.
+        assert len(nested_entries) == 1


### PR DESCRIPTION
HUMAN:

Checked a nested repo under a parent whose path is a string prefix of it: the child's changes no longer get swallowed. Existing git_changes tests still pass.

---

AGENT:

## Why

`get_git_changes()` decides a change belongs to a nested repository by string prefix:

```python
if str(change.path).startswith(git_dir)
```

That is not directory containment. With a nested repository named `foo`, the root-repository changes `foobar/file.py` and `foo-config.yaml` both match and are dropped, with nothing logged — the agent simply does not see files it changed.

## Summary

- Compare path ancestry with `Path.is_relative_to` instead of `str.startswith`.
- The rewritten filter also reads as what it does; the previous `next(iter(...), None) is None` spelling was doing an `any()`.
- Two tests in `tests/sdk/git/test_git_changes.py`: one for the prefix-sharing paths, one pinning that changes genuinely inside a nested repository are still excluded and reported once.

## Issue Number

Closes #4662

## How to Test

Build a repository with a nested repo named `foo` plus two root changes that share that prefix:

```bash
W=$(mktemp -d); cd "$W"
git init -q . && git config user.email a@b.c && git config user.name t
mkdir -p foo foobar && echo base > README.md
git add -A && git commit -qm init

cd foo && git init -q . && git config user.email a@b.c && git config user.name t
echo nested > nested.txt && git add -A && git commit -qm init && cd ..

echo changed > foobar/file.py
echo changed > foo-config.yaml
echo changed > README.md

uv run python -c "
from openhands.sdk.git.git_changes import get_git_changes
for c in get_git_changes('$W'):
    print(c.status.value, c.path)
"
```

On `main`:

```
UPDATED README.md
```

`foobar/file.py` and `foo-config.yaml` are gone.

On this branch:

```
UPDATED README.md
ADDED   foo-config.yaml
ADDED   foobar/file.py
```

Suites:

```bash
uv run pytest tests/sdk/git/ tests/agent_server/test_git_router.py -q
# 158 passed

uv run ruff check && uv run ruff format --check
# clean
```

`test_get_git_changes_keeps_paths_that_merely_share_a_nested_repo_prefix` fails on `main` and passes here. `test_get_git_changes_still_excludes_paths_inside_a_nested_repo` passes either way — it is there so the exclusion this preserves stays preserved.

## Video/Screenshots

Not applicable — no GUI surface; the console transcripts above are the evidence.

## Design Doc

Not added; the change is one expression.

