### PR TITLE
fix(tools): preserve Tom processing checkpoints

### DIFF
--- a/openhands-tools/openhands/tools/tom_consult/executor.py
+++ b/openhands-tools/openhands/tools/tom_consult/executor.py
@@ -281,7 +281,7 @@ class TomConsultExecutor(
         processing_history = self._load_processing_history()
 
         # Find sessions that need processing
-        sessions_to_process = []
+        sessions_to_process: dict[str, int] = {}
         for session_id in all_sessions:
             events_dir = f"{self.conversations_dir}/{session_id}/events"
             event_files = self.file_store.list(events_dir)  # type: ignore
@@ -292,12 +292,12 @@ class TomConsultExecutor(
 
             # Check if needs processing (new or has new events)
             if session_id not in processing_history:
-                sessions_to_process.append(session_id)
+                sessions_to_process[session_id] = current_event_count
                 logger.info(f"📋 Tom: Session {session_id} needs processing (new)")
             elif current_event_count > processing_history[session_id].get(
                 "last_event_count", 0
             ):
-                sessions_to_process.append(session_id)
+                sessions_to_process[session_id] = current_event_count
                 logger.info(
                     f"📋 Tom: Session {session_id} has new events "
                     f"({current_event_count} events)"
@@ -312,10 +312,12 @@ class TomConsultExecutor(
         logger.info(f"📊 Tom: Found {len(sessions_to_process)} sessions to process")
         # Collect session data for each conversation
         sessions_data = []
-        for session_id in sessions_to_process:
+        processed_event_counts: dict[str, int] = {}
+        for session_id, event_count in sessions_to_process.items():
             session_data = self._extract_session_data(session_id, conversation)
             if session_data:
                 sessions_data.append(session_data)
+                processed_event_counts[session_id] = event_count
         if not sessions_data:
             logger.info("📭 Tom: No valid session data extracted")
             return SleeptimeComputeObservation(
@@ -332,7 +334,7 @@ class TomConsultExecutor(
         )
 
         # Update processing history
-        self._save_processing_history(sessions_to_process)
+        self._save_processing_history(processed_event_counts)
 
         logger.info(f"✅ Tom: Successfully indexed {len(sessions_data)} conversations")
         return SleeptimeComputeObservation(
@@ -394,7 +396,7 @@ class TomConsultExecutor(
             logger.debug(f"Could not load processing history: {e}")
             return {}
 
-    def _save_processing_history(self, session_ids: list[str]) -> None:
+    def _save_processing_history(self, event_counts: dict[str, int]) -> None:
         """Save processing history for processed sessions."""
         try:
             from tom_swe.memory.locations import get_usermodeling_dir
@@ -402,14 +404,7 @@ class TomConsultExecutor(
             history = self._load_processing_history()
             timestamp = datetime.now().isoformat()
 
-            for session_id in session_ids:
-                events_dir = f"{self.conversations_dir}/{session_id}/events"
-                try:
-                    event_files = self.file_store.list(events_dir)
-                    event_count = len(event_files)
-                except Exception:
-                    event_count = 0
-
+            for session_id, event_count in event_counts.items():
                 history[session_id] = {
                     "processed_at": timestamp,
                     "last_event_count": event_count,
@@ -419,7 +414,7 @@ class TomConsultExecutor(
 
             self.file_store.write(history_file, json.dumps(history, indent=2))
             logger.info(
-                f"📝 Tom: Updated processing history for {len(session_ids)} sessions"
+                f"📝 Tom: Updated processing history for {len(event_counts)} sessions"
             )  # noqa: E501
         except Exception as e:
             logger.error(f"Failed to save processing history: {e}")

--- a/tests/tools/tom_consult/test_tom_consult_executor.py
+++ b/tests/tools/tom_consult/test_tom_consult_executor.py
@@ -1,0 +1,126 @@
+"""Tests for Tom sleeptime processing checkpoints."""
+
+import json
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+
+from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.event import MessageEvent
+from openhands.sdk.io import InMemoryFileStore
+from openhands.sdk.llm import Message, TextContent
+from openhands.tools.tom_consult.definition import (
+    SleeptimeComputeAction,
+    SleeptimeComputeObservation,
+)
+from openhands.tools.tom_consult.executor import TomConsultExecutor
+
+
+HISTORY_DIR = "user-model"
+HISTORY_FILE = f"{HISTORY_DIR}/processed_sessions_timestamps.json"
+
+
+def _make_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TomConsultExecutor, Mock, InMemoryFileStore]:
+    monkeypatch.setattr(
+        "tom_swe.memory.locations.get_usermodeling_dir",
+        lambda _user_id: HISTORY_DIR,
+    )
+    file_store = InMemoryFileStore()
+    tom_agent = Mock()
+    executor = TomConsultExecutor(file_store)
+    executor._tom_agent = cast(Any, tom_agent)
+    return executor, tom_agent, file_store
+
+
+def _append_user_message(
+    file_store: InMemoryFileStore,
+    session_id: str,
+    event_id: str,
+    text: str,
+) -> None:
+    event_log = EventLog(file_store, f"conversations/{session_id}/events")
+    event_log.append(
+        MessageEvent(
+            id=event_id,
+            llm_message=Message(
+                role="user",
+                content=[TextContent(text=text)],
+            ),
+            source="user",
+        )
+    )
+
+
+def test_sleeptime_checkpoint_preserves_pre_submission_file_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, tom_agent, file_store = _make_executor(monkeypatch)
+    session_id = "session-1"
+    events_dir = f"conversations/{session_id}/events"
+    _append_user_message(file_store, session_id, "00000000", "first")
+    file_store.write(f"{events_dir}/metadata.json", "{}")
+
+    def append_during_tom_call(**_kwargs: Any) -> None:
+        _append_user_message(file_store, session_id, "11111111", "second")
+
+    tom_agent.sleeptime_compute.side_effect = append_during_tom_call
+
+    first_result = executor(SleeptimeComputeAction())
+
+    assert isinstance(first_result, SleeptimeComputeObservation)
+    assert first_result.sessions_processed == 1
+    first_payload = tom_agent.sleeptime_compute.call_args.kwargs["sessions_data"]
+    assert first_payload[0]["event_count"] == 1
+    history = json.loads(file_store.read(HISTORY_FILE))
+    assert history[session_id]["last_event_count"] == 2
+    assert len(file_store.list(events_dir)) == 3
+
+    tom_agent.sleeptime_compute.reset_mock(side_effect=True)
+
+    second_result = executor(SleeptimeComputeAction())
+
+    assert isinstance(second_result, SleeptimeComputeObservation)
+    assert second_result.sessions_processed == 1
+    second_payload = tom_agent.sleeptime_compute.call_args.kwargs["sessions_data"]
+    assert second_payload[0]["event_count"] == 2
+
+
+def test_sleeptime_does_not_checkpoint_session_without_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, tom_agent, file_store = _make_executor(monkeypatch)
+    _append_user_message(file_store, "valid-session", "00000000", "hello")
+    file_store.write("conversations/empty-session/events/metadata.json", "{}")
+
+    result = executor(SleeptimeComputeAction())
+
+    assert isinstance(result, SleeptimeComputeObservation)
+    assert result.sessions_processed == 1
+    payload = tom_agent.sleeptime_compute.call_args.kwargs["sessions_data"]
+    assert [session["session_id"] for session in payload] == ["valid-session"]
+    history = json.loads(file_store.read(HISTORY_FILE))
+    assert set(history) == {"valid-session"}
+
+
+def test_sleeptime_failure_does_not_advance_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, tom_agent, file_store = _make_executor(monkeypatch)
+    session_id = "session-1"
+    _append_user_message(file_store, session_id, "00000000", "hello")
+    existing_history = {
+        session_id: {
+            "processed_at": "2026-08-01T00:00:00",
+            "last_event_count": 0,
+        }
+    }
+    file_store.write(HISTORY_FILE, json.dumps(existing_history))
+    tom_agent.sleeptime_compute.side_effect = RuntimeError("Tom failed")
+
+    with pytest.raises(RuntimeError, match="Tom failed"):
+        executor(SleeptimeComputeAction())
+
+    assert json.loads(file_store.read(HISTORY_FILE)) == existing_history


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Tom candidate selection counted event-directory files before extraction, but processing history re-listed each mutable directory after the Tom call. An event appended during that call could therefore be checkpointed even though it was never indexed. Sessions that produced no payload could also be marked processed.

## Summary

- Carry each selected session's pre-submission file count through processing.
- Advance history only for sessions successfully extracted and submitted to Tom.
- Preserve the existing history JSON shape and file-count comparison unit.

## Issue Number

Fixes #4667

## How to Test

- `uv run pytest tests/tools/tom_consult -q` — 5 passed.
- `uv run pre-commit run --files openhands-tools/openhands/tools/tom_consult/executor.py tests/tools/tom_consult/test_tom_consult_executor.py` — all hooks passed.

The regression adds a non-event metadata file so directory file count differs from `EventLog` length, appends a new event inside the Tom call, verifies the stored checkpoint remains at the pre-submission count, and confirms the next run detects the new event. Separate tests cover empty extraction and failed Tom calls.

## Video/Screenshots

Not applicable; this changes backend checkpoint persistence.

## Design Doc

Not applicable; this is a scoped persistence fix with no public API or file-format change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This follows the issue review feedback: checkpoint and candidate comparison both remain in event-directory file-count units rather than mixing in `EventLog` length.