### PR TITLE
fix(sdk): remove title from LocalConversation.fork() — store it on StoredConversation instead

### DIFF
--- a/examples/01_standalone_sdk/48_conversation_fork.py
+++ b/examples/01_standalone_sdk/48_conversation_fork.py
@@ -47,13 +47,12 @@ print(f"Source events count    : {len(source.state.events)}")
 # =================================================================
 # 2. Fork and continue independently
 # =================================================================
-fork = source.fork(title="Follow-up fork")
+fork = source.fork()
 source_event_count = len(source.state.events)
 
 print("\n--- Fork created ---")
 print(f"Fork ID                : {fork.id}")
 print(f"Fork events (copied)   : {len(fork.state.events)}")
-print(f"Fork title             : {fork.state.tags.get('title')}")
 
 assert fork.id != source.id
 assert len(fork.state.events) == source_event_count
@@ -80,7 +79,6 @@ alt_agent = Agent(llm=alt_llm, tools=[Tool(name=TerminalTool.name)])
 
 fork_alt = source.fork(
     agent=alt_agent,
-    title="Tool-change experiment",
     tags={"purpose": "a/b-test"},
 )
 
@@ -104,7 +102,7 @@ cut_event_id = next(
     if isinstance(e, MessageEvent) and e.source == "user"
 )
 
-fork_slice = source.fork(from_event_id=cut_event_id, title="Branch from first turn")
+fork_slice = source.fork(from_event_id=cut_event_id)
 
 print("\n--- Branch-slice fork (from_event_id) ---")
 print(f"Cut event id          : {cut_event_id}")

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1986,10 +1986,11 @@ class ConversationService:
         source_conversation = source_service.get_conversation()
 
         # fork() deep-copies events, state, and writes to a new persistence dir.
+        # Title is applied to StoredConversation via fork_overrides below — not
+        # passed to fork() since LocalConversation has no title field.
         fork_conv = await asyncio.to_thread(
             source_conversation.fork,
             conversation_id=fork_id,
-            title=title,
             tags=tags,
             reset_metrics=reset_metrics,
             from_event_id=from_event_id,

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -429,7 +429,10 @@ class BaseConversation(ABC):
                 if ``None``).
             agent: Agent for the fork. Defaults to a deep-copy of the
                 source agent.
-            title: Optional title for the forked conversation.
+            title: Deprecated on ``LocalConversation`` since 1.44.1 — has no
+                effect there and emits a ``DeprecationWarning``. Still
+                honoured by ``RemoteConversation`` (passed to the agent
+                server which stores it on ``StoredConversation``).
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -4,7 +4,6 @@ import contextlib
 import copy
 import json
 import uuid
-import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePath
 from typing import Any, Final, TypeGuard, cast
@@ -113,6 +112,7 @@ from openhands.sdk.tool.builtins import InvokeSkillTool
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.deprecation import warn_deprecated
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -805,11 +805,14 @@ class LocalConversation(BaseConversation):
             ValueError: If ``from_event_id`` is not an event in this conversation.
         """
         if title is not None:
-            warnings.warn(
-                "The 'title' parameter of LocalConversation.fork() is deprecated and "
-                "has no effect. LocalConversation has no title field; titles are "
-                "managed by StoredConversation in the agent-server layer.",
-                DeprecationWarning,
+            warn_deprecated(
+                "LocalConversation.fork() title parameter",
+                deprecated_in="1.44.1",
+                removed_in="1.47.0",
+                details=(
+                    "LocalConversation has no title field; titles are managed by "
+                    "StoredConversation in the agent-server layer."
+                ),
                 stacklevel=2,
             )
         fork_id = conversation_id or uuid.uuid4()

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -808,7 +808,7 @@ class LocalConversation(BaseConversation):
             warn_deprecated(
                 "LocalConversation.fork() title parameter",
                 deprecated_in="1.44.1",
-                removed_in="1.47.0",
+                removed_in="1.50.0",
                 details=(
                     "LocalConversation has no title field; titles are managed by "
                     "StoredConversation in the agent-server layer."

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import json
 import uuid
+import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePath
 from typing import Any, Final, TypeGuard, cast
@@ -762,6 +763,7 @@ class LocalConversation(BaseConversation):
         *,
         conversation_id: ConversationID | None = None,
         agent: AgentBase | None = None,
+        title: str | None = None,
         tags: dict[str, str] | None = None,
         reset_metrics: bool = True,
         from_event_id: EventID | None = None,
@@ -777,6 +779,10 @@ class LocalConversation(BaseConversation):
                 if ``None``).
             agent: Agent for the fork. Defaults to a deep-copy of the
                 source agent.
+            title: Deprecated. ``LocalConversation`` has no title field;
+                ``ConversationState`` does not store titles (they live on
+                ``StoredConversation`` in the agent-server layer). Passing a
+                value is accepted for backwards compatibility but has no effect.
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.
@@ -791,6 +797,14 @@ class LocalConversation(BaseConversation):
         Raises:
             ValueError: If ``from_event_id`` is not an event in this conversation.
         """
+        if title is not None:
+            warnings.warn(
+                "The 'title' parameter of LocalConversation.fork() is deprecated and "
+                "has no effect. LocalConversation has no title field; titles are "
+                "managed by StoredConversation in the agent-server layer.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         fork_id = conversation_id or uuid.uuid4()
         # Always deep-copy the agent (supplied or source) so the fork owns
         # its own object graph. Required because __init__ binds

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -762,7 +762,6 @@ class LocalConversation(BaseConversation):
         *,
         conversation_id: ConversationID | None = None,
         agent: AgentBase | None = None,
-        title: str | None = None,
         tags: dict[str, str] | None = None,
         reset_metrics: bool = True,
         from_event_id: EventID | None = None,
@@ -778,7 +777,6 @@ class LocalConversation(BaseConversation):
                 if ``None``).
             agent: Agent for the fork. Defaults to a deep-copy of the
                 source agent.
-            title: Optional title for the forked conversation.
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.
@@ -872,13 +870,6 @@ class LocalConversation(BaseConversation):
                 self._state.activated_path_rules
             )
             fork_conv._state.agent_state = copy.deepcopy(self._state.agent_state)
-
-            # Copy title via tags if provided
-            if title is not None:
-                fork_conv._state.tags = {
-                    **fork_conv._state.tags,
-                    "title": title,
-                }
 
             # Reset or copy metrics
             if not reset_metrics:

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -222,7 +222,7 @@ def test_fork_with_tags():
 
 
 def test_fork_with_title_is_deprecated():
-    """title= is accepted for backwards compat but warns and does not pollute tags."""
+    """Passing title is accepted for backwards compat but warns and does not pollute tags."""
     with tempfile.TemporaryDirectory() as tmpdir:
         src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
         with pytest.warns(DeprecationWarning, match="title.*deprecated"):

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -225,7 +225,7 @@ def test_fork_with_title_is_deprecated():
     """Passing title is accepted for backwards compat but warns and does not pollute tags."""
     with tempfile.TemporaryDirectory() as tmpdir:
         src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
-        with pytest.warns(DeprecationWarning, match="title.*deprecated"):
+        with pytest.warns(DeprecationWarning, match="title parameter is deprecated"):
             fork = src.fork(title="My Fork")
 
         assert "title" not in fork.state.tags

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -221,13 +221,6 @@ def test_fork_with_tags():
         assert fork.state.tags.get("env") == "test"
 
 
-def test_fork_with_title_sets_tag():
-    """Title is stored as a 'title' tag."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
-        fork = src.fork(title="My Fork")
-
-        assert fork.state.tags.get("title") == "My Fork"
 
 
 def test_fork_shares_workspace():

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -222,14 +222,13 @@ def test_fork_with_tags():
 
 
 def test_fork_with_title_is_deprecated():
-    """Passing title is accepted for backwards compat but warns and does not pollute tags."""
+    """Passing title is accepted for compat but warns and does not pollute tags."""
     with tempfile.TemporaryDirectory() as tmpdir:
         src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
         with pytest.warns(DeprecationWarning, match="title parameter is deprecated"):
             fork = src.fork(title="My Fork")
 
         assert "title" not in fork.state.tags
-
 
 
 def test_fork_shares_workspace():

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -221,6 +221,15 @@ def test_fork_with_tags():
         assert fork.state.tags.get("env") == "test"
 
 
+def test_fork_with_title_is_deprecated():
+    """title= is accepted for backwards compat but warns and does not pollute tags."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
+        with pytest.warns(DeprecationWarning, match="title.*deprecated"):
+            fork = src.fork(title="My Fork")
+
+        assert "title" not in fork.state.tags
+
 
 
 def test_fork_shares_workspace():


### PR DESCRIPTION
HUMAN:
Inspired by some digging I did for #4617. Turns out there are some duplicate values between `StoredConversation` and `ConversationState`. I discovered this because `tags` is one of them. So I had to worry about syncing, which was actually an already existing issue in `update_conversation`.

Anyway, while considering whether `tags` should be pulled from `ConversationState`, I discovered that, when forking with a title, the title is written into the forked conversation's `_state.tags`. On its own, that's worth fixing.

In this change, it may look like the title is being removed completely, but the agent explains below how the functionality is preserved via `fork_overrides`.

---

AGENT:

## Why

Forking a `LocalConversation` with a title injected `{"title": "<value>"}` into `state.tags`, polluting the user-defined tag map. This conflated a display/metadata field with user-defined tags and leaked into tag-based queries and any downstream consumer iterating over tags.

`ConversationState` has no `title` field (title belongs on `StoredConversation` in the agent-server layer). Rather than add a duplicate field, the `title` parameter on `LocalConversation.fork()` is deprecated: it is still accepted to avoid a breaking API change, but emits a `DeprecationWarning` and no longer writes into `state.tags`.

## Summary

- Deprecates `title` on `LocalConversation.fork()` with a `DeprecationWarning` — the parameter is kept for backwards compatibility but has no effect; `ConversationState` has no title field and adding one would duplicate `StoredConversation`
- Removes the `tags["title"]` injection workaround from the fork body (the fix for the actual bug)
- Drops the `title=title` passthrough in `conversation_service.py` — the agent server applies title via `fork_overrides` on `StoredConversation` independently, so passing it to `fork()` would only trigger the deprecation warning unnecessarily
- `RemoteConversation.fork(title=...)` is **unaffected** — it routes through the agent server which owns `StoredConversation`

## Issue Number

Fixes #4811

## How to Test

```bash
uv run pytest tests/sdk/conversation/local/test_fork.py tests/sdk/conversation/remote/test_remote_fork.py -v
```

All 23 tests pass. `test_fork_with_title_is_deprecated` verifies that `title=` emits a `DeprecationWarning` and that `"title"` does not appear in `state.tags`.

For the agent-server path, title on a forked conversation is set via `fork_overrides["title"]` in `conversation_service.py` — that path is unchanged.

## Video/Screenshots

N/A — pure logic change with no UI impact.

## Design Doc

N/A — follow-up discussion on whether the standalone SDK should eventually surface fork titles (e.g. a `LocalConversation.title` property backed by a proper field) is tracked on #4811.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `title` parameter remains fully functional on `RemoteConversation.fork()` since the agent server handles it correctly via `StoredConversation`. An intentional eventual removal of the deprecated parameter from `LocalConversation.fork()` should follow the SDK's deprecation policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
