### PR TITLE
feat(ci): catch overdue Pydantic Field-level deprecations in check_deprecations.py

### DIFF
--- a/.github/scripts/check_deprecations.py
+++ b/.github/scripts/check_deprecations.py
@@ -2,12 +2,20 @@
 """Static analysis for deprecation deadlines.
 
 This script scans Python deprecation metadata (`deprecated`, `warn_deprecated`,
-`warn_cleanup`) and agent-server REST routes marked `deprecated=True`. It fails
-when a version-based deprecation schedule provides less than 5 minor releases of
-runway, or when the current project version has reached or passed a feature's
-removal marker. This catches invalid schedules when they are introduced and later
-ensures legacy shims and overdue deprecated REST endpoints are cleaned up before
-release.
+`warn_cleanup`), agent-server REST routes marked `deprecated=True`, and Pydantic
+`Field(deprecated=True, ...)` declarations whose description carries the same
+versioned schedule wording. It fails when a version-based deprecation schedule
+provides less than 5 minor releases of runway, or when the current project
+version has reached or passed a feature's removal marker. This catches invalid
+schedules when they are introduced and later ensures legacy shims, overdue
+deprecated REST endpoints, and overdue deprecated schema fields are cleaned up
+before release.
+
+Not every `Field(deprecated=True)` declares a version-based schedule -- some are
+open-ended backward-compatibility aliases with no planned removal. Only fields
+whose description matches the "Deprecated since vX.Y.Z and scheduled for
+removal in vA.B.C." wording are subject to the runway/overdue check; others are
+left alone.
 """
 
 from __future__ import annotations
@@ -87,7 +95,9 @@ class DeprecationRecord:
     deprecated_in: str | None
     path: Path
     line: int
-    kind: Literal["decorator", "warn_call", "cleanup_call", "rest_route"]
+    kind: Literal[
+        "decorator", "warn_call", "cleanup_call", "rest_route", "pydantic_field"
+    ]
     package: str
 
 
@@ -328,6 +338,60 @@ def _gather_rest_route_deprecations(
             )
 
 
+def _gather_pydantic_field_deprecations(
+    tree: ast.AST, path: Path, *, package: str
+) -> Iterator[DeprecationRecord]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        for stmt in node.body:
+            if not isinstance(stmt, ast.AnnAssign):
+                continue
+            if not isinstance(stmt.target, ast.Name) or not isinstance(
+                stmt.value, ast.Call
+            ):
+                continue
+
+            call = stmt.value
+            func = call.func
+            if isinstance(func, ast.Name):
+                call_name = func.id
+            elif isinstance(func, ast.Attribute):
+                call_name = func.attr
+            else:
+                continue
+            if call_name != "Field":
+                continue
+
+            deprecated_value = _extract_kw(call, "deprecated")
+            if (
+                not isinstance(deprecated_value, ast.Constant)
+                or deprecated_value.value is not True
+            ):
+                continue
+
+            description = _extract_string_literal(_extract_kw(call, "description"))
+            if description is None:
+                continue
+
+            match = REST_ROUTE_DEPRECATION_RE.search(" ".join(description.split()))
+            if match is None:
+                # No version-based schedule declared; treat as an open-ended
+                # backward-compatibility alias, not subject to this check.
+                continue
+
+            yield DeprecationRecord(
+                identifier=f"{node.name}.{stmt.target.id}",
+                removed_in=match.group("removed").rstrip("."),
+                deprecated_in=match.group("deprecated").rstrip("."),
+                path=path,
+                line=stmt.lineno,
+                kind="pydantic_field",
+                package=package,
+            )
+
+
 def _gather_decorators(
     tree: ast.AST, path: Path, *, package: str
 ) -> Iterator[DeprecationRecord]:
@@ -467,6 +531,16 @@ def _collect_rest_route_records(
     return records
 
 
+def _collect_pydantic_field_records(
+    files: Iterable[Path], *, package: str
+) -> list[DeprecationRecord]:
+    records: list[DeprecationRecord] = []
+    for path in files:
+        tree = ast.parse(path.read_text())
+        records.extend(_gather_pydantic_field_deprecations(tree, path, package=package))
+    return records
+
+
 def _version_ge(current: str, target: str) -> bool:
     try:
         return pkg_version.parse(current) >= pkg_version.parse(target)
@@ -584,6 +658,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         records = _collect_records(files, package=package.name)
         if package.name == "openhands-agent-server":
             records.extend(_collect_rest_route_records(files, package=package.name))
+        records.extend(_collect_pydantic_field_records(files, package=package.name))
 
         overdue.extend(r for r in records if _should_fail(current_version, r))
         invalid_runway.extend(

--- a/tests/cross/test_check_deprecations.py
+++ b/tests/cross/test_check_deprecations.py
@@ -26,6 +26,7 @@ def _load_prod_module():
 _prod = _load_prod_module()
 DeprecationRecord = _prod.DeprecationRecord
 _gather_rest_route_deprecations = _prod._gather_rest_route_deprecations
+_gather_pydantic_field_deprecations = _prod._gather_pydantic_field_deprecations
 _runway_error = _prod._runway_error
 _should_fail = _prod._should_fail
 
@@ -111,6 +112,94 @@ def test_gather_rest_route_deprecations_requires_parseable_docstring(tmp_path):
         )
 
 
+def test_gather_pydantic_field_deprecations_collects_scheduled_field(tmp_path):
+    path = tmp_path / "model.py"
+    tree = ast.parse(
+        "class Foo(BaseModel):\n"
+        "    bar: str | None = Field(\n"
+        "        default=None,\n"
+        "        deprecated=True,\n"
+        "        description=(\n"
+        '            "Deprecated since v1.10.0 and scheduled for removal in '
+        'v1.15.0. "\n'
+        '            "Use baz instead."\n'
+        "        ),\n"
+        "    )\n"
+    )
+
+    records = list(
+        _gather_pydantic_field_deprecations(
+            tree, path, package="openhands-agent-server"
+        )
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.identifier == "Foo.bar"
+    assert record.deprecated_in == "1.10.0"
+    assert record.removed_in == "1.15.0"
+    assert record.kind == "pydantic_field"
+    assert record.path == path
+
+
+def test_gather_pydantic_field_deprecations_skips_open_ended_field(tmp_path):
+    """A deprecated=True field with no versioned schedule is not tracked.
+
+    Some deprecations are deliberately open-ended backward-compatibility
+    aliases (e.g. SubAgentInfo.mcp_servers) with no planned removal version.
+    """
+    path = tmp_path / "model.py"
+    tree = ast.parse(
+        "class Foo(BaseModel):\n"
+        "    baz: str | None = Field(\n"
+        "        default=None,\n"
+        "        deprecated=True,\n"
+        '        description="Deprecated compat alias, use bar instead.",\n'
+        "    )\n"
+    )
+
+    assert (
+        list(
+            _gather_pydantic_field_deprecations(
+                tree, path, package="openhands-agent-server"
+            )
+        )
+        == []
+    )
+
+
+def test_gather_pydantic_field_deprecations_ignores_non_deprecated_fields(tmp_path):
+    path = tmp_path / "model.py"
+    tree = ast.parse(
+        "class Foo(BaseModel):\n"
+        '    bar: str | None = Field(default=None, description="Not deprecated.")\n'
+    )
+
+    assert (
+        list(
+            _gather_pydantic_field_deprecations(
+                tree, path, package="openhands-agent-server"
+            )
+        )
+        == []
+    )
+
+
+def test_should_fail_for_overdue_pydantic_field_record():
+    record = DeprecationRecord(
+        identifier="Foo.bar",
+        removed_in="1.15.0",
+        deprecated_in="1.10.0",
+        path=Path("model.py"),
+        line=5,
+        kind="pydantic_field",
+        package="openhands-agent-server",
+    )
+
+    assert _should_fail("1.15.0", record) is True
+    assert _should_fail("1.14.9", record) is False
+
+
 def test_should_fail_for_overdue_rest_route_record():
     record = DeprecationRecord(
         identifier="POST /foo",
@@ -174,6 +263,41 @@ def test_main_fails_for_invalid_runway(monkeypatch, tmp_path, capsys):
     output = capsys.readouterr().out
     assert "less than 5 minor releases" in output
     assert "minimum removed_in: 1.33.0" in output
+
+
+def test_main_fails_for_overdue_pydantic_field(monkeypatch, tmp_path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "1.20.0"\n')
+    source_root = tmp_path / "pkg"
+    source_root.mkdir()
+    (source_root / "model.py").write_text(
+        "class Foo(BaseModel):\n"
+        "    bar: str | None = Field(\n"
+        "        default=None,\n"
+        "        deprecated=True,\n"
+        "        description=(\n"
+        '            "Deprecated since v1.10.0 and scheduled for removal in '
+        'v1.15.0."\n'
+        "        ),\n"
+        "    )\n"
+    )
+    monkeypatch.setattr(_prod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        _prod,
+        "PACKAGES",
+        (
+            _prod.PackageConfig(
+                name="test-package",
+                pyproject=pyproject,
+                source_roots=(source_root,),
+            ),
+        ),
+    )
+
+    assert _prod.main([]) == 1
+    output = capsys.readouterr().out
+    assert "passed their removal deadline" in output
+    assert "Foo.bar" in output
 
 
 def test_runway_error_accepts_five_minor_releases():


### PR DESCRIPTION
HUMAN:

Extend check_deprecations.py to catch overdue Pydantic Field-level deprecations, per the follow-up from #4792/#4795.

---

AGENT:

## Why

`check_deprecations.py` fails CI when a version-based deprecation schedule provides less than 5 minor releases of runway, or when the current package version has reached/passed a feature's declared removal version. It already covers two mechanisms:

1. The `openhands.sdk.utils.deprecation.deprecated` decorator (`removed_in` / `deprecated_in` kwargs).
2. FastAPI REST route operations marked `deprecated=True`, via a docstring note (`Deprecated since vX.Y.Z and scheduled for removal in vA.B.C.`).

It does not scan Pydantic `Field(deprecated=True, description="Deprecated since v... and scheduled for removal in v...")` declarations on request/response models. That gap let `SkillsRequest.org_config` (`openhands-agent-server/openhands/agent_server/skills_router.py`, removed in #4795) sit 11 minor releases past its own v1.33.0 removal deadline with zero CI signal. `check_agent_server_rest_api_breakage.py` recognizes the same wording for schema-property removals, but only at the moment a property is actually removed — it never flags one that's simply overdue and still present, which is exactly what `check_deprecations.py`'s overdue/runway logic is for.

## Summary

- Add `_gather_pydantic_field_deprecations()`, which walks `ClassDef` bodies for `AnnAssign` attributes assigned a `Field(...)` call with `deprecated=True`, and — only when the field's `description` matches the existing `Deprecated since vX.Y.Z and scheduled for removal in vA.B.C.` wording (reusing `REST_ROUTE_DEPRECATION_RE`) — yields a `DeprecationRecord` of a new `"pydantic_field"` kind, feeding the same overdue/invalid-runway checks that REST routes and the Python decorator already go through.
- **Deliberately permissive, not strict**: a `Field(deprecated=True)` with no version-based schedule in its description is silently skipped rather than flagged as a format violation. Unlike REST route operations (where this repo's policy mandates the versioned wording for every public `/api/**` deprecation), several existing Pydantic fields are intentionally open-ended backward-compatibility aliases with no planned removal — e.g. `SubAgentInfo.mcp_servers` and `MCPProbeResult.resolved_mcp_servers` in `openhands-agent-server`, and `TaskAction.max_turns` in `openhands-tools`. Requiring all of them to adopt a hard removal date wasn't the ask and would force a policy change on working code well outside this issue's scope — so only fields that *do* declare a schedule are held to it.
- Wire the new gatherer into `main()`'s per-package loop unconditionally (not gated to `openhands-agent-server`, since Field-level deprecations can appear in any of the four packages).
- Add unit tests mirroring the existing REST-route test style: positive detection of a scheduled field, a skip test for an open-ended field, a skip test for a non-deprecated field, an overdue-record `_should_fail` test, and an end-to-end `main()` fixture test (analogous to `test_main_fails_for_invalid_runway`) proving an overdue Pydantic field actually fails the script with a clear message.

Verified against the live repo tree: the only currently-scheduled `Field(deprecated=True, ...)` was `org_config`, removed in #4795 (this branch is stacked on that PR so its own CI stays green); the four open-ended ones above are correctly left untouched.

## How to Test

```bash
uv run --frozen ruff check .github/scripts/check_deprecations.py tests/cross/test_check_deprecations.py
uv run --frozen ruff format --check .github/scripts/check_deprecations.py tests/cross/test_check_deprecations.py
# All checks passed! / already formatted

uv run --frozen pytest tests/cross/test_check_deprecations.py -q
# 14 passed (7 new)

uv run --frozen pytest tests/cross -q --timeout=60
# full cross-tests suite, no regressions

# Live run against this repo tree
uv run --with packaging python .github/scripts/check_deprecations.py
# openhands-agent-server: checked 1 deprecation metadata entries against version 1.44.1.
# (the desktop_router stub from #4792 — correctly within its runway)
```

## Stacking note

This branch is stacked on #4795 (removes the only currently-overdue field this check would have caught) so this PR's own CI isn't red on day one from pre-existing repo state unrelated to this diff. GitHub will show only this PR's own commit once #4795 merges and this branch is rebased onto `main`.

## Issue Number

Fixes #4794
