### PR TITLE
fix(sdk): remove secrets from subprocess env

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -15,8 +15,19 @@ logger = get_logger(__name__)
 
 # Env vars that should not be exposed to subprocesses (e.g., bash commands
 # executed by the agent). These credentials allow access to user secrets via
-# the SaaS API and must remain isolated to the SDK's Python process.
-_SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})
+# the SaaS API and/or decrypt persisted secrets, and must remain isolated to
+# the SDK's Python process.
+#
+# - ``SESSION_API_KEY``: legacy (V0) session key name.
+# - ``OH_SECRET_KEY``: cipher key that decrypts persisted conversation/provider
+#   secrets; leaking it is at least as damaging as leaking the session key.
+# See ``openhands.agent_server.config`` for where these are read from the env.
+_SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY", "OH_SECRET_KEY"})
+
+# Session keys are also delivered as an indexed list ``OH_SESSION_API_KEYS_0``,
+# ``OH_SESSION_API_KEYS_1``, ... (V1). Strip every slot by prefix so a rename or
+# an added rotation key cannot silently re-expose the credential to subprocesses.
+_SENSITIVE_ENV_PREFIXES: tuple[str, ...] = ("OH_SESSION_API_KEYS_",)
 _AI_AGENT_ENV_VAR: Final[str] = "AI_AGENT"
 
 
@@ -45,6 +56,14 @@ def sanitized_env(
 
     # Strip sensitive env vars to prevent agent access via bash commands
     for key in _SENSITIVE_ENV_VARS:
+        base_env.pop(key, None)
+
+    # Strip indexed / prefixed credential slots (e.g. OH_SESSION_API_KEYS_0..N).
+    for key in [
+        k
+        for k in base_env
+        if any(k.startswith(prefix) for prefix in _SENSITIVE_ENV_PREFIXES)
+    ]:
         base_env.pop(key, None)
 
     if not base_env.get(_AI_AGENT_ENV_VAR, "").strip():

--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 
 # Env vars that should not be exposed to subprocesses (e.g., bash commands
 # executed by the agent). These credentials allow access to user secrets via
-# the SaaS API and/or decrypt persisted secrets, and must remain isolated to
+# the SaaS API and/or decrypting persisted secrets, and must remain isolated to
 # the SDK's Python process.
 #
 # - ``SESSION_API_KEY``: legacy (V0) session key name.

--- a/tests/sdk/utils/test_command.py
+++ b/tests/sdk/utils/test_command.py
@@ -14,6 +14,27 @@ def test_sanitized_env_returns_copy():
     assert result is not env
 
 
+def test_sanitized_env_strips_sensitive_credentials():
+    """Session key (V0), the cipher key, and indexed session-key slots (V1)
+    must never reach subprocesses, while ordinary vars are preserved."""
+    env = {
+        "SESSION_API_KEY": "v0-session",
+        "OH_SECRET_KEY": "cipher-secret",
+        "OH_SESSION_API_KEYS_0": "v1-session-0",
+        "OH_SESSION_API_KEYS_1": "v1-session-1",
+        "OH_WEB_URL": "https://example.test",
+        "FOO": "bar",
+    }
+    result = sanitized_env(env)
+    assert "SESSION_API_KEY" not in result
+    assert "OH_SECRET_KEY" not in result
+    assert "OH_SESSION_API_KEYS_0" not in result
+    assert "OH_SESSION_API_KEYS_1" not in result
+    # Non-sensitive vars (including other OH_* config) are preserved.
+    assert result["OH_WEB_URL"] == "https://example.test"
+    assert result["FOO"] == "bar"
+
+
 def test_sanitized_env_preserves_explicit_ai_agent():
     result = sanitized_env({"AI_AGENT": "wrapper"})
     assert result["AI_AGENT"] == "wrapper"


### PR DESCRIPTION
HUMAN:
My agent was looking into the codebase in relation to a proposal for adding more API keys handling to agent-server, and found some code which strips session api key, but not the secret keys for custom secrets encryption.

---

AGENT:

Verified end-to-end, not just unit tests. On a clean worktree off `upstream/main` I reproduced the leak, applied the fix, and confirmed the regression test fails before and passes after.

Repro before the fix (agent-visible env):
```
$ uv run python -c "from openhands.sdk.utils.command import sanitized_env; \
  print({k: '<present>' for k in sanitized_env({'OH_SECRET_KEY':'x','OH_SESSION_API_KEYS_0':'y'})})"
# OH_SECRET_KEY and OH_SESSION_API_KEYS_0 both present -> readable by an agent via `echo $OH_SECRET_KEY`
```

Test evidence:
```
$ uv run pytest tests/sdk/utils/test_command.py -q
13 passed in 0.04s
# with the source fix reverted, the new test fails exactly on OH_SECRET_KEY:
$ git stash -- openhands-sdk/.../command.py && uv run pytest -q tests/sdk/utils/test_command.py::test_sanitized_env_strips_sensitive_credentials
FAILED ... AssertionError: assert 'OH_SECRET_KEY' not in {...'OH_SECRET_KEY': 'cipher-secret'...}
```
pre-commit (ruff, ruff-format, pycodestyle, pyright, import rules) all pass.

## Why

`sanitized_env()` is the single chokepoint for the environment handed to every agent-run subprocess (bash, file_editor, grep, glob, and hooks all call it). It stripped **only** the legacy V0 name `SESSION_API_KEY`, while the same server process env also holds:

- **`OH_SECRET_KEY`** — the cipher that decrypts persisted conversation/provider secrets (unlocks *every* stored credential, not one), and
- **`OH_SESSION_API_KEYS_0..N`** — the **V1 name(s)** for the very session key the denylist was meant to hide (`config.py`: `V1_SESSION_API_KEY_ENV = "OH_SESSION_API_KEYS_0"`, parsed as an indexed list).

Both are read from the process env by the agent-server `EnvParser`, so before this change a prompt-injected or misbehaving agent could recover them from a shell (`echo "$OH_SECRET_KEY"`). The V0-only strip gives a false sense of protection: it blocks `SESSION_API_KEY` but not the *current* name of the same secret, nor the cipher key.

## Summary

- Add `OH_SECRET_KEY` to `_SENSITIVE_ENV_VARS`.
- Strip the `OH_SESSION_API_KEYS_` **prefix** (not a single literal), so renames / added rotation slots can't silently re-expose the credential.
- Non-sensitive `OH_*` config (e.g. `OH_WEB_URL`) is preserved.
- Add `test_sanitized_env_strips_sensitive_credentials` (fails on pre-fix code for `OH_SECRET_KEY` and the V1 slots).

## Issue Number

Fixes #4802

## How to Test

```bash
uv run pytest tests/sdk/utils/test_command.py -q      # all green, incl. new regression test

# confirm the test actually catches the bug:
git stash -- openhands-sdk/openhands/sdk/utils/command.py
uv run pytest tests/sdk/utils/test_command.py::test_sanitized_env_strips_sensitive_credentials -q   # FAILS on OH_SECRET_KEY
git stash pop
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This is a denylist; a follow-up could derive the sensitive names from the `config.py` constants (single source of truth) or move to an allowlist for defense in depth. Kept this PR minimal and surgical.
- Broader context: even with this fix, the agent-server still runs the agent's tools inside the same process/sandbox that holds these credentials, so env-scrubbing is a mitigation, not an isolation boundary. Relevant to the RBAC discussion in OpenHands/OpenHands#17055.
