### PR TITLE
fix(agent-server): persist conversation meta before mutating in-memory state

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -553,6 +553,19 @@ def _update_state_tags_sync(
     return state
 
 
+async def _persist_stored(
+    event_service: EventService, stored: StoredConversation
+) -> None:
+    """Write ``stored`` to meta.json, then commit it in memory.
+
+    ``save_meta`` persists the given payload without mutating
+    ``event_service.stored``. In-memory state is updated only after the
+    write succeeds so a failed persist cannot leave memory ahead of disk.
+    """
+    await event_service.save_meta(stored)
+    event_service.stored = stored
+
+
 def _compose_webhook_conversation_info_sync(
     stored: StoredConversation, state: ConversationState
 ) -> ConversationInfo:
@@ -1873,22 +1886,24 @@ class ConversationService:
 
         loop = asyncio.get_running_loop()
         state = await event_service.get_state()
+        updates: dict[str, Any] = {"updated_at": utc_now()}
         if request.title is not None:
-            event_service.stored.title = request.title.strip()
+            updates["title"] = request.title.strip()
         if request.tags is not None:
-            event_service.stored.tags = request.tags
+            updates["tags"] = request.tags
+        await _persist_stored(
+            event_service, event_service.stored.model_copy(update=updates)
+        )
+        if request.tags is not None:
             # Keep the persisted ConversationState update under the state lock so
             # autosave and state-change callbacks observe a consistent mutation.
             state = await loop.run_in_executor(
                 None, _update_state_tags_sync, state, request.tags
             )
-        event_service.stored.updated_at = utc_now()
         record = self._conversation_records.get(conversation_id)
         if record is not None:
             record.stored = event_service.stored
             record.cached_info = None
-        # Save the updated metadata to disk
-        await event_service.save_meta()
 
         # Notify conversation webhooks about the updated conversation. Compose the
         # full-state snapshot under the state lock, but do the synchronous wait in a
@@ -2568,9 +2583,12 @@ class AutoTitleSubscriber(Subscriber):
                     _on_title_error,
                 )
                 if title and self.service.stored.title is None:
-                    self.service.stored.title = title
-                    self.service.stored.updated_at = utc_now()
-                    await self.service.save_meta()
+                    await _persist_stored(
+                        self.service,
+                        self.service.stored.model_copy(
+                            update={"title": title, "updated_at": utc_now()}
+                        ),
+                    )
             except Exception:
                 logger.warning(
                     f"Auto-title generation failed for "

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -174,11 +174,12 @@ class EventService:
             },
         )
 
-    async def save_meta(self):
+    async def save_meta(self, stored: StoredConversation | None = None) -> None:
+        payload = self.stored if stored is None else stored
         with self._write_guard():
             meta_file = self.conversation_dir / "meta.json"
             meta_file.write_text(
-                self.stored.model_dump_json(
+                payload.model_dump_json(
                     context={
                         "cipher": self.cipher,
                     }

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2738,6 +2738,51 @@ class TestConversationServiceUpdateConversation:
 
         assert mock_service.stored.updated_at > original_updated_at
 
+    @pytest.mark.asyncio
+    async def test_update_conversation_leaves_stored_unchanged_when_save_meta_fails(
+        self, conversation_service, sample_stored_conversation
+    ):
+        """Failed persist must not leave in-memory title/tags ahead of disk."""
+        sample_stored_conversation.title = "Original Title"
+        sample_stored_conversation.tags = {"env": "dev"}
+        mock_service = AsyncMock(spec=EventService)
+        mock_service.stored = sample_stored_conversation
+        mock_service.save_meta.side_effect = RuntimeError("disk full")
+        mock_state = ConversationState(
+            id=sample_stored_conversation.id,
+            agent=_sample_agent(),
+            workspace=sample_stored_conversation.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=sample_stored_conversation.confirmation_policy,
+            tags={"env": "dev"},
+        )
+        mock_service.get_state.return_value = mock_state
+
+        conversation_id = sample_stored_conversation.id
+        conversation_service._event_services[conversation_id] = mock_service
+        conversation_service._conversation_records[conversation_id] = (
+            _ConversationRecord(
+                stored=sample_stored_conversation,
+                execution_status=ConversationExecutionStatus.IDLE,
+            )
+        )
+
+        original_updated_at = mock_service.stored.updated_at
+        with pytest.raises(RuntimeError, match="disk full"):
+            await conversation_service.update_conversation(
+                conversation_id,
+                UpdateConversationRequest(title="New Title", tags={"env": "prod"}),
+            )
+
+        assert mock_service.stored.title == "Original Title"
+        assert mock_service.stored.tags == {"env": "dev"}
+        assert mock_service.stored.updated_at == original_updated_at
+        assert mock_state.tags == {"env": "dev"}
+        record = conversation_service._conversation_records[conversation_id]
+        assert record.stored.title == "Original Title"
+        assert record.stored.tags == {"env": "dev"}
+        assert record.stored.updated_at == original_updated_at
+
 
 class TestConversationServiceDeleteConversation:
     """Test cases for ConversationService.delete_conversation method."""
@@ -3206,6 +3251,22 @@ class TestAutoTitle:
             await self._drain_title_task(lambda: service.stored.title is not None)
 
         assert service.stored.title == "✨ Generated Title"
+        service.save_meta.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_autotitle_leaves_title_unchanged_when_save_meta_fails(self):
+        """Failed persist must not leave the generated title in memory."""
+        service = self._make_service()
+        original_updated_at = service.stored.updated_at
+        service.save_meta.side_effect = RuntimeError("disk full")
+
+        with patch(self._GENERATE_TITLE_PATH, return_value="✨ Generated Title"):
+            subscriber = AutoTitleSubscriber(service=service)
+            await subscriber(self._user_message_event())
+            await self._drain_title_task(lambda: service.save_meta.called)
+
+        assert service.stored.title is None
+        assert service.stored.updated_at == original_updated_at
         service.save_meta.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1865,6 +1865,26 @@ class TestEventServiceSaveMeta:
         assert loaded.updated_at == original_updated_at
 
     @pytest.mark.asyncio
+    async def test_save_meta_writes_provided_payload_without_mutating_stored(
+        self, event_service, tmp_path
+    ):
+        """An explicit payload is written first; in-memory stored stays put."""
+        event_service.conversations_dir = tmp_path
+        conv_dir = tmp_path / event_service.stored.id.hex
+        conv_dir.mkdir(parents=True, exist_ok=True)
+
+        original_title = event_service.stored.title
+        updated = event_service.stored.model_copy(update={"title": "Persisted Title"})
+
+        await event_service.save_meta(updated)
+
+        assert event_service.stored.title == original_title
+        loaded = StoredConversation.model_validate_json(
+            (conv_dir / "meta.json").read_text()
+        )
+        assert loaded.title == "Persisted Title"
+
+    @pytest.mark.asyncio
     async def test_save_meta_round_trips_agent_definition_mcp_secrets(
         self, sample_stored_conversation, tmp_path
     ):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`ConversationService` mutated `StoredConversation` fields (`title`, `tags`, `updated_at`) in memory and only then called `EventService.save_meta()`. If that write failed (disk full, ownership lost, etc.), in-process state was ahead of `meta.json`. After idle eviction or restart the change disappeared with no error to the caller that had already observed the new value.

## Summary

- `EventService.save_meta()` now accepts an optional `stored` payload and writes that copy without touching `self.stored`.
- `update_conversation` and `AutoTitleSubscriber` persist via `_persist_stored()` (write first, then assign in memory). `_update_state_tags_sync` and `_conversation_records` updates run only after a successful persist.
- `set_conversation_tag` / `delete_conversation_tag` / `_flush_tags_mutation` are **not** on current `main` (they exist only on unmerged PR #4617) and were not implemented here.

## Issue Number

Fixes #4800

## How to Test

```bash
uv run pytest \
  tests/agent_server/test_event_service.py::TestEventServiceSaveMeta \
  tests/agent_server/test_conversation_service.py::TestConversationServiceUpdateConversation \
  tests/agent_server/test_conversation_service.py::TestAutoTitle
```

Targeted failure-path tests:

```bash
uv run pytest tests/agent_server/test_conversation_service.py \
  -k "leaves_stored_unchanged_when_save_meta_fails or leaves_title_unchanged_when_save_meta_fails"
```

These mock `save_meta` to raise `RuntimeError("disk full")` and assert `stored.title` / `stored.tags` / `stored.updated_at` (and `ConversationState.tags` for the update path) stay at their original values.

There is no GUI. A live disk-full E2E would need a running agent-server plus a failing filesystem; the contract under test is "if persist raises, memory must not already show the new title/tags," which the mocks cover.

## Test evidence (ran on this branch)

```
uv run pytest \
  tests/agent_server/test_event_service.py::TestEventServiceSaveMeta \
  tests/agent_server/test_conversation_service.py::TestConversationServiceUpdateConversation \
  tests/agent_server/test_conversation_service.py::TestAutoTitle -q --tb=short

======================= 31 passed, 13 warnings in 1.39s ========================
```

The 13 warnings are existing `LLM.modify_params` deprecation notices, unrelated to this change.

## Video/Screenshots

N/A — agent-server persistence fix; covered by unit tests, no UI.

## Design Doc

N/A — small bug fix, no API/schema change beyond an optional `save_meta(stored=...)` argument.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Optional `save_meta(stored=None)` is backward compatible; existing `save_meta()` callers still persist `self.stored`.
- Per-key tag endpoints from #4617 were intentionally skipped so this PR does not depend on that branch.