### PR TITLE
fix(tools): mask secrets in every tool's observation at the shared chokepoint

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -21,22 +21,29 @@ FAILED_LOOKUP_RETRY_SECONDS: Final[float] = 60.0
 
 def _mask_value(value: Any, mask: Callable[[str], str]) -> Any:
     """Recursively mask every ``str`` reachable from ``value``."""
-    if isinstance(value, Enum):
-        # A str-subclass enum is a str, but masking it would downgrade the
-        # member to a plain str and break the field's serialization. Its
-        # vocabulary is fixed, so it can never hold a secret anyway.
-        return value
-    if isinstance(value, str):
-        return mask(value)
-    if isinstance(value, BaseModel):
-        return _mask_model(value, mask)
-    if isinstance(value, list):
-        return [_mask_value(item, mask) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_mask_value(item, mask) for item in value)
-    if isinstance(value, dict):
-        return {key: _mask_value(item, mask) for key, item in value.items()}
-    return value
+    match value:
+        case Enum():
+            # A str-subclass enum is a str, but masking it would downgrade the
+            # member to a plain str and break the field's serialization. Its
+            # vocabulary is fixed, so it can never hold a secret anyway.
+            return value
+        case str():
+            return mask(value)
+        case BaseModel():
+            return _mask_model(value, mask)
+        case list():
+            return [_mask_value(item, mask) for item in value]
+        case tuple():
+            items = [_mask_value(item, mask) for item in value]
+            # Rebuild a NamedTuple through its own constructor; tuple(items)
+            # would downgrade it the same way masking an Enum member does.
+            return type(value)(*items) if hasattr(value, "_fields") else tuple(items)
+        case set() | frozenset():
+            return type(value)(_mask_value(item, mask) for item in value)
+        case dict():
+            return {key: _mask_value(item, mask) for key, item in value.items()}
+        case _:
+            return value
 
 
 def _mask_model[ModelT: BaseModel](model: ModelT, mask: Callable[[str], str]) -> ModelT:

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -1,11 +1,12 @@
 """Secrets manager for handling sensitive data in conversations."""
 
 import time
-from collections.abc import Collection, Mapping
+from collections.abc import Callable, Collection, Mapping
+from enum import Enum
 from threading import RLock
-from typing import Final
+from typing import Any, Final
 
-from pydantic import Field, PrivateAttr, SecretStr
+from pydantic import BaseModel, Field, PrivateAttr, SecretStr
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.secret import SecretSource, SecretValue, StaticSecret
@@ -16,6 +17,39 @@ logger = get_logger(__name__)
 
 # Back-off before retrying a failed source; a failed lookup masks nothing anyway.
 FAILED_LOOKUP_RETRY_SECONDS: Final[float] = 60.0
+
+
+def _mask_value(value: Any, mask: Callable[[str], str]) -> Any:
+    """Recursively mask every ``str`` reachable from ``value``."""
+    if isinstance(value, Enum):
+        # A str-subclass enum is a str, but masking it would downgrade the
+        # member to a plain str and break the field's serialization. Its
+        # vocabulary is fixed, so it can never hold a secret anyway.
+        return value
+    if isinstance(value, str):
+        return mask(value)
+    if isinstance(value, BaseModel):
+        return _mask_model(value, mask)
+    if isinstance(value, list):
+        return [_mask_value(item, mask) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_mask_value(item, mask) for item in value)
+    if isinstance(value, dict):
+        return {key: _mask_value(item, mask) for key, item in value.items()}
+    return value
+
+
+def _mask_model[ModelT: BaseModel](model: ModelT, mask: Callable[[str], str]) -> ModelT:
+    """Rebuild ``model`` with every nested string masked.
+
+    ``model_copy`` is used rather than a validate round-trip so private
+    attributes survive and no field is re-coerced.
+    """
+    updates = {
+        name: _mask_value(getattr(model, name), mask)
+        for name in type(model).model_fields
+    }
+    return model.model_copy(update=updates)
 
 
 class SecretRegistry(OpenHandsModel):
@@ -177,6 +211,16 @@ class SecretRegistry(OpenHandsModel):
                 masked_text = masked_text.replace(value, "<secret-hidden>")
 
         return masked_text
+
+    def mask_secrets_in_model[ModelT: BaseModel](self, model: ModelT) -> ModelT:
+        """Return ``model`` with secret values masked in every nested string.
+
+        Masking one known text field is not enough for tool output:
+        ``Observation.to_llm_content`` is overridable, and several tools build
+        what the model sees out of their own fields rather than ``content``.
+        Walking the whole model is what keeps tool #14 covered by default.
+        """
+        return _mask_model(model, self.mask_secrets_in_output)
 
     def get_secret_infos(self) -> list[dict[str, str | None]]:
         """Get secret information (name and description) for prompt inclusion.

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -621,19 +621,26 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         # Coerce output only if we declared a model; else wrap in base Observation
         if self.observation_type:
             if isinstance(result, self.observation_type):
-                return result
-            return self.observation_type.model_validate(result)
+                observation = result
+            else:
+                observation = self.observation_type.model_validate(result)
+        elif isinstance(result, Observation):
+            observation = result
+        elif isinstance(result, BaseModel):
+            observation = Observation.model_validate(result.model_dump())
+        elif isinstance(result, dict):
+            observation = Observation.model_validate(result)
         else:
-            # When no output schema is defined, wrap the result in Observation
-            if isinstance(result, Observation):
-                return result
-            elif isinstance(result, BaseModel):
-                return Observation.model_validate(result.model_dump())
-            elif isinstance(result, dict):
-                return Observation.model_validate(result)
             raise TypeError(
                 "Output must be dict or BaseModel when no output schema is defined"
             )
+
+        # Every tool's output funnels through here, so masking once keeps a new
+        # tool covered by default instead of by remembering to patch it.
+        if conversation is None:
+            return observation
+        registry = conversation.state.secret_registry
+        return registry.mask_secrets_in_model(observation)
 
     async def acall(
         self, action: ActionT, conversation: "LocalConversation | None" = None

--- a/tests/sdk/conversation/test_secret_registry_model_masking.py
+++ b/tests/sdk/conversation/test_secret_registry_model_masking.py
@@ -1,6 +1,7 @@
 """Unit tests for SecretRegistry.mask_secrets_in_model (issue #4677)."""
 
 from enum import Enum
+from typing import NamedTuple
 
 from pydantic import BaseModel, SecretStr
 
@@ -13,6 +14,11 @@ MASK = "<secret-hidden>"
 
 class Kind(str, Enum):
     ADD = "add"
+
+
+class Span(NamedTuple):
+    label: str
+    line: int
 
 
 class Inner(BaseModel):
@@ -28,6 +34,8 @@ class Outer(BaseModel):
     count: int = 0
     blob: bytes = b""
     opaque: SecretStr | None = None
+    tags: set[str] = set()
+    span: Span | None = None
 
 
 def _registry() -> SecretRegistry:
@@ -92,3 +100,25 @@ def test_returns_input_unchanged_when_nothing_is_registered():
     masked = SecretRegistry().mask_secrets_in_model(model)
 
     assert masked.title == f"title {SECRET}"
+
+
+def test_masks_set_members():
+    """A ``set`` field is walked like any other container."""
+    model = Outer(
+        title="clean", inner=Inner(note="clean"), tags={f"t {SECRET}", "plain"}
+    )
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert masked.tags == {f"t {MASK}", "plain"}
+
+
+def test_preserves_namedtuple_type():
+    """A NamedTuple keeps its type, like an Enum keeps its member."""
+    model = Outer(title="clean", inner=Inner(note="clean"), span=Span(f"s {SECRET}", 3))
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert isinstance(masked.span, Span)
+    assert masked.span.label == f"s {MASK}"
+    assert masked.span.line == 3

--- a/tests/sdk/conversation/test_secret_registry_model_masking.py
+++ b/tests/sdk/conversation/test_secret_registry_model_masking.py
@@ -1,0 +1,94 @@
+"""Unit tests for SecretRegistry.mask_secrets_in_model (issue #4677)."""
+
+from enum import Enum
+
+from pydantic import BaseModel, SecretStr
+
+from openhands.sdk.conversation.secret_registry import SecretRegistry
+
+
+SECRET = "sk-supersecret-value"
+MASK = "<secret-hidden>"
+
+
+class Kind(str, Enum):
+    ADD = "add"
+
+
+class Inner(BaseModel):
+    note: str
+    kind: Kind = Kind.ADD
+
+
+class Outer(BaseModel):
+    title: str
+    inner: Inner
+    items: list[str] = []
+    mapping: dict[str, str] = {}
+    count: int = 0
+    blob: bytes = b""
+    opaque: SecretStr | None = None
+
+
+def _registry() -> SecretRegistry:
+    registry = SecretRegistry()
+    registry.update_secrets({"TOKEN": SECRET})
+    registry.get_secret_value("TOKEN")  # resolve -> tracked for masking
+    return registry
+
+
+def test_masks_nested_models_lists_and_dict_values():
+    model = Outer(
+        title=f"title {SECRET}",
+        inner=Inner(note=f"note {SECRET}"),
+        items=[f"a {SECRET}", "b"],
+        mapping={"k": f"v {SECRET}"},
+    )
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert masked.title == f"title {MASK}"
+    assert masked.inner.note == f"note {MASK}"
+    assert masked.items == [f"a {MASK}", "b"]
+    assert masked.mapping == {"k": f"v {MASK}"}
+    assert SECRET not in masked.model_dump_json()
+
+
+def test_leaves_non_string_values_alone():
+    model = Outer(title="clean", inner=Inner(note="clean"), count=7, blob=b"raw")
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert masked.count == 7
+    assert masked.blob == b"raw"
+
+
+def test_preserves_str_subclass_enum_members():
+    """A str-subclass enum must stay an enum member.
+
+    Masking it would downgrade it to a plain ``str`` and break the field's
+    serialization, and its vocabulary can never hold a secret anyway.
+    """
+    model = Outer(title="clean", inner=Inner(note="clean", kind=Kind.ADD))
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert masked.inner.kind is Kind.ADD
+    assert isinstance(masked.inner.kind, Kind)
+
+
+def test_secretstr_is_not_walked_as_a_string():
+    model = Outer(title="clean", inner=Inner(note="clean"), opaque=SecretStr(SECRET))
+
+    masked = _registry().mask_secrets_in_model(model)
+
+    assert isinstance(masked.opaque, SecretStr)
+    assert masked.opaque.get_secret_value() == SECRET
+
+
+def test_returns_input_unchanged_when_nothing_is_registered():
+    model = Outer(title=f"title {SECRET}", inner=Inner(note="clean"))
+
+    masked = SecretRegistry().mask_secrets_in_model(model)
+
+    assert masked.title == f"title {SECRET}"

--- a/tests/tools/test_tool_output_secret_masking.py
+++ b/tests/tools/test_tool_output_secret_masking.py
@@ -1,0 +1,172 @@
+"""Tool output is masked at the shared chokepoint (issue #4677).
+
+``ToolDefinition.__call__`` is the one place every tool's observation passes
+through, so masking there covers a new tool by default rather than by
+remembering to patch it.
+"""
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.llm import LLM
+from openhands.sdk.tool import Tool, ToolDefinition, register_tool
+from openhands.tools.apply_patch.definition import (
+    ApplyPatchAction,
+    ApplyPatchObservation,
+    ApplyPatchTool,
+)
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.file_editor.definition import FileEditorAction
+from openhands.tools.glob import GlobTool
+from openhands.tools.glob.definition import GlobAction, GlobObservation
+from openhands.tools.grep import GrepTool
+from openhands.tools.grep.definition import GrepAction, GrepObservation
+
+
+SECRET = "sk-supersecret-value"
+MASK = "<secret-hidden>"
+
+_TOOLS = {
+    "FileEditorTool": FileEditorTool,
+    "GrepTool": GrepTool,
+    "GlobTool": GlobTool,
+    "ApplyPatchTool": ApplyPatchTool,
+}
+
+
+@pytest.fixture
+def conversation(tmp_path: Path) -> LocalConversation:
+    for name, cls in _TOOLS.items():
+        register_tool(name, cls)
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[Tool(name=name) for name in _TOOLS])
+    convo = LocalConversation(agent, workspace=str(tmp_path))
+    convo._ensure_agent_ready()
+    convo.update_secrets({"TOKEN": SECRET})
+    return convo
+
+
+def test_file_editor_view_masks_file_contents(
+    conversation: LocalConversation, tmp_path: Path
+):
+    """The headline case: reading a secret-bearing file no longer leaks it."""
+    env = tmp_path / ".env"
+    env.write_text(f"API_KEY={SECRET}\n")
+
+    action = FileEditorAction(command="view", path=str(env))
+    observation = conversation.agent.tools_map["file_editor"](action, conversation)
+
+    assert SECRET not in observation.text
+    assert f"API_KEY={MASK}" in observation.text
+    # The file itself is untouched — only the returned record is masked.
+    assert env.read_text() == f"API_KEY={SECRET}\n"
+
+
+def test_grep_masks_the_echoed_pattern(conversation: LocalConversation, tmp_path: Path):
+    """``grep`` returns paths, not file contents — the leak is the echoed pattern."""
+    action = GrepAction(pattern=SECRET, path=str(tmp_path))
+    observation = conversation.agent.tools_map["grep"](action, conversation)
+
+    assert isinstance(observation, GrepObservation)
+    assert observation.pattern == MASK
+    assert SECRET not in observation.text
+
+
+def test_glob_masks_a_matched_path(conversation: LocalConversation, tmp_path: Path):
+    """``glob`` returns paths, so a secret-bearing filename is the leak."""
+    (tmp_path / f"note-{SECRET}.txt").write_text("hi\n")
+
+    action = GlobAction(pattern="*.txt", path=str(tmp_path))
+    observation = conversation.agent.tools_map["glob"](action, conversation)
+
+    assert isinstance(observation, GlobObservation)
+    assert observation.files and all(SECRET not in f for f in observation.files)
+    assert SECRET not in observation.text
+
+
+def test_apply_patch_masks_nested_commit_content(conversation: LocalConversation):
+    """The nested-model case ``Observation.content`` masking would have missed.
+
+    The secret lands in ``commit.changes[...].new_content``, not in ``content``.
+    """
+    patch = (
+        f"*** Begin Patch\n*** Add File: secrets.txt\n+TOKEN={SECRET}\n*** End Patch"
+    )
+    action = ApplyPatchAction(patch=patch)
+    observation = conversation.agent.tools_map["apply_patch"](action, conversation)
+
+    assert isinstance(observation, ApplyPatchObservation)
+    assert observation.commit is not None
+    change = observation.commit.changes["secrets.txt"]
+    assert change.new_content == f"TOKEN={MASK}"
+    assert SECRET not in observation.model_dump_json()
+
+
+def test_no_conversation_means_no_masking(tmp_path: Path):
+    """Called without a conversation there is no registry, so nothing is masked."""
+    for name, cls in _TOOLS.items():
+        register_tool(name, cls)
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[Tool(name="FileEditorTool")])
+    convo = LocalConversation(agent, workspace=str(tmp_path))
+    convo._ensure_agent_ready()
+
+    env = tmp_path / ".env"
+    env.write_text(f"API_KEY={SECRET}\n")
+    action = FileEditorAction(command="view", path=str(env))
+    observation = convo.agent.tools_map["file_editor"](action, None)
+
+    assert SECRET in observation.text
+
+
+def _all_tool_definition_subclasses() -> set[type[ToolDefinition]]:
+    """Import every shipped tool package, then collect ToolDefinition subclasses."""
+    import openhands.tools
+
+    for module in pkgutil.walk_packages(
+        openhands.tools.__path__, prefix="openhands.tools."
+    ):
+        try:
+            importlib.import_module(module.name)
+        except Exception:  # optional extras must not fail the guard
+            continue
+
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from walk(sub)
+
+    return set(walk(ToolDefinition))
+
+
+def test_no_tool_bypasses_the_masking_chokepoint():
+    """Fails when a new tool overrides __call__ without delegating to super().
+
+    This is the property the issue asks for: tool #14 is covered by default.
+    An override that builds its own Observation and returns it silently opts
+    out of masking, so it has to go through ``super().__call__``.
+    """
+    offenders = []
+    for cls in _all_tool_definition_subclasses():
+        override = cls.__dict__.get("__call__")
+        if override is None:
+            continue
+        try:
+            source = inspect.getsource(override)
+        except (OSError, TypeError):  # pragma: no cover - source always available
+            continue
+        if "super().__call__" not in source:
+            offenders.append(f"{cls.__module__}.{cls.__qualname__}")
+
+    assert not offenders, (
+        "These ToolDefinition subclasses override __call__ without delegating to "
+        "super().__call__, so their output never reaches the secret-masking "
+        f"chokepoint: {sorted(offenders)}"
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix secrets leakage in tools obs.

---

AGENT:

## Why

Sweeping `openhands-tools` for masking call sites returned exactly one file, `terminal/impl.py:371`. Of the 13 shipped tool packages, only `terminal` masked its output (plus `mcp/tool.py:187` in the SDK). Which tool the model happened to pick decided whether a secret was masked:

```
cat .env            via bash          ->  MASKED
open .env           via file_editor   ->  RAW
```

There was no security boundary — just one tool that happened to carry the code.

## Summary

- Mask at `ToolDefinition.__call__` (`openhands-sdk/openhands/sdk/tool/tool.py`), the single point every tool's observation passes through. It already receives `conversation`, and `acall` delegates to it, so the async path comes along for free.
- Add `SecretRegistry.mask_secrets_in_model`, which rebuilds a model with every nested string masked (nested models, lists, tuples, dict values).
- Add a guard test that fails when a new tool overrides `__call__` without delegating to `super().__call__` — the "tool #14 is covered by default" property the issue asks for.

## Issue Number

Fixes #4677

## How to Test

```
uv run pytest tests/tools/test_tool_output_secret_masking.py tests/sdk/conversation/test_secret_registry_model_masking.py -q
# 13 passed
```

The four tools named in the acceptance criteria, driven end-to-end through a real `LocalConversation` with a registered secret (not by calling the masking helper directly):

```
--file_editor--  view .env      ->  "API_KEY=<secret-hidden>"   (file on disk unchanged)
--grep--         pattern echo   ->  pattern='<secret-hidden>'
--glob--         matched path   ->  ['.../note-<secret-hidden>.txt']
--apply_patch--  nested commit  ->  commit.changes['secrets.txt'].new_content='TOKEN=<secret-hidden>'
```

The guard test was negative-checked by adding a bypassing tool and confirming it fails with a usable message:

```
These ToolDefinition subclasses override __call__ without delegating to
super().__call__, so their output never reaches the secret-masking
chokepoint: ['tests.tools.test_guard_negative_tmp.SneakyTool']
```

Wider suites, re-run against the current HEAD:

```
uv run pytest tests/sdk tests/tools -q -p no:randomly
# 1 failed, 6950 passed, 24 skipped, 10 xfailed
```

The single failure is a tmux timing flake in `tests/tools/terminal/test_terminal_session.py`, not this change:

- It passes on its own (`uv run pytest "…::test_long_running_command_follow_by_execute" -q` → 1 passed).
- A previous full run failed a *different* test in the same file (`test_command_backslash[tmux]`), which is the signature of a flaky tmux harness rather than a real regression.
- The file cannot reach the changed code path: it contains zero references to `ToolDefinition`, `conversation` or `Conversation`, and drives `create_terminal_session` directly. Its one secret-related test asserts a token *is* present in `session.execute(...)` output — correct, since calling the session directly bypasses `ToolDefinition.__call__` and therefore the mask. That test passes.

`pre-commit run --files <the four changed files>` passes (ruff format, ruff lint, pycodestyle, pyright, import rules, tool registration).

## Video/Screenshots

Not applicable — no user-facing surface. The observable behaviour is the tool output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Why the whole model, not `Observation.content`.** Masking `content` at the chokepoint looks sufficient and is not. `to_llm_content` is a property subclasses override, and several tools build what the model sees out of their own fields: `tom_consult` from `suggestions`/`reasoning`, `SleeptimeComputeObservation` from `message`, `terminal` from `metadata.prefix`/`suffix`/`working_dir`, `task` from `_get_task_info()`. `ApplyPatchObservation` is the clearest case — the secret lands in `commit.changes[...].new_content`, a nested model two levels below `content`. A `content`-only chokepoint would have passed review and still leaked, which is the same failure mode that produced this issue.

**One correction to the issue's framing.** The issue lists `grep -r "API_KEY" . via grep -> RAW`. The SDK's `grep` does not return file contents at all — `GrepObservation.matches` is a list of file paths, and `GlobObservation.files` likewise. The real leak on those two is the echoed `pattern` and any secret-bearing path, both of which this covers. Worth correcting so the acceptance criteria are read against what the tools actually return.

**Self-review catch.** The first cut of the recursive masker downgraded str-subclass enums: `ActionType` in `apply_patch` subclasses `str`, so `isinstance(value, str)` matched and `mask()` turned the enum member into a plain `str`, which surfaced as `PydanticSerializationUnexpectedValue` on `apply_patch`. Enum members are now returned untouched — their vocabulary is fixed, so they cannot hold a secret. Regression test: `test_preserves_str_subclass_enum_members`.

**Audit of the other ways this could miss.** Since the helper's promise is "covered by default", I checked the 26 `Observation` subclasses actually shipped for the surfaces a whole-model walk can still miss: none declare `extra="allow"` (extras live outside `model_fields`), none have `set`/`frozenset` fields, none have NamedTuple fields. Five carry a `_diff_cache` private attribute, which `model_copy` preserves — but it is populated lazily inside `visualize`, so it is `None` at mask time and the diff is rebuilt from masked fields. Verified end-to-end on a `str_replace` that writes a secret: `_diff_cache` is `None` at mask time, `new_content` comes back masked, `model_dump_json()` has no secret, the lazily-built `visualize` diff is masked, and the file on disk still holds the real value.

Rewriting the dispatch as a `match` (review feedback) surfaced two gaps of the same shape as the Enum one, fixed in `958e1af92`: `set`/`frozenset` had no branch and fell through to the catch-all unmasked, and a NamedTuple matched the `tuple` branch and came back as a plain tuple. Neither is reachable today, both are now covered by tests verified to fail without the fix.

**Known trade-off, needs your call — `file_editor` read/modify/write.** A masked `view` means the model can no longer reconstruct `old_str` for a `str_replace` on a file containing a registered secret; the edit fails to match. This is the same trade-off `terminal` masking has had all along (`cat .env` is already masked today), and failing to match is loud rather than silent. But `file_editor` both reads and writes, so it is worth deciding deliberately rather than inheriting it. The file on disk is never modified by masking — only the returned observation is, which the `file_editor` test asserts.

**Not addressed here.** `browser_use` returns screenshots; a secret rendered into an image cannot be string-masked, so the tool named in the issue title is only partly covered. Also, `screenshot_data` is a `str` of base64, so it now gets scanned per registered secret — correct but wasteful on large screenshots. Say the word if you want an opt-out hook for fields like that.

**Left in place deliberately.** `terminal/impl.py:371` and `mcp/tool.py:187` now mask redundantly. Masking is idempotent, terminal masks before its full-output-save-to-disk path, and removing them is a behaviour change in tools with their own tests. Happy to strip them in a follow-up if you would rather have one code path.
