### PR TITLE
fix(sdk): render the no-text placeholder for an empty TextContent block

### DIFF
--- a/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/message.py
@@ -76,9 +76,8 @@ class MessageEvent(LLMConvertibleEvent):
         content = Text()
 
         # Message text content
-        text_parts = content_to_str(self.llm_message.content)
-        if text_parts:
-            full_content = "".join(text_parts)
+        full_content = "".join(content_to_str(self.llm_message.content))
+        if full_content:
             content.append(full_content)
         else:
             content.append("[no text content]")

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from typing import IO, TYPE_CHECKING, Self, cast
 from unittest.mock import MagicMock
 
+import pytest
 from pydantic import Field
 from rich.console import Group
 from rich.text import Text
@@ -338,6 +339,25 @@ def test_message_event_visualize_omits_empty_responses_reasoning_label():
 
     assert "Reasoning:" not in text_content
     assert "Hello, how can you help me?" in text_content
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param([], id="no_blocks"),
+        pytest.param([TextContent(text="")], id="empty_text_block"),
+    ],
+)
+def test_message_event_visualize_empty_text_uses_placeholder(content):
+    """Both empty message representations render the placeholder (#4774)."""
+    event = MessageEvent(
+        source="user",
+        llm_message=Message(role="user", content=content),
+    )
+    visualizer = DefaultConversationVisualizer()
+
+    assert event.visualize.plain == "[no text content]"
+    assert visualizer._create_event_block(event) is not None
 
 
 def test_environment_user_role_message_is_not_titled_as_human_user():


### PR DESCRIPTION
HUMAN:

I hit this while looking at empty assistant messages disappearing from the conversation view. I read the diff and the new test, and the one-line change makes sense to me; I left __str__ alone on purpose since the issue only covers visualize.

---

AGENT:

This branch was prepared with an AI coding assistant; the author reviewed the diff and ran the checks listed below.

## Why

`MessageEvent.visualize` checked whether `content_to_str(...)` returned any parts. For `[TextContent(text="")]` that list is `[""]`, which is truthy, so the event rendered as an empty string and `DefaultConversationVisualizer._create_event_block` dropped it on its `plain.strip()` check — while `content=[]` correctly rendered `[no text content]`.

## Summary

- Join the text parts first and fall back to `[no text content]` when the joined text is empty.
- Add a parametrized regression test covering both empty representations and asserting the visualizer creates an event block for each.

## Issue Number

Fixes #4774

## How to Test

```bash
uv run pytest tests/sdk/conversation/test_visualizer.py -k empty_text_uses_placeholder
```

Reverting the change in `message.py` makes the `empty_text_block` case fail; with the change both cases pass.

Also run on `main` @ 94fca57 plus this change:

- `uv run pytest tests/sdk` → 6000 passed, 9 skipped, 10 xfailed
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/event/llm_convertible/message.py tests/sdk/conversation/test_visualizer.py` → all hooks passed (ruff format/lint, pycodestyle, pyright, import dependency rules, tool registration)

`MessageEvent.__str__` uses the same list-truthiness pattern for its preview text; it is left unchanged because the issue only covers `visualize`.

## Video/Screenshots

Repro script output (`MessageEvent(source="user", llm_message=Message(role="user", content=...))`, then `event.visualize.plain` and `DefaultConversationVisualizer()._create_event_block(event) is not None`):

```
before:
no_blocks:   visualize.plain='[no text content]' block_created=True
empty_block: visualize.plain=''                  block_created=False

after:
no_blocks:   visualize.plain='[no text content]' block_created=True
empty_block: visualize.plain='[no text content]' block_created=True
```

## Design Doc

Not needed for a one-line bug fix.
