### PR TITLE
fix(events): use the WebSocket global and drop the ws dependency

### DIFF
--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.44.1",
       "license": "MIT",
       "dependencies": {
-        "@openrouter/sdk": "^1.2.11",
-        "ws": "^8.20.0"
+        "@openrouter/sdk": "^1.2.11"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -7800,27 +7799,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/wsl-utils": {

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -86,8 +86,7 @@
   "author": "OpenHands Team",
   "license": "MIT",
   "dependencies": {
-    "@openrouter/sdk": "^1.2.11",
-    "ws": "^8.20.0"
+    "@openrouter/sdk": "^1.2.11"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.29.5",

--- a/clients/typescript/src/__tests__/package-import.test.ts
+++ b/clients/typescript/src/__tests__/package-import.test.ts
@@ -11,15 +11,15 @@
  *
  *     import { RemoteWorkspace } from "@openhands/typescript-client";
  *
- * These tests pin the new behaviour: the WebSocket modules never throw at
- * module load, and the "no WebSocket implementation" condition is reported
- * via the existing `onError` callback only when `start()` is called.
+ * The `ws` fallback is gone. Every runtime this package supports supplies a
+ * standards-compatible WebSocket global, so the clients read
+ * `globalThis.WebSocket` directly.
  *
- * Implementation note: the default Jest runner is CommonJS, so plain
- * `require('ws')` *succeeds* in tests and hides the bug. Each test below
- * uses `jest.isolateModules` + `jest.doMock('ws', () => { throw ... })` so
- * the module-load path is exercised against the same conditions a real
- * Node.js ESM consumer hits.
+ * These tests pin two things: the WebSocket modules never throw at module
+ * load even when no implementation exists, and the "no WebSocket
+ * implementation" condition is reported via the existing `onError` callback
+ * only when `start()` is called. Deleting the global is the real condition a
+ * consumer would hit, rather than a simulation of it.
  */
 
 const WEBSOCKET_MODULES = [
@@ -27,18 +27,24 @@ const WEBSOCKET_MODULES = [
   '../events/bash-websocket-client',
 ] as const;
 
-const mockWsAsUnavailable = (): void => {
-  jest.doMock('ws', () => {
-    throw new Error('ws is not available in this environment');
-  });
+const originalWebSocket = globalThis.WebSocket;
+
+/** Remove the global before the module under test reads it at load time. */
+const removeWebSocketGlobal = (): void => {
+  globalThis.WebSocket = undefined as unknown as typeof WebSocket;
 };
 
-describe('package imports do not crash when `ws` is unavailable', () => {
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+  jest.resetModules();
+});
+
+describe('package imports do not crash without a WebSocket implementation', () => {
   describe.each(WEBSOCKET_MODULES)('%s', (modulePath) => {
     it('does not throw at module load', () => {
       expect(() => {
         jest.isolateModules(() => {
-          mockWsAsUnavailable();
+          removeWebSocketGlobal();
           // eslint-disable-next-line @typescript-eslint/no-require-imports
           require(modulePath);
         });
@@ -46,13 +52,13 @@ describe('package imports do not crash when `ws` is unavailable', () => {
     });
   });
 
-  it('importing the package barrel does not throw when `ws` is unavailable', () => {
+  it('importing the package barrel does not throw', () => {
     // This is the exact failure agent-canvas hit:
     //   import { RemoteWorkspace } from "@openhands/typescript-client";
     // would crash because the barrel transitively loads the websocket modules.
     expect(() => {
       jest.isolateModules(() => {
-        mockWsAsUnavailable();
+        removeWebSocketGlobal();
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const pkg = require('../index');
         // Touch a non-WebSocket export to make sure nothing is lazy in a way
@@ -64,10 +70,10 @@ describe('package imports do not crash when `ws` is unavailable', () => {
     }).not.toThrow();
   });
 
-  it('constructing RemoteWorkspace does not require `ws`', () => {
+  it('constructing RemoteWorkspace does not need a WebSocket', () => {
     expect(() => {
       jest.isolateModules(() => {
-        mockWsAsUnavailable();
+        removeWebSocketGlobal();
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { RemoteWorkspace } = require('../index');
         new RemoteWorkspace({
@@ -79,54 +85,77 @@ describe('package imports do not crash when `ws` is unavailable', () => {
     }).not.toThrow();
   });
 
-  it('WebSocketCallbackClient.start() reports the missing implementation via onError instead of throwing', () => {
-    let captured: Error | undefined;
+  it.each([
+    ['../events/websocket-client', 'WebSocketCallbackClient', { conversationId: 'conv-1' }],
+    ['../events/bash-websocket-client', 'BashWebSocketClient', {}],
+  ])(
+    '%s %s.start() reports the missing implementation via onError',
+    (modulePath, exportName, extra) => {
+      let captured: Error | undefined;
+
+      jest.isolateModules(() => {
+        removeWebSocketGlobal();
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const module = require(modulePath);
+        const client = new module[exportName]({
+          host: 'http://example.com',
+          callback: () => {},
+          onError: (err: Error) => {
+            captured = err;
+          },
+          ...(extra as Record<string, unknown>),
+        });
+        try {
+          client.start();
+        } finally {
+          client.stop();
+        }
+      });
+
+      expect(captured).toBeInstanceOf(Error);
+      expect(captured?.message).toMatch(/WebSocket implementation not available/i);
+    }
+  );
+});
+
+describe('the clients use globalThis.WebSocket when it exists', () => {
+  it.each([
+    {
+      modulePath: '../events/websocket-client',
+      exportName: 'WebSocketCallbackClient',
+      options: { host: 'http://example.com', conversationId: 'conv-1', callback: () => {} },
+      expectedUrl: 'ws://example.com/sockets/events/conv-1',
+    },
+    {
+      modulePath: '../events/bash-websocket-client',
+      exportName: 'BashWebSocketClient',
+      options: { host: 'http://example.com', callback: () => {} },
+      expectedUrl: 'ws://example.com/sockets/bash-events',
+    },
+  ])('$exportName opens $expectedUrl', ({ modulePath, exportName, options, expectedUrl }) => {
+    const urls: string[] = [];
+    class FakeWebSocket {
+      onopen?: () => void;
+      onmessage?: (event: { data: unknown }) => void;
+      onclose?: () => void;
+      onerror?: () => void;
+
+      constructor(url: string) {
+        urls.push(url);
+      }
+
+      close(): void {}
+    }
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
 
     jest.isolateModules(() => {
-      mockWsAsUnavailable();
       // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { WebSocketCallbackClient } = require('../events/websocket-client');
-      const client = new WebSocketCallbackClient({
-        host: 'http://example.com',
-        conversationId: 'conv-1',
-        callback: () => {},
-        onError: (err: Error) => {
-          captured = err;
-        },
-      });
-      try {
-        client.start();
-      } finally {
-        client.stop();
-      }
+      const module = require(modulePath);
+      const client = new module[exportName](options);
+      client.start();
+      client.stop();
     });
 
-    expect(captured).toBeInstanceOf(Error);
-    expect(captured?.message).toMatch(/WebSocket implementation not available/i);
-  });
-
-  it('BashWebSocketClient.start() reports the missing implementation via onError instead of throwing', () => {
-    let captured: Error | undefined;
-
-    jest.isolateModules(() => {
-      mockWsAsUnavailable();
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { BashWebSocketClient } = require('../events/bash-websocket-client');
-      const client = new BashWebSocketClient({
-        host: 'http://example.com',
-        callback: () => {},
-        onError: (err: Error) => {
-          captured = err;
-        },
-      });
-      try {
-        client.start();
-      } finally {
-        client.stop();
-      }
-    });
-
-    expect(captured).toBeInstanceOf(Error);
-    expect(captured?.message).toMatch(/WebSocket implementation not available/i);
+    expect(urls).toEqual([expectedUrl]);
   });
 });

--- a/clients/typescript/src/events/bash-websocket-client.ts
+++ b/clients/typescript/src/events/bash-websocket-client.ts
@@ -5,23 +5,11 @@
 import { BashEvent } from '../models/workspace';
 import { ErrorCallbackType } from './websocket-client';
 
-// IMPORTANT: this block must never throw. See the matching note in
-// `events/websocket-client.ts` — the "no WebSocket implementation"
-// condition is deferred to connect() time so importing this module does
-// not crash consumers that never use bash event streaming.
-let WebSocketImpl: any;
-
-if (typeof window !== 'undefined' && window.WebSocket) {
-  WebSocketImpl = window.WebSocket;
-} else {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const ws = require('ws');
-    WebSocketImpl = ws;
-  } catch {
-    WebSocketImpl = undefined;
-  }
-}
+// See the matching note in `events/websocket-client.ts`: reading the global
+// never throws, and the "no WebSocket implementation" condition stays
+// deferred to connect() time so importing this module does not crash
+// consumers that never use bash event streaming.
+const WebSocketImpl: typeof WebSocket | undefined = globalThis.WebSocket;
 
 export interface BashWebSocketClientOptions {
   host: string;

--- a/clients/typescript/src/events/websocket-client.ts
+++ b/clients/typescript/src/events/websocket-client.ts
@@ -4,31 +4,18 @@
 
 import { Event, ConversationCallbackType } from '../types/base';
 
-// Use native WebSocket in browser, ws library in Node.js.
+// Every runtime this package supports supplies a standards-compatible
+// WebSocket global: browsers, and Node.js since 22.4.
 //
-// IMPORTANT: this block must never throw. It runs whenever this file is
-// imported, and this file is transitively imported by the package barrel
-// (via RemoteConversation), so any throw here crashes consumers that
-// merely `import { RemoteWorkspace } from "@openhands/typescript-client"`
-// even when they have no intent to open a WebSocket. The "no implementation
-// available" condition is deferred to connect() time, where it is surfaced
-// through the existing onError callback channel.
-let WebSocketImpl: any;
-
-if (typeof window !== 'undefined' && window.WebSocket) {
-  // Browser environment
-  WebSocketImpl = window.WebSocket;
-} else {
-  // Node.js environment
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const ws = require('ws');
-    WebSocketImpl = ws;
-  } catch {
-    // Leave WebSocketImpl undefined; connect() reports the error via onError.
-    WebSocketImpl = undefined;
-  }
-}
+// IMPORTANT: this must never throw. It runs whenever this file is imported,
+// and this file is transitively imported by the package barrel (via
+// RemoteConversation), so any throw here crashes consumers that merely
+// `import { RemoteWorkspace } from "@openhands/typescript-client"` even when
+// they have no intent to open a WebSocket. Reading a missing global yields
+// undefined rather than throwing, and the "no implementation available"
+// condition stays deferred to connect() time, where it is surfaced through
+// the existing onError callback channel.
+const WebSocketImpl: typeof WebSocket | undefined = globalThis.WebSocket;
 
 /**
  * Error callback type for reporting non-fatal errors.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Human verified, Screenshot attached.

---

AGENT:

Ported from OpenHands/typescript-client#370 (closed unmerged when that repo was archived and the client moved here; the moved files are byte-identical to the pre-fix versions, so the bug crossed repos untouched). Verified end-to-end from `clients/typescript`:

- Reproduced the issue on `main` first: `npm ci && npm run build`, then the repro from the linked issue — `onError` receives `WebSocket implementation not available` on Node 22.22.2 despite `globalThis.WebSocket` existing.
- Same repro on this branch: the error is gone; the client reads the global and attempts the connection.
- `npx jest src/__tests__/package-import.test.ts` → 8 passed, including new cases asserting each client opens the exact expected URL against a fake `globalThis.WebSocket`.
- `npm test` → 311 passed, 18 suites. `npm run lint` → 0 errors (and two fewer pre-existing `any` warnings in these files). `npm run format:check` → clean. `npm run build` → clean.

## Why

The package is emitted as ESM, and Node 22 provides a standards-compatible `globalThis.WebSocket`. The conversation and bash event clients only checked `window.WebSocket`, then attempted `require('ws')` — which is unavailable in ESM — so starting either client in a Node ESM process reported `WebSocket implementation not available` even though the global exists. Full repro in the linked issue.

## Summary

- Read `globalThis.WebSocket` directly in both event clients and drop the `ws` dependency (every supported runtime supplies the global: browsers, and Node.js since 22.4).
- Keep the "no implementation" condition deferred to `connect()` time and surfaced via the existing `onError` callback, so importing the package barrel still never throws.
- Rewrite the package-import tests to delete the global for real instead of mocking `ws`, and add coverage pinning the URL each client opens.

## Issue Number

Fixes #4846.

## How to Test

```bash
cd clients/typescript
npm ci
npm run build
node --input-type=module -e "const {WebSocketCallbackClient}=await import('./dist/events/websocket-client.js'); const client=new WebSocketCallbackClient({host:'http://127.0.0.1:9',conversationId:'test',callback:()=>{},onError:(e)=>console.error('ONERROR:',e.message)}); client.start(); client.stop()"
```

On `main` this prints `ONERROR: ... WebSocket implementation not available`; on this branch it does not. Then `npm test` and `npx jest src/__tests__/package-import.test.ts`.

## Video/Screenshots

<img width="1771" height="1724" alt="image" src="https://github.com/user-attachments/assets/4b2544d7-a93d-4548-9073-8c2cd70d2ed3" />


## Design Doc

N/A — small runtime-detection fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The same change was previously reviewed as OpenHands/typescript-client#370 and went unmerged only because that repository was archived on 2026-08-30 when the client moved into this repo (OpenHands/typescript-client#371). Consumers on Node < 22.4 would lose the `ws` fallback, but the package already requires Node 22-era tooling throughout its CI and the global has been unflagged since Node 22.4.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.53s · commit b39586a  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 8/8 hunks, 5/5 files (missing context: 4).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 21.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 47.0% | No primary concern to locate |

</details>


<!-- jev-input-signature d4d93fbc2803367900e5406a367d98104f74855717d9200dfb42c62f5eed1b10 -->
<!-- jev-fast-audit:end -->
