### PR TITLE
fix(file_editor): prefer valid UTF-8 encoding

### DIFF
--- a/openhands-tools/openhands/tools/file_editor/utils/encoding.py
+++ b/openhands-tools/openhands/tools/file_editor/utils/encoding.py
@@ -1,5 +1,6 @@
 """Encoding management for file operations."""
 
+import codecs
 import functools
 import inspect
 import os
@@ -48,6 +49,16 @@ class EncodingManager:
         sample_size = min(os.path.getsize(path), 1024 * 1024)  # Max 1MB sample
         with open(path, "rb") as f:
             raw_data = f.read(sample_size)
+
+        if raw_data.startswith(codecs.BOM_UTF8):
+            return "utf-8-sig"
+
+        try:
+            raw_data.decode(self.default_encoding)
+        except UnicodeDecodeError:
+            pass
+        else:
+            return self.default_encoding
 
         # Use charset_normalizer instead of chardet
         results = charset_normalizer.detect(raw_data)

--- a/tests/tools/file_editor/utils/test_encoding.py
+++ b/tests/tools/file_editor/utils/test_encoding.py
@@ -51,22 +51,12 @@ def test_detect_encoding_utf8(encoding_manager, temp_file):
     assert encoding.lower() in ("utf-8", "ascii")
 
 
-def test_detect_encoding_utf8_with_icon(encoding_manager, temp_file):
-    """Test detecting UTF-8 encoding with a word and an emoji."""
-    # Create a UTF-8 encoded file with a single word and an emoji
-    with open(temp_file, "w", encoding="utf-8") as f:
-        f.write("Hello 😊")
-
-    encoding = encoding_manager.detect_encoding(temp_file)
-    assert encoding.lower() == "utf-8"
-
-
 def test_detect_encoding_prefers_valid_utf8(encoding_manager, temp_file):
     temp_file.write_text('{"title": "用户研究"}', encoding="utf-8")
 
     with patch(
         "charset_normalizer.detect",
-        return_value={"encoding": "windows-1251", "confidence": 1.0},
+        side_effect=AssertionError("valid UTF-8 should skip heuristic detection"),
     ):
         encoding = encoding_manager.detect_encoding(temp_file)
 

--- a/tests/tools/file_editor/utils/test_encoding.py
+++ b/tests/tools/file_editor/utils/test_encoding.py
@@ -61,6 +61,18 @@ def test_detect_encoding_utf8_with_icon(encoding_manager, temp_file):
     assert encoding.lower() == "utf-8"
 
 
+def test_detect_encoding_prefers_valid_utf8(encoding_manager, temp_file):
+    temp_file.write_text('{"title": "用户研究"}', encoding="utf-8")
+
+    with patch(
+        "charset_normalizer.detect",
+        return_value={"encoding": "windows-1251", "confidence": 1.0},
+    ):
+        encoding = encoding_manager.detect_encoding(temp_file)
+
+    assert encoding.lower() == "utf-8"
+
+
 def test_detect_encoding_cp1251(encoding_manager, temp_file):
     """Test detecting CP1251 encoding."""
     # Create a CP1251 encoded file with Cyrillic characters

--- a/tests/tools/file_editor/utils/test_encoding.py
+++ b/tests/tools/file_editor/utils/test_encoding.py
@@ -51,12 +51,22 @@ def test_detect_encoding_utf8(encoding_manager, temp_file):
     assert encoding.lower() in ("utf-8", "ascii")
 
 
+def test_detect_encoding_utf8_with_icon(encoding_manager, temp_file):
+    """Test detecting UTF-8 encoding with a word and an emoji."""
+    # Create a UTF-8 encoded file with a single word and an emoji
+    with open(temp_file, "w", encoding="utf-8") as f:
+        f.write("Hello 😊")
+
+    encoding = encoding_manager.detect_encoding(temp_file)
+    assert encoding.lower() == "utf-8"
+
+
 def test_detect_encoding_prefers_valid_utf8(encoding_manager, temp_file):
     temp_file.write_text('{"title": "用户研究"}', encoding="utf-8")
 
     with patch(
         "charset_normalizer.detect",
-        side_effect=AssertionError("valid UTF-8 should skip heuristic detection"),
+        return_value={"encoding": "windows-1251", "confidence": 1.0},
     ):
         encoding = encoding_manager.detect_encoding(temp_file)
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

UTF-8 is the encoding used by most text files. I think we should try strict UTF-8 decoding first and fall back to heuristic encoding detection only when it fails. This generally has no practical downside, while ensuring valid UTF-8 files remain readable when charset-normalizer misclassifies them, as seen with Chinese JSON in charset-normalizer 3.5.0 ([jawah/charset_normalizer#796](https://github.com/jawah/charset_normalizer/pull/796)).

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The file editor currently runs heuristic encoding detection for every text file, including files that decode strictly as UTF-8. A high-confidence heuristic misclassification can therefore override a valid UTF-8 interpretation. UTF-8 is the common case for source code, JSON, Markdown, and configuration files, so it should be handled deterministically before falling back to charset detection.

## Summary

- Return `utf-8` immediately when the sampled bytes decode strictly as UTF-8.
- Preserve `utf-8-sig` handling for files with a UTF-8 BOM.
- Keep `charset-normalizer` as the fallback for non-UTF-8 content.

## Issue Number

Related to #3678

## How to Test

- `uv run pytest tests/tools/file_editor -q` — 153 passed.
- `uv run pre-commit run --files openhands-tools/openhands/tools/file_editor/utils/encoding.py tests/tools/file_editor/utils/test_encoding.py` — all hooks passed.
- Exercised the public `file_editor(command="view", ...)` path with a Chinese UTF-8 JSON file while configuring `charset_normalizer.detect` to raise if called. The file was read successfully and printed: `PASS: public file_editor read valid UTF-8 without heuristic detection`.

## Video/Screenshots

Not applicable; this is a backend file-encoding change.

## Design Doc

Not applicable; the change is limited to one fast path and one regression test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fallback behavior for files that are not valid UTF-8 is unchanged.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.38s · commit bb1e866  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 2/2 files.  
**Limits:** Supplied code only; tests were not run. Probabilities are model estimates.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 2.0% | No direct hunk selected |
| Contract regression | 14.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 1.0% | No direct hunk selected |
| Unverified remote execution | 1.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 1.0% | No direct hunk selected |
| Primary concern | None selected; confidence 81.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 46538ed49cb7196b26b89ad985db1e991b41f8a252d60eb726cc4e2aca54b83d -->
<!-- jev-fast-audit:end -->
