### PR TITLE
feat(agent-server): explain Docker's absence in images built without it

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -367,7 +367,23 @@ RUN --mount=type=bind,from=builder,source=/agent-server/openhands-agent-server/o
 RUN set -eux; \
     case ",$INSTALL_CAPABILITIES," in \
       *,docker,*) ;; \
-      *) echo "INSTALL_CAPABILITIES excludes docker; skipping Docker Engine"; exit 0;; \
+      *) echo "INSTALL_CAPABILITIES excludes docker; skipping Docker Engine"; \
+         # Stand in for the missing CLI. Without this the agent gets a bare
+         # "docker: command not found" and cannot tell a deliberately Docker-less
+         # image from a broken PATH, so it retries instead of adapting. Unlike
+         # every other gated capability, Docker cannot be recovered at runtime:
+         # dockerd needs --privileged (or Sysbox) at container start, which a
+         # running container cannot grant itself. This message is therefore the
+         # only recovery path, and its primary reader is the agent.
+         { \
+           echo '#!/bin/sh'; \
+           echo 'echo "docker: Docker Engine is not installed in this image." >&2'; \
+           echo 'echo "This image was built without the \"docker\" capability, so no Docker CLI or daemon is present. Container builds and \`docker compose\` cannot work here, and Docker cannot be installed at runtime: the daemon needs --privileged (or the Sysbox runtime) granted when the container starts." >&2'; \
+           echo 'echo "To use Docker: run an image built with \"docker\" in INSTALL_CAPABILITIES, and start the container with --privileged." >&2'; \
+           echo 'exit 127'; \
+         } > /usr/local/bin/docker; \
+         chmod +x /usr/local/bin/docker; \
+         exit 0;; \
     esac; \
     \
     # Determine OS type and install Docker accordingly

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -10,6 +10,14 @@ AGENT_SERVER_SPEC = (
     / "agent_server"
     / "agent-server.spec"
 )
+AGENT_SERVER_DOCKERFILE = (
+    REPO_ROOT
+    / "openhands-agent-server"
+    / "openhands"
+    / "agent_server"
+    / "docker"
+    / "Dockerfile"
+)
 
 
 def test_server_workflow_passes_git_metadata_build_args() -> None:
@@ -89,3 +97,36 @@ def test_agent_server_binary_copies_openhands_distribution_metadata() -> None:
         "openhands-workspace",
     ):
         assert f'*copy_metadata("{distribution}")' in spec_text
+
+
+def test_docker_absent_shim_only_exists_when_docker_is_excluded() -> None:
+    """A Docker-less image must explain itself, and must not shadow real Docker.
+
+    Docker is the one gated capability with no runtime recovery — dockerd needs
+    --privileged (or Sysbox) granted at container start — so this message is the
+    only path a user has. It must be written in the exclusion branch only: a shim
+    reachable from the inclusion branch would mask the real CLI.
+    """
+    dockerfile = AGENT_SERVER_DOCKERFILE.read_text(encoding="utf-8")
+
+    marker = "# --- Docker ---"
+    start = dockerfile.index(marker)
+    block = dockerfile[start : dockerfile.index("# --- GitHub CLI ---", start)]
+
+    shim_path = "/usr/local/bin/docker"
+    assert shim_path in block, (
+        f"expected the Docker block to write a shim at {shim_path}"
+    )
+
+    # The shim must be written before the exclusion branch exits, and the
+    # inclusion branch (`*,docker,*) ;;`) must fall through untouched.
+    exclusion = block.index("INSTALL_CAPABILITIES excludes docker")
+    assert block.index(shim_path) > exclusion, (
+        "the docker shim must be written inside the exclusion branch, otherwise "
+        "it would shadow the real Docker CLI in the default image"
+    )
+
+    # The message has to name both halves of the fix. Installing Docker is not
+    # enough on its own — the daemon still needs elevated privileges at start.
+    assert "INSTALL_CAPABILITIES" in block
+    assert "--privileged" in block


### PR DESCRIPTION
HUMAN:

Make a Docker-less image say so, instead of a bare "command not found".

---

AGENT:

## Why

`INSTALL_CAPABILITIES` (#4698) already lets an image be built without Docker Engine — 135.5 MB compressed, 354.2 MB on disk. Nothing publishes such an image yet, but the capability works today and the slim variant in #4805 makes it reachable.

The problem is what happens inside one. The agent runs `docker build ...` in bash and gets `docker: command not found`, which is indistinguishable from a broken PATH. So it retries, or fails the task without being able to tell the user why.

That matters more for Docker than for anything else we gate, because **Docker cannot be recovered at runtime**. Installing `docker-ce` later does not help: `dockerd` needs `--privileged` or the Sysbox runtime at *container start*, which a running container cannot grant itself. Verified:

```
failed to start daemon: Error initializing network controller:
error creating default "bridge" network: operation not permitted
```

So unlike ACP providers — which the npx fallback can fetch on demand — a message is the *entire* recovery path here.

**The primary reader is the agent, not a human.** The shim's output arrives as bash tool output, so it is written to let a model adapt ("Docker isn't available; verify the Dockerfile by inspection instead") and report the limitation accurately, rather than retry.

## Summary

When `INSTALL_CAPABILITIES` excludes `docker`, write a small `/usr/local/bin/docker` that exits 127 and explains three things: that Docker is deliberately absent, how to get an image with it, and that `--privileged` is *also* required. That last point is the wall users hit immediately after solving the first one, so pre-empting it is most of the value.

Written in the exclusion branch of the existing `case` statement, so it cannot shadow a real install.

## Verification

**Excluded build** — `--build-arg INSTALL_CAPABILITIES=vscode`:

```
$ docker ps
docker: Docker Engine is not installed in this image.
This image was built without the "docker" capability, so no Docker CLI or daemon is
present. Container builds and `docker compose` cannot work here, and Docker cannot be
installed at runtime: the daemon needs --privileged (or the Sysbox runtime) granted
when the container starts.
To use Docker: run an image built with "docker" in INSTALL_CAPABILITIES, and start the
container with --privileged.
exit=127
```

**Default build — the regression that matters most.** Enterprise, Replicated and cloud all depend on Docker-in-sandbox (`saas-deploy` sets `RUNTIME_CLASS: "sysbox-runc"` in prod/staging/dev; Replicated exposes it as a customer-facing option defaulting to sysbox), so a shim leaking into the default image would be serious:

```
which docker:   /usr/bin/docker
is it a shim?   NO-real-binary
Docker version 29.7.2, build a7dcaa6
compose plugin: Docker Compose version v5.5.0
```

**Size impact on the default image — zero.** Built `--target base-image` from `origin/main` and from this branch, `--output type=oci`, summing compressed `layers[].size`:

```
main default:   818.3 MB
branch default: 818.3 MB
delta:          +0.000 MB
```

**Test, and proof it can fail.** Added `test_docker_absent_shim_only_exists_when_docker_is_excluded` to `tests/cross/test_agent_server_build_metadata.py`, which asserts the shim is written *after* the exclusion marker (so it cannot be reachable from the inclusion branch) and that the message names both `INSTALL_CAPABILITIES` and `--privileged`.

A structural test that cannot fail is worthless, so I checked it catches the drift it exists for — redirecting the shim to a decoy path:

```
E   AssertionError: expected the Docker block to write a shim at /usr/local/bin/docker
FAILED tests/cross/test_agent_server_build_metadata.py::test_docker_absent_shim_only_exists_when_docker_is_excluded
```

Restored, 6 passed. `ruff check` and `ruff format --check` clean on the touched package.

## How to Test

```bash
# Excluded: shim explains itself
docker buildx build -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
  --target base-image --build-arg BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22-slim \
  --build-arg INSTALL_CAPABILITIES=vscode --load -t local/shim:test .
docker run --rm --entrypoint /bin/sh local/shim:test -c 'docker ps; echo "exit=$?"'

# Default: real Docker, untouched
docker buildx build ... --load -t local/shim:default .
docker run --rm --entrypoint /bin/sh local/shim:default -c 'command -v docker; docker --version'

uv run --frozen pytest tests/cross/test_agent_server_build_metadata.py -q
```

## Deliberately out of scope

- **Removing Docker from any image, or changing any default.** Docker-in-sandbox is a live, marketed enterprise feature. This PR only improves the experience of a configuration that already exists.
- The related case where Docker *is* installed but the container is unprivileged, which produces a confusing daemon-connection error. Worth a follow-up.

## Issue Number

Relates to #4643

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cd92225-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cd92225-python \
  ghcr.io/openhands/agent-server:cd92225-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cd92225-golang-amd64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-golang-amd64
ghcr.io/openhands/agent-server:docker-absent-shim-golang-amd64
ghcr.io/openhands/agent-server:cd92225-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cd92225-golang-arm64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-golang-arm64
ghcr.io/openhands/agent-server:docker-absent-shim-golang-arm64
ghcr.io/openhands/agent-server:cd92225-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cd92225-java-amd64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-java-amd64
ghcr.io/openhands/agent-server:docker-absent-shim-java-amd64
ghcr.io/openhands/agent-server:cd92225-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cd92225-java-arm64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-java-arm64
ghcr.io/openhands/agent-server:docker-absent-shim-java-arm64
ghcr.io/openhands/agent-server:cd92225-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cd92225-python-amd64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-python-amd64
ghcr.io/openhands/agent-server:docker-absent-shim-python-amd64
ghcr.io/openhands/agent-server:cd92225-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cd92225-python-arm64
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-python-arm64
ghcr.io/openhands/agent-server:docker-absent-shim-python-arm64
ghcr.io/openhands/agent-server:cd92225-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cd92225-golang
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-golang
ghcr.io/openhands/agent-server:docker-absent-shim-golang
ghcr.io/openhands/agent-server:cd92225-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:cd92225-java
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-java
ghcr.io/openhands/agent-server:docker-absent-shim-java
ghcr.io/openhands/agent-server:cd92225-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:cd92225-python
ghcr.io/openhands/agent-server:cd92225bc0f6b3f675fe6fcd99a41260a790abfc-python
ghcr.io/openhands/agent-server:docker-absent-shim-python
ghcr.io/openhands/agent-server:cd92225-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cd92225-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cd92225-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->