### PR TITLE
fix(acp): bump codex-acp to 1.7.0

### DIFF
--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -41,7 +41,7 @@ describe('ACP provider credential descriptors', () => {
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {
     const codex = ACP_PROVIDERS.codex;
-    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.1.7']);
+    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.6.2']);
     expect(codex.default_session_mode).toBe('agent-full-access');
     expect(codex.available_models.map((model) => model.id)).toEqual(
       expect.arrayContaining(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])

--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -41,7 +41,7 @@ describe('ACP provider credential descriptors', () => {
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {
     const codex = ACP_PROVIDERS.codex;
-    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.6.2']);
+    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.7.0']);
     expect(codex.default_session_mode).toBe('agent-full-access');
     expect(codex.available_models.map((model) => model.id)).toEqual(
       expect.arrayContaining(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -40,7 +40,7 @@
   "codex": {
     "key": "codex",
     "display_name": "Codex",
-    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.1.7"],
+    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.6.2"],
     "api_key_env_var": "OPENAI_API_KEY",
     "base_url_env_var": "OPENAI_BASE_URL",
     "default_session_mode": "agent-full-access",

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -40,7 +40,7 @@
   "codex": {
     "key": "codex",
     "display_name": "Codex",
-    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.6.2"],
+    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.7.0"],
     "api_key_env_var": "OPENAI_API_KEY",
     "base_url_env_var": "OPENAI_BASE_URL",
     "default_session_mode": "agent-full-access",

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -121,7 +121,7 @@ RUN set -eux; \
       case "$provider" in \
         claude-code) PACKAGES="$PACKAGES @agentclientprotocol/claude-agent-acp@0.63.0"; \
           WRAPPER_BINS="$WRAPPER_BINS claude-agent-acp";; \
-        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.6.2"; \
+        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.7.0"; \
           WRAPPER_BINS="$WRAPPER_BINS codex-acp";; \
         gemini-cli) PACKAGES="$PACKAGES @google/gemini-cli@0.46.0"; \
           WRAPPER_BINS="$WRAPPER_BINS gemini";; \

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -121,7 +121,7 @@ RUN set -eux; \
       case "$provider" in \
         claude-code) PACKAGES="$PACKAGES @agentclientprotocol/claude-agent-acp@0.63.0"; \
           WRAPPER_BINS="$WRAPPER_BINS claude-agent-acp";; \
-        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.1.7"; \
+        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.6.2"; \
           WRAPPER_BINS="$WRAPPER_BINS codex-acp";; \
         gemini-cli) PACKAGES="$PACKAGES @google/gemini-cli@0.46.0"; \
           WRAPPER_BINS="$WRAPPER_BINS gemini";; \

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -391,7 +391,7 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
 CLAUDE_AGENT_ACP_VERSION = "0.63.0"
-CODEX_ACP_VERSION = "1.1.7"
+CODEX_ACP_VERSION = "1.6.2"
 GEMINI_CLI_VERSION = "0.46.0"
 
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -391,7 +391,7 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
 CLAUDE_AGENT_ACP_VERSION = "0.63.0"
-CODEX_ACP_VERSION = "1.6.2"
+CODEX_ACP_VERSION = "1.7.0"
 GEMINI_CLI_VERSION = "0.46.0"
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5059,7 +5059,7 @@ class TestWithCodexBaseUrl:
         original = env.copy()
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.7.0"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"]) == {
@@ -5095,7 +5095,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.7.0"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"])["openai_base_url"] == (
@@ -5110,7 +5110,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
+            ["-y", "@agentclientprotocol/codex-acp@1.7.0"],
             env,
         )
         assert result == env

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5059,7 +5059,7 @@ class TestWithCodexBaseUrl:
         original = env.copy()
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
+            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"]) == {
@@ -5095,7 +5095,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
+            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
             env,
         )
         assert json.loads(result["CODEX_CONFIG"])["openai_base_url"] == (
@@ -5110,7 +5110,7 @@ class TestWithCodexBaseUrl:
         }
         result = _with_codex_base_url(
             "npx",
-            ["-y", "@agentclientprotocol/codex-acp@1.1.7"],
+            ["-y", "@agentclientprotocol/codex-acp@1.6.2"],
             env,
         )
         assert result == env

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1546,7 +1546,7 @@ def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
     monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
     for pkg in (
         "@agentclientprotocol/codex-acp",
-        "@agentclientprotocol/codex-acp@1.1.7",
+        "@agentclientprotocol/codex-acp@1.6.2",
     ):
         settings = ACPAgentSettings(
             acp_server="codex",
@@ -1568,7 +1568,7 @@ def test_acp_resolve_command_keeps_npx_when_binary_absent(
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
-        "@agentclientprotocol/codex-acp@1.1.7",
+        "@agentclientprotocol/codex-acp@1.6.2",
     ]
 
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1546,7 +1546,7 @@ def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
     monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
     for pkg in (
         "@agentclientprotocol/codex-acp",
-        "@agentclientprotocol/codex-acp@1.6.2",
+        "@agentclientprotocol/codex-acp@1.7.0",
     ):
         settings = ACPAgentSettings(
             acp_server="codex",
@@ -1568,7 +1568,7 @@ def test_acp_resolve_command_keeps_npx_when_binary_absent(
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
-        "@agentclientprotocol/codex-acp@1.6.2",
+        "@agentclientprotocol/codex-acp@1.7.0",
     ]
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The built-in Codex ACP provider still launches `@agentclientprotocol/codex-acp@1.1.7`, both through the native `npx` fallback and the preinstalled agent-server Docker wrapper. Bump both paths to the explicitly pinned `1.7.0` release and keep the TypeScript provider registry aligned.

Release notes: https://github.com/agentclientprotocol/codex-acp/releases/tag/v1.7.0

## Summary

- Update the SDK launcher and Docker installation from 1.1.7 to 1.7.0.
- Update the TypeScript registry mirror and existing launch-command / proxy-configuration test expectations.
- Leave custom-command handling, model defaults, authentication, and other provider versions unchanged.

## Issue Number
No existing issue identified for this version bump.

## How to Test

Verified locally:

- `make build` — development environment setup passed.
- `uv run pre-commit run --files <the six changed files>` — passed, including Ruff and Pyright for Python files.
- `uv run pytest tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py -q` — **617 passed**.
- `uv run python clients/typescript/scripts/check-acp-drift.py` — all three provider records match the SDK.
- In `clients/typescript`: `npm ci`, `npm run lint`, `npm run build`, and `npm test -- --runInBand` — passed; **309 tests across 18 suites**.
- `uv build --package openhands-sdk --out-dir /tmp/openhands-codex-acp-1.7.0-dist` — wheel and sdist built successfully.
- `npx -y @agentclientprotocol/codex-acp@1.7.0 --version` — reports `@agentclientprotocol/codex-acp 1.7.0`.

Runtime validation (Linux arm64):

```sh
docker build --target acp-providers --build-arg INSTALL_ACP_PROVIDERS=codex \
  -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
  -t codex-acp-upstream:1.7.0 .
docker run --rm --network none codex-acp-upstream:1.7.0 \
  /opt/acp-wrappers/codex-acp --version
```

The provider stage builds and the installed wrapper reports version 1.7.0. Sending the following JSON-RPC line over stdin to the wrapper in an interactive container (`docker run --rm -i --network none ...`) completes the real ACP initialization handshake:

```json
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"openhands-pin-smoke","version":"1.0.0"}}}
```

The response contains `protocolVersion: 1` and `agentInfo: {name: "@agentclientprotocol/codex-acp", title: "Codex", version: "1.7.0"}`. No credentials, host mounts, or network access were provided.

The full Python suite has not been run to completion for 1.7.0; the 617 focused Python tests above were rerun on this version. An authenticated model conversation, the complete agent-server image, and Linux amd64 have not been validated locally.

## Video/Screenshots

No UI changes. Runtime commands and observed handshake output are recorded above.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This targets 1.7.0 as explicitly requested by the contributor. Npm published it on 2026-08-27, so it is within the repository's seven-day dependency freshness window at PR preparation time (2026-08-31). Maintainers should account for that before merging.

The canonical provider configuration lives in this SDK repository; `OpenHands/OpenHands` consumes it through `@openhands/typescript-client`. Canvas will need to adopt a client release containing this updated registry. This PR does not migrate previously saved explicit commands.

Kept as a draft pending the human testing note and maintainer review.


