### PR TITLE
feat: add ACP-less agent-server image fallback

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -278,17 +278,42 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Explicit matrix: 3 variants × 2 architectures = 6 jobs
+                # Explicit matrix: 4 variants × 2 architectures = 8 jobs
                 # Each job specifies exactly what it builds and where it runs
                 include:
                     # Python variant
                     - variant: python
+                      custom_tags: python
+                      image_flavor: default
+                      acp_provider_flavor: default
                       arch: amd64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: python
+                      custom_tags: python
+                      image_flavor: default
+                      acp_provider_flavor: default
+                      arch: arm64
+                      base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
+                      runner: ubuntu-24.04-arm
+                      platform: linux/arm64
+
+                    # Python variant without preinstalled ACP providers
+                    - variant: python-slim
+                      custom_tags: python
+                      image_flavor: slim
+                      acp_provider_flavor: none
+                      arch: amd64
+                      base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
+                      runner: ubuntu-24.04
+                      platform: linux/amd64
+
+                    - variant: python-slim
+                      custom_tags: python
+                      image_flavor: slim
+                      acp_provider_flavor: none
                       arch: arm64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04-arm
@@ -296,12 +321,18 @@ jobs:
 
                     # Java variant
                     - variant: java
+                      custom_tags: java
+                      image_flavor: default
+                      acp_provider_flavor: default
                       arch: amd64
                       base_image: eclipse-temurin:17-jdk
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: java
+                      custom_tags: java
+                      image_flavor: default
+                      acp_provider_flavor: default
                       arch: arm64
                       base_image: eclipse-temurin:17-jdk
                       runner: ubuntu-24.04-arm
@@ -309,12 +340,18 @@ jobs:
 
                     # Golang variant
                     - variant: golang
+                      custom_tags: golang
+                      image_flavor: default
+                      acp_provider_flavor: default
                       arch: amd64
                       base_image: golang:1.21-bookworm
                       runner: ubuntu-24.04
                       platform: linux/amd64
 
                     - variant: golang
+                      custom_tags: golang
+                      image_flavor: default
+                      acp_provider_flavor: default
                       arch: arm64
                       base_image: golang:1.21-bookworm
                       runner: ubuntu-24.04-arm
@@ -334,7 +371,8 @@ jobs:
             # Same last-operand reasoning as INSTALL_ACP_PROVIDERS above: an
             # explicit "" dispatch input ("install none") must survive.
             INSTALL_CAPABILITIES: ${{ github.event_name != 'workflow_dispatch' && 'vscode,browser,docker' || inputs.install_capabilities }}
-            CUSTOM_TAGS: ${{ matrix.variant }}
+            CUSTOM_TAGS: ${{ matrix.custom_tags }}
+            IMAGE_FLAVOR: ${{ matrix.image_flavor }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}
             TARGET: binary
@@ -395,6 +433,12 @@ jobs:
                   VERSIONED_TAGS_CSV=$(grep '^versioned_tags_csv=' $GITHUB_OUTPUT | cut -d= -f2- || echo "")
                   echo "versioned_tags_csv=$VERSIONED_TAGS_CSV" >> $GITHUB_OUTPUT
 
+                  if [ "${{ matrix.acp_provider_flavor }}" = "none" ]; then
+                      echo "install_acp_providers=" >> $GITHUB_OUTPUT
+                  else
+                      echo "install_acp_providers=$INSTALL_ACP_PROVIDERS" >> $GITHUB_OUTPUT
+                  fi
+
                   # Verify outputs
                   echo "=== Build outputs ==="
                   echo "Build context: $(grep '^build_context=' $GITHUB_OUTPUT | cut -d= -f2-)"
@@ -413,13 +457,13 @@ jobs:
                   platforms: ${{ env.PLATFORM }}
                   push: true
                   tags: ${{ steps.prep.outputs.tags }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+                  cache-from: type=gha,scope=agent-server-${{ matrix.variant }}-${{ matrix.arch }}
+                  cache-to: type=gha,scope=agent-server-${{ matrix.variant }}-${{ matrix.arch }},mode=max
                   build-args: |
                       BASE_IMAGE=${{ env.BASE_IMAGE }}
                       OPENHANDS_BUILD_GIT_SHA=${{ env.SDK_SHA }}
                       OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}
-                      INSTALL_ACP_PROVIDERS=${{ env.INSTALL_ACP_PROVIDERS }}
+                      INSTALL_ACP_PROVIDERS=${{ steps.prep.outputs.install_acp_providers }}
                       INSTALL_CAPABILITIES=${{ env.INSTALL_CAPABILITIES }}
 
             - name: Cleanup build context
@@ -491,7 +535,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                variant: [python, java, golang]
+                variant: [python, python-slim, java, golang]
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
 

--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -41,7 +41,12 @@ describe('ACP provider credential descriptors', () => {
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {
     const codex = ACP_PROVIDERS.codex;
-    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.1.7']);
+    expect(codex.default_command).toEqual([
+      'npx',
+      '-y',
+      '--prefer-offline',
+      '@agentclientprotocol/codex-acp@1.1.7',
+    ]);
     expect(codex.default_session_mode).toBe('agent-full-access');
     expect(codex.available_models.map((model) => model.id)).toEqual(
       expect.arrayContaining(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -2,7 +2,7 @@
   "claude-code": {
     "key": "claude-code",
     "display_name": "Claude Code",
-    "default_command": ["npx", "-y", "@agentclientprotocol/claude-agent-acp@0.63.0"],
+    "default_command": ["npx", "-y", "--prefer-offline", "@agentclientprotocol/claude-agent-acp@0.63.0"],
     "api_key_env_var": "ANTHROPIC_API_KEY",
     "base_url_env_var": "ANTHROPIC_BASE_URL",
     "default_session_mode": "bypassPermissions",
@@ -40,7 +40,7 @@
   "codex": {
     "key": "codex",
     "display_name": "Codex",
-    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.1.7"],
+    "default_command": ["npx", "-y", "--prefer-offline", "@agentclientprotocol/codex-acp@1.1.7"],
     "api_key_env_var": "OPENAI_API_KEY",
     "base_url_env_var": "OPENAI_BASE_URL",
     "default_session_mode": "agent-full-access",
@@ -95,7 +95,7 @@
   "gemini-cli": {
     "key": "gemini-cli",
     "display_name": "Gemini CLI",
-    "default_command": ["npx", "-y", "@google/gemini-cli@0.46.0", "--acp"],
+    "default_command": ["npx", "-y", "--prefer-offline", "@google/gemini-cli@0.46.0", "--acp"],
     "api_key_env_var": "GEMINI_API_KEY",
     "base_url_env_var": "GEMINI_BASE_URL",
     "default_session_mode": "default",

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -27,6 +27,7 @@ import time
 import tomllib
 from contextlib import chdir
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -389,6 +390,7 @@ class BuildOptions(BaseModel):
         default="", description="Comma-separated list of custom tags."
     )
     image: str = Field(default="ghcr.io/openhands/agent-server")
+    image_flavor: Literal["default", "slim"] = Field(default="default")
     target: TargetType = Field(default="binary")
     platforms: list[PlatformType] = Field(default=["linux/amd64"])
     push: bool | None = Field(
@@ -545,18 +547,22 @@ class BuildOptions(BaseModel):
         if not self.release_tag_source:
             return []
         return [
-            f"{release_tag}-{custom_tag}"
+            f"{release_tag}-{custom_tag}{self.flavor_suffix}"
             for custom_tag in self.custom_tag_list
             for release_tag in _release_tag_aliases(self.release_tag_source)
         ]
 
     @property
+    def flavor_suffix(self) -> str:
+        return "" if self.image_flavor == "default" else f"-{self.image_flavor}"
+
+    @property
     def base_tag(self) -> str:
-        return f"{self.short_sha}-{self.base_image_slug}"
+        return f"{self.short_sha}-{self.base_image_slug}{self.flavor_suffix}"
 
     @property
     def cache_tags(self) -> tuple[str, str]:
-        base = f"buildcache-{self.target}-{self.base_image_slug}"
+        base = f"buildcache-{self.target}-{self.base_image_slug}{self.flavor_suffix}"
         if self.git_ref in ("main", "refs/heads/main"):
             return f"{base}-main", base
         elif self.git_ref != "unknown":
@@ -570,6 +576,7 @@ class BuildOptions(BaseModel):
         arch_suffix = f"-{self.arch}" if self.arch else ""
 
         for custom_tag in self.custom_tag_list:
+            custom_tag = f"{custom_tag}{self.flavor_suffix}"
             tags.extend(
                 [
                     f"{self.image}:{self.short_sha}-{custom_tag}{arch_suffix}",
@@ -1061,6 +1068,12 @@ def main(argv: list[str]) -> int:
         help="Image repo/name (default from $IMAGE).",
     )
     parser.add_argument(
+        "--image-flavor",
+        default=_env("IMAGE_FLAVOR", "default"),
+        choices=("default", "slim"),
+        help="Image flavor (default from $IMAGE_FLAVOR).",
+    )
+    parser.add_argument(
         "--target",
         default=_env("TARGET", "binary"),
         choices=sorted(VALID_TARGETS),
@@ -1156,6 +1169,7 @@ def main(argv: list[str]) -> int:
             base_image=args.base_image,
             custom_tags=args.custom_tags,
             image=args.image,
+            image_flavor=args.image_flavor,
             target=args.target,  # type: ignore
             platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
             push=None,  # Not relevant for build-ctx-only
@@ -1206,6 +1220,7 @@ def main(argv: list[str]) -> int:
         base_image=args.base_image,
         custom_tags=args.custom_tags,
         image=args.image,
+        image_flavor=args.image_flavor,
         target=args.target,  # type: ignore
         platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
         push=push,

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2790,10 +2790,18 @@ class ACPAgent(AgentBase):
         package = _npx_package(self.acp_command)
         if provider is not None and package is not None:
             env["npm_config_cache"] = str(self._acp_npm_cache_dir(state))
-            self._executor.run_async(
-                self._warm_npx_cache(package, provider.key, env, working_dir),
-                timeout=_ACP_NPX_CACHE_WARM_TIMEOUT + 5,
-            )
+            try:
+                self._executor.run_async(
+                    self._warm_npx_cache(package, provider.key, env, working_dir),
+                    timeout=_ACP_NPX_CACHE_WARM_TIMEOUT + 5,
+                )
+            except Exception as error:
+                logger.warning(
+                    "ACP provider npx cache warm failed: provider=%s; "
+                    "continuing with normal startup: %s",
+                    provider.key,
+                    error,
+                )
 
         # Prior ACP session id — typically survives agent-server restarts via
         # ConversationState.agent_state (serialized into base_state.json).

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -145,6 +145,9 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
 )
 
 _ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
+_ACP_NPX_CACHE_WARM_TIMEOUT: float = float(
+    os.environ.get("ACP_NPX_CACHE_WARM_TIMEOUT", "300")
+)
 _ACP_VERSION_RE = re.compile(r"v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)")
 
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
@@ -415,6 +418,15 @@ def _log_acp_provider_version(agent_name: str, agent_version: str) -> None:
             agent_name,
             agent_version,
         )
+
+
+def _npx_package(command: list[str]) -> str | None:
+    if not command or command[0] != "npx":
+        return None
+    for arg in command[1:]:
+        if not arg.startswith("-"):
+            return arg
+    return None
 
 
 def _with_codex_base_url(
@@ -2396,6 +2408,59 @@ class ACPAgent(AgentBase):
             root = Path(state.workspace.working_dir) / ".openhands" / "acp" / subdir
         return Path(os.path.abspath(root))
 
+    def _acp_npm_cache_dir(self, state: ConversationState) -> Path:
+        if state.persistence_dir:
+            root = Path(state.persistence_dir).parent
+        else:
+            root = Path(state.workspace.working_dir) / ".openhands"
+        cache_dir = root / "npm-cache"
+        cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return Path(os.path.abspath(cache_dir))
+
+    async def _warm_npx_cache(
+        self,
+        package: str,
+        provider_key: str,
+        env: dict[str, str],
+        cwd: str,
+    ) -> None:
+        logger.info(
+            "Warming ACP provider npx cache: provider=%s, package=%s; "
+            "first use may download the provider before session startup",
+            provider_key,
+            package,
+        )
+        process = await asyncio.create_subprocess_exec(
+            "npx",
+            "--yes",
+            "--prefer-offline",
+            "--package",
+            package,
+            "--",
+            "node",
+            "-e",
+            "",
+            cwd=cwd,
+            env=env,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_ACP_NPX_CACHE_WARM_TIMEOUT)
+        except TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise RuntimeError(
+                "ACP provider cache warm timed out after "
+                f"{_ACP_NPX_CACHE_WARM_TIMEOUT:.0f}s for {provider_key}"
+            ) from exc
+        if process.returncode:
+            raise RuntimeError(
+                f"ACP provider cache warm failed for {provider_key} "
+                f"(exit code {process.returncode})"
+            )
+
     def _isolate_acp_data_dir(
         self, state: ConversationState, env: dict[str, str]
     ) -> None:
@@ -2721,6 +2786,14 @@ class ACPAgent(AgentBase):
         env = _with_codex_base_url(command, args, env)
 
         working_dir = str(state.workspace.working_dir)
+        provider = detect_acp_provider_by_command(self.acp_command)
+        package = _npx_package(self.acp_command)
+        if provider is not None and package is not None:
+            env["npm_config_cache"] = str(self._acp_npm_cache_dir(state))
+            self._executor.run_async(
+                self._warm_npx_cache(package, provider.key, env, working_dir),
+                timeout=_ACP_NPX_CACHE_WARM_TIMEOUT + 5,
+            )
 
         # Prior ACP session id — typically survives agent-server restarts via
         # ConversationState.agent_state (serialized into base_state.json).

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -145,6 +145,7 @@ _ACP_CANCEL_DRAIN_TIMEOUT: float = float(
 )
 
 _ACP_AUTH_TIMEOUT: float = float(os.environ.get("ACP_AUTH_TIMEOUT", "30.0"))
+_ACP_VERSION_RE = re.compile(r"v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)")
 
 _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
 
@@ -360,6 +361,60 @@ def _warn_auth_selection_failure(auth_methods: list[Any], env: dict[str, str]) -
         [m.id for m in auth_methods],
         _auth_selection_failure_reason(auth_methods, env),
     )
+
+
+def _log_acp_provider_version(agent_name: str, agent_version: str) -> None:
+    try:
+        provider = detect_acp_provider_by_agent_name(agent_name)
+        if provider is None:
+            return
+        pinned_version = None
+        for command_part in provider.default_command:
+            package, separator, version = command_part.rpartition("@")
+            if separator and package:
+                pinned_version = version
+                break
+        reported_version = next(
+            (
+                match.group(1)
+                for value in (agent_version, agent_name)
+                if (match := _ACP_VERSION_RE.search(value)) is not None
+            ),
+            None,
+        )
+        logger.info(
+            "ACP provider version: provider=%s, pinned_version=%r, "
+            "agent_name=%r, agent_version=%r, reported_version=%r",
+            provider.key,
+            pinned_version,
+            agent_name,
+            agent_version,
+            reported_version,
+        )
+        if reported_version is None:
+            logger.warning(
+                "Could not parse ACP provider version: provider=%s, "
+                "pinned_version=%r, agent_name=%r, agent_version=%r",
+                provider.key,
+                pinned_version,
+                agent_name,
+                agent_version,
+            )
+        elif pinned_version is not None and reported_version != pinned_version:
+            logger.warning(
+                "ACP provider version mismatch: provider=%s, pinned_version=%r, "
+                "reported_version=%r; provider was probably installed at runtime "
+                "via the npx fallback rather than preinstalled in the image",
+                provider.key,
+                pinned_version,
+                reported_version,
+            )
+    except Exception:
+        logger.warning(
+            "Could not verify ACP provider version: agent_name=%r, agent_version=%r",
+            agent_name,
+            agent_version,
+        )
 
 
 def _with_codex_base_url(
@@ -2779,6 +2834,7 @@ class ACPAgent(AgentBase):
                 agent_name,
                 agent_version,
             )
+            _log_acp_provider_version(agent_name, agent_version)
 
             # Translate any configured MCP servers into ACP protocol objects,
             # gating remote (http/sse) transports on what this server advertised

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -403,6 +403,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             default_command=(
                 "npx",
                 "-y",
+                "--prefer-offline",
                 f"@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
             ),
             api_key_env_var="ANTHROPIC_API_KEY",
@@ -432,6 +433,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             default_command=(
                 "npx",
                 "-y",
+                "--prefer-offline",
                 f"@agentclientprotocol/codex-acp@{CODEX_ACP_VERSION}",
             ),
             api_key_env_var="OPENAI_API_KEY",
@@ -453,6 +455,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             default_command=(
                 "npx",
                 "-y",
+                "--prefer-offline",
                 f"@google/gemini-cli@{GEMINI_CLI_VERSION}",
                 "--acp",
             ),

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -454,6 +454,29 @@ def test_all_tags_include_short_long_sha_and_branch():
     ]
 
 
+def test_slim_flavor_has_distinct_image_and_cache_tags():
+    from openhands.agent_server.docker.build import BuildOptions
+
+    opts = BuildOptions(
+        base_image="python:3.13",
+        custom_tags="python",
+        git_sha="abc1234567890fedcba",
+        git_ref="refs/heads/main",
+        image_flavor="slim",
+        include_base_tag=False,
+    )
+
+    assert opts.all_tags == [
+        "ghcr.io/openhands/agent-server:abc1234-python-slim",
+        "ghcr.io/openhands/agent-server:abc1234567890fedcba-python-slim",
+        "ghcr.io/openhands/agent-server:main-python-slim",
+    ]
+    assert opts.cache_tags == (
+        "buildcache-binary-python_tag_3.13-slim-main",
+        "buildcache-binary-python_tag_3.13-slim",
+    )
+
+
 def test_all_tags_includes_versioned_tags():
     """Test that all_tags includes bare semver aliases when enabled for a tag build."""
     from openhands.agent_server.docker.build import BuildOptions

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -144,3 +144,24 @@ def test_agent_server_dockerfile_acp_package_versions_match_registry() -> None:
             f"{AGENT_SERVER_DOCKERFILE}: ACP package {dockerfile_package} has version "
             f"{dockerfile_version}, but acp_providers.py pins {expected_version}"
         )
+
+
+def test_server_workflow_publishes_python_slim_without_acp_providers() -> None:
+    workflow_text = SERVER_WORKFLOW.read_text(encoding="utf-8")
+
+    assert re.search(
+        r"- variant: python-slim\n"
+        r"\s+custom_tags: python\n"
+        r"\s+image_flavor: slim\n"
+        r"\s+acp_provider_flavor: none",
+        workflow_text,
+    )
+    assert (
+        "INSTALL_ACP_PROVIDERS=${{ steps.prep.outputs.install_acp_providers }}"
+        in workflow_text
+    )
+    assert "INSTALL_CAPABILITIES=${{ env.INSTALL_CAPABILITIES }}" in workflow_text
+    assert (
+        "scope=agent-server-${{ matrix.variant }}-${{ matrix.arch }}" in workflow_text
+    )
+    assert "variant: [python, python-slim, java, golang]" in workflow_text

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -1,8 +1,23 @@
+import re
 from pathlib import Path
+
+from openhands.sdk.settings.acp_providers import (
+    CLAUDE_AGENT_ACP_VERSION,
+    CODEX_ACP_VERSION,
+    GEMINI_CLI_VERSION,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SERVER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "server.yml"
+AGENT_SERVER_DOCKERFILE = (
+    REPO_ROOT
+    / "openhands-agent-server"
+    / "openhands"
+    / "agent_server"
+    / "docker"
+    / "Dockerfile"
+)
 AGENT_SERVER_SPEC = (
     REPO_ROOT
     / "openhands-agent-server"
@@ -10,6 +25,17 @@ AGENT_SERVER_SPEC = (
     / "agent_server"
     / "agent-server.spec"
 )
+
+_DOCKERFILE_ACP_PACKAGE = re.compile(
+    r'^\s*(?P<key>[\w-]+)\) PACKAGES="\$PACKAGES '
+    r'(?P<package>@[^@\s]+)@(?P<version>[^\s";]+)";',
+    re.MULTILINE,
+)
+_REGISTRY_ACP_PACKAGES = {
+    "claude-code": ("@agentclientprotocol/claude-agent-acp", CLAUDE_AGENT_ACP_VERSION),
+    "codex": ("@agentclientprotocol/codex-acp", CODEX_ACP_VERSION),
+    "gemini-cli": ("@google/gemini-cli", GEMINI_CLI_VERSION),
+}
 
 
 def test_server_workflow_passes_git_metadata_build_args() -> None:
@@ -89,3 +115,32 @@ def test_agent_server_binary_copies_openhands_distribution_metadata() -> None:
         "openhands-workspace",
     ):
         assert f'*copy_metadata("{distribution}")' in spec_text
+
+
+def test_agent_server_dockerfile_acp_package_versions_match_registry() -> None:
+    dockerfile_text = AGENT_SERVER_DOCKERFILE.read_text(encoding="utf-8")
+    case_arms = dockerfile_text.partition('case "$provider" in')[2].partition("esac")[0]
+    dockerfile_packages = list(_DOCKERFILE_ACP_PACKAGE.finditer(case_arms))
+
+    assert dockerfile_packages, (
+        f"No ACP package versions found in {AGENT_SERVER_DOCKERFILE} "
+        "INSTALL_ACP_PROVIDERS case arms"
+    )
+
+    for match in dockerfile_packages:
+        provider_key = match["key"]
+        registry_package = _REGISTRY_ACP_PACKAGES.get(provider_key)
+        if registry_package is None:
+            continue
+        expected_package, expected_version = registry_package
+        dockerfile_package = match["package"]
+        dockerfile_version = match["version"]
+
+        assert dockerfile_package == expected_package, (
+            f"{AGENT_SERVER_DOCKERFILE}: ACP provider {provider_key!r} uses package "
+            f"{dockerfile_package}, but acp_providers.py uses {expected_package}"
+        )
+        assert dockerfile_version == expected_version, (
+            f"{AGENT_SERVER_DOCKERFILE}: ACP package {dockerfile_package} has version "
+            f"{dockerfile_version}, but acp_providers.py pins {expected_version}"
+        )

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -37,6 +37,7 @@ from openhands.sdk.agent.acp_agent import (
     _extract_session_models,
     _extract_token_usage,
     _image_url_to_acp_block,
+    _log_acp_provider_version,
     _log_acp_subprocess_stderr,
     _mask_json_value,
     _maybe_set_session_model,
@@ -159,6 +160,26 @@ def _make_state(tmp_path) -> ConversationState:
         agent=agent,
         workspace=workspace,
     )
+
+
+def test_logs_matching_acp_provider_version(caplog):
+    with caplog.at_level("INFO"):
+        _log_acp_provider_version("codex-acp", "1.1.7")
+
+    assert "provider=codex" in caplog.text
+    assert "pinned_version='1.1.7'" in caplog.text
+    assert "reported_version='1.1.7'" in caplog.text
+    assert "mismatch" not in caplog.text
+
+
+def test_warns_when_acp_provider_version_differs_from_pin(caplog):
+    with caplog.at_level("INFO"):
+        _log_acp_provider_version("gemini-cli 0.38.0", "")
+
+    assert "provider=gemini-cli" in caplog.text
+    assert "pinned_version='0.46.0'" in caplog.text
+    assert "reported_version='0.38.0'" in caplog.text
+    assert "probably installed at runtime via the npx fallback" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -233,6 +233,43 @@ async def test_warm_npx_cache_uses_prefer_offline_and_durable_env(tmp_path):
     )
 
 
+def test_npx_cache_warm_failure_continues_with_normal_startup(tmp_path, caplog):
+    agent = ACPAgent(
+        acp_command=[
+            "npx",
+            "-y",
+            "--prefer-offline",
+            "@agentclientprotocol/codex-acp@1.1.7",
+        ],
+        acp_server="codex",
+    )
+    state = ConversationState.create(
+        id=uuid.uuid4(),
+        agent=agent,
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+    )
+    conn = TestACPSessionIdPersistence._make_conn()
+
+    try:
+        with caplog.at_level("WARNING"):
+            with patch.object(
+                ACPAgent,
+                "_warm_npx_cache",
+                new=AsyncMock(side_effect=RuntimeError("registry unavailable")),
+            ):
+                TestACPSessionIdPersistence._patched_start_acp_server(
+                    agent, state, conn=conn
+                )
+    finally:
+        agent._unregister_atexit_cleanup()
+        assert agent._executor is not None
+        agent._executor.close()
+        agent._executor = None
+
+    assert "continuing with normal startup" in caplog.text
+    conn.initialize.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Instantiation
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -42,6 +42,7 @@ from openhands.sdk.agent.acp_agent import (
     _mask_json_value,
     _maybe_set_session_model,
     _mcp_config_to_acp_servers,
+    _npx_package,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
     _select_auth_method,
@@ -180,6 +181,56 @@ def test_warns_when_acp_provider_version_differs_from_pin(caplog):
     assert "pinned_version='0.46.0'" in caplog.text
     assert "reported_version='0.38.0'" in caplog.text
     assert "probably installed at runtime via the npx fallback" in caplog.text
+
+
+def test_npx_package_skips_prefer_offline():
+    assert (
+        _npx_package(
+            ["npx", "-y", "--prefer-offline", "@agentclientprotocol/codex-acp@1.1.7"]
+        )
+        == "@agentclientprotocol/codex-acp@1.1.7"
+    )
+
+
+def test_acp_npm_cache_is_shared_across_conversations(tmp_path):
+    agent = _make_agent()
+    state = _make_state(tmp_path)
+    state.persistence_dir = str(tmp_path / "conversations" / "conversation-id")
+
+    assert agent._acp_npm_cache_dir(state) == tmp_path / "conversations" / "npm-cache"
+
+
+async def test_warm_npx_cache_uses_prefer_offline_and_durable_env(tmp_path):
+    agent = _make_agent()
+    process = MagicMock()
+    process.returncode = 0
+    process.wait = AsyncMock(return_value=0)
+    env = {"npm_config_cache": str(tmp_path / "npm-cache")}
+
+    with patch(
+        "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=process),
+    ) as create_process:
+        await agent._warm_npx_cache(
+            "@agentclientprotocol/codex-acp@1.1.7", "codex", env, str(tmp_path)
+        )
+
+    create_process.assert_awaited_once_with(
+        "npx",
+        "--yes",
+        "--prefer-offline",
+        "--package",
+        "@agentclientprotocol/codex-acp@1.1.7",
+        "--",
+        "node",
+        "-e",
+        "",
+        cwd=str(tmp_path),
+        env=env,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -25,6 +25,10 @@ class TestACPProviderInfo:
         for info in ACP_PROVIDERS.values():
             assert isinstance(info, ACPProviderInfo)
 
+    def test_default_commands_prefer_offline_cache(self):
+        for info in ACP_PROVIDERS.values():
+            assert info.default_command[:3] == ("npx", "-y", "--prefer-offline")
+
     def test_claude_code_metadata(self):
         info = ACP_PROVIDERS["claude-code"]
         assert info.key == "claude-code"

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1390,6 +1390,7 @@ def test_acp_create_agent_uses_server_default_command(
     assert agent.acp_command == [
         "npx",
         "-y",
+        "--prefer-offline",
         "@agentclientprotocol/claude-agent-acp@0.63.0",
     ]
     assert agent.acp_model == "claude-opus-4-6"
@@ -1568,6 +1569,7 @@ def test_acp_resolve_command_keeps_npx_when_binary_absent(
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
+        "--prefer-offline",
         "@agentclientprotocol/codex-acp@1.1.7",
     ]
 


### PR DESCRIPTION
HUMAN:

Publishes an ACP-less `python-slim` agent-server variant and makes the npx fallback good enough to depend on, so Agent Canvas can stop shipping ~300 MB of ACP payload that most users never touch. The default `python` tag is deliberately unchanged — enterprise, Replicated, cloud and evaluation all consume it and all genuinely use preinstalled ACP.

AGENT:

---

## Why

Agent Canvas needs an agent-server image without baked ACP payloads while ACP users retain a reliable, version-pinned on-demand path. This also makes the image/runtime version contract observable and testable.

## Summary

- Keep the Dockerfile ↔ ACP registry pin-parity guard and startup pin/reported-version diagnostics from the original scope.
- Publish a new `python-slim` tag namespace for amd64 and arm64. It preserves the default Python image unchanged and leaves `vscode,browser,docker` enabled; the matrix adds two image builds, increasing CI time accordingly.
- Give slim tags and build caches a distinct `image_flavor=slim` suffix.
- Make npx fallback practical: `--prefer-offline`, a shared persistent `npm_config_cache` at `<conversations>/npm-cache`, and a visible, independently budgeted cache warm before the 90-second ACP startup handshake.
- Canvas integration remains a follow-up in `OpenHands/OpenHands` once this variant is published.

## Scope boundaries — deliberately not in this PR

- **The default `python` tag is unchanged.** Enterprise, Replicated, cloud and evaluation all consume it, and all use preinstalled ACP. Verified above: `acp-node entries=7`, all three wrappers present at pinned versions.
- **Evaluation and benchmarks keep preloaded providers.** They pass a bare `acp_command`, which `_prefer_pinned_binary` does not rewrite, so they have no npx fallback — a slim image would break them outright. Separately, image layers cache per node while npx downloads happen per pod, so lazy install is strictly worse at eval scale.
- **Docker Engine is untouched.** A different decision with a different risk profile: `dockerd` works in Canvas under `--privileged` (daemon 29.7.2 verified), so excluding it is a real regression with no runtime fallback. Tracked separately; #4808 lands the explanatory shim first.
- **Canvas adoption is a follow-up** in `OpenHands/OpenHands`, blocked until this variant is released and published. It cannot be in this PR — different repository.

## Reviewer notes

- **Measured cold installs** (clean Node 22 container): gemini 1 s, codex 3 s, claude 4 s. Comfortably inside the 90 s `acp_startup_timeout` on broadband — the separate warm step matters for slow links, where ~100 MB over the wire can approach the deadline and would otherwise surface as a hang rather than a download.
- **npm package size is a poor proxy for cost**: `@agentclientprotocol/claude-agent-acp` is a 0.5 MB package that pulls ~314 MB on disk; `codex-acp` is 1.1 MB pulling ~321 MB. Relevant when sizing a cache volume.
- **The cache is shared across conversations, not per-conversation**: `_acp_npm_cache_dir()` takes `state` but uses `Path(state.persistence_dir).parent`, landing at `<conversations>/npm-cache` — one level above any single conversation. `test_acp_npm_cache_is_shared_across_conversations` pins that.
- **The preinstalled path skips the warm step**: `_npx_package()` returns `None` unless `command[0] == "npx"`, and `_prefer_pinned_binary()` has already rewritten to the pinned binary in the default image — so no spurious npx spawn on enterprise session start.

## Issue Number

Relates to #4643, OHE-3179

## How to Test

```text
$ uv run --frozen pytest tests/agent_server/test_docker_build.py tests/cross/test_agent_server_build_metadata.py tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py -q
692 passed, 36 warnings in 12.31s

$ temporary Dockerfile edit: @agentclientprotocol/codex-acp@1.1.7 -> @agentclientprotocol/codex-acp@1.1.8
$ uv run --frozen pytest tests/cross/test_agent_server_build_metadata.py::test_agent_server_dockerfile_acp_package_versions_match_registry -q
AssertionError: ... Dockerfile: ACP package @agentclientprotocol/codex-acp has version 1.1.8, but acp_providers.py pins 1.1.7

$ docker buildx build --platform linux/arm64 ... INSTALL_ACP_PROVIDERS= --output type=oci,dest=/tmp/acp-python-slim-arm64.oci .
$ docker run ... slim ...
acp-node entries=0
claude-agent-acp=absent
codex-acp=absent
gemini=absent
v22.23.2
10.9.8
chromium=present
openvscode=present

$ docker buildx build --platform linux/arm64 ... INSTALL_ACP_PROVIDERS=claude-code,codex,gemini-cli --output type=oci,dest=/tmp/acp-python-default-arm64.oci .
acp-node entries=7
/usr/local/bin/claude-agent-acp
0.63.0
/usr/local/bin/codex-acp
@agentclientprotocol/codex-acp 1.1.7
/usr/local/bin/gemini
0.46.0

$ jq '[.layers[].size] | add' <OCI manifest>
default compressed layers: 1242627511 bytes
slim compressed layers:     927318804 bytes
delta:                      315308707 bytes (300.7 MiB)

# Slim-image Codex ACP conversation, using the npx fallback:
Warming ACP provider npx cache: provider=codex, package=@agentclientprotocol/codex-acp@1.1.7; first use may download the provider before session startup
ACP server initialized: agent_name='@agentclientprotocol/codex-acp', agent_version='1.1.7'
ACP provider version: provider=codex, pinned_version='1.1.7', ... reported_version='1.1.7'
ACP prompt returned in 3.6s (async)
{"response":"ACP fallback verified."}

# Restarted container with the same conversation volume:
second_conversation_http=201 elapsed_seconds=0.081557
ACP server initialized: agent_name='@agentclientprotocol/codex-acp', agent_version='1.1.7'
{"response":"warm cache verified."}

# Delayed only the cache-warm npx call by six seconds; ACP startup timeout was 5s:
Warming ACP provider npx cache: provider=codex, package=@agentclientprotocol/codex-acp@1.1.7; first use may download the provider before session startup
# 10.3 seconds later: initialized successfully, then completed the turn
{"response":"timeout separation verified."}

$ uv run --frozen ruff check <touched Python files>
All checks passed!
$ uv run --frozen ruff format --check <touched Python files>
8 files already formatted

$ uv run --frozen pytest tests/cross tests/sdk/settings -q
2 failed, 463 passed, 1 skipped in 111.52s
# Both failures are local-environment artefacts, not regressions:
#   - tmux socket path "File name too long" (long worktree path on this machine)
#   - ambient OPENHANDS_AUTOMATION_API_KEY leaking into the settings API response
# Both reproduce on an unmodified origin/main checkout, and neither touches any
# file this PR changes. CI is the authority here.
```

## Type

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore





<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2a3874a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2a3874a-python \
  ghcr.io/openhands/agent-server:2a3874a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2a3874a-golang-amd64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-golang-amd64
ghcr.io/openhands/agent-server:acp-version-parity-golang-amd64
ghcr.io/openhands/agent-server:2a3874a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2a3874a-golang-arm64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-golang-arm64
ghcr.io/openhands/agent-server:acp-version-parity-golang-arm64
ghcr.io/openhands/agent-server:2a3874a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2a3874a-java-amd64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-java-amd64
ghcr.io/openhands/agent-server:acp-version-parity-java-amd64
ghcr.io/openhands/agent-server:2a3874a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2a3874a-java-arm64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-java-arm64
ghcr.io/openhands/agent-server:acp-version-parity-java-arm64
ghcr.io/openhands/agent-server:2a3874a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2a3874a-python-amd64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python-amd64
ghcr.io/openhands/agent-server:acp-version-parity-python-amd64
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2a3874a-python-arm64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python-arm64
ghcr.io/openhands/agent-server:acp-version-parity-python-arm64
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2a3874a-python-slim-amd64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python-slim-amd64
ghcr.io/openhands/agent-server:acp-version-parity-python-slim-amd64
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:2a3874a-python-slim-arm64
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python-slim-arm64
ghcr.io/openhands/agent-server:acp-version-parity-python-slim-arm64
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:2a3874a-golang
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-golang
ghcr.io/openhands/agent-server:acp-version-parity-golang
ghcr.io/openhands/agent-server:2a3874a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2a3874a-java
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-java
ghcr.io/openhands/agent-server:acp-version-parity-java
ghcr.io/openhands/agent-server:2a3874a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2a3874a-python-slim
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python-slim
ghcr.io/openhands/agent-server:acp-version-parity-python-slim
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:2a3874a-python
ghcr.io/openhands/agent-server:2a3874a1455e22f48c2f47c11f4d1db7a865df4d-python
ghcr.io/openhands/agent-server:acp-version-parity-python
ghcr.io/openhands/agent-server:2a3874a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2a3874a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2a3874a-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

