### PR TITLE
fix(ci): stop the endpoint audit failing every fork PR

### DIFF
--- a/.github/scripts/post-typescript-endpoint-audit-report.cjs
+++ b/.github/scripts/post-typescript-endpoint-audit-report.cjs
@@ -95,6 +95,17 @@ function renderEndpointAuditReport(report) {
   ].join('\n');
 }
 
+// A pull_request raised from a fork runs with a read-only GITHUB_TOKEN, so
+// `pull-requests: write` cannot be honoured and the comment POST comes back
+// 403 "Resource not accessible by integration". Push events have no PR at all
+// (context.issue.number is undefined), and the same guard covers them.
+function canCommentOnPullRequest(context) {
+  if (!context || context.eventName !== 'pull_request') return false;
+  const head = context.payload?.pull_request?.head;
+  if (!head?.repo?.full_name) return false;
+  return head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+}
+
 async function postEndpointAuditReport({ github, context, core, reportPath = REPORT_PATH }) {
   if (!fs.existsSync(reportPath)) {
     core.warning(`No audit report at ${reportPath}; skipping PR comment.`);
@@ -102,6 +113,21 @@ async function postEndpointAuditReport({ github, context, core, reportPath = REP
   }
 
   const body = renderEndpointAuditReport(JSON.parse(fs.readFileSync(reportPath, 'utf8')));
+
+  // The job summary is the one surface every run can write, so the report
+  // reaches a reviewer even when the comment is unavailable.
+  if (core?.summary) {
+    await core.summary.addRaw(body).write();
+  }
+
+  if (!canCommentOnPullRequest(context)) {
+    core.info(
+      'Skipping the PR comment: this run is a push or a fork pull_request, ' +
+        'whose token cannot write comments. The report is in the job summary.'
+    );
+    return;
+  }
+
   const { owner, repo } = context.repo;
   const issue_number = context.issue.number;
   const comments = await github.paginate(github.rest.issues.listComments, {
@@ -118,4 +144,4 @@ async function postEndpointAuditReport({ github, context, core, reportPath = REP
   }
 }
 
-module.exports = { postEndpointAuditReport, renderEndpointAuditReport };
+module.exports = { canCommentOnPullRequest, postEndpointAuditReport, renderEndpointAuditReport };

--- a/.github/workflows/typescript-client-endpoint-audit.yml
+++ b/.github/workflows/typescript-client-endpoint-audit.yml
@@ -4,12 +4,12 @@ name: TypeScript client endpoint audit
 on:
     push:
         branches: [main]
-  # Required for the "Comment audit report on PR" step: it is gated on
-  # github.event_name == 'pull_request' and relies on the PR context
-  # (context.issue.number), neither of which exists on a push event.
     pull_request:
 
-# Needed so the audit can post its report as a comment on the PR.
+# pull-requests: write lets same-repo PR runs post the report as a comment.
+# Fork pull_request runs get a read-only token regardless, so they and push
+# runs publish the report to the job summary instead (see
+# canCommentOnPullRequest in .github/scripts/post-typescript-endpoint-audit-report.cjs).
 permissions:
     contents: read
     pull-requests: write
@@ -53,11 +53,13 @@ jobs:
           # .audit/ is a dot-directory; upload-artifact@v4 skips hidden paths by default.
                   include-hidden-files: true
 
-      # Post the report as a single, self-updating comment on the PR. Runs even
-      # when the audit gate fails (the report is written before the gate), so
-      # reviewers see the mismatches that failed the check.
-            - name: Comment audit report on PR
-              if: always() && github.event_name == 'pull_request'
+      # Publish the report. It always lands in the job summary, and additionally
+      # as a single self-updating PR comment when the run's token can write one
+      # (same-repo pull requests). Runs even when the audit gate fails (the
+      # report is written before the gate), so reviewers see the mismatches that
+      # failed the check.
+            - name: Publish audit report
+              if: always()
               uses: actions/github-script@v7
               with:
                   script: |

--- a/clients/typescript/scripts/test-endpoint-audit.mjs
+++ b/clients/typescript/scripts/test-endpoint-audit.mjs
@@ -15,6 +15,50 @@ const { postEndpointAuditReport, renderEndpointAuditReport } = require(
 );
 const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'endpoint-audit-'));
 
+const summaryWrites = [];
+
+function fakeCore(overrides = {}) {
+  let buffer = '';
+  return {
+    warning: assert.fail,
+    info: () => {},
+    ...overrides,
+    summary: {
+      addRaw(text) {
+        buffer += text;
+        return this;
+      },
+      async write() {
+        summaryWrites.push(buffer);
+        buffer = '';
+        return this;
+      },
+    },
+  };
+}
+
+function sameRepoContext(number) {
+  return {
+    eventName: 'pull_request',
+    repo: { owner: 'OpenHands', repo: 'software-agent-sdk' },
+    issue: { number },
+    payload: {
+      pull_request: { head: { repo: { full_name: 'OpenHands/software-agent-sdk' } } },
+    },
+  };
+}
+
+function forkContext(number) {
+  return {
+    eventName: 'pull_request',
+    repo: { owner: 'OpenHands', repo: 'software-agent-sdk' },
+    issue: { number },
+    payload: {
+      pull_request: { head: { repo: { full_name: 'georgeglarson/software-agent-sdk' } } },
+    },
+  };
+}
+
 try {
   fs.mkdirSync(path.join(fixtureRoot, 'src/client'), { recursive: true });
 
@@ -113,8 +157,8 @@ try {
   let updatedComment;
   await postEndpointAuditReport({
     reportPath: path.join(fixtureRoot, '.audit/endpoint-audit.json'),
-    context: { repo: { owner: 'OpenHands', repo: 'typescript-client' }, issue: { number: 307 } },
-    core: { warning: assert.fail },
+    context: sameRepoContext(4775),
+    core: fakeCore(),
     github: {
       paginate: async () => [{ id: 123, body: '<!-- endpoint-audit-report -->old' }],
       rest: {
@@ -129,9 +173,74 @@ try {
     },
   });
   assert.equal(updatedComment.owner, 'OpenHands');
-  assert.equal(updatedComment.repo, 'typescript-client');
+  assert.equal(updatedComment.repo, 'software-agent-sdk');
   assert.equal(updatedComment.comment_id, 123);
   assert.equal(updatedComment.body, body);
+
+  assert(summaryWrites.length === 1, 'a same-repo PR still writes the job summary');
+  assert(summaryWrites[0].includes('Endpoint audit'), 'the summary carries the report');
+
+  // A fork PR runs with a read-only GITHUB_TOKEN, so the comment POST 403s and
+  // takes the whole job red. The report goes to the job summary and the
+  // comment is skipped rather than attempted.
+  summaryWrites.length = 0;
+  const forkInfo = [];
+  await postEndpointAuditReport({
+    reportPath: path.join(fixtureRoot, '.audit/endpoint-audit.json'),
+    context: forkContext(4775),
+    core: fakeCore({ info: (msg) => forkInfo.push(msg) }),
+    github: {
+      paginate: async () => assert.fail('a fork PR must not read comments'),
+      rest: {
+        issues: {
+          listComments: () => assert.fail('a fork PR must not read comments'),
+          updateComment: async () => assert.fail('a fork PR must not post a comment'),
+          createComment: async () => assert.fail('a fork PR must not post a comment'),
+        },
+      },
+    },
+  });
+  assert.equal(summaryWrites.length, 1, 'a fork PR still writes the job summary');
+  assert(summaryWrites[0].includes('Endpoint audit'), 'the fork summary carries the report');
+  assert(
+    forkInfo.some((msg) => msg.includes('fork')),
+    'the skip is announced, not silent'
+  );
+
+  // A push event has no PR to comment on at all (context.issue.number is
+  // undefined there), so the same guard covers it.
+  summaryWrites.length = 0;
+  await postEndpointAuditReport({
+    reportPath: path.join(fixtureRoot, '.audit/endpoint-audit.json'),
+    context: { eventName: 'push', repo: { owner: 'OpenHands', repo: 'software-agent-sdk' } },
+    core: fakeCore(),
+    github: {
+      paginate: async () => assert.fail('a push event must not read comments'),
+      rest: {
+        issues: {
+          listComments: () => assert.fail('a push event must not read comments'),
+          updateComment: async () => assert.fail('a push event must not post a comment'),
+          createComment: async () => assert.fail('a push event must not post a comment'),
+        },
+      },
+    },
+  });
+  assert.equal(summaryWrites.length, 1, 'a push run still writes the job summary');
+
+  // A missing report is still a warning with nothing published.
+  summaryWrites.length = 0;
+  const warnings = [];
+  await postEndpointAuditReport({
+    reportPath: path.join(fixtureRoot, '.audit/does-not-exist.json'),
+    context: sameRepoContext(4775),
+    core: fakeCore({ warning: (msg) => warnings.push(msg) }),
+    github: {
+      paginate: async () => assert.fail('a missing report must not read comments'),
+      rest: { issues: { listComments: () => assert.fail('no report, no comment') } },
+    },
+  });
+  assert.equal(summaryWrites.length, 0, 'no report means no summary');
+  assert.equal(warnings.length, 1, 'a missing report warns');
 
   console.log('endpoint-audit tooling test passed');
 } finally {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Human verified. Screenshot attached.

---

AGENT:

Ported the fix from OpenHands/typescript-client#367 (closed unmerged when that repo was archived and the client moved here) onto the copies that arrived with the move. Verified end-to-end from `clients/typescript`:

- `npm ci && npm run test:endpoint-audit-tooling` → `endpoint-audit tooling test passed`. The extended test drives `postEndpointAuditReport` through three contexts against a real rendered report: a fork `pull_request` (comment API must not be touched, report lands in the job summary, skip is logged), a `push` event (same guard), and a same-repo PR (existing comment updated as before). It also covers a missing report warning with nothing published.
- `npm run audit:endpoints` → `✅ endpoint audit passed`, so report generation is unchanged.
- `pre-commit run --files` on all three changed files → passed.

## Why

A `pull_request` raised from a fork runs with a read-only `GITHUB_TOKEN`, so the workflow's `pull-requests: write` grant cannot be honoured and the report's comment POST comes back `403 Resource not accessible by integration`. The step is `if: always()`, so that 403 fails the whole `endpoint-audit` check on every fork pull request, whatever the audit itself found. It is red on #4775 right now: https://github.com/OpenHands/software-agent-sdk/actions/runs/33341834102 (the audit itself passes; only the comment step fails).

Push events have no PR to comment on at all, so `context.issue.number` is undefined there and the same guard covers them.

## Summary

- Write the rendered report to the job summary on every run, so it reaches a reviewer when the comment is unavailable.
- Attempt the comment only when the run's token can write one, which is a same-repo `pull_request`.
- Drop the step's `pull_request`-only condition so push runs publish the summary too.

No permission change and no move to `pull_request_target`. The 403 is not swallowed: a same-repo run that cannot comment still fails loudly.

## Issue Number

Fixes #4798. Reproducible on any fork PR — the failure currently red on the MCP-structured-results PR is the run linked above.

## How to Test

```bash
cd clients/typescript
npm ci
npm run test:endpoint-audit-tooling   # includes the fork/push/same-repo comment-guard cases
npm run audit:endpoints               # report generation unchanged
```

The workflow-level behaviour can also be observed on this PR's own `TypeScript client endpoint audit` run: this is a fork PR, so the previously-red comment step should now complete, skip the comment with an explanatory log line, and publish the report to the job summary.

## Video/Screenshots

<img width="867" height="835" alt="image" src="https://github.com/user-attachments/assets/700e895e-6405-469a-8c03-0a25984e1f51" />


## Design Doc

N/A — small CI fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This same fix was previously reviewed as OpenHands/typescript-client#367 and was closed unmerged only because that repository was archived on 2026-08-30 when the client moved into this repo (#371). The bug came along with the moved files.


