### PR TITLE
fix(sdk): mask model output in the durable MessageEvent

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/response_dispatch.py
+++ b/openhands-sdk/openhands/sdk/agent/response_dispatch.py
@@ -297,27 +297,12 @@ class ResponseDispatchMixin:
     def _mask_secrets(message: Message, conversation: LocalConversation) -> Message:
         """Return ``message`` with registered secret values masked in its text.
 
-        Tool output is masked by its executor, but nothing masked the model's
-        own words: a secret the model echoed back was persisted verbatim into
-        the durable ``MessageEvent`` — the copy that is stored, replayed to the
-        LLM, rendered, exported and POSTed to webhooks.
-
-        Masking here rather than per response type covers every non-tool-call
-        response, because both ``_handle_content_response`` and
-        ``_handle_no_content_response`` build their event through
-        ``_emit_message_event``, on the sync and async paths alike.
-        ``reasoning_content`` is masked too — it is the only text a
-        reasoning-only response carries, so leaving it out would make this a
-        no-op for exactly one of the two callers.
-
-        ``thinking_blocks`` and ``responses_reasoning_item`` are deliberately
-        left untouched: they are signed provider payloads, and rewriting them
-        invalidates the signature the next request replays.
+        ``thinking_blocks`` and ``responses_reasoning_item`` are left alone:
+        they are signed provider payloads, and rewriting them invalidates the
+        signature replayed on the next request.
         """
-        registry = conversation.state.secret_registry
-        if not registry.secret_sources:
-            return message
-        mask = registry.mask_secrets_in_output
+        mask = conversation.state.secret_registry.mask_secrets_in_output
+        reasoning = message.reasoning_content
         return message.model_copy(
             update={
                 "content": [
@@ -326,11 +311,7 @@ class ResponseDispatchMixin:
                     else part
                     for part in message.content
                 ],
-                "reasoning_content": (
-                    mask(message.reasoning_content)
-                    if message.reasoning_content
-                    else message.reasoning_content
-                ),
+                "reasoning_content": mask(reasoning) if reasoning else reasoning,
             }
         )
 

--- a/openhands-sdk/openhands/sdk/agent/response_dispatch.py
+++ b/openhands-sdk/openhands/sdk/agent/response_dispatch.py
@@ -281,7 +281,7 @@ class ResponseDispatchMixin:
         """Create and emit a MessageEvent, running critic if configured."""
         msg_event = MessageEvent(
             source="agent",
-            llm_message=message,
+            llm_message=self._mask_secrets(message, conversation),
             llm_response_id=llm_response.id,
         )
         if self.critic is not None and self.critic.mode == "finish_and_message":
@@ -292,6 +292,47 @@ class ResponseDispatchMixin:
                 )
         on_event(msg_event)
         return msg_event
+
+    @staticmethod
+    def _mask_secrets(message: Message, conversation: LocalConversation) -> Message:
+        """Return ``message`` with registered secret values masked in its text.
+
+        Tool output is masked by its executor, but nothing masked the model's
+        own words: a secret the model echoed back was persisted verbatim into
+        the durable ``MessageEvent`` — the copy that is stored, replayed to the
+        LLM, rendered, exported and POSTed to webhooks.
+
+        Masking here rather than per response type covers every non-tool-call
+        response, because both ``_handle_content_response`` and
+        ``_handle_no_content_response`` build their event through
+        ``_emit_message_event``, on the sync and async paths alike.
+        ``reasoning_content`` is masked too — it is the only text a
+        reasoning-only response carries, so leaving it out would make this a
+        no-op for exactly one of the two callers.
+
+        ``thinking_blocks`` and ``responses_reasoning_item`` are deliberately
+        left untouched: they are signed provider payloads, and rewriting them
+        invalidates the signature the next request replays.
+        """
+        registry = conversation.state.secret_registry
+        if not registry.secret_sources:
+            return message
+        mask = registry.mask_secrets_in_output
+        return message.model_copy(
+            update={
+                "content": [
+                    part.model_copy(update={"text": mask(part.text)})
+                    if isinstance(part, TextContent)
+                    else part
+                    for part in message.content
+                ],
+                "reasoning_content": (
+                    mask(message.reasoning_content)
+                    if message.reasoning_content
+                    else message.reasoning_content
+                ),
+            }
+        )
 
     def _send_corrective_nudge(self, on_event: ConversationCallbackType) -> None:
         """Inject corrective feedback when no tool call and no content.

--- a/tests/sdk/agent/test_response_dispatch.py
+++ b/tests/sdk/agent/test_response_dispatch.py
@@ -200,6 +200,7 @@ def _run_single_step(
     *,
     seed_events: list[Event] | None = None,
     record_emitted_events_in_state: bool = False,
+    secrets: dict[str, str] | None = None,
 ) -> tuple[list[Event], LocalConversation]:
     """Run one agent step with a canned LLM response."""
     from pydantic import PrivateAttr
@@ -220,6 +221,8 @@ def _run_single_step(
     agent = Agent(llm=llm, tools=[])
     conversation = Conversation(agent=agent)
     conversation._ensure_agent_ready()
+    if secrets is not None:
+        conversation.update_secrets(secrets)
     if seed_events is not None:
         for event in seed_events:
             conversation.state.append_event(event)
@@ -397,3 +400,78 @@ def test_batch_action_events_are_emitted_consecutively():
     assert [a.tool_call_id for a in action_events] == ["tc-1", "tc-2"]
     # Only the first event of the batch carries the turn's thought.
     assert action_events[0].thought and not action_events[1].thought
+
+
+# ---------------------------------------------------------------------------
+# Secret masking on the model's own output (issue #4678)
+# ---------------------------------------------------------------------------
+
+
+def _agent_message_text(events: list[Event]) -> str:
+    """Text of the single agent MessageEvent emitted by a step."""
+    msg_event = next(
+        e for e in events if isinstance(e, MessageEvent) and e.source == "agent"
+    )
+    part = msg_event.llm_message.content[0]
+    assert isinstance(part, TextContent)
+    return part.text
+
+
+def test_content_response_masks_registered_secret():
+    """The model's own words are masked in the durable MessageEvent.
+
+    Only tool output was masked before, so a secret the model echoed back was
+    persisted verbatim into the copy that is stored, replayed to the LLM,
+    rendered, exported and POSTed to webhooks.
+    """
+    msg = Message(
+        role="assistant", content=[TextContent(text="the value is supersecret now")]
+    )
+    events, _ = _run_single_step(
+        _make_llm_response(msg), secrets={"TOKEN": "supersecret"}
+    )
+
+    text = _agent_message_text(events)
+    assert "supersecret" not in text
+    assert text == "the value is <secret-hidden> now"
+
+
+def test_content_response_masks_secret_joined_from_stream_chunks():
+    """A secret straddling two deltas is masked in the durable message.
+
+    The ``Agent`` path accumulates deltas before it builds the ``Message``, so
+    neither chunk matches on its own — only the reassembled text does, and that
+    is what the durable copy is built from.
+    """
+    chunks = ["the value is super", "secret now"]
+    msg = Message(role="assistant", content=[TextContent(text="".join(chunks))])
+    events, _ = _run_single_step(
+        _make_llm_response(msg), secrets={"TOKEN": "supersecret"}
+    )
+
+    assert _agent_message_text(events) == "the value is <secret-hidden> now"
+
+
+def test_content_response_without_secrets_is_left_alone():
+    """An empty registry short-circuits: the message is passed through as-is."""
+    msg = Message(role="assistant", content=[TextContent(text="nothing to hide")])
+    events, _ = _run_single_step(_make_llm_response(msg))
+
+    assert _agent_message_text(events) == "nothing to hide"
+
+
+def test_reasoning_only_response_masks_registered_secret():
+    """The nudge path routes through the same chokepoint.
+
+    A reasoning-only message carries no ``content``, so masking that alone
+    would be a no-op here — ``reasoning_content`` is the text that leaks.
+    """
+    msg = Message(role="assistant", reasoning_content="the value is supersecret now")
+    events, _ = _run_single_step(
+        _make_llm_response(msg), secrets={"TOKEN": "supersecret"}
+    )
+
+    msg_event = next(
+        e for e in events if isinstance(e, MessageEvent) and e.source == "agent"
+    )
+    assert msg_event.llm_message.reasoning_content == "the value is <secret-hidden> now"

--- a/tests/sdk/agent/test_response_dispatch.py
+++ b/tests/sdk/agent/test_response_dispatch.py
@@ -1,5 +1,6 @@
 """Unit tests for LLM response classification and dispatch."""
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -201,6 +202,7 @@ def _run_single_step(
     seed_events: list[Event] | None = None,
     record_emitted_events_in_state: bool = False,
     secrets: dict[str, str] | None = None,
+    prepare: Callable[[LocalConversation], None] | None = None,
 ) -> tuple[list[Event], LocalConversation]:
     """Run one agent step with a canned LLM response."""
     from pydantic import PrivateAttr
@@ -226,6 +228,8 @@ def _run_single_step(
     if seed_events is not None:
         for event in seed_events:
             conversation.state.append_event(event)
+    if prepare is not None:
+        prepare(conversation)
 
     events: list[Event] = []
 
@@ -402,11 +406,6 @@ def test_batch_action_events_are_emitted_consecutively():
     assert action_events[0].thought and not action_events[1].thought
 
 
-# ---------------------------------------------------------------------------
-# Secret masking on the model's own output (issue #4678)
-# ---------------------------------------------------------------------------
-
-
 def _agent_message_text(events: list[Event]) -> str:
     """Text of the single agent MessageEvent emitted by a step."""
     msg_event = next(
@@ -453,7 +452,7 @@ def test_content_response_masks_secret_joined_from_stream_chunks():
 
 
 def test_content_response_without_secrets_is_left_alone():
-    """An empty registry short-circuits: the message is passed through as-is."""
+    """With nothing registered, the message text is passed through unchanged."""
     msg = Message(role="assistant", content=[TextContent(text="nothing to hide")])
     events, _ = _run_single_step(_make_llm_response(msg))
 
@@ -475,3 +474,32 @@ def test_reasoning_only_response_masks_registered_secret():
         e for e in events if isinstance(e, MessageEvent) and e.source == "agent"
     )
     assert msg_event.llm_message.reasoning_content == "the value is <secret-hidden> now"
+
+
+def test_content_response_masks_value_dropped_from_secret_sources():
+    """Masking follows the tracked values, not the registry's source list.
+
+    ``EventService.activate_credential_binding`` pops a name from
+    ``secret_sources`` while the resolved value stays tracked for masking, so
+    keying off ``secret_sources`` would leak a live credential here.
+    """
+
+    def drop_source(convo: LocalConversation) -> None:
+        registry = convo.state.secret_registry
+        registry.get_secret_value("TOKEN")  # resolve -> tracked for masking
+        with convo.state:
+            convo.state.secret_registry = registry.model_copy(
+                update={"secret_sources": {}}
+            )
+
+    msg = Message(
+        role="assistant", content=[TextContent(text="the value is supersecret now")]
+    )
+    events, convo = _run_single_step(
+        _make_llm_response(msg),
+        secrets={"TOKEN": "supersecret"},
+        prepare=drop_source,
+    )
+
+    assert not convo.state.secret_registry.secret_sources
+    assert _agent_message_text(events) == "the value is <secret-hidden> now"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix leakage of secrets.

---

AGENT:

## Why

`SecretRegistry.mask_secrets_in_output` had, outside `acp_agent.py`, exactly two non-test call sites — `openhands-tools/openhands/tools/terminal/impl.py:371` (bash output) and `openhands-sdk/openhands/sdk/mcp/tool.py:187` (MCP tool output). Both are *tool* output. Nothing masked the model's own response text on the standard `Agent` path.

That copy is the durable one. A secret the model echoes back was persisted verbatim into the `MessageEvent` that is stored, replayed to the LLM on the next turn, rendered, exported, and POSTed to webhooks.

This is the off-ACP half of the problem. On ACP the situation was already the better one: `_handle_update` masks each chunk and `_finalize_successful_turn` re-masks the joined text at the persistence boundary, so the durable ACP record was already safe (covered today by `TestACPStepMasksPersistedTurn::test_finish_action_masks_secret_split_across_chunks`). Off ACP there was no masking at either end.

## Summary

- Mask registered secret values in the agent's own `MessageEvent` at `_emit_message_event` (`openhands-sdk/openhands/sdk/agent/response_dispatch.py`) — the single point where both `_handle_content_response` and `_handle_no_content_response` build that event, shared by the sync (`step`) and async (`astep`) paths.
- Mask `reasoning_content` alongside `content`: it is the only text a reasoning-only response carries, so masking `content` alone would be a no-op for exactly one of the two callers.
- Masking is unconditional: it reads the registry's tracked values, which are not the same thing as its `secret_sources` list (see Notes).

## Issue Number

Fixes #4678

## How to Test

New regression tests in `tests/sdk/agent/test_response_dispatch.py`, driven through the existing `_run_single_step` harness (a real `agent.step()` with a canned `LLMResponse`, not a direct call to the masking helper):

```
uv run pytest tests/sdk/agent/test_response_dispatch.py -q
# 26 passed
```

To confirm they actually catch the bug, revert only the source file and re-run — all three masking tests fail against the previous behaviour:

```
git stash push openhands-sdk/openhands/sdk/agent/response_dispatch.py
uv run pytest tests/sdk/agent/test_response_dispatch.py -q -k mask
```
```
FAILED test_content_response_masks_registered_secret
  - AssertionError: assert 'supersecret' not in 'the value i...ersecret now'
FAILED test_content_response_masks_secret_joined_from_stream_chunks
  - AssertionError: assert 'the value is supersecret now' == 'the value is...t-...
FAILED test_reasoning_only_response_masks_registered_secret
  - AssertionError: assert 'the value is supersecret now' == 'the value is...t-...
3 failed, 22 deselected
```

Wider suites, to show nothing else moved:

```
uv run pytest tests/sdk tests/cross -q -p no:randomly
# 2 failed, 6381 passed, 10 skipped, 10 xfailed
```

The two failures are `tests/cross/test_remote_conversation_live_server.py::test_openai_chat_completions_gateway_over_real_server` and `::test_settings_and_secrets_api_with_live_server`. Both are **pre-existing on `origin/main`** — verified by stashing this branch's changes and re-running the same file on a clean tree, which produces the identical two failures.

`pre-commit run --files <both changed files>` passes (ruff format, ruff lint, pycodestyle, pyright, import rules, tool registration).

## Video/Screenshots

Not applicable — no user-facing surface. The observable behaviour is the assertion output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Acceptance criteria.** Both are met. "A secret split across two chunks is masked in the durable message on both the `Agent` and ACP paths" — the ACP half already held and is covered by the existing test named above; the `Agent` half is `test_content_response_masks_secret_joined_from_stream_chunks`. "Model response text containing a registered secret is masked on the standard `Agent` path" — `test_content_response_masks_registered_secret`.

**Why no stream snapshot.** The issue sketches a snapshot compiled at stream open. That is not needed for these acceptance criteria and is deliberately left out of this PR: deltas are accumulated *before* the `Message` is constructed, so the durable copy is built from the joined text and the join-boundary mask catches a secret that straddles two chunks. Masking the deltas themselves belongs with the streaming work in #4671.

**Self-review catch (fixed in 37341bdf1).** The first push guarded the mask with `if not registry.secret_sources: return message`. That was wrong. Masking reads `_exported_values`, a *separate* field from `secret_sources`, and `EventService.activate_credential_binding` pops a name out of `secret_sources` via `model_copy` while the resolved value stays tracked for masking. In that window the guard skipped masking a live credential that `mask_secrets_in_output` would still have masked — a leak in exactly the credential-binding flow. Reproduced directly against the registry:

```
before: sources=['TOKEN'] exported=['TOKEN']  mask -> "the value is <secret-hidden> now"
after : sources=[]        exported=['TOKEN']  mask -> "the value is <secret-hidden> now"
                                              guard would skip masking: True
```

The guard is gone; masking is unconditional, which is also cheaper to reason about (an empty `_exported_values` makes it a no-op). Regression test: `test_content_response_masks_value_dropped_from_secret_sources`, verified to fail with the guard restored.

**Deliberately not masked.** `thinking_blocks` and `responses_reasoning_item` are signed provider payloads; rewriting their text invalidates the signature replayed on the next request.

**Known gap, not in scope here.** `ActionEvent.thought` on the tool-call path (`agent.py:1318`) is still unmasked — `_handle_tool_calls` does not route through `_emit_message_event`. Happy to fold it in if you would rather it landed together; I kept this PR to the one chokepoint the acceptance criteria name.

**Lock cost.** `agent.step()` runs under the state lock, and `mask_secrets_in_output` resolves uncached sources, which may do blocking I/O. Exposure is unchanged in practice: it is one call per agent step, it already has failed-lookup backoff, values are normally resolved and cached well before the model replies, and with no secrets registered it degrades to an empty loop. `terminal/impl.py` already calls it from inside a step.

**Not verified locally.** `.github/scripts/check_sdk_api_breakage.py` could not run here (griffe fails to fetch the baseline from PyPI in this environment). The change adds no public API — one private static method, no changed signatures.

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:37341bd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-37341bd-python \
  ghcr.io/openhands/agent-server:37341bd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:37341bd-golang-amd64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-golang-amd64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-golang-amd64
ghcr.io/openhands/agent-server:37341bd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:37341bd-golang-arm64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-golang-arm64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-golang-arm64
ghcr.io/openhands/agent-server:37341bd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:37341bd-java-amd64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-java-amd64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-java-amd64
ghcr.io/openhands/agent-server:37341bd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:37341bd-java-arm64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-java-arm64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-java-arm64
ghcr.io/openhands/agent-server:37341bd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:37341bd-python-amd64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-python-amd64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-python-amd64
ghcr.io/openhands/agent-server:37341bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:37341bd-python-arm64
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-python-arm64
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-python-arm64
ghcr.io/openhands/agent-server:37341bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:37341bd-golang
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-golang
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-golang
ghcr.io/openhands/agent-server:37341bd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:37341bd-java
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-java
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-java
ghcr.io/openhands/agent-server:37341bd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:37341bd-python
ghcr.io/openhands/agent-server:37341bdf1003a42128577ccf8ae8e0087c3b9a3c-python
ghcr.io/openhands/agent-server:vasco-security-4678-mask-agent-message-output-python
ghcr.io/openhands/agent-server:37341bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `37341bd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `37341bd-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->