### PR TITLE
fix(agent-server): serialize bash output ordering

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -266,6 +266,28 @@ class BashEventService:
 
     async def _execute_bash_command(self, command: BashCommand) -> None:
         """Execute the bash event and create an observation event."""
+        output_order = 0
+
+        async def emit_output(
+            *,
+            exit_code: int | None = None,
+            stdout: str | None = None,
+            stderr: str | None = None,
+        ) -> None:
+            nonlocal output_order
+
+            output_event = BashOutput(
+                command_id=command.id,
+                order=output_order,
+                exit_code=exit_code,
+                stdout=stdout,
+                stderr=stderr,
+            )
+            self._save_event_to_file(output_event)
+            # Commit the sequence after persistence and before publication can yield.
+            output_order += 1
+            await self._pub_sub(output_event)
+
         try:
             # Create subprocess in a new session so we can signal the whole
             # process group on teardown (the shell's children, e.g. sleep, must
@@ -280,13 +302,12 @@ class BashEventService:
                 start_new_session=True,
             )
 
-            # Track output order and buffers
-            output_order = 0
+            # Track output buffers
             stdout_buffer = ""
             stderr_buffer = ""
 
             async def read_stream(stream, is_stderr=False):
-                nonlocal output_order, stdout_buffer, stderr_buffer
+                nonlocal stdout_buffer, stderr_buffer
 
                 buffer = stderr_buffer if is_stderr else stdout_buffer
 
@@ -312,17 +333,10 @@ class BashEventService:
                             chunk = buffer[:MAX_CONTENT_CHAR_LENGTH]
                             buffer = buffer[MAX_CONTENT_CHAR_LENGTH:]
 
-                            # Create and publish BashOutput event
-                            output_event = BashOutput(
-                                command_id=command.id,
-                                order=output_order,
+                            await emit_output(
                                 stdout=chunk if not is_stderr else None,
                                 stderr=chunk if is_stderr else None,
                             )
-
-                            self._save_event_to_file(output_event)
-                            await self._pub_sub(output_event)
-                            output_order += 1
 
                             # Update the appropriate buffer
                             if is_stderr:
@@ -375,16 +389,11 @@ class BashEventService:
             # Only create final event if there's remaining content or we need to report
             # exit code
             if final_stdout or final_stderr or exit_code is not None:
-                final_output = BashOutput(
-                    command_id=command.id,
-                    order=output_order,
+                await emit_output(
                     exit_code=exit_code,
                     stdout=final_stdout,
                     stderr=final_stderr,
                 )
-
-                self._save_event_to_file(final_output)
-                await self._pub_sub(final_output)
 
         except Exception as e:
             logger.error(
@@ -392,16 +401,10 @@ class BashEventService:
                 command.id,
                 type(e).__name__,
             )
-            # Create error output event
-            error_output = BashOutput(
-                command_id=command.id,
-                order=0,
+            await emit_output(
                 exit_code=-1,
                 stderr=f"Error executing command: {str(e)}",
             )
-
-            self._save_event_to_file(error_output)
-            await self._pub_sub(error_output)
 
     def delete_events_older_than(self, cutoff: datetime) -> int:
         """Delete bash event files with a recorded timestamp older than ``cutoff``.

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -16,7 +16,10 @@ import pytest_asyncio
 from fastapi import FastAPI
 
 from openhands.agent_server import bash_router as bash_router_module
-from openhands.agent_server.bash_service import BashEventService
+from openhands.agent_server.bash_service import (
+    MAX_CONTENT_CHAR_LENGTH,
+    BashEventService,
+)
 from openhands.agent_server.config import Config
 from openhands.agent_server.models import BashCommand, BashEventSortOrder, BashOutput
 from openhands.agent_server.server_details_router import (
@@ -108,6 +111,95 @@ async def test_bash_execution_error_log_omits_command(
 
     assert "Error executing bash command" in caplog.text
     assert secret not in caplog.text
+
+
+async def test_interleaved_bash_output_orders_are_contiguous(
+    bash_service: BashEventService,
+) -> None:
+    stdout = "o" * (MAX_CONTENT_CHAR_LENGTH + 3)
+    stderr = "e" * (MAX_CONTENT_CHAR_LENGTH + 5)
+    process = AsyncMock()
+    process.stdout.read.side_effect = [stdout.encode(), b""]
+    process.stderr.read.side_effect = [stderr.encode(), b""]
+    process.wait = AsyncMock(return_value=0)
+    process.returncode = 0
+    published: list[BashOutput] = []
+
+    async def yielding_publish(event: BashOutput) -> None:
+        assert await bash_service.get_bash_event(event.id.hex) == event
+        published.append(event)
+        await asyncio.sleep(0)
+
+    command = BashCommand(command="interleaved output")
+    with (
+        patch(
+            "openhands.agent_server.bash_service.asyncio.create_subprocess_shell",
+            new=AsyncMock(return_value=process),
+        ),
+        patch.object(
+            bash_service,
+            "_pub_sub",
+            new=AsyncMock(side_effect=yielding_publish),
+        ),
+    ):
+        await bash_service._execute_bash_command(command)
+
+    assert [event.order for event in published] == list(range(len(published)))
+    assert published[-1].exit_code == 0
+    assert "".join(event.stdout or "" for event in published) == stdout
+    assert "".join(event.stderr or "" for event in published) == stderr
+
+    page = await bash_service.search_bash_events(command_id__eq=command.id)
+    persisted = [event for event in page.items if isinstance(event, BashOutput)]
+    persisted.sort(key=lambda event: event.order)
+    assert [event.order for event in persisted] == list(range(len(persisted)))
+    assert persisted[-1].exit_code == 0
+
+
+async def test_bash_output_persistence_failure_does_not_consume_order(
+    bash_service: BashEventService,
+) -> None:
+    stdout = "o" * (MAX_CONTENT_CHAR_LENGTH + 1)
+    process = AsyncMock()
+    process.stdout.read.side_effect = [stdout.encode(), b""]
+    process.stderr.read.side_effect = [b""]
+    process.wait = AsyncMock(return_value=0)
+    process.returncode = 0
+    published: list[BashOutput] = []
+    original_save = bash_service._save_event_to_file
+    failed = False
+
+    def fail_first_save(event: BashOutput) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise OSError("simulated persistence failure")
+        original_save(event)
+
+    async def yielding_publish(event: BashOutput) -> None:
+        published.append(event)
+        await asyncio.sleep(0)
+
+    command = BashCommand(command="persistence failure")
+    with (
+        patch(
+            "openhands.agent_server.bash_service.asyncio.create_subprocess_shell",
+            new=AsyncMock(return_value=process),
+        ),
+        patch.object(bash_service, "_save_event_to_file", new=fail_first_save),
+        patch.object(
+            bash_service,
+            "_pub_sub",
+            new=AsyncMock(side_effect=yielding_publish),
+        ),
+    ):
+        await bash_service._execute_bash_command(command)
+
+    assert failed
+    assert [event.order for event in published] == [0]
+    assert published[0].exit_code == 0
+    assert published[0].stdout == stdout
+    assert await bash_service.get_bash_event(published[0].id.hex) == published[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The stdout and stderr reader coroutines shared one output counter, but incremented it only after awaiting publication. A yielding subscriber could therefore let both streams persist and publish the same order value, making reconstruction and order-based polling ambiguous.

## Summary

- Route chunk, final, and error events through one sequenced emitter.
- Persist first, then reserve the next order before publication can yield.
- Add concurrent stream and persistence-failure regression coverage.

## Issue Number

Fixes #4659

## How to Test

- `uv run pytest tests/agent_server/test_bash_service.py::test_interleaved_bash_output_orders_are_contiguous tests/agent_server/test_bash_service.py::test_bash_output_persistence_failure_does_not_consume_order -q` — 2 passed.
- `uv run pytest tests/agent_server/test_bash_service.py` with the existing POSIX SIGTERM trap test deselected — 12 passed, 1 deselected.
- `uv run pre-commit run --files tests/agent_server/test_bash_service.py` — all hooks passed.
- `uv run pyright --pythonplatform Linux openhands-agent-server/openhands/agent_server/bash_service.py` — 0 errors.

The regression drives the production `BashEventService` execution path with interleaved stdout/stderr streams and a subscriber that yields. It verifies persistence before publication, contiguous unique orders, exact stream reconstruction, and the final exit event.

## Video/Screenshots

Not applicable; this changes backend event sequencing.

## Design Doc

Not applicable; the change is a small concurrency fix with no API or schema change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The one excluded full-file test exercises POSIX SIGTERM traps and is not supported on Windows. This change touches terminal/stdout behavior, so a maintainer should run the repository's lightweight eval before approval.