### PR TITLE
fix(acp): add fable to Claude Code model picker options

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -308,7 +308,7 @@ _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="default", label="Default (recommended)"),
     ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
     ACPModelOption(id="claude-opus-5", label="Claude Opus 5"),
-    ACPModelOption(id="fable", label="Claude Fable 5"),
+    ACPModelOption(id="fable", label="Claude Fable"),
     ACPModelOption(id="sonnet", label="Claude Sonnet"),
     ACPModelOption(id="haiku", label="Claude Haiku"),
 )

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -308,6 +308,7 @@ _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="default", label="Default (recommended)"),
     ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
     ACPModelOption(id="claude-opus-5", label="Claude Opus 5"),
+    ACPModelOption(id="fable", label="Claude Fable 5"),
     ACPModelOption(id="sonnet", label="Claude Sonnet"),
     ACPModelOption(id="haiku", label="Claude Haiku"),
 )

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -49,6 +49,7 @@ class TestACPProviderInfo:
         models = {model.id: model.label for model in info.available_models}
         assert models["opus[1m]"] == "Claude Opus (1M)"
         assert models["claude-opus-5"] == "Claude Opus 5"
+        assert models["fable"] == "Claude Fable 5"
         assert models["sonnet"] == "Claude Sonnet"
         assert models["haiku"] == "Claude Haiku"
         # Pinned binary exposed by the agent-server image wrappers.

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -49,7 +49,7 @@ class TestACPProviderInfo:
         models = {model.id: model.label for model in info.available_models}
         assert models["opus[1m]"] == "Claude Opus (1M)"
         assert models["claude-opus-5"] == "Claude Opus 5"
-        assert models["fable"] == "Claude Fable 5"
+        assert models["fable"] == "Claude Fable"
         assert models["sonnet"] == "Claude Sonnet"
         assert models["haiku"] == "Claude Haiku"
         # Pinned binary exposed by the agent-server image wrappers.


### PR DESCRIPTION
HUMAN:

Verified the fable model picker option locally by running the ACP provider tests.

AGENT:

## Why

Fixes #4812 where `fable` was missing from the available model suggestions for ACP Claude Code sessions.

## Summary

- Added `ACPModelOption(id="fable", label="Claude Fable 5")` to `_CLAUDE_MODELS` in `acp_providers.py`.
- Updated unit test assertions in `test_acp_providers.py`.

## Issue Number

Fixes #4812

## How to Test

Run unit tests:
```bash
uv run pytest tests/sdk/settings/test_acp_providers.py
```
