### PR TITLE
feat(agent-server): drop Docker Engine from the python-slim variant

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -441,10 +441,8 @@ jobs:
                       echo "install_acp_providers=$INSTALL_ACP_PROVIDERS" >> $GITHUB_OUTPUT
                   fi
 
-                  # Docker Engine is dropped from the slim variant: dockerd cannot
-                  # start without --privileged (or Sysbox) granted at container
-                  # start, which the documented Canvas/OSS launch does not pass.
-                  # Images built without it carry a `docker` shim that says so.
+                  # dockerd needs privilege granted at container start, which the
+                  # documented Canvas/OSS launch does not pass, so slim omits it.
                   if [ "${{ matrix.capability_flavor }}" = "no-docker" ]; then
                       echo "install_capabilities=$(echo "$INSTALL_CAPABILITIES" | sed -E 's/(^|,)docker(,|$)/\1/; s/,$//')" >> $GITHUB_OUTPUT
                   else

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -305,6 +305,7 @@ jobs:
                       custom_tags: python
                       image_flavor: slim
                       acp_provider_flavor: none
+                      capability_flavor: no-docker
                       arch: amd64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04
@@ -314,6 +315,7 @@ jobs:
                       custom_tags: python
                       image_flavor: slim
                       acp_provider_flavor: none
+                      capability_flavor: no-docker
                       arch: arm64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
                       runner: ubuntu-24.04-arm
@@ -439,6 +441,16 @@ jobs:
                       echo "install_acp_providers=$INSTALL_ACP_PROVIDERS" >> $GITHUB_OUTPUT
                   fi
 
+                  # Docker Engine is dropped from the slim variant: dockerd cannot
+                  # start without --privileged (or Sysbox) granted at container
+                  # start, which the documented Canvas/OSS launch does not pass.
+                  # Images built without it carry a `docker` shim that says so.
+                  if [ "${{ matrix.capability_flavor }}" = "no-docker" ]; then
+                      echo "install_capabilities=$(echo "$INSTALL_CAPABILITIES" | sed -E 's/(^|,)docker(,|$)/\1/; s/,$//')" >> $GITHUB_OUTPUT
+                  else
+                      echo "install_capabilities=$INSTALL_CAPABILITIES" >> $GITHUB_OUTPUT
+                  fi
+
                   # Verify outputs
                   echo "=== Build outputs ==="
                   echo "Build context: $(grep '^build_context=' $GITHUB_OUTPUT | cut -d= -f2-)"
@@ -464,7 +476,7 @@ jobs:
                       OPENHANDS_BUILD_GIT_SHA=${{ env.SDK_SHA }}
                       OPENHANDS_BUILD_GIT_REF=${{ env.SDK_REF }}
                       INSTALL_ACP_PROVIDERS=${{ steps.prep.outputs.install_acp_providers }}
-                      INSTALL_CAPABILITIES=${{ env.INSTALL_CAPABILITIES }}
+                      INSTALL_CAPABILITIES=${{ steps.prep.outputs.install_capabilities }}
 
             - name: Cleanup build context
               if: always()


### PR DESCRIPTION
HUMAN:

Drops Docker Engine from the `python-slim` variant only — 129.7 MB that provably cannot function in the launch we document for Canvas and OSS. Draft until its two dependencies land; the default `python` tag is untouched.

---

AGENT:

> [!WARNING]
> **Draft — stacked on #4805, and should not merge before #4808.**
> - Base is `acp-version-parity` (#4805), which introduces the `python-slim` variant this modifies. There is nothing to change on `main` yet.
> - **#4808 should land first.** It adds the `docker` shim that explains the absence. Without it a slim user gets a bare `docker: command not found` — confirmed on this branch, since #4808 is not in this stack. Merging this first would ship the regression without the mitigation.
>
> Retarget to `main` once #4805 merges.

## Why

`dockerd` cannot start in an unprivileged container:

```
failed to start daemon: Error initializing network controller:
error creating default "bridge" network: operation not permitted
```

And the documented Canvas/OSS launch (`docs/openhands/usage/agent-canvas/backend-setup/docker.mdx`) is a plain `docker run -p 8000:8000 -v … agent-canvas:latest` — no `--privileged`, no `runtime:`, no socket mount. Nothing in Canvas's own code uses the Docker CLI either: no `DockerWorkspace` usage, no server-side shelling out, no socket in its compose examples.

So for the audience the slim variant targets, this is 129.7 MB of payload that cannot be used.

**Be precise about what this is, though.** With `--privileged`, Docker *does* work — verified against published `latest-python`, daemon 29.7.2 starts normally. So this is **a real regression for an undocumented-but-working configuration**, not the removal of dead code. Unlike ACP providers there is no runtime fallback: privilege is granted at container start, so nothing can be installed later. That is why #4808's shim is a hard prerequisite rather than a nicety, and why this needs release notes.

## Summary

Adds a per-matrix `capability_flavor` that strips `docker` from `INSTALL_CAPABILITIES` for `python-slim` only, mirroring the existing `acp_provider_flavor` mechanism exactly — same matrix-key shape, same resolution in the `prep` step, same `steps.prep.outputs.*` plumbing into the build arg.

One workflow file, no Dockerfile change, no new build argument.

## Verification

**Resulting slim image** — built with `INSTALL_ACP_PROVIDERS=` and `INSTALL_CAPABILITIES=vscode,browser`:

```
docker binary:  ABSENT      <- bare "command not found" without #4808
dockerd:        ABSENT
chromium:       /usr/bin/chromium
openvscode:     PRESENT
/acp-node:      0 entries
npx:            /usr/local/bin/npx      <- the ACP fallback still works
```

**Size**, `--target base-image`, arm64, `--output type=oci`, summed compressed `layers[].size`:

| Build | Compressed |
|---|---:|
| today's default (ACP + all capabilities) | 1133.6 MB |
| slim, with Docker (#4805 as it stands) | 818.3 MB |
| **slim, without Docker (this PR)** | **688.6 MB** |

−129.7 MB against #4805, and **−39% against today's default**.

**The `docker`-stripping expression is position-independent** — the fragile part, so tested directly:

```
'vscode,browser,docker'  -> 'vscode,browser'
'docker,vscode,browser'  -> 'vscode,browser'
'vscode,docker,browser'  -> 'vscode,browser'
'docker'                 -> ''
'vscode,browser'         -> 'vscode,browser'   (no-op when absent)
''                       -> ''
```

**The default variant is unaffected by construction**: `capability_flavor` is set only on the two `python-slim` matrix entries, and the `prep` step falls through to `$INSTALL_CAPABILITIES` unchanged for every other variant. The `workflow_dispatch` override path is untouched.

## How to Test

```bash
# The slim variant as the workflow will now build it: no ACP, no Docker
docker buildx build -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
  --target base-image \
  --build-arg BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22-slim \
  --build-arg INSTALL_ACP_PROVIDERS= \
  --build-arg INSTALL_CAPABILITIES=vscode,browser \
  --load -t local/slim:nodocker .

docker run --rm --entrypoint /bin/sh local/slim:nodocker -c '
  echo "docker:     $(command -v docker || echo ABSENT)"
  echo "dockerd:    $(command -v dockerd || echo ABSENT)"
  echo "chromium:   $(command -v chromium || echo ABSENT)"
  echo "npx:        $(command -v npx || echo ABSENT)"'

# The default variant must be unaffected — Docker still present and working
docker buildx build -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
  --target base-image \
  --build-arg BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22-slim \
  --load -t local/slim:default .
docker run --rm --entrypoint /bin/sh local/slim:default -c 'docker --version'

# Compressed sizes, compared the same way
docker buildx build ... --output type=oci,dest=/tmp/slim.tar .
python3 -c "import json,tarfile; ..."   # sum layers[].size from the manifest

# The docker-stripping expression, in every position
strip() { echo "$1" | sed -E 's/(^|,)docker(,|$)/\1/; s/,$//'; }
for v in "vscode,browser,docker" "docker,vscode,browser" "vscode,docker,browser" \
         "docker" "vscode,browser" ""; do printf '%-24s -> %s\n' "'$v'" "'$(strip "$v")'"; done
```

Output from all of the above is quoted under **Verification**.

## Before merging

- [ ] #4805 merges, then retarget this to `main`
- [ ] #4808 merges, so absence is explained rather than a bare `command not found`
- [ ] Release notes: any OSS user running Canvas with `--privileged` for docker-in-sandbox loses it on the slim tag and must use the full tag
- [ ] Re-measure on amd64 — every figure here is arm64

## Deliberately out of scope

- **The default `python` tag.** Enterprise, Replicated, cloud and evaluation all consume it, and docker-in-sandbox is a marketed feature there: `saas-deploy` sets `RUNTIME_CLASS: "sysbox-runc"` in production, staging and development; Sysbox is installed via ArgoCD in every environment; Replicated exposes "Sandbox Isolation" as a customer-facing option defaulting to sysbox.
- Removing the Docker install block from the Dockerfile. It stays; only the slim variant declines it.
- Canvas adoption — different repository, and blocked on a published slim tag.

## Issue Number

Relates to #4643

