### PR TITLE
fix(agent-server): keep the idle timer alive during streamed completions

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -160,8 +160,8 @@ class EventService:
     _goal_loop_outcome: GoalOutcome | None = field(default=None, init=False)
     # Monotonic clock of the last activity, used for idle eviction.
     _last_active_monotonic: float = field(default_factory=time.monotonic, init=False)
-    # Monotonic clock of the last throttled streaming heartbeat (0 = never).
-    _last_stream_activity_signal: float = field(default=0.0, init=False)
+    # Monotonic clock of the last throttled streaming heartbeat.
+    _last_stream_activity_signal: float = field(default=float("-inf"), init=False)
     # Subscribers attached at startup; later ones (e.g. websockets) are external.
     _internal_subscriber_ids: set[UUID] = field(default_factory=set, init=False)
 
@@ -914,19 +914,12 @@ class EventService:
             agent._on_activity = update_last_execution_time
 
     def _signal_stream_activity(self) -> None:
-        """Keep the idle timer fresh while a completion streams (throttled).
+        """Refresh the runtime idle timer while a completion streams.
 
-        Same concern as _setup_acp_activity_heartbeat above, for the standard
-        streaming path: deltas are published straight to _pub_sub and never
-        persisted, so the durable-event path that normally calls
-        update_last_execution_time() (_EventSubscriber) stays silent for the
-        whole of a long completion and the runtime-api reaps the pod.
-
-        Signalled by the producer rather than by a subscriber, so a delta
-        still refreshes the timer once deltas stop travelling on the shared
-        event bus. Throttled to ACTIVITY_SIGNAL_INTERVAL like the ACP
-        bridge's _maybe_signal_activity: token rate is far too chatty for a
-        per-delta call.
+        Deltas are never persisted, so the durable-event path that calls
+        update_last_execution_time() is silent for the length of a stream.
+        Signalled from the producer so it survives deltas leaving the shared
+        bus; throttled like the ACP bridge's _maybe_signal_activity.
         """
         now = time.monotonic()
         if now - self._last_stream_activity_signal < ACTIVITY_SIGNAL_INTERVAL:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -23,8 +23,10 @@ from openhands.agent_server.models import (
     StoredConversation,
 )
 from openhands.agent_server.pub_sub import PubSub, Subscriber
+from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk import LLM, AgentBase, Event, Message, TextContent, get_logger
 from openhands.sdk.agent import ACPAgent
+from openhands.sdk.agent.acp_agent import ACTIVITY_SIGNAL_INTERVAL
 from openhands.sdk.agent.acp_file_credentials import (
     CODEX_AUTH_SECRET_NAME,
     is_valid_codex_auth,
@@ -158,6 +160,8 @@ class EventService:
     _goal_loop_outcome: GoalOutcome | None = field(default=None, init=False)
     # Monotonic clock of the last activity, used for idle eviction.
     _last_active_monotonic: float = field(default_factory=time.monotonic, init=False)
+    # Monotonic clock of the last throttled streaming heartbeat (0 = never).
+    _last_stream_activity_signal: float = field(default=0.0, init=False)
     # Subscribers attached at startup; later ones (e.g. websockets) are external.
     _internal_subscriber_ids: set[UUID] = field(default_factory=set, init=False)
 
@@ -907,11 +911,28 @@ class EventService:
         from openhands.sdk.agent import ACPAgent
 
         if isinstance(agent, ACPAgent):
-            from openhands.agent_server.server_details_router import (
-                update_last_execution_time,
-            )
-
             agent._on_activity = update_last_execution_time
+
+    def _signal_stream_activity(self) -> None:
+        """Keep the idle timer fresh while a completion streams (throttled).
+
+        Same concern as _setup_acp_activity_heartbeat above, for the standard
+        streaming path: deltas are published straight to _pub_sub and never
+        persisted, so the durable-event path that normally calls
+        update_last_execution_time() (_EventSubscriber) stays silent for the
+        whole of a long completion and the runtime-api reaps the pod.
+
+        Signalled by the producer rather than by a subscriber, so a delta
+        still refreshes the timer once deltas stop travelling on the shared
+        event bus. Throttled to ACTIVITY_SIGNAL_INTERVAL like the ACP
+        bridge's _maybe_signal_activity: token rate is far too chatty for a
+        per-delta call.
+        """
+        now = time.monotonic()
+        if now - self._last_stream_activity_signal < ACTIVITY_SIGNAL_INTERVAL:
+            return
+        self._last_stream_activity_signal = now
+        update_last_execution_time()
 
     def _setup_stats_streaming(self, agent: AgentBase) -> None:
         """Configure stats update callbacks to stream stats changes via events."""
@@ -1057,6 +1078,7 @@ class EventService:
                 content=content,
                 reasoning_content=reasoning_content,
             )
+            self._signal_stream_activity()
             with suppress(RuntimeError):  # main loop already closed during teardown
                 asyncio.run_coroutine_threadsafe(self._pub_sub(event), self._main_loop)
 

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -244,7 +244,7 @@ _STREAM_READER_LIMIT: int = 100 * 1024 * 1024  # 100 MiB
 # Throttled to avoid excessive calls while still keeping the idle timer
 # well below the ~20 min runtime-api kill threshold.  Shared with the
 # agent-server's streaming-delta heartbeat so both paths keep the same pace.
-ACTIVITY_SIGNAL_INTERVAL: float = 30.0
+ACTIVITY_SIGNAL_INTERVAL: Final[float] = 30.0
 
 # ACP tool-call statuses that represent a terminal outcome.  Non-terminal
 # statuses (``pending``, ``in_progress``) mean the call is still in flight

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -242,8 +242,9 @@ _STREAM_READER_LIMIT: int = 100 * 1024 * 1024  # 100 MiB
 
 # Minimum interval between on_activity heartbeat signals (seconds).
 # Throttled to avoid excessive calls while still keeping the idle timer
-# well below the ~20 min runtime-api kill threshold.
-_ACTIVITY_SIGNAL_INTERVAL: float = 30.0
+# well below the ~20 min runtime-api kill threshold.  Shared with the
+# agent-server's streaming-delta heartbeat so both paths keep the same pace.
+ACTIVITY_SIGNAL_INTERVAL: float = 30.0
 
 # ACP tool-call statuses that represent a terminal outcome.  Non-terminal
 # statuses (``pending``, ``in_progress``) mean the call is still in flight
@@ -1429,13 +1430,13 @@ class _OpenHandsACPBridge:
         the server's idle_time grows unboundedly and the runtime-api kills
         the pod (default idle threshold ~20 min).
 
-        Throttled to at most once per _ACTIVITY_SIGNAL_INTERVAL seconds to
+        Throttled to at most once per ACTIVITY_SIGNAL_INTERVAL seconds to
         avoid excessive overhead on chatty ACP servers.
         """
         if self.on_activity is None:
             return
         now = time.monotonic()
-        if now - self._last_activity_signal >= _ACTIVITY_SIGNAL_INTERVAL:
+        if now - self._last_activity_signal >= ACTIVITY_SIGNAL_INTERVAL:
             self._last_activity_signal = now
             try:
                 self.on_activity()

--- a/tests/agent_server/test_event_streaming.py
+++ b/tests/agent_server/test_event_streaming.py
@@ -352,12 +352,17 @@ async def test_deltas_keep_idle_time_below_the_threshold(
 
 @pytest.mark.asyncio
 async def test_delta_idle_signal_is_throttled(event_service, tmp_path, monkeypatch):
-    """Only the first delta of an interval touches the idle timer."""
+    """The first delta touches the idle timer; the rest of the interval does not."""
     callback = await _start_and_capture_callback(event_service, tmp_path)
-    callback(_make_chunk(content="first"))
 
     stale = time.time() - 2 * ACTIVITY_SIGNAL_INTERVAL
     monkeypatch.setattr(server_details_router, "_last_event_time", stale)
-    callback(_make_chunk(content="second"))
 
+    # A service that has never signalled must not throttle its own first
+    # delta, however long the process clock has been running.
+    callback(_make_chunk(content="first"))
+    assert server_details_router._last_event_time > stale
+
+    monkeypatch.setattr(server_details_router, "_last_event_time", stale)
+    callback(_make_chunk(content="second"))
     assert server_details_router._last_event_time == stale

--- a/tests/agent_server/test_event_streaming.py
+++ b/tests/agent_server/test_event_streaming.py
@@ -1,6 +1,7 @@
 """Tests for the token streaming callback wiring in EventService."""
 
 import asyncio
+import time
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -8,11 +9,13 @@ import pytest
 from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
 from pydantic import SecretStr
 
+from openhands.agent_server import server_details_router
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import StoredConversation
 from openhands.agent_server.pub_sub import Subscriber
 from openhands.sdk import Event
 from openhands.sdk.agent import ACPAgent, Agent
+from openhands.sdk.agent.acp_agent import ACTIVITY_SIGNAL_INTERVAL
 from openhands.sdk.event import StreamingDeltaEvent
 from openhands.sdk.llm import LLM
 from openhands.sdk.workspace import LocalWorkspace
@@ -316,3 +319,45 @@ async def test_deltas_only_reach_subscribers_that_opted_in(event_service, tmp_pa
 
     assert [e for e in streaming.events if isinstance(e, StreamingDeltaEvent)]
     assert not [e for e in plain.events if isinstance(e, StreamingDeltaEvent)]
+
+
+# The runtime-api reaps a managed pod once /server_info reports this much
+# idle time; the value it injects is ~20 min.
+_IDLE_THRESHOLD = 20 * 60.0
+
+
+@pytest.mark.asyncio
+async def test_deltas_keep_idle_time_below_the_threshold(
+    event_service, tmp_path, monkeypatch
+):
+    """A completion that streams past the idle threshold keeps the pod alive.
+
+    Deltas are never persisted, so nothing on the durable-event path refreshes
+    the idle clock for the length of a single streamed completion.
+    """
+    callback = await _start_and_capture_callback(event_service, tmp_path)
+
+    # Where a stream longer than the idle threshold, emitting no durable
+    # event, leaves the server: one reap away from losing the completion.
+    monkeypatch.setattr(
+        server_details_router,
+        "_last_event_time",
+        time.time() - 2 * _IDLE_THRESHOLD,
+    )
+
+    callback(_make_chunk(content="tok"))
+
+    assert (await server_details_router.get_server_info()).idle_time < _IDLE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_delta_idle_signal_is_throttled(event_service, tmp_path, monkeypatch):
+    """Only the first delta of an interval touches the idle timer."""
+    callback = await _start_and_capture_callback(event_service, tmp_path)
+    callback(_make_chunk(content="first"))
+
+    stale = time.time() - 2 * ACTIVITY_SIGNAL_INTERVAL
+    monkeypatch.setattr(server_details_router, "_last_event_time", stale)
+    callback(_make_chunk(content="second"))
+
+    assert server_details_router._last_event_time == stale


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small fix to make idle timer alive during streamed completions.

---

AGENT:

## Why

`#4689` made streaming-delta delivery opt-in (`Subscriber.receives_streaming_deltas`). Only `_WebSocketSubscriber` opts in; `_EventSubscriber` — the subscriber that calls `update_last_execution_time()` — does not.

That function drives `idle_time` on `/server_info`, which the runtime-api reaps managed pods on. So nothing refreshes the idle clock for the length of a single streamed completion, and a long stream that emits no durable event can have its pod killed mid-stream. The ACP path already has `_setup_acp_activity_heartbeat` for exactly this reason; the standard streaming path had nothing.

## Summary

- `EventService._signal_stream_activity()` refreshes the idle timer when a delta is published, throttled to the `ACTIVITY_SIGNAL_INTERVAL` (30 s) the ACP bridge's `_maybe_signal_activity` already uses.
- Signalled from the **producer** (`_publish_stream_delta`) rather than from a subscriber, so the heartbeat is not lost again when deltas move off the shared event bus in #4671.
- `_ACTIVITY_SIGNAL_INTERVAL` → `ACTIVITY_SIGNAL_INTERVAL` so both heartbeat paths share one constant instead of drifting; the now-redundant local import in `_setup_acp_activity_heartbeat` is dropped.

## Issue Number

Fix #4695

## How to Test

**End-to-end** — real `create_app` + lifespan, real `ConversationService`/`EventService`, real `Agent` with a streaming `LLM`, real `GET /server_info`. Only the provider network call is faked: `litellm_acompletion` yields one token every 0.5 s for 75 s, so the conversation spends that whole time inside one streamed completion and emits no durable event. `idle_time` is polled every 5 s.

<details>
<summary><code>repro_idle_e2e.py</code></summary>

```python
"""End-to-end repro for #4695. Run with: uv run python repro_idle_e2e.py"""

import asyncio
import tempfile
import time
from pathlib import Path
from unittest.mock import MagicMock, patch

from fastapi.testclient import TestClient
from litellm.types.utils import (
    Choices,
    Delta,
    Message as LiteLLMMessage,
    ModelResponse,
    ModelResponseStream,
    StreamingChoices,
    Usage,
)

from openhands.agent_server.api import create_app
from openhands.agent_server.config import Config

STREAM_SECONDS = 75.0
CHUNK_INTERVAL = 0.5


def _chunk(text: str) -> ModelResponseStream:
    return ModelResponseStream(
        id="chunk-id",
        model="test-model",
        choices=[
            StreamingChoices(
                delta=Delta(role="assistant", content=text), index=0, finish_reason=None
            )
        ],
    )


def _final_response(*args, **kwargs) -> ModelResponse:
    return ModelResponse(
        id="final",
        choices=[
            Choices(
                finish_reason="stop",
                index=0,
                message=LiteLLMMessage(content="done", role="assistant"),
            )
        ],
        created=1234567890,
        model="test-model",
        object="chat.completion",
        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
    )


async def _slow_acompletion(*args, **kwargs):
    """A completion that streams one token every CHUNK_INTERVAL seconds."""

    async def agen():
        for i in range(int(STREAM_SECONDS / CHUNK_INTERVAL)):
            await asyncio.sleep(CHUNK_INTERVAL)
            yield _chunk(f"tok{i} ")

    if not kwargs.get("stream"):
        return _final_response()
    return agen()


def _completion(*args, **kwargs):
    """Non-streaming calls (e.g. title generation) get a plain response."""
    return _final_response()


def main() -> None:
    tmp = Path(tempfile.mkdtemp(prefix="oh4695-"))
    (tmp / "workspace").mkdir()
    config = Config(
        conversations_path=tmp / "conversations",
        workspace_path=tmp / "workspace",
        session_api_keys=[],
    )

    agent = {
        "kind": "Agent",
        "llm": {
            "usage_id": "repro-llm",
            "model": "gpt-4o",
            "api_key": "test-key",
            "stream": True,
        },
        "tools": [],
    }

    with (
        patch("openhands.sdk.llm.llm.litellm_acompletion", _slow_acompletion),
        patch("openhands.sdk.llm.llm.litellm_completion", _completion),
        patch("openhands.sdk.llm.llm.litellm.stream_chunk_builder", _final_response),
        patch("openhands.sdk.llm.utils.model_info.httpx.get") as mock_get,
    ):
        mock_get.return_value = MagicMock(json=lambda: {"data": []})

        with TestClient(create_app(config)) as client:
            resp = client.post(
                "/api/conversations",
                json={
                    "agent": agent,
                    "workspace": {
                        "kind": "LocalWorkspace",
                        "working_dir": str(tmp / "workspace"),
                    },
                    "initial_message": {
                        "role": "user",
                        "content": [{"type": "text", "text": "stream please"}],
                    },
                },
            )
            resp.raise_for_status()
            print(f"conversation {resp.json()['id']} started; "
                  f"streaming for ~{STREAM_SECONDS:.0f}s\n")

            print(f"{'t (s)':>6}  {'idle_time (s)':>13}")
            worst, start = 0.0, time.monotonic()
            while time.monotonic() - start < STREAM_SECONDS:
                time.sleep(5)
                info = client.get("/server_info").json()
                worst = max(worst, info["idle_time"])
                print(f"{time.monotonic() - start:6.0f}  {info['idle_time']:13.0f}")

            print(f"\nmax idle_time seen during the stream: {worst:.0f}s")


if __name__ == "__main__":
    main()
```

</details>

`main` @ `881c49835` — the idle clock climbs for the whole completion:

```
 t (s)  idle_time (s)
     5              5
    25             25
    50             50
    75             75

max idle_time seen during the stream: 75s
```

This branch — the heartbeat lands every 30 s, so the clock never runs away:

```
 t (s)  idle_time (s)
     5              4
    25             24
    30             29
    35              4      <- heartbeat
    60             29
    65              4      <- heartbeat
    75             14

max idle_time seen during the stream: 29s
```

**Regression tests** (`tests/agent_server/test_event_streaming.py`) — `test_deltas_keep_idle_time_below_the_threshold` fails on `main` with `assert 2400.0 < 1200.0` and passes here; `test_delta_idle_signal_is_throttled` pins the 30 s throttle.

```
uv run pytest tests/agent_server -q       # 2110 passed
uv run pytest tests/sdk/agent -q          # 842 passed
uv run pytest tests/cross/test_check_sdk_api_breakage.py -q   # 64 passed
uv run pre-commit run --files <changed>   # all passed
```

## Video/Screenshots

Terminal output from the end-to-end run is inlined above (before/after `idle_time` tables).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `ACTIVITY_SIGNAL_INTERVAL` is newly public on `openhands.sdk.agent.acp_agent`. Griffe ignores private members, so dropping the underscored name is not a reported API breakage (`tests/cross/test_check_sdk_api_breakage.py` passes).
- Placing the signal on the producer is what keeps #4671 safe: when deltas stop being `Event`s on the shared `PubSub`, `_publish_stream_delta` is still the one place they are born.


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d8d2034-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d8d2034-python \
  ghcr.io/openhands/agent-server:d8d2034-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d8d2034-golang-amd64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-golang-amd64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-golang-amd64
ghcr.io/openhands/agent-server:d8d2034-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d8d2034-golang-arm64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-golang-arm64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-golang-arm64
ghcr.io/openhands/agent-server:d8d2034-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d8d2034-java-amd64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-java-amd64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-java-amd64
ghcr.io/openhands/agent-server:d8d2034-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d8d2034-java-arm64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-java-arm64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-java-arm64
ghcr.io/openhands/agent-server:d8d2034-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d8d2034-python-amd64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-python-amd64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-python-amd64
ghcr.io/openhands/agent-server:d8d2034-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d8d2034-python-arm64
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-python-arm64
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-python-arm64
ghcr.io/openhands/agent-server:d8d2034-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d8d2034-golang
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-golang
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-golang
ghcr.io/openhands/agent-server:d8d2034-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d8d2034-java
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-java
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-java
ghcr.io/openhands/agent-server:d8d2034-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d8d2034-python
ghcr.io/openhands/agent-server:d8d203414e8168b51436af6f71d4e48cd5031591-python
ghcr.io/openhands/agent-server:vasco-idle-timer-streaming-deltas-python
ghcr.io/openhands/agent-server:d8d2034-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d8d2034-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d8d2034-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->