### PR TITLE
fix(sdk): skip cancelled lock waiters

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -308,6 +308,8 @@ class ParallelToolExecutor:
             if not lock_keys:
                 return tool_runner(action)
             with self._lock_manager.lock(*lock_keys):
+                if cancel_token is not None and cancel_token.is_cancelled:
+                    return self._cancelled_error(action, span_owner)
                 return tool_runner(action)
 
         except ValueError as e:

--- a/tests/sdk/agent/test_parallel_executor_locking.py
+++ b/tests/sdk/agent/test_parallel_executor_locking.py
@@ -1,11 +1,16 @@
 """Integration tests for ParallelToolExecutor resource locking."""
 
+import asyncio
 import threading
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from openhands.sdk.agent.parallel_executor import ParallelToolExecutor
+from openhands.sdk.conversation.cancellation import CancellationToken
 from openhands.sdk.conversation.resource_lock_manager import ResourceLockManager
+from openhands.sdk.event.llm_convertible import AgentErrorEvent
 from openhands.sdk.tool.tool import DeclaredResources, ToolAnnotations
 
 
@@ -171,3 +176,93 @@ def test_none_action_falls_back_to_tool_mutex():
 
     assert len(results) == 1
     tool.declared_resources.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("resources", "lock_key", "use_async"),
+    [
+        pytest.param(
+            DeclaredResources(
+                keys=("file:/tmp/cancelled-waiter",),
+                declared=True,
+            ),
+            "file:/tmp/cancelled-waiter",
+            False,
+            id="sync-declared-resource",
+        ),
+        pytest.param(
+            DeclaredResources(keys=(), declared=False),
+            "tool:editor",
+            False,
+            id="sync-tool-mutex",
+        ),
+        pytest.param(
+            DeclaredResources(
+                keys=("file:/tmp/cancelled-async-waiter",),
+                declared=True,
+            ),
+            "file:/tmp/cancelled-async-waiter",
+            True,
+            id="async-declared-resource",
+        ),
+    ],
+)
+def test_cancellation_while_waiting_for_lock_skips_tool(
+    resources: DeclaredResources,
+    lock_key: str,
+    use_async: bool,
+):
+    lock_mgr = ResourceLockManager(timeouts={"file": 1.0, "tool": 1.0})
+    executor = ParallelToolExecutor(max_workers=2, lock_manager=lock_mgr)
+    action = _make_action("editor", "c0")
+    token = CancellationToken()
+    resources_resolved = threading.Event()
+    runner_called = threading.Event()
+
+    tool = _make_tool("editor")
+
+    def declared_resources(_: Any) -> DeclaredResources:
+        resources_resolved.set()
+        return resources
+
+    tool.declared_resources = declared_resources
+
+    def runner(_: Any) -> list[Any]:
+        runner_called.set()
+        return [_ok_event()]
+
+    results: list[list[Any]] = []
+
+    def execute() -> None:
+        if use_async:
+            batch = asyncio.run(
+                executor.aexecute_batch(
+                    [action],
+                    runner,
+                    {"editor": tool},
+                    token,
+                )
+            )
+        else:
+            batch = executor.execute_batch(
+                [action],
+                runner,
+                {"editor": tool},
+                token,
+            )
+        results.extend(batch)
+
+    worker = threading.Thread(target=execute)
+    with lock_mgr.lock(lock_key):
+        worker.start()
+        assert resources_resolved.wait(timeout=1)
+        token.cancel()
+
+    worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    assert not runner_called.is_set()
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert isinstance(results[0][0], AgentErrorEvent)
+    assert results[0][0].error == "Tool call cancelled by interrupt."


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`ParallelToolExecutor` checks cancellation before resolving resources, but a pending call can be cancelled while blocked on a resource lock. Without another check after lock acquisition, the tool starts after the user has interrupted the run.

## Summary

- Re-check the existing `CancellationToken` after a declared-resource lock or fallback tool mutex is acquired.
- Return the existing synthetic cancellation error instead of invoking the tool runner.
- Cover synchronous declared resources, the fallback tool mutex, and the asynchronous batch entry point with real cancellation and lock coordination.

## Issue Number

Fixes #4777

## How to Test

Run the affected executor, integration, interruption, and lock-manager surface:

```bash
uv run pytest \
  tests/sdk/agent/test_parallel_executor.py \
  tests/sdk/agent/test_parallel_execution_integration.py \
  tests/sdk/agent/test_parallel_executor_locking.py \
  tests/sdk/conversation/test_interrupt.py \
  tests/sdk/conversation/test_resource_lock_manager.py \
  -q
```

Result: `61 passed`.

The three new cases fail before the guard because the runner starts after cancellation; the five pre-existing locking cases still pass. The new cases use the real `CancellationToken` and `ResourceLockManager`, coordinate a real waiting thread, and verify that the runner is never called through both sync and async batch entry points.

Repository checks:

```bash
uv run pre-commit run --all-files
```

Result: all hooks passed.

## Video/Screenshots

Not applicable; this is a deterministic executor concurrency path without visual output.

## Design Doc

Not included. This is a two-line guard with no public API or serialized-shape change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Tools that began running before cancellation are unchanged. Calls without lock keys are also unchanged. Because this touches tool execution behavior, maintainers should decide whether a lightweight eval is needed before the PR is marked ready or merged.