### PR TITLE
fix(sdk): persist events before publishing them, return the assigned seq

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -181,8 +181,11 @@ class EventLog(EventsListBase):
             self._event_cache[i] = evt
             yield evt
 
-    def append(self, event: Event) -> None:
+    def append(self, event: Event) -> int:
         """Append an event with locking for thread/process safety.
+
+        Returns:
+            The sequence number (index) the log assigned to ``event``.
 
         Raises:
             TimeoutError: If the lock cannot be acquired within LOCK_TIMEOUT_SECONDS.
@@ -218,13 +221,15 @@ class EventLog(EventsListBase):
                 write_guard = (
                     nullcontext() if self._write_guard is None else self._write_guard()
                 )
+                idx = self._length
                 with write_guard:
-                    target_path = self._path(self._length, event_id=evt_id)
+                    target_path = self._path(idx, event_id=evt_id)
                     self._fs.write(target_path, payload)
-                self._idx_to_id[self._length] = evt_id
-                self._id_to_idx[evt_id] = self._length
-                self._event_cache[self._length] = event
+                self._idx_to_id[idx] = evt_id
+                self._id_to_idx[evt_id] = idx
+                self._event_cache[idx] = event
                 self._length += 1
+                return idx
         except TimeoutError:
             logger.error(
                 f"Failed to acquire EventLog lock within {LOCK_TIMEOUT_SECONDS}s "

--- a/openhands-sdk/openhands/sdk/conversation/events_list_base.py
+++ b/openhands-sdk/openhands/sdk/conversation/events_list_base.py
@@ -12,6 +12,6 @@ class EventsListBase(Sequence[Event], ABC):
     """
 
     @abstractmethod
-    def append(self, event: Event) -> None:
-        """Add a new event to the list."""
+    def append(self, event: Event) -> int:
+        """Add a new event to the list, returning its assigned sequence number."""
         ...

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -425,7 +425,11 @@ class LocalConversation(BaseConversation):
                 self._state.last_user_message_id = e.id
 
         callback_list = list(callbacks) if callbacks else []
-        composed_list = callback_list + [_default_callback]
+        # _default_callback (persist) runs before the caller-supplied callbacks
+        # (e.g. a PubSub publish) so nothing is announced before it is durable.
+        # compose_callbacks' plain for-loop has no try/except, so if persist
+        # raises here, the callbacks after it in the list never run.
+        composed_list = [_default_callback] + callback_list
         # Handle visualization configuration
         if isinstance(visualizer, ConversationVisualizerBase):
             # Use custom visualizer instance

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -426,9 +426,12 @@ class LocalConversation(BaseConversation):
 
         callback_list = list(callbacks) if callbacks else []
         # _default_callback (persist) runs before the caller-supplied callbacks
-        # (e.g. a PubSub publish) so nothing is announced before it is durable.
-        # compose_callbacks' plain for-loop has no try/except, so if persist
-        # raises here, the callbacks after it in the list never run.
+        # (e.g. a PubSub publish), so no subscriber is told about an event that
+        # is not on disk yet. compose_callbacks' plain for-loop has no
+        # try/except, so if persist raises here, the callbacks after it in the
+        # list never run. The visualizer is prepended below and so still renders
+        # ahead of persist — that is local terminal output, not an announcement
+        # a client can act on.
         composed_list = [_default_callback] + callback_list
         # Handle visualization configuration
         if isinstance(visualizer, ConversationVisualizerBase):
@@ -451,7 +454,7 @@ class LocalConversation(BaseConversation):
             # No visualization (visualizer is None)
             self._visualizer = None
 
-        # Compose the base callback chain (visualizer -> user callbacks -> default)
+        # Compose the base callback chain (visualizer -> default -> user callbacks)
         base_callback = BaseConversation.compose_callbacks(composed_list)
         self._base_callback = base_callback  # Store for _ensure_plugins_loaded
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -461,9 +461,16 @@ class RemoteEventsList(EventsListBase):
             if event.id not in self._cached_event_ids:
                 self._add_event_unsafe(event)
 
-    def append(self, event: Event) -> None:
-        """Add a new event to the list (for compatibility with EventLog interface)."""
+    def append(self, event: Event) -> int:
+        """Add a new event to the list (for compatibility with EventLog interface).
+
+        Unlike ``EventLog``, this cache orders by event timestamp (not call
+        order) and merges some ACP pairs in place, so there is no per-event
+        sequence number to hand back. Returns the cache's length after the
+        write, only to satisfy ``EventsListBase``.
+        """
         self.add_event(event)
+        return len(self._cached_events) - 1
 
     def create_default_callback(self) -> ConversationCallbackType:
         """Create a default callback that adds events to this list."""

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -312,15 +312,18 @@ class ConversationState(OpenHandsModel):
             parent = ROOT_PARENT_ID
         return event.model_copy(update={"parent_id": parent})
 
-    def append_event(self, event: Event) -> Event:
+    def append_event(self, event: Event) -> int:
         """Single storage chokepoint: stamp parent_id, append, advance HEAD.
 
         Stamping here (not only at the emit callback) ensures no event enters the
         log unstamped, even one a hook swaps in downstream. ``fork`` copies
         pre-stamped events and sets HEAD itself, so it bypasses this.
+
+        Returns:
+            The sequence number ``EventLog`` assigned to the appended event.
         """
         event = self._stamp_parent_id(event)
-        self._events.append(event)
+        seq = self._events.append(event)
         # ConversationStateUpdateEvent is a state-sync artifact, not a tree node;
         # advancing HEAD for it would recurse (moving HEAD re-emits one).
         from openhands.sdk.event.conversation_state import (
@@ -331,7 +334,7 @@ class ConversationState(OpenHandsModel):
             self.leaf_event_id = event.id
             if self.head_is_empty:  # HEAD now points at a real event again
                 self.head_is_empty = False
-        return event
+        return seq
 
     @property
     def view(self) -> View:

--- a/tests/sdk/conversation/local/test_conversation_default_callback.py
+++ b/tests/sdk/conversation/local/test_conversation_default_callback.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import SecretStr
 
 from openhands.sdk.agent.base import AgentBase
@@ -77,3 +78,46 @@ def test_send_message_appends_once():
 
     # Ensure callback saw both events
     assert set(seen_ids) == {e.id for e in conversation.state.events}
+
+
+def test_user_callback_runs_after_event_is_persisted():
+    """A user callback (e.g. a socket publish) must never see an event before
+    it is durable: it should already be able to resolve the event's sequence
+    number via ``EventLog.get_index``.
+    """
+    agent = ConversationDefaultCallbackDummyAgent()
+    seen_indices: list[int] = []
+
+    conversation = Conversation(
+        agent=agent,
+        callbacks=[
+            lambda e: seen_indices.append(conversation.state.events.get_index(e.id))
+        ],
+    )
+
+    conversation._ensure_agent_ready()
+
+    assert seen_indices == [0]
+
+
+def test_persist_failure_blocks_downstream_callback():
+    """If persisting an event raises, no user callback runs for it: nothing is
+    announced for an event that never reached disk.
+    """
+    agent = ConversationDefaultCallbackDummyAgent()
+    seen_ids: list[str] = []
+
+    conversation = Conversation(
+        agent=agent, callbacks=[lambda e: seen_ids.append(e.id)]
+    )
+    conversation._ensure_agent_ready()
+
+    duplicate = conversation.state.events[0]
+    assert seen_ids == [duplicate.id]
+
+    # Re-emitting an event whose ID is already in the log makes
+    # EventLog.append raise. The user callback must not see this attempt.
+    with pytest.raises(ValueError, match="already exists"):
+        conversation._on_event(duplicate)
+
+    assert seen_ids == [duplicate.id]

--- a/tests/sdk/conversation/test_event_store.py
+++ b/tests/sdk/conversation/test_event_store.py
@@ -42,6 +42,17 @@ def test_event_log_empty_initialization():
         log[-1]
 
 
+def test_event_log_append_returns_assigned_index():
+    """``append`` returns the sequence number it assigned, so callers don't
+    need a separate ``get_index`` lookup right after appending."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+
+    assert log.append(create_test_event("event-1")) == 0
+    assert log.append(create_test_event("event-2")) == 1
+    assert log.append(create_test_event("event-3")) == 2
+
+
 def test_event_log_id_validation_duplicate_id():
     """Test that duplicate event IDs are prevented."""
     fs = InMemoryFileStore()

--- a/tests/sdk/test_agent_step_bounded_scan.py
+++ b/tests/sdk/test_agent_step_bounded_scan.py
@@ -35,8 +35,9 @@ class _LimitedIterEvents(EventLog):
             raise AssertionError("events iterated too many times")
         return iter(self._events)
 
-    def append(self, event) -> None:  # type: ignore[override]
+    def append(self, event) -> int:  # type: ignore[override]
         self._events.append(event)
+        return len(self._events) - 1
 
 
 class _FailingIterEvents(EventLog):
@@ -56,8 +57,9 @@ class _FailingIterEvents(EventLog):
     def __iter__(self) -> Iterator:  # type: ignore[override]
         raise AssertionError("events iterated unexpectedly")
 
-    def append(self, event) -> None:  # type: ignore[override]
+    def append(self, event) -> int:  # type: ignore[override]
         self._events.append(event)
+        return len(self._events) - 1
 
 
 def test_agent_step_latest_user_message_scan_is_bounded(tmp_path):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small fix to persist events before publishing them.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

`compose_callbacks` composed the caller-supplied callbacks (which include a
`PubSub` publish via `AsyncCallbackWrapper` on the agent-server) *ahead of*
`_default_callback`, the one that persists the event via
`ConversationState.append_event` / `EventLog.append`. That means a socket
publish could announce an event before it was durably written to disk, and if
the append then raised, an event that never existed had already been
announced.

This is step 2 of the streaming two-channel design (part of #4671); step 3
(the session socket) needs `append_event` to hand back the sequence number a
durable frame should carry, without racing a separate `get_index` lookup
against an event that might not be persisted yet.

## Summary

- `LocalConversation` composes `_default_callback` (persist) *before* the
  caller-supplied callbacks, so a publish never runs on an event that hasn't
  reached disk yet. `compose_callbacks`' plain `for` loop already stops calling
  further callbacks if persist raises, so no separate exception handling was
  needed.
- `EventLog.append` and `ConversationState.append_event` now return the
  sequence number (index) assigned to the event, instead of `None` / the
  stamped `Event`. Widened `EventsListBase.append`'s abstract signature to
  match, updating `RemoteEventsList.append`'s override accordingly (its
  return value isn't a meaningful per-event sequence number there, since that
  cache orders by timestamp and merges some ACP events in place — it's kept
  only to satisfy the shared interface).
- No caller anywhere in the codebase used `append_event`'s previous `Event`
  return value.

## Performance

**No performance degradation.** Two independent things changed, both O(1) and
neither adds work:

- **Reordering `composed_list`**: `[_default_callback] + callback_list` vs.
  the old `callback_list + [_default_callback]` builds a list of the same
  length from the same two pieces — same number of callback invocations,
  same locks, same disk writes, just a different order. No callback runs
  twice, none is skipped.
- **`EventLog.append` returning the index**: the only change is capturing
  `self._length` into a local `idx` once instead of re-reading the
  `self._length` attribute several times, then `return idx`. Benchmarked this
  head-to-head (2000 appends/rep x 15 reps, old/new interleaved to cancel out
  drift, `InMemoryFileStore` to isolate Python overhead from disk I/O):
  old mean 826.0ms vs. new mean 827.3ms per rep — **+0.16%**, well inside the
  ~1% rep-to-rep stdev, i.e. noise.

The one deliberate, bounded latency tradeoff (not a throughput/complexity
regression): `AsyncCallbackWrapper` — the agent-server's socket-publish
callback — is fire-and-forget (`asyncio.run_coroutine_threadsafe`, no
blocking wait). Since persistence now runs first, that scheduling call lands
a few microseconds/milliseconds later than before (bounded by one disk write
+ lock acquisition), so a subscriber sees the event that many
microseconds/milliseconds later than under the old, incorrect ordering.
That's exactly the tradeoff #4680 asks for: never announce an event that
isn't durable yet, at the cost of a small, bounded delay in when it's
announced.

## Issue Number

Fixes #4680

## How to Test

- `uv run pytest tests/sdk/conversation/test_event_store.py tests/sdk/conversation/local/test_conversation_default_callback.py -q` — includes new tests:
  - `test_event_log_append_returns_assigned_index` — `EventLog.append` returns the correct index for successive appends.
  - `test_user_callback_runs_after_event_is_persisted` — a user callback can resolve the event's sequence number via `EventLog.get_index` from *inside* the callback, proving persistence already happened by the time the callback runs. Verified this test fails on the pre-fix code (`KeyError: Unknown event_id`) and passes after the reorder.
  - `test_persist_failure_blocks_downstream_callback` — re-appending a duplicate event ID makes `EventLog.append` raise, and the user callback never sees that attempt. Verified this test also fails on the pre-fix code (assertion mismatch — the callback fires before the failing persist).
- Ran the full `tests/sdk` suite (5986 passed, 9 skipped, 10 xfailed, 0 failed) — no regressions.
- Ran the full `tests/agent_server` suite (2066 passed, 13 deselected, 0 failed) — this is where the real consumer of the changed ordering (`AsyncCallbackWrapper` / `EventService`) lives; no regressions there either.
- Ran `tests/sdk/conversation` alone both before and after this change: the same 3 pre-existing failures appear in both runs (`test_fork_copies_system_prompt_event_with_non_picklable_executor`, `test_conversation_with_agent_different_llm_config`, `test_fork_copies_activated_path_rules` — all `pydantic_core.ValidationError` from cross-test pollution when this subdirectory runs standalone, each passes individually), confirming they are unrelated to this change.
- `pre-commit run` (ruff format, ruff lint, pycodestyle, pyright, import-dependency rules, Tool subclass registration) all pass on the changed files.
- For each of the two new ordering tests above, verified they *fail* against the pre-fix ordering (temporarily reverted `local_conversation.py` via a plain file swap, confirmed red, restored the fix, confirmed green again) — so they're proven to catch a regression, not just pass vacuously.
- Also tried reproducing the ordering guarantee through the *real* production callback (`AsyncCallbackWrapper`, which hops the event onto a separate thread's asyncio loop before publishing) instead of a plain lambda. That version passed under both the fixed and the reverted code, so it does **not** reliably distinguish the two — the thread-hop/event-loop scheduling latency alone is enough for persistence to finish first regardless of `composed_list` order, on this machine. Since it can't prove a regression, it isn't included here: it would only add a flaky test with no real regression-catching value. The two lambda-based tests above are the actual, deterministic regression guard.

## Video/Screenshots

N/A — backend event-ordering change, no UI surface.

## Design Doc

N/A — small, self-contained fix; the reasoning is covered under Why/Summary above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Scoped narrowly to what #4680 asks for: no client/protocol changes, no
migration needed (the on-disk `event-{idx:05d}-{event_id}.json` naming already
encodes the sequence number). Step 3 (wiring the session socket to use the
returned sequence number instead of a post-hoc `get_index` call) is left for a
follow-up PR against #4671.





<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:93fc8e8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-93fc8e8-python \
  ghcr.io/openhands/agent-server:93fc8e8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:93fc8e8-golang-amd64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-golang-amd64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-golang-amd64
ghcr.io/openhands/agent-server:93fc8e8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:93fc8e8-golang-arm64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-golang-arm64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-golang-arm64
ghcr.io/openhands/agent-server:93fc8e8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:93fc8e8-java-amd64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-java-amd64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-java-amd64
ghcr.io/openhands/agent-server:93fc8e8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:93fc8e8-java-arm64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-java-arm64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-java-arm64
ghcr.io/openhands/agent-server:93fc8e8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:93fc8e8-python-amd64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python-amd64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python-amd64
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:93fc8e8-python-arm64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python-arm64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python-arm64
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:93fc8e8-python-slim-amd64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python-slim-amd64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python-slim-amd64
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:93fc8e8-python-slim-arm64
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python-slim-arm64
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python-slim-arm64
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:93fc8e8-golang
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-golang
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-golang
ghcr.io/openhands/agent-server:93fc8e8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:93fc8e8-java
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-java
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-java
ghcr.io/openhands/agent-server:93fc8e8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:93fc8e8-python-slim
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python-slim
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python-slim
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:93fc8e8-python
ghcr.io/openhands/agent-server:93fc8e87fd05aade730265e38bc71960b4df6309-python
ghcr.io/openhands/agent-server:vasco-streaming-4680-persist-before-publish-python
ghcr.io/openhands/agent-server:93fc8e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `93fc8e8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `93fc8e8-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
