### PR TITLE
Add parameterized ACP session capability and config support

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -33,9 +33,13 @@ from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
     AllowedOutcome,
+    ClientCapabilities,
+    ConfigOptionUpdate,
     ImageContentBlock,
     PromptResponse,
     RequestPermissionResponse,
+    SessionConfigOption,
+    SessionModelState,
     TextContentBlock,
     ToolCallProgress,
     ToolCallStart,
@@ -133,6 +137,13 @@ _ENV_CONFLICT_MAP: dict[str, frozenset[str]] = {
 # for large tool output.
 _STREAM_READER_LIMIT: int = 100 * 1024 * 1024  # 100 MiB
 
+# Bound on each await performed while tearing down a partially initialized
+# ACP subprocess.  Initialization can fail after the process is spawned but
+# before its handles reach the ACPAgent attributes, so that teardown is the
+# only thing able to reap it — and it must not hang the failing init_state
+# call on a subprocess that is already wedged or gone.
+_ACP_INIT_ABORT_TIMEOUT: float = float(os.environ.get("ACP_INIT_ABORT_TIMEOUT", "5.0"))
+
 # Minimum interval between on_activity heartbeat signals (seconds).
 # Throttled to avoid excessive calls while still keeping the idle timer
 # well below the ~20 min runtime-api kill threshold.
@@ -201,11 +212,20 @@ def _select_auth_method(
     return None
 
 
+class ACPSessionConfigError(RuntimeError):
+    """A requested ACP session configuration could not be applied or verified.
+
+    Raised during initialization so the session is never prompted with a
+    configuration the ACP server did not confirm.
+    """
+
+
 async def _maybe_set_session_model(
     conn: ClientSideConnection,
     agent_name: str,
     session_id: str,
     acp_model: str | None,
+    model_state: SessionModelState | None = None,
 ) -> None:
     """Apply a protocol-level session model override when the server supports it.
 
@@ -213,12 +233,115 @@ async def _maybe_set_session_model(
     to check whether the server supports ``set_session_model``.
     claude-agent-acp uses session ``_meta`` via
     :func:`~openhands.sdk.settings.acp_providers.build_session_model_meta` instead.
+
+    Servers outside the provider registry are routed by capability rather than
+    by name: *model_state* is the ``models`` field the ACP server returned from
+    ``new_session`` / ``load_session``, and its presence is the protocol-level
+    signal that the server supports ``session/set_model``.  Registry providers
+    keep their existing routing, and servers that advertise no model state are
+    left untouched.
     """
     if not acp_model:
         return
     provider = detect_acp_provider_by_agent_name(agent_name)
-    if provider is not None and provider.supports_set_session_model:
+    if provider is not None:
+        if provider.supports_set_session_model:
+            await conn.set_session_model(model_id=acp_model, session_id=session_id)
+        return
+    if model_state is not None:
         await conn.set_session_model(model_id=acp_model, session_id=session_id)
+
+
+def _config_option_values(
+    options: list[SessionConfigOption] | None,
+) -> dict[str, str]:
+    """Map ``option id -> current value`` for a complete config option state."""
+    if not options:
+        return {}
+    return {option.root.id: option.root.current_value for option in options}
+
+
+async def _apply_session_config_options(
+    conn: ClientSideConnection,
+    client: _OpenHandsACPBridge,
+    agent_name: str,
+    session_id: str,
+    requested: dict[str, str],
+    initial_options: list[SessionConfigOption] | None,
+) -> None:
+    """Apply *requested* session config options and verify the observed state.
+
+    Runs once per session — after ``new_session`` and after a successful
+    ``load_session`` — so a resumed session is configured exactly like a fresh
+    one, before any prompt is sent.
+
+    Every requested option is set with ``set_config_option`` and then verified
+    against the *complete* option state the server reports back.  The state
+    returned by the response is preferred; the ``ConfigOptionUpdate``
+    notification recorded for this exact session is only consulted when the
+    response does not describe the option (some servers publish the new state
+    asynchronously, and selecting one option can reveal another).
+
+    Raises:
+        ACPSessionConfigError: if the server exposes no config options, a
+            requested option is absent, ``set_config_option`` fails, no
+            complete state comes back, or the reported value differs from the
+            requested one.  Never returns while a requested option is
+            unverified.
+    """
+    if not requested:
+        return
+
+    state = _config_option_values(initial_options)
+    observed = _config_option_values(client.get_config_options(session_id))
+    if not state and not observed:
+        raise ACPSessionConfigError(
+            f"ACP server {agent_name!r} session {session_id} reported no session "
+            f"configuration options, but {sorted(requested)} were requested."
+        )
+
+    for config_id, value in requested.items():
+        if config_id not in state and config_id in observed:
+            state = observed
+        if config_id not in state:
+            raise ACPSessionConfigError(
+                f"ACP server {agent_name!r} session {session_id} does not expose "
+                f"configuration option {config_id!r}; available options: "
+                f"{sorted(state)}."
+            )
+        try:
+            response = await conn.set_config_option(
+                config_id=config_id,
+                session_id=session_id,
+                value=value,
+            )
+        except Exception as e:
+            raise ACPSessionConfigError(
+                f"ACP server {agent_name!r} session {session_id} failed to set "
+                f"configuration option {config_id!r}={value!r}: {e}"
+            ) from e
+
+        observed = _config_option_values(client.get_config_options(session_id))
+        state = _config_option_values(response.config_options) or observed
+        if not state:
+            raise ACPSessionConfigError(
+                f"ACP server {agent_name!r} session {session_id} returned no "
+                f"configuration state after setting {config_id!r}={value!r}; "
+                "the requested configuration cannot be verified."
+            )
+        current = state.get(config_id)
+        if current != value:
+            raise ACPSessionConfigError(
+                f"ACP server {agent_name!r} session {session_id} reports "
+                f"configuration option {config_id!r}={current!r} after "
+                f"requesting {value!r}."
+            )
+        logger.info(
+            "ACP session config option verified: %s=%s (session %s)",
+            config_id,
+            value,
+            session_id,
+        )
 
 
 def _extract_token_usage(
@@ -343,6 +466,57 @@ async def _filter_jsonrpc_lines(source: Any, dest: Any) -> None:
         dest.feed_eof()
 
 
+def _signal_acp_process(process: Any, method: Literal["terminate", "kill"]) -> None:
+    """Send ``terminate``/``kill`` to *process*, ignoring any failure.
+
+    Deliberately synchronous: this is the one teardown step that still works
+    when the coroutine doing the cleanup is itself being cancelled.
+    """
+    try:
+        getattr(process, method)()
+    except Exception as e:
+        logger.debug("Error sending %s to ACP process: %s", method, e)
+
+
+async def _await_bounded(awaitable: Any, what: str) -> bool:
+    """Await *awaitable* under ``_ACP_INIT_ABORT_TIMEOUT``; report completion.
+
+    Teardown-only helper: a hung or already-broken transport must not keep a
+    failing initialization alive, so a timeout, a transport error, or a
+    non-awaitable is logged and reported as "did not complete" rather than
+    raised.  Cancellation still propagates so the caller can escalate.
+    """
+    try:
+        await asyncio.wait_for(awaitable, timeout=_ACP_INIT_ABORT_TIMEOUT)
+        return True
+    except Exception as e:
+        logger.debug("ACP init teardown: %s did not complete (%s)", what, e)
+        return False
+
+
+async def _abort_partial_acp_init(
+    process: Any,
+    conn: Any,
+    filter_task: asyncio.Task | None,
+) -> None:
+    """Close the connection and reap an ACP subprocess whose init failed.
+
+    Every step is best-effort and bounded, so the teardown can neither raise
+    over the original failure nor stall it: the stdout filter task is
+    cancelled, the JSON-RPC connection is closed, and the subprocess is
+    terminated — escalating to ``kill`` if it does not exit in time.
+    """
+    if filter_task is not None:
+        filter_task.cancel()
+    if conn is not None:
+        await _await_bounded(conn.close(), "closing the ACP connection")
+    _signal_acp_process(process, "terminate")
+    if await _await_bounded(process.wait(), "waiting for the ACP process to exit"):
+        return
+    _signal_acp_process(process, "kill")
+    await _await_bounded(process.wait(), "reaping the killed ACP process")
+
+
 class _OpenHandsACPBridge:
     """Bridge between OpenHands and ACP that accumulates session updates.
 
@@ -412,6 +586,10 @@ class _OpenHandsACPBridge:
         # Per-turn synchronization for UsageUpdate notifications.
         self._turn_usage_updates: dict[str, Any] = {}
         self._usage_received: dict[str, asyncio.Event] = {}
+        # Last complete session config option state observed per session id.
+        # Keyed by session so an update for a different session can never
+        # satisfy the verification of this one.
+        self._config_options_by_session: dict[str, list[SessionConfigOption]] = {}
         # Fork session state for ask_agent() — guarded by _fork_lock to
         # prevent concurrent ask_agent() calls from colliding.
         self._fork_lock = threading.Lock()
@@ -429,6 +607,7 @@ class _OpenHandsACPBridge:
         self._usage_received.clear()
         # Note: telemetry state (_last_cost, _context_window, _last_activity_signal,
         # etc.) is intentionally NOT cleared — it accumulates across turns.
+        # Session config option state is likewise session-scoped, not per-turn.
 
     def prepare_usage_sync(self, session_id: str) -> asyncio.Event:
         """Prepare per-turn UsageUpdate synchronization for a session."""
@@ -445,6 +624,10 @@ class _OpenHandsACPBridge:
         """Consume per-turn UsageUpdate synchronization state for a session."""
         self._usage_received.pop(session_id, None)
         return self._turn_usage_updates.pop(session_id, None)
+
+    def get_config_options(self, session_id: str) -> list[SessionConfigOption] | None:
+        """Return the last complete config option state seen for *session_id*."""
+        return self._config_options_by_session.get(session_id)
 
     # -- Client protocol methods ------------------------------------------
 
@@ -484,6 +667,11 @@ class _OpenHandsACPBridge:
             event = self._usage_received.get(session_id)
             if event is not None:
                 event.set()
+        elif isinstance(update, ConfigOptionUpdate):
+            # The Agent publishes the full option set on every change; record
+            # it per session so initialization can verify requested options
+            # even when the server answers set_config_option asynchronously.
+            self._config_options_by_session[session_id] = list(update.config_options)
         elif isinstance(update, ToolCallStart):
             entry = {
                 "tool_call_id": update.tool_call_id,
@@ -718,6 +906,28 @@ class ACPAgent(AgentBase):
             "'gpt-5.4'). For Claude ACP, passed via session _meta. For Codex "
             "ACP, applied via the protocol-level set_session_model call. "
             "If None, the server picks its default."
+        ),
+    )
+    acp_client_capabilities: ClientCapabilities | None = Field(
+        default=None,
+        description=(
+            "Explicit ACP client capabilities to send with initialize(). "
+            "When None (default) the argument is omitted and the ACP library's "
+            "own default capabilities apply. Capability flags that are not part "
+            "of the ACP schema travel through the protocol's extensibility "
+            "field, e.g. ClientCapabilities(field_meta="
+            "{'parameterizedModelPicker': True})."
+        ),
+    )
+    acp_config_options: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Session configuration options to apply before the first prompt, "
+            "as ACP config option id -> requested value (e.g. "
+            "{'effort': 'medium', 'fast': 'false'}). Applied in order and "
+            "verified against the option state the server reports, on both new "
+            "and resumed sessions. Initialization fails if a requested option "
+            "is missing or the session does not report the requested value."
         ),
     )
 
@@ -1020,119 +1230,181 @@ class ACPAgent(AgentBase):
             assert process.stdin is not None
             assert process.stdout is not None
 
-            # Wrap the subprocess stdout in a filtering reader that
-            # only passes lines starting with '{' (JSON-RPC messages).
-            filtered_reader = asyncio.StreamReader(limit=_STREAM_READER_LIMIT)
-            asyncio.get_event_loop().create_task(
-                _filter_jsonrpc_lines(process.stdout, filtered_reader)
-            )
+            # ``conn`` / ``filter_task`` stay None until they exist so the
+            # teardown below only touches what was actually created.
+            conn: ClientSideConnection | None = None
+            filter_task: asyncio.Task | None = None
+            try:
+                # Wrap the subprocess stdout in a filtering reader that
+                # only passes lines starting with '{' (JSON-RPC messages).
+                filtered_reader = asyncio.StreamReader(limit=_STREAM_READER_LIMIT)
+                filter_task = asyncio.get_event_loop().create_task(
+                    _filter_jsonrpc_lines(process.stdout, filtered_reader)
+                )
 
-            conn = ClientSideConnection(
-                client,
-                process.stdin,  # write to subprocess
-                filtered_reader,  # read filtered output
-            )
+                conn = ClientSideConnection(
+                    client,
+                    process.stdin,  # write to subprocess
+                    filtered_reader,  # read filtered output
+                )
 
-            # Initialize the protocol and discover server identity
-            init_response = await conn.initialize(protocol_version=1)
-            agent_name = ""
-            agent_version = ""
-            if init_response.agent_info is not None:
-                agent_name = init_response.agent_info.name or ""
-                agent_version = init_response.agent_info.version or ""
-            logger.info(
-                "ACP server initialized: agent_name=%r, agent_version=%r",
-                agent_name,
-                agent_version,
-            )
-
-            # Authenticate if the server requires it.  Some ACP servers
-            # (e.g. codex-acp) require an explicit authenticate call
-            # before session creation.  We auto-detect the method from
-            # the env vars that are available to the process.
-            auth_methods = init_response.auth_methods or []
-            if auth_methods:
-                method_id = _select_auth_method(auth_methods, env)
-                if method_id is not None:
-                    logger.info("Authenticating with ACP method: %s", method_id)
-                    auth_kwargs: dict[str, Any] = {}
-                    # gemini-cli: pass gateway baseUrl to route API calls
-                    # through LiteLLM proxy. claude-agent-acp and codex-acp
-                    # read their provider base URL from env vars directly.
-                    if method_id == "gemini-api-key":
-                        provider = detect_acp_provider_by_agent_name(agent_name)
-                        base_url_var = (
-                            provider.base_url_env_var if provider is not None else None
-                        )
-                        if base_url_var:
-                            base_url = env.get(base_url_var)
-                            if base_url:
-                                auth_kwargs["gateway"] = {"baseUrl": base_url}
-                    await conn.authenticate(method_id=method_id, **auth_kwargs)
+                # Initialize the protocol and discover server identity.  The
+                # capabilities argument is only sent when the caller supplied one,
+                # so servers keep seeing the library defaults otherwise.
+                if self.acp_client_capabilities is not None:
+                    init_response = await conn.initialize(
+                        protocol_version=1,
+                        client_capabilities=self.acp_client_capabilities,
+                    )
                 else:
-                    logger.warning(
-                        "ACP server offers auth methods %s but no matching "
-                        "env var is set — session creation may fail",
-                        [m.id for m in auth_methods],
-                    )
+                    init_response = await conn.initialize(protocol_version=1)
+                agent_name = ""
+                agent_version = ""
+                if init_response.agent_info is not None:
+                    agent_name = init_response.agent_info.name or ""
+                    agent_version = init_response.agent_info.version or ""
+                logger.info(
+                    "ACP server initialized: agent_name=%r, agent_version=%r",
+                    agent_name,
+                    agent_version,
+                )
 
-            # Resume the prior ACP session if we have its id.  If the server
-            # has forgotten it (state wiped, new host, etc.) fall through to
-            # new_session so the conversation still starts cleanly.
-            #
-            # We only swallow ACPRequestError here: that is the protocol-level
-            # "I don't know this session" signal and is recoverable by
-            # starting fresh.  Transport failures (broken pipe, EOF, timeout,
-            # subprocess crash) propagate — there is no working connection to
-            # fall back on, and the outer init_state handler cleans up.
-            session_id: str | None = None
-            if prior_session_id is not None:
+                # Authenticate if the server requires it.  Some ACP servers
+                # (e.g. codex-acp) require an explicit authenticate call
+                # before session creation.  We auto-detect the method from
+                # the env vars that are available to the process.
+                auth_methods = init_response.auth_methods or []
+                if auth_methods:
+                    method_id = _select_auth_method(auth_methods, env)
+                    if method_id is not None:
+                        logger.info("Authenticating with ACP method: %s", method_id)
+                        auth_kwargs: dict[str, Any] = {}
+                        # gemini-cli: pass gateway baseUrl to route API calls
+                        # through LiteLLM proxy. claude-agent-acp and codex-acp
+                        # read their provider base URL from env vars directly.
+                        if method_id == "gemini-api-key":
+                            provider = detect_acp_provider_by_agent_name(agent_name)
+                            base_url_var = (
+                                provider.base_url_env_var
+                                if provider is not None
+                                else None
+                            )
+                            if base_url_var:
+                                base_url = env.get(base_url_var)
+                                if base_url:
+                                    auth_kwargs["gateway"] = {"baseUrl": base_url}
+                        await conn.authenticate(method_id=method_id, **auth_kwargs)
+                    else:
+                        logger.warning(
+                            "ACP server offers auth methods %s but no matching "
+                            "env var is set — session creation may fail",
+                            [m.id for m in auth_methods],
+                        )
+
+                # Resume the prior ACP session if we have its id.  If the server
+                # has forgotten it (state wiped, new host, etc.) fall through to
+                # new_session so the conversation still starts cleanly.
+                #
+                # We only swallow ACPRequestError here: that is the protocol-level
+                # "I don't know this session" signal and is recoverable by
+                # starting fresh.  Transport failures (broken pipe, EOF, timeout,
+                # subprocess crash) propagate — there is no working connection to
+                # fall back on, and the outer init_state handler cleans up.
+                session_id: str | None = None
+                # Initial session state reported by load_session / new_session.
+                # Both are used to configure the session identically below.
+                config_options: list[SessionConfigOption] | None = None
+                model_state: SessionModelState | None = None
+                if prior_session_id is not None:
+                    try:
+                        load_response = await conn.load_session(
+                            cwd=working_dir,
+                            session_id=prior_session_id,
+                            mcp_servers=[],
+                        )
+                        session_id = prior_session_id
+                        config_options = load_response.config_options
+                        model_state = load_response.models
+                        logger.info(
+                            "Resumed ACP session: %s (cwd=%s)",
+                            session_id,
+                            working_dir,
+                        )
+                    except ACPRequestError as e:
+                        logger.warning(
+                            "ACP load_session(%s) failed (%s); starting fresh session",
+                            prior_session_id,
+                            e,
+                        )
+
+                if session_id is None:
+                    # Build _meta content for session options (e.g. model selection).
+                    # Extra kwargs to new_session() become the _meta dict in the
+                    # JSON-RPC request — do NOT wrap in _meta= (that double-nests).
+                    session_meta = build_session_model_meta(agent_name, self.acp_model)
+                    response = await conn.new_session(cwd=working_dir, **session_meta)
+                    session_id = response.session_id
+                    config_options = response.config_options
+                    model_state = response.models
+                await _maybe_set_session_model(
+                    conn,
+                    agent_name,
+                    session_id,
+                    self.acp_model,
+                    model_state,
+                )
+
+                # Resolve the permission mode.  Known providers each have their
+                # own mode ID (bypassPermissions, full-access, yolo …).
+                # Unknown/custom servers get None — skip the call rather than
+                # sending a provider-specific string they won't recognise.
+                provider = detect_acp_provider_by_agent_name(agent_name)
+                mode_id = self.acp_session_mode or (
+                    provider.default_session_mode if provider else None
+                )
+                if mode_id is not None:
+                    logger.info("Setting ACP session mode: %s", mode_id)
+                    await conn.set_session_mode(mode_id=mode_id, session_id=session_id)
+
+                # Requested session configuration is applied and verified here —
+                # part of initialization, so step() never prompts a session whose
+                # configuration the server did not confirm.  Runs last so options
+                # that depend on the selected model are resolved against the
+                # server's post-model state.
+                await _apply_session_config_options(
+                    conn,
+                    client,
+                    agent_name,
+                    session_id,
+                    self.acp_config_options,
+                    config_options,
+                )
+
+                return (
+                    conn,
+                    process,
+                    filtered_reader,
+                    session_id,
+                    agent_name,
+                    agent_version,
+                )
+            except BaseException:
+                # The subprocess is already running, but its handles have not
+                # been published to the ACPAgent attributes yet — ``init_state``
+                # cleanup cannot see them, so nothing else would ever reap the
+                # process.  Tear it down here before the failure propagates.
+                teardown = asyncio.ensure_future(
+                    _abort_partial_acp_init(process, conn, filter_task)
+                )
                 try:
-                    await conn.load_session(
-                        cwd=working_dir,
-                        session_id=prior_session_id,
-                        mcp_servers=[],
-                    )
-                    session_id = prior_session_id
-                    logger.info(
-                        "Resumed ACP session: %s (cwd=%s)",
-                        session_id,
-                        working_dir,
-                    )
-                except ACPRequestError as e:
-                    logger.warning(
-                        "ACP load_session(%s) failed (%s); starting a fresh session",
-                        prior_session_id,
-                        e,
-                    )
-
-            if session_id is None:
-                # Build _meta content for session options (e.g. model selection).
-                # Extra kwargs to new_session() become the _meta dict in the
-                # JSON-RPC request — do NOT wrap in _meta= (that double-nests).
-                session_meta = build_session_model_meta(agent_name, self.acp_model)
-                response = await conn.new_session(cwd=working_dir, **session_meta)
-                session_id = response.session_id
-            await _maybe_set_session_model(
-                conn,
-                agent_name,
-                session_id,
-                self.acp_model,
-            )
-
-            # Resolve the permission mode.  Known providers each have their
-            # own mode ID (bypassPermissions, full-access, yolo …).
-            # Unknown/custom servers get None — skip the call rather than
-            # sending a provider-specific string they won't recognise.
-            provider = detect_acp_provider_by_agent_name(agent_name)
-            mode_id = self.acp_session_mode or (
-                provider.default_session_mode if provider else None
-            )
-            if mode_id is not None:
-                logger.info("Setting ACP session mode: %s", mode_id)
-                await conn.set_session_mode(mode_id=mode_id, session_id=session_id)
-
-            return conn, process, filtered_reader, session_id, agent_name, agent_version
+                    await asyncio.shield(teardown)
+                except BaseException:
+                    # Cancelled while unwinding: the shielded teardown keeps
+                    # running, but the event loop may disappear with us, so
+                    # kill the subprocess without awaiting anything.
+                    _signal_acp_process(process, "kill")
+                # Re-raises the original failure, not anything from teardown.
+                raise
 
         result = self._executor.run_async(_init)
         (

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -3790,6 +3790,7 @@ def _make_config_conn(
     session_id: str = "sess-new",
     options: list[SessionConfigOption] | None = None,
     models: SessionModelState | None = None,
+    load_exc: Exception | None = None,
 ):
     """MagicMock ACP connection whose session responses carry typed config state.
 
@@ -3797,6 +3798,8 @@ def _make_config_conn(
     ids, records the new value, and answers with the complete option state.
     The same *options* are reported by both ``new_session`` and
     ``load_session`` so fresh and resumed sessions can be compared directly.
+    If *load_exc* is given, ``load_session`` raises it instead of returning a
+    response, so a stale-session fallback to ``new_session`` can be exercised.
     """
     conn = MagicMock()
 
@@ -3812,9 +3815,12 @@ def _make_config_conn(
             session_id=session_id, config_options=options, models=models
         )
     )
-    conn.load_session = AsyncMock(
-        return_value=LoadSessionResponse(config_options=options, models=models)
-    )
+    if load_exc is not None:
+        conn.load_session = AsyncMock(side_effect=load_exc)
+    else:
+        conn.load_session = AsyncMock(
+            return_value=LoadSessionResponse(config_options=options, models=models)
+        )
 
     current = list(options or [])
 
@@ -3951,7 +3957,7 @@ class TestACPSessionConfigOptions:
         """A persisted session is configured exactly like a fresh one."""
         agent = _make_agent(
             acp_model="grok-4.6",
-            acp_config_options={"effort": "medium"},
+            acp_config_options={"effort": "medium", "fast": "false"},
         )
         state = _make_state(tmp_path)
         state.agent_state = {
@@ -3960,7 +3966,10 @@ class TestACPSessionConfigOptions:
             "acp_session_cwd": str(tmp_path),
         }
         conn = _make_config_conn(
-            options=[_config_option("effort", "low", ["low", "medium"])],
+            options=[
+                _config_option("effort", "low", ["low", "medium", "high"]),
+                _config_option("fast", "true", ["true", "false"]),
+            ],
             models=_GROK_MODELS,
         )
 
@@ -3972,10 +3981,45 @@ class TestACPSessionConfigOptions:
             model_id="grok-4.6",
             session_id="stored-sess",
         )
-        conn.set_config_option.assert_awaited_once_with(
-            config_id="effort",
+        assert [call.kwargs for call in conn.set_config_option.await_args_list] == [
+            {"config_id": "effort", "session_id": "stored-sess", "value": "medium"},
+            {"config_id": "fast", "session_id": "stored-sess", "value": "false"},
+        ]
+
+    def test_composer_resumed_session_applies_same_config(self, tmp_path):
+        """A persisted Composer session is configured exactly like a fresh one."""
+        agent = _make_agent(
+            acp_model="composer-2.5",
+            acp_config_options={"fast": "false"},
+        )
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "stored-sess",
+            "acp_session_cwd": str(tmp_path),
+        }
+        conn = _make_config_conn(
+            options=[_config_option("fast", "true", ["true", "false"])],
+            models=SessionModelState(
+                available_models=[
+                    ModelInfo(model_id="composer-2.5", name="Composer 2.5")
+                ],
+                current_model_id="auto",
+            ),
+        )
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_not_awaited()
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="composer-2.5",
             session_id="stored-sess",
-            value="medium",
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="fast",
+            session_id="stored-sess",
+            value="false",
         )
 
     def test_no_requested_options_leaves_session_untouched(self, tmp_path):
@@ -4007,6 +4051,78 @@ class TestACPSessionConfigOptions:
         assert agent._executor is None
         assert agent._initialized is False
         assert "acp_session_id" not in state.agent_state
+
+    @pytest.mark.parametrize(
+        ("acp_model", "acp_config_options", "expected_config_calls"),
+        [
+            (
+                "grok-4.6",
+                {"effort": "medium", "fast": "false"},
+                [
+                    {
+                        "config_id": "effort",
+                        "session_id": "replacement-sess",
+                        "value": "medium",
+                    },
+                    {
+                        "config_id": "fast",
+                        "session_id": "replacement-sess",
+                        "value": "false",
+                    },
+                ],
+            ),
+            (
+                "composer-2.5",
+                {"fast": "false"},
+                [
+                    {
+                        "config_id": "fast",
+                        "session_id": "replacement-sess",
+                        "value": "false",
+                    }
+                ],
+            ),
+        ],
+    )
+    def test_stale_load_session_falls_back_to_new_session_with_config(
+        self, tmp_path, acp_model, acp_config_options, expected_config_calls
+    ):
+        """A stale load_session id must not skip model/config setup on the
+        replacement session created via new_session.
+        """
+        agent = _make_agent(
+            acp_model=acp_model, acp_config_options=acp_config_options
+        )
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "stale-sess",
+            "acp_session_cwd": str(tmp_path),
+        }
+        conn = _make_config_conn(
+            session_id="replacement-sess",
+            options=[
+                _config_option("effort", "low", ["low", "medium", "high"]),
+                _config_option("fast", "true", ["true", "false"]),
+            ],
+            models=SessionModelState(
+                available_models=[ModelInfo(model_id=acp_model, name=acp_model)],
+                current_model_id="auto",
+            ),
+            load_exc=ACPRequestError(-32602, "unknown session"),
+        )
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_awaited_once()
+        conn.set_session_model.assert_awaited_once_with(
+            model_id=acp_model,
+            session_id="replacement-sess",
+        )
+        assert [
+            call.kwargs for call in conn.set_config_option.await_args_list
+        ] == expected_config_calls
 
 
 class TestApplySessionConfigOptions:
@@ -4191,6 +4307,7 @@ class TestFailedInitReapsSubprocess:
         agent = _make_agent(acp_config_options={"effort": "medium"})
         state = _make_state(tmp_path)
         conn = self._unverifiable_conn()
+        conn.prompt = AsyncMock()
         process = _FakeACPProcess()
 
         with TestACPSessionIdPersistence._transport_patches(conn, process):
@@ -4198,7 +4315,10 @@ class TestFailedInitReapsSubprocess:
                 agent.init_state(state, on_event=lambda _: None)
 
         # The verification failure itself still surfaces (asserted above) and
-        # the subprocess it spawned is gone rather than orphaned.
+        # the subprocess it spawned is gone rather than orphaned. Config is
+        # verified before any prompt could be sent, so a session that fails
+        # verification must never reach conn.prompt (fail-close).
+        conn.prompt.assert_not_awaited()
         conn.close.assert_awaited_once()
         assert process.terminated is True
         assert process.returncode is not None

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -10,9 +10,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from acp.exceptions import RequestError as ACPRequestError
+from acp.schema import (
+    ClientCapabilities,
+    ConfigOptionUpdate,
+    LoadSessionResponse,
+    ModelInfo,
+    NewSessionResponse,
+    SessionConfigOption,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
+    SessionModelState,
+    SetSessionConfigOptionResponse,
+)
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
+    ACPSessionConfigError,
+    _apply_session_config_options,
     _estimate_cost_from_tokens,
     _extract_token_usage,
     _image_url_to_acp_block,
@@ -2648,6 +2662,32 @@ class TestMaybeSetSessionModel:
         await _maybe_set_session_model(conn, "codex-acp", "session-1", None)
         conn.set_session_model.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_unregistered_agent_without_model_state_is_untouched(self):
+        """Servers that advertise no model state keep the legacy no-op path."""
+        conn = AsyncMock()
+        await _maybe_set_session_model(conn, "some-custom-acp", "session-1", "grok-4.6")
+        conn.set_session_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unregistered_agent_with_model_state_uses_protocol_override(self):
+        """``models`` in the session response is the signal to use set_model."""
+        conn = AsyncMock()
+        await _maybe_set_session_model(
+            conn,
+            "some-custom-acp",
+            "session-1",
+            "grok-4.6",
+            SessionModelState(
+                available_models=[ModelInfo(model_id="grok-4.6", name="Grok 4.6")],
+                current_model_id="auto",
+            ),
+        )
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="grok-4.6",
+            session_id="session-1",
+        )
+
 
 # ---------------------------------------------------------------------------
 # acp_session_mode field
@@ -3066,18 +3106,22 @@ class TestACPSessionIdPersistence:
     """
 
     @staticmethod
-    def _transport_patches(conn):
+    def _transport_patches(conn, process=None):
         """Context manager stacking the transport-layer mocks that let
         _start_acp_server run without spawning a real subprocess.
+
+        *process* overrides the stand-in subprocess handle, for tests that
+        need to observe how the handle is torn down.
         """
         from contextlib import ExitStack
 
-        mock_process = MagicMock()
-        mock_process.stdin = MagicMock()
-        mock_process.stdout = MagicMock()
+        if process is None:
+            process = MagicMock()
+            process.stdin = MagicMock()
+            process.stdout = MagicMock()
 
         async def _fake_create_subprocess_exec(*_args, **_kwargs):
-            return mock_process
+            return process
 
         async def _fake_filter(_src, _dst):
             return None
@@ -3707,3 +3751,512 @@ class TestACPEnvConflictSuppression:
 
         assert env.get("ANTHROPIC_API_KEY") == "sk-valid"
         assert "CLAUDE_CONFIG_DIR" not in env
+
+
+# ---------------------------------------------------------------------------
+# Explicit client capabilities and session config options
+# ---------------------------------------------------------------------------
+
+
+def _config_option(
+    option_id: str,
+    current_value: str,
+    values: list[str] | None = None,
+) -> SessionConfigOption:
+    """Build one ACP select config option sitting at *current_value*."""
+    choices = values or [current_value]
+    return SessionConfigOption(
+        SessionConfigOptionSelect(
+            id=option_id,
+            name=option_id,
+            type="select",
+            current_value=current_value,
+            options=[SessionConfigSelectOption(name=v, value=v) for v in choices],
+        )
+    )
+
+
+def _config_update(**options: str) -> ConfigOptionUpdate:
+    """Build a ``config_option_update`` notification for a complete state."""
+    return ConfigOptionUpdate(
+        session_update="config_option_update",
+        config_options=[_config_option(k, v) for k, v in options.items()],
+    )
+
+
+def _make_config_conn(
+    *,
+    agent_name: str = "cursor-agent",
+    session_id: str = "sess-new",
+    options: list[SessionConfigOption] | None = None,
+    models: SessionModelState | None = None,
+):
+    """MagicMock ACP connection whose session responses carry typed config state.
+
+    ``set_config_option`` behaves like a real Agent: it rejects unknown option
+    ids, records the new value, and answers with the complete option state.
+    The same *options* are reported by both ``new_session`` and
+    ``load_session`` so fresh and resumed sessions can be compared directly.
+    """
+    conn = MagicMock()
+
+    init_response = MagicMock()
+    init_response.agent_info = MagicMock()
+    init_response.agent_info.name = agent_name
+    init_response.agent_info.version = "1.0"
+    init_response.auth_methods = []
+    conn.initialize = AsyncMock(return_value=init_response)
+
+    conn.new_session = AsyncMock(
+        return_value=NewSessionResponse(
+            session_id=session_id, config_options=options, models=models
+        )
+    )
+    conn.load_session = AsyncMock(
+        return_value=LoadSessionResponse(config_options=options, models=models)
+    )
+
+    current = list(options or [])
+
+    async def _set_config_option(*, config_id: str, session_id: str, value: str):
+        for i, option in enumerate(current):
+            if option.root.id == config_id:
+                current[i] = _config_option(config_id, value)
+                return SetSessionConfigOptionResponse(config_options=list(current))
+        raise ACPRequestError(-32602, f"unknown config option {config_id}")
+
+    conn.set_config_option = AsyncMock(side_effect=_set_config_option)
+    conn.set_session_mode = AsyncMock()
+    conn.set_session_model = AsyncMock()
+    conn.authenticate = AsyncMock()
+    conn.close = AsyncMock()
+    return conn
+
+
+_GROK_MODELS = SessionModelState(
+    available_models=[ModelInfo(model_id="grok-4.6", name="Grok 4.6")],
+    current_model_id="auto",
+)
+
+
+class TestACPClientCapabilities:
+    """``acp_client_capabilities`` reaches initialize() only when supplied."""
+
+    def test_defaults_are_empty(self):
+        agent = _make_agent()
+        assert agent.acp_client_capabilities is None
+        assert agent.acp_config_options == {}
+
+    def test_explicit_capabilities_passed_to_initialize(self, tmp_path):
+        capabilities = ClientCapabilities(field_meta={"parameterizedModelPicker": True})
+        agent = _make_agent(acp_client_capabilities=capabilities)
+        state = _make_state(tmp_path)
+        conn = _make_config_conn()
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.initialize.assert_awaited_once_with(
+            protocol_version=1,
+            client_capabilities=capabilities,
+        )
+
+    def test_absent_capabilities_preserve_initialize_call(self, tmp_path):
+        """No capabilities configured → the call is unchanged from before."""
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = _make_config_conn()
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.initialize.assert_awaited_once_with(protocol_version=1)
+
+    def test_serialization_roundtrip(self):
+        agent = ACPAgent(
+            acp_command=["cursor-agent"],
+            acp_client_capabilities=ClientCapabilities(
+                field_meta={"parameterizedModelPicker": True}
+            ),
+            acp_config_options={"effort": "medium"},
+        )
+        restored = AgentBase.model_validate_json(agent.model_dump_json())
+        assert isinstance(restored, ACPAgent)
+        assert restored.acp_client_capabilities is not None
+        assert restored.acp_client_capabilities.field_meta == {
+            "parameterizedModelPicker": True
+        }
+        assert restored.acp_config_options == {"effort": "medium"}
+
+
+class TestACPSessionConfigOptions:
+    """Requested session config is applied and verified during initialization."""
+
+    def test_fresh_session_applies_and_verifies_config(self, tmp_path):
+        """Grok-like setup: model via acp_model, effort/fast via config options."""
+        agent = _make_agent(
+            acp_model="grok-4.6",
+            acp_client_capabilities=ClientCapabilities(
+                field_meta={"parameterizedModelPicker": True}
+            ),
+            acp_config_options={"effort": "medium", "fast": "false"},
+        )
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(
+            options=[
+                _config_option("effort", "low", ["low", "medium", "high"]),
+                _config_option("fast", "true", ["true", "false"]),
+            ],
+            models=_GROK_MODELS,
+        )
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="grok-4.6",
+            session_id="sess-new",
+        )
+        assert [call.kwargs for call in conn.set_config_option.await_args_list] == [
+            {"config_id": "effort", "session_id": "sess-new", "value": "medium"},
+            {"config_id": "fast", "session_id": "sess-new", "value": "false"},
+        ]
+
+    def test_composer_model_and_fast_disabled(self, tmp_path):
+        agent = _make_agent(
+            acp_model="composer-2.5",
+            acp_config_options={"fast": "false"},
+        )
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(
+            options=[_config_option("fast", "true", ["true", "false"])],
+            models=SessionModelState(
+                available_models=[
+                    ModelInfo(model_id="composer-2.5", name="Composer 2.5")
+                ],
+                current_model_id="auto",
+            ),
+        )
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="composer-2.5",
+            session_id="sess-new",
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="fast",
+            session_id="sess-new",
+            value="false",
+        )
+
+    def test_resumed_session_applies_same_config(self, tmp_path):
+        """A persisted session is configured exactly like a fresh one."""
+        agent = _make_agent(
+            acp_model="grok-4.6",
+            acp_config_options={"effort": "medium"},
+        )
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "stored-sess",
+            "acp_session_cwd": str(tmp_path),
+        }
+        conn = _make_config_conn(
+            options=[_config_option("effort", "low", ["low", "medium"])],
+            models=_GROK_MODELS,
+        )
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_not_awaited()
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="grok-4.6",
+            session_id="stored-sess",
+        )
+        conn.set_config_option.assert_awaited_once_with(
+            config_id="effort",
+            session_id="stored-sess",
+            value="medium",
+        )
+
+    def test_no_requested_options_leaves_session_untouched(self, tmp_path):
+        """Empty acp_config_options → no config traffic at all."""
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(options=[_config_option("effort", "low")])
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.set_config_option.assert_not_awaited()
+        assert agent._session_id == "sess-new"
+
+    def test_missing_option_fails_init_state_and_cleans_up(self, tmp_path):
+        """A requested option the server does not expose aborts initialization."""
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent(acp_config_options={"effort": "medium"})
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(options=[_config_option("fast", "true")])
+
+        agent._executor = AsyncExecutor()
+        with TestACPSessionIdPersistence._transport_patches(conn):
+            with pytest.raises(ACPSessionConfigError, match="effort"):
+                agent.init_state(state, on_event=lambda _: None)
+
+        conn.set_config_option.assert_not_awaited()
+        # init_state's failure handler ran the existing cleanup path.
+        assert agent._executor is None
+        assert agent._initialized is False
+        assert "acp_session_id" not in state.agent_state
+
+
+class TestApplySessionConfigOptions:
+    """Direct tests for the shared apply-and-verify helper."""
+
+    @staticmethod
+    def _conn(*responses):
+        conn = MagicMock()
+        conn.set_config_option = AsyncMock(side_effect=list(responses))
+        return conn
+
+    async def test_empty_request_is_a_noop(self):
+        conn = self._conn()
+        await _apply_session_config_options(
+            conn, _OpenHandsACPBridge(), "cursor", "sess-1", {}, None
+        )
+        conn.set_config_option.assert_not_awaited()
+
+    async def test_server_without_config_options_fails_closed(self):
+        conn = self._conn()
+        with pytest.raises(ACPSessionConfigError, match="no session configuration"):
+            await _apply_session_config_options(
+                conn,
+                _OpenHandsACPBridge(),
+                "cursor",
+                "sess-1",
+                {"effort": "medium"},
+                None,
+            )
+        conn.set_config_option.assert_not_awaited()
+
+    async def test_set_config_option_error_fails_closed(self):
+        conn = MagicMock()
+        conn.set_config_option = AsyncMock(
+            side_effect=ACPRequestError(-32603, "internal error")
+        )
+        with pytest.raises(ACPSessionConfigError, match="failed to set configuration"):
+            await _apply_session_config_options(
+                conn,
+                _OpenHandsACPBridge(),
+                "cursor",
+                "sess-1",
+                {"effort": "medium"},
+                [_config_option("effort", "low")],
+            )
+
+    async def test_reported_value_mismatch_fails_closed(self):
+        """Server acknowledges the set but still reports the old value."""
+        conn = self._conn(
+            SetSessionConfigOptionResponse(
+                config_options=[_config_option("effort", "low")]
+            )
+        )
+        with pytest.raises(ACPSessionConfigError, match="'effort'='low'"):
+            await _apply_session_config_options(
+                conn,
+                _OpenHandsACPBridge(),
+                "cursor",
+                "sess-1",
+                {"effort": "medium"},
+                [_config_option("effort", "low")],
+            )
+
+    async def test_option_revealed_by_an_earlier_set_is_accepted(self):
+        """Selecting the model can add options the initial state did not list."""
+        conn = self._conn(
+            SetSessionConfigOptionResponse(
+                config_options=[
+                    _config_option("model", "grok-4.6"),
+                    _config_option("effort", "low"),
+                ]
+            ),
+            SetSessionConfigOptionResponse(
+                config_options=[
+                    _config_option("model", "grok-4.6"),
+                    _config_option("effort", "medium"),
+                ]
+            ),
+        )
+        await _apply_session_config_options(
+            conn,
+            _OpenHandsACPBridge(),
+            "cursor",
+            "sess-1",
+            {"model": "grok-4.6", "effort": "medium"},
+            [_config_option("model", "auto")],
+        )
+        assert conn.set_config_option.await_count == 2
+
+    async def test_observed_update_verifies_a_stateless_response(self):
+        """Servers that publish state asynchronously still verify."""
+        bridge = _OpenHandsACPBridge()
+        await bridge.session_update("sess-1", _config_update(effort="medium"))
+        conn = self._conn(SetSessionConfigOptionResponse(config_options=[]))
+
+        await _apply_session_config_options(
+            conn,
+            bridge,
+            "cursor",
+            "sess-1",
+            {"effort": "medium"},
+            [_config_option("effort", "low")],
+        )
+
+        conn.set_config_option.assert_awaited_once()
+        assert bridge.get_config_options("sess-1") is not None
+        assert bridge.get_config_options("other-sess") is None
+
+    async def test_update_from_another_session_does_not_verify(self):
+        """A different session's update must never satisfy this session."""
+        bridge = _OpenHandsACPBridge()
+        await bridge.session_update("other-sess", _config_update(effort="medium"))
+        conn = self._conn(SetSessionConfigOptionResponse(config_options=[]))
+
+        with pytest.raises(ACPSessionConfigError, match="no configuration state"):
+            await _apply_session_config_options(
+                conn,
+                bridge,
+                "cursor",
+                "sess-1",
+                {"effort": "medium"},
+                [_config_option("effort", "low")],
+            )
+
+
+class _FakeACPProcess:
+    """Stand-in for the ACP subprocess handle ``_init`` spawns.
+
+    ``wait()`` only resolves once the process has been signalled, so a fake
+    built with ``exits_on_terminate=False`` reproduces a subprocess that
+    ignores SIGTERM and forces the teardown to escalate to ``kill``.
+    """
+
+    def __init__(self, *, exits_on_terminate: bool = True) -> None:
+        self.stdin = MagicMock()
+        self.stdout = MagicMock()
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+        self._exits_on_terminate = exits_on_terminate
+        self._exited = asyncio.Event()
+
+    def terminate(self) -> None:
+        self.terminated = True
+        if self._exits_on_terminate:
+            self.returncode = -15
+            self._exited.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+        self._exited.set()
+
+    async def wait(self) -> int | None:
+        await self._exited.wait()
+        return self.returncode
+
+
+class TestFailedInitReapsSubprocess:
+    """A post-spawn init failure must not leak the ACP subprocess.
+
+    ``_init`` spawns the process and only hands its handles back to the
+    ACPAgent attributes on a successful return, so a failure in between
+    (config verification, auth, session setup, mode) leaves ``_cleanup``
+    with nothing to terminate — the teardown has to happen inside ``_init``.
+    """
+
+    @staticmethod
+    def _unverifiable_conn():
+        """Connection whose server acks the config set but reports the old value."""
+        conn = _make_config_conn(
+            options=[_config_option("effort", "low", ["low", "medium"])],
+        )
+        conn.set_config_option = AsyncMock(
+            return_value=SetSessionConfigOptionResponse(
+                config_options=[_config_option("effort", "low", ["low", "medium"])]
+            )
+        )
+        return conn
+
+    def test_config_verification_failure_closes_conn_and_reaps_process(self, tmp_path):
+        agent = _make_agent(acp_config_options={"effort": "medium"})
+        state = _make_state(tmp_path)
+        conn = self._unverifiable_conn()
+        process = _FakeACPProcess()
+
+        with TestACPSessionIdPersistence._transport_patches(conn, process):
+            with pytest.raises(ACPSessionConfigError, match="'effort'='low'"):
+                agent.init_state(state, on_event=lambda _: None)
+
+        # The verification failure itself still surfaces (asserted above) and
+        # the subprocess it spawned is gone rather than orphaned.
+        conn.close.assert_awaited_once()
+        assert process.terminated is True
+        assert process.returncode is not None
+        # Nothing was published to the agent, so only _init's teardown could
+        # have reaped the process.
+        assert agent._process is None
+        assert agent._conn is None
+        assert agent._initialized is False
+        # The existing outer cleanup path still runs.
+        assert agent._executor is None
+        assert "acp_session_id" not in state.agent_state
+
+    def test_unresponsive_process_is_killed(self, tmp_path):
+        """A subprocess that ignores terminate() is killed within the bound."""
+        agent = _make_agent(acp_config_options={"effort": "medium"})
+        state = _make_state(tmp_path)
+        conn = self._unverifiable_conn()
+        process = _FakeACPProcess(exits_on_terminate=False)
+
+        with patch("openhands.sdk.agent.acp_agent._ACP_INIT_ABORT_TIMEOUT", 0.05):
+            with TestACPSessionIdPersistence._transport_patches(conn, process):
+                with pytest.raises(ACPSessionConfigError):
+                    agent.init_state(state, on_event=lambda _: None)
+
+        assert process.terminated is True
+        assert process.killed is True
+        assert process.returncode == -9
+
+    def test_session_mode_failure_reaps_process(self, tmp_path):
+        """Non-config post-spawn failures take the same teardown path."""
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(agent_name="claude-agent-acp")
+        conn.set_session_mode = AsyncMock(side_effect=ACPRequestError(-32603, "boom"))
+        process = _FakeACPProcess()
+
+        with TestACPSessionIdPersistence._transport_patches(conn, process):
+            with pytest.raises(ACPRequestError):
+                agent.init_state(state, on_event=lambda _: None)
+
+        conn.close.assert_awaited_once()
+        assert process.terminated is True
+
+    def test_successful_init_leaves_process_running(self, tmp_path):
+        """The teardown never fires on the normal path."""
+        agent = _make_agent(acp_config_options={"effort": "medium"})
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(
+            options=[_config_option("effort", "low", ["low", "medium"])],
+        )
+        process = _FakeACPProcess()
+
+        with TestACPSessionIdPersistence._transport_patches(conn, process):
+            agent.init_state(state, on_event=lambda _: None)
+
+        assert process.terminated is False
+        assert process.killed is False
+        conn.close.assert_not_awaited()
+        assert agent._process is process
+        assert agent._conn is conn
+        assert state.agent_state["acp_session_id"] == "sess-new"

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4033,6 +4033,24 @@ class TestACPSessionConfigOptions:
         conn.set_config_option.assert_not_awaited()
         assert agent._session_id == "sess-new"
 
+    def test_claude_fresh_session_uses_meta_not_set_session_model(self, tmp_path):
+        """claude-agent-acp selects its model via new_session's ``claudeCode``
+        _meta, not the set_session_model protocol call used by other
+        providers.
+        """
+        agent = _make_agent(acp_model="claude-opus-4-6")
+        state = _make_state(tmp_path)
+        conn = _make_config_conn(agent_name="claude-agent-acp")
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.new_session.assert_awaited_once_with(
+            cwd=str(tmp_path),
+            claudeCode={"options": {"model": "claude-opus-4-6"}},
+        )
+        conn.set_session_model.assert_not_called()
+        conn.set_config_option.assert_not_called()
+
     def test_missing_option_fails_init_state_and_cleans_up(self, tmp_path):
         """A requested option the server does not expose aborts initialization."""
         from openhands.sdk.utils.async_executor import AsyncExecutor


### PR DESCRIPTION
## Summary

- add optional ACP client capabilities, including extensible `field_meta`
- apply and verify ACP session config options before prompting
- support fresh and resumed sessions with fail-closed mismatch handling
- preserve existing behavior when no new options are supplied

## Validation

- focused ACP tests: 192 passed
- full SDK: 3596 passed, 2 failed, 5 xfailed; the two failures reproduce on the v1.21.0 base and are pre-existing/environment-dependent
- package build: successful
- Cursor ACP live smoke: Grok-like session returned the expected marker with `effort=medium` and `fast=false`

The final fork commit is `e2a5cfc497ad52a2628c081ce4460a0c2520533e`.

Effective provider-internal inference attestation is not claimed; validation covers requested and observed ACP session configuration.
