### PR TITLE
feat(acp): add OpenCode as a built-in ACP provider

### DIFF
--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -38,6 +38,9 @@ describe('ACP provider credential descriptors', () => {
     // pi reads a provider key out of the environment but resolves base URLs
     // from its own catalogue, so it has no base-URL override var.
     ['pi', 'ANTHROPIC_API_KEY', null],
+    // opencode's own gateway (OpenCode Zen) resolves its endpoint from the
+    // model catalogue, so it has no base-URL override var either.
+    ['opencode', 'OPENCODE_API_KEY', null],
   ])('%s declares its api_key/base_url env vars', (key, apiKeyEnvVar, baseUrlEnvVar) => {
     const provider = ACP_PROVIDERS[key];
     expect(provider.api_key_env_var).toBe(apiKeyEnvVar);
@@ -57,6 +60,19 @@ describe('ACP provider credential descriptors', () => {
     // pi-acp maps ACP modes onto pi's thinking levels, so there is no
     // permission-suppressing mode to set at session start.
     expect(pi.default_session_mode).toBeNull();
+  });
+
+  it('opencode enters ACP mode via an acp subcommand', () => {
+    const opencode = ACP_PROVIDERS.opencode;
+    expect(opencode.default_command).toEqual([
+      'npx',
+      '-y',
+      '--prefer-offline',
+      'opencode-ai@1.18.23',
+      'acp',
+    ]);
+    expect(opencode.default_session_mode).toBe('build');
+    expect(opencode.file_secrets).toEqual([]);
   });
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -206,6 +206,61 @@
     "supports_runtime_model_switch": true,
     "supports_set_session_model": true
   },
+  "opencode": {
+    "agent_name_patterns": [
+      "opencode"
+    ],
+    "api_key_env_var": "OPENCODE_API_KEY",
+    "available_models": [
+      {
+        "id": "opencode/big-pickle",
+        "label": "Big Pickle"
+      },
+      {
+        "id": "opencode/claude-opus-5",
+        "label": "Claude Opus 5"
+      },
+      {
+        "id": "opencode/claude-sonnet-5",
+        "label": "Claude Sonnet 5"
+      },
+      {
+        "id": "opencode/gpt-5.5",
+        "label": "GPT-5.5"
+      },
+      {
+        "id": "opencode/gemini-3.1-pro",
+        "label": "Gemini 3.1 Pro"
+      },
+      {
+        "id": "opencode/kimi-k3",
+        "label": "Kimi K3"
+      },
+      {
+        "id": "opencode/nemotron-3-ultra-free",
+        "label": "Nemotron 3 Ultra (free)"
+      }
+    ],
+    "base_url_env_var": null,
+    "binary_name": "opencode",
+    "data_dir_env_var": "HOME",
+    "default_command": [
+      "npx",
+      "-y",
+      "--prefer-offline",
+      "opencode-ai@1.18.23",
+      "acp"
+    ],
+    "default_model": "opencode/big-pickle",
+    "default_session_mode": "build",
+    "display_name": "OpenCode",
+    "env_conflicts": [],
+    "file_secrets": [],
+    "key": "opencode",
+    "session_meta_key": null,
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
+  },
   "pi": {
     "agent_name_patterns": [
       "pi-acp"

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1686,8 +1686,8 @@ class ACPAgent(AgentBase):
         default=None,
         description=(
             "Provider registry key identifying which ACP CLI this agent runs "
-            "('claude-code', 'codex', 'gemini-cli', 'pi', or 'custom'); None "
-            "when the agent is built directly rather than via ACPAgentSettings. Set by "
+            "(any ACP_PROVIDERS key, or 'custom'); None when the agent is "
+            "built directly rather than via ACPAgentSettings. Set by "
             "ACPAgentSettings.create_agent() from ACPAgentSettings.acp_server so "
             "the authoritative key survives onto the agent — and thus onto "
             "ConversationInfo.agent — because the launch command in acp_command "

--- a/openhands-sdk/openhands/sdk/agent/acp_tracing.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_tracing.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 
 #: Marks a span as produced by an ACP agent rather than the native loop.
 AGENT_KIND_METADATA_KEY = "agent_kind"
-#: Which ACP CLI produced it ('claude-code', 'codex', 'gemini-cli', 'pi', 'custom').
+#: Which ACP CLI produced it: an ACP_PROVIDERS key, or 'custom'.
 ACP_SERVER_METADATA_KEY = "acp_server"
 #: Model the ACP CLI reported for the turn, when it reports one.
 ACP_MODEL_METADATA_KEY = "acp_model"

--- a/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
@@ -112,6 +112,8 @@ KIMI_CODE_VERSION = "0.38.0"
 PI_ACP_VERSION = "0.0.33"
 PI_CODING_AGENT_VERSION = "0.83.0"
 
+OPENCODE_VERSION = "1.18.23"
+
 
 ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
     "claude-code": ACPInstallSpec(
@@ -161,6 +163,18 @@ ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
         # having already died on `webidl.util.markAsUncloneable is not a
         # function`.
         min_node_version="22.19.0",
+    ),
+    "opencode": ACPInstallSpec(
+        key="opencode",
+        # The npm package is a 7.8KB shim whose postinstall pulls the matching
+        # per-platform compiled binary (~184MB unpacked) from an
+        # optionalDependency, so `--ignore-scripts` leaves a stub that errors.
+        packages=(ACPPackagePin("opencode-ai", OPENCODE_VERSION),),
+        # The shim's npm bin is ``opencode``, not the package basename.
+        binary_name="opencode",
+        trailing_args=("acp",),
+        # No `engines` field on opencode-ai or its platform packages: the CLI
+        # is a compiled Bun binary and only its postinstall runs on Node.
     ),
 }
 """Every ACP provider installable via npm. Registry membership only makes a

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -414,6 +414,27 @@ _PI_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="anthropic/claude-haiku-4-5", label="Claude Haiku 4.5"),
 )
 
+# Model IDs accepted by ``opencode acp``, mirroring the ``model`` configOptions
+# select OpenCode reports at ``session/new``. Every id is ``<provider>/<model>``
+# and the offered set is credential-dependent, but unlike Kimi's it is not
+# *user-defined*: these are OpenCode Zen ids, the catalogue that
+# ``OPENCODE_API_KEY`` — the provider's own credential — unlocks, so a curated
+# list is meaningful. Without a key the server offers only the free tier, which
+# is why ``nemotron-3-ultra-free`` is kept. A user may still configure any
+# ``<provider>/<model>`` the CLI knows (e.g. ``anthropic/...`` with
+# ANTHROPIC_API_KEY supplied as a conversation secret).
+_OPENCODE_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="opencode/big-pickle", label="Big Pickle"),
+    ACPModelOption(id="opencode/claude-opus-5", label="Claude Opus 5"),
+    ACPModelOption(id="opencode/claude-sonnet-5", label="Claude Sonnet 5"),
+    ACPModelOption(id="opencode/gpt-5.5", label="GPT-5.5"),
+    ACPModelOption(id="opencode/gemini-3.1-pro", label="Gemini 3.1 Pro"),
+    ACPModelOption(id="opencode/kimi-k3", label="Kimi K3"),
+    ACPModelOption(
+        id="opencode/nemotron-3-ultra-free", label="Nemotron 3 Ultra (free)"
+    ),
+)
+
 
 # ---------------------------------------------------------------------------
 # Reserved file-content credential secrets for the built-in providers.
@@ -630,6 +651,48 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             default_model=None,
             file_secrets=_PI_FILE_SECRETS,
             binary_name=ACP_INSTALL_CATALOG["pi"].binary_name,
+            data_dir_env_var="HOME",
+        ),
+        "opencode": ACPProviderInfo(
+            key="opencode",
+            display_name="OpenCode",
+            default_command=ACP_INSTALL_CATALOG["opencode"].npx_command(),
+            # OpenCode Zen, the CLI's own gateway and the provider its model
+            # ids are namespaced under. Third-party keys (ANTHROPIC_API_KEY,
+            # OPENAI_API_KEY, ...) also enable their providers inside OpenCode,
+            # but none of them is OpenCode's own credential.
+            api_key_env_var="OPENCODE_API_KEY",
+            # Zen's endpoint comes from the model catalogue, not the
+            # environment: verified against a local sink that neither
+            # OPENCODE_BASE_URL nor OPENAI_BASE_URL diverts it. A per-provider
+            # ``options.baseURL`` in the config file is the only override.
+            base_url_env_var=None,
+            # OpenCode exposes exactly two modes, ``build`` and ``plan``.
+            # ``build`` is the tool-executing default and raised no permission
+            # requests for read/write/bash under the stock permission config.
+            default_session_mode="build",
+            # ``opencode acp`` reports ``agentInfo.name = "OpenCode"``; the
+            # pattern also prefixes the package basename ``opencode-ai`` and the
+            # binary ``opencode`` for command-time detection.
+            agent_name_patterns=("opencode",),
+            supports_set_session_model=True,
+            supports_runtime_model_switch=True,
+            # ``session/new`` ignores a ``_meta`` model selection (tried under
+            # three plausible keys); the configOptions select is the only path
+            # that takes effect.
+            session_meta_key=None,
+            available_models=_OPENCODE_MODELS,
+            # The CLI's own default (model configOptions ``currentValue``),
+            # both with and without a key.
+            default_model="opencode/big-pickle",
+            # No ``file_secrets``: OpenCode reads its whole auth store from
+            # OPENCODE_AUTH_CONTENT when set, ahead of the on-disk auth.json, so
+            # the credential rides the ordinary env-var channel.
+            binary_name=ACP_INSTALL_CATALOG["opencode"].binary_name,
+            # OPENCODE_CONFIG_DIR exists but points at a config *file* only;
+            # auth, sessions, the SQLite store and caches follow
+            # XDG_{DATA,CONFIG,CACHE,STATE}_HOME, which all fall back to HOME.
+            # Relocating HOME is the only single lever that moves all of them.
             data_dir_env_var="HOME",
         ),
     }

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1203,7 +1203,7 @@ class ConversationSettings(BaseModel):
 AgentKind = Literal["openhands", "llm", "acp"]
 
 ACPServerKind = Literal[
-    "claude-code", "codex", "gemini-cli", "kimi-code", "pi", "custom"
+    "claude-code", "codex", "gemini-cli", "kimi-code", "pi", "opencode", "custom"
 ]
 """Known ACP backend servers the GUI can pick from.
 

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -136,6 +136,12 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         # bogus credential, which is what this suite needs. Setting the name
         # without the key makes the CLI exit, so both must be set.
         "KIMI_MODEL_API_KEY",
+        # opencode gates its *catalogue* on this, not just auth-method
+        # selection: unauthenticated, ``session/new`` advertises only the free
+        # tier and the live set_config_option call rejects the rest of
+        # available_models. A syntactically-present key is enough to be offered
+        # what a key-holding user sees (verified: 7 model options -> 90).
+        "OPENCODE_API_KEY",
     ):
         monkeypatch.setenv(var, _BOGUS_KEY)
     monkeypatch.setenv("KIMI_MODEL_NAME", "kimi-k2.7-code")
@@ -151,6 +157,12 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "KIMI_BASE_URL",
         "KIMI_CODE_HOME",
         "KIMI_MODEL_BASE_URL",
+        "OPENCODE_CONFIG_DIR",
+        "OPENCODE_CONFIG",
+        "OPENCODE_CONFIG_CONTENT",
+        # Carries an entire opencode auth store by value, so an ambient one
+        # would smuggle host credentials into a credential-free probe.
+        "OPENCODE_AUTH_CONTENT",
     ):
         monkeypatch.delenv(var, raising=False)
 

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -177,6 +177,41 @@ class TestACPProviderInfo:
         assert spec.env_points_to == "dir"
         assert spec.subdir == "pi"
 
+    def test_opencode_metadata(self):
+        info = ACP_PROVIDERS["opencode"]
+        assert info.key == "opencode"
+        assert info.display_name == "OpenCode"
+        assert info.default_command[:3] == ("npx", "-y", "--prefer-offline")
+        assert "opencode-ai@" in info.default_command[3]
+        # ``acp`` is the subcommand that puts the CLI into ACP mode; it is
+        # preserved as a trailing arg when resolve_acp_command rewrites to the
+        # pinned binary.
+        assert info.default_command[4] == "acp"
+        assert info.api_key_env_var == "OPENCODE_API_KEY"
+        # OpenCode Zen resolves its endpoint from the model catalogue, so there
+        # is no base-URL override var.
+        assert info.base_url_env_var is None
+        # OpenCode's only modes are ``build`` and ``plan``.
+        assert info.default_session_mode == "build"
+        assert "opencode" in info.agent_name_patterns
+        assert info.supports_set_session_model is True
+        assert info.supports_runtime_model_switch is True
+        # session/new ignores a _meta model selection.
+        assert info.session_meta_key is None
+        assert info.default_model == "opencode/big-pickle"
+        model_ids = [m.id for m in info.available_models]
+        assert "opencode/big-pickle" in model_ids
+        assert "opencode/claude-opus-5" in model_ids
+        # One free-tier id, which is the only kind that works with no key.
+        assert "opencode/nemotron-3-ultra-free" in model_ids
+        assert info.binary_name == "opencode"
+        # OPENCODE_CONFIG_DIR relocates only the config file; auth, sessions and
+        # caches follow XDG dirs that fall back to HOME.
+        assert info.data_dir_env_var == "HOME"
+        # OPENCODE_AUTH_CONTENT carries the auth store, so there is no
+        # credential file to materialise.
+        assert info.file_secrets == ()
+
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
         with pytest.raises((AttributeError, TypeError)):
@@ -229,6 +264,12 @@ class TestDetectACPProviderByAgentName:
         info = detect_acp_provider_by_agent_name("Kimi Code CLI")
         assert info is not None
         assert info.key == "kimi-code"
+
+    def test_detects_opencode_by_agent_name(self):
+        # ``opencode acp`` reports agentInfo.name "OpenCode".
+        info = detect_acp_provider_by_agent_name("OpenCode")
+        assert info is not None
+        assert info.key == "opencode"
 
     def test_case_insensitive_detection(self):
         assert detect_acp_provider_by_agent_name("CLAUDE-AGENT-ACP") is not None

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -394,6 +394,7 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
         "gemini-cli",
         "kimi-code",
         "pi",
+        "opencode",
         "custom",
     }
 
@@ -1414,7 +1415,15 @@ def test_acp_create_agent_carries_provider_key() -> None:
     directly (not from settings) defaults to ``None``; and the key survives a
     serialization round-trip through the ``AgentBase`` discriminated union.
     """
-    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi", "custom"):
+    for server in (
+        "claude-code",
+        "codex",
+        "gemini-cli",
+        "kimi-code",
+        "pi",
+        "opencode",
+        "custom",
+    ):
         kwargs: dict[str, Any] = {"acp_server": server}
         if server == "custom":
             kwargs["acp_command"] = ["my-acp"]
@@ -1437,7 +1446,7 @@ def test_acp_resolve_command_for_known_servers(
     default stays the ``npx`` invocation.
     """
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi"):
+    for server in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi", "opencode"):
         settings = ACPAgentSettings(acp_server=server)
         cmd = settings.resolve_acp_command()
         assert cmd, f"expected default command for {server}, got empty"
@@ -1513,6 +1522,9 @@ def _which_returning(*available: str):
         # gemini's default carries a trailing ``--acp`` that must be preserved.
         ("gemini-cli", "gemini", ["gemini", "--acp"]),
         ("pi", "pi-acp", ["pi-acp"]),
+        # opencode's trailing arg is an ``acp`` subcommand, preserved the same
+        # way as gemini's ``--acp`` flag.
+        ("opencode", "opencode", ["opencode", "acp"]),
     ],
 )
 def test_acp_resolve_command_rewrites_default_to_pinned_binary(
@@ -2238,7 +2250,14 @@ def test_acp_resolve_command_uses_registry_defaults(
 
     # No pinned binary on PATH → registry default is returned verbatim.
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    for server_key in ("claude-code", "codex", "gemini-cli", "kimi-code", "pi"):
+    for server_key in (
+        "claude-code",
+        "codex",
+        "gemini-cli",
+        "kimi-code",
+        "pi",
+        "opencode",
+    ):
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)
         assert settings.resolve_acp_command() == expected


### PR DESCRIPTION
HUMAN:

Adds OpenCode as a built-in ACP provider under the #4820 parity contract. Every registry field was determined against a live `opencode acp` server rather than copied from a neighbour, and the preinstall decision is deliberate: OpenCode stays out of the default image because its per-platform binaries are large. Measurements below.

AGENT:

Closes #4639. Part of #4820 (built-in ACP harness parity), and unblocks the SDK half of #4627.

## Why

OpenCode ships first-party ACP support via `opencode acp`. This registers it as a built-in provider with the same feature surface as `claude-code`, `codex` and `gemini-cli` — model picker, mid-conversation model switching, per-conversation data isolation, a pinned version, and a pinned image binary — rather than as a partial addition.

## Summary

Rebased onto #4714 (Kimi) and #4419 (Pi). Between them those two generalised most of what a provider PR used to have to touch, so this is now a catalog entry plus a registry record and little else:

- **`ACP_INSTALL_CATALOG` entry** — `opencode-ai` pinned via `OPENCODE_VERSION`, `binary_name="opencode"`, `trailing_args=("acp",)`. `min_node_version` stays `None`: opencode-ai declares no `engines` field at all (the CLI is a compiled Bun binary; only its postinstall runs on Node), so the 22.19.0 pin #4714 raised already clears it.
- **Registry record** with `default_command`/`binary_name` derived from that spec. No `file_secrets`, no `env_conflicts`.
- **`ACPServerKind`** gains `"opencode"` — still the one hand-maintained duplicate, and `test_acp_server_kind_matches_registry_keys` is what forces it.
- **TypeScript mirror** regenerated with `check-acp-drift.py --write`, plus two test cases.

Three things a provider PR needed a week ago and this one does **not**:

| | why not |
|---|---|
| Dockerfile change | #4714 replaced the hardcoded `rm -f /usr/local/bin/...` fallback with a wrapper manifest the install stage writes, so it tracks `INSTALL_ACP_PROVIDERS`. Verified by building with `INSTALL_ACP_PROVIDERS=opencode` against an unmodified Dockerfile. |
| `acp.ts` union edit | `ACPProviderKey` is now `keyof typeof providersData`, so regenerating the JSON widens it. |
| `_BINARY_NAME_BASENAME_EXEMPTIONS` entry | that static list is gone; `test_binary_name_is_declared_by_one_of_the_pinned_packages` checks the real npm `bin` field instead, and opencode passes it without an exemption. |

While here, two prose lists that enumerate provider keys — `ACPAgent.acp_server`'s description and `acp_tracing`'s `ACP_SERVER_METADATA_KEY` comment — had already drifted (both omit `kimi-code`). Rather than add `opencode` to a list that would still be wrong, they now point at `ACP_PROVIDERS`.

### Live conformance coverage

#4834's probes parametrize over the registry, so opencode picks up three cases automatically, and all stay off the required merge path via the `acp_live` marker and the non-required `acp-live-tests` job:

```
$ uv run --frozen python -m pytest -m acp_live tests/sdk/agent/test_acp_conformance.py \
      tests/sdk/settings/test_acp_install_catalog_pins_live.py -v
test_acp_conformance_probe[opencode] PASSED
test_pinned_version_resolves_and_is_not_deprecated[opencode:opencode-ai@1.18.23] PASSED
test_binary_name_is_declared_by_one_of_the_pinned_packages[opencode] PASSED
19 passed in 46.57s          # all six providers
```

One addition was needed, and it is the kind of thing the probe exists to catch. **OpenCode gates its model *catalogue* on its API key**, not just auth-method selection: unauthenticated, `session/new` advertises only the 7 free-tier ids and the live `set_config_option` call rejects the rest of `available_models`. Run without it the probe failed for real with `Invalid params: model not found: opencode/claude-opus-5`.

A *bogus* key is sufficient, so the suite stays credential-free:

```
--- NO key: session advertises 7 model options
    curated ids REJECTED: ['opencode/claude-opus-5', 'opencode/claude-sonnet-5',
                           'opencode/gpt-5.5', 'opencode/gemini-3.1-pro', 'opencode/kimi-k3']
--- BOGUS OPENCODE_API_KEY: session advertises 90 model options
    curated ids REJECTED: none — all 7 accepted
```

`_isolate_env` therefore seeds `OPENCODE_API_KEY` alongside the others, and strips `OPENCODE_CONFIG_DIR` / `OPENCODE_CONFIG` / `OPENCODE_CONFIG_CONTENT` / `OPENCODE_AUTH_CONTENT` — the last carries an entire auth store *by value*, so an ambient one would smuggle host credentials into a probe that advertises itself as credential-free.

### The registry record, and how each field was verified

Every value below comes from a live `opencode acp` handshake (raw JSON-RPC over stdio) or from the CLI's own behaviour under a controlled `HOME`.

| Field | Value | How it was determined |
|---|---|---|
| `key` / `display_name` | `opencode` / `OpenCode` | — |
| `default_command` | `npx -y --prefer-offline opencode-ai@1.18.23 acp` | `opencode --help`: `acp  start ACP (Agent Client Protocol) server`. `--prefer-offline` matches the other three. |
| `binary_name` | `opencode` | npm `bin` field of `opencode-ai`. The trailing `acp` subcommand is preserved on rewrite (`["opencode", "acp"]`), same shape as gemini's `--acp`; covered by the parametrized rewrite test. |
| `api_key_env_var` | `OPENCODE_API_KEY` | OpenCode Zen is the CLI's own gateway; models.dev declares `env: ["OPENCODE_API_KEY"]`, `api: https://opencode.ai/zen/v1`. Live: unauthenticated `session/new` advertises 7 model options; with `OPENCODE_API_KEY` set it advertises 90. The catalogue is served live, so the counts drift. |
| `base_url_env_var` | `None` | Verified against a local HTTP sink: with `OPENCODE_API_KEY` set and both `OPENCODE_BASE_URL` and `OPENAI_BASE_URL` pointed at the sink, the Zen provider produced **0 sink hits** — its endpoint comes from the model catalogue, not the environment. (For contrast, the *`openai`* provider does honour `OPENAI_BASE_URL`: 9 sink hits at `/v1/responses`. That is a third-party provider inside OpenCode, not OpenCode's own credential.) |
| `default_session_mode` | `build` | `session/new` advertises exactly two modes, `build` and `plan`. `session/set_mode("build")` → `{}`; `set_mode("no-such-mode")` → `-32602 mode not found`. A `build`-mode turn ran `read`, `write` and `bash` with **0** `session/request_permission` calls. |
| `agent_name_patterns` | `("opencode",)` | `initialize` returns `agentInfo: {"name": "OpenCode", "version": "1.18.23"}`. `"opencode"` is also a prefix of both the package basename `opencode-ai` and the binary `opencode`, so command-time detection matches before the process starts. |
| `supports_set_session_model` | `True` | `session/new` advertises a `configOptions` entry `id: "model"` (`type: select`, `currentValue: opencode/big-pickle`). `session/set_config_option(configId="model")` returns the updated select; an unknown id is rejected with `-32602 model not found`. |
| `supports_runtime_model_switch` | `True` | Switched mid-conversation on one live session and confirmed **authoritatively via `opencode export <sid>`**: turn 1 served by `modelID=nemotron-3.5-lightning-free`, turn 2 by `modelID=mimo-v2.5-free`. `session/set_model` (legacy extension) also returns `{}`. |
| `session_meta_key` | `None` | `session/new` with `_meta` model payloads under `opencode`, `openCode` and `opencodeAi` all left `currentValue` at the default `opencode/big-pickle` — the `_meta` selection is ignored. |
| `available_models` / `default_model` | 7 Zen ids / `opencode/big-pickle` | All ids checked present in the live catalogue. `opencode/big-pickle` is the CLI's own `currentValue` both with and without a key. `opencode/nemotron-3-ultra-free` is retained because it is one of the free ids that work with no credential at all. |
| `file_secrets` | `()` | OpenCode's auth store is `$XDG_DATA_HOME/opencode/auth.json`, but `Auth.all()` reads `OPENCODE_AUTH_CONTENT` **first**. Verified: `OPENCODE_AUTH_CONTENT='{"anthropic":{"type":"api","key":"dummy"}}'` took the anthropic catalogue from 0 → 16 models with **nothing written to disk**. The credential rides the ordinary env-var channel, so there is no file to materialise. |
| `data_dir_env_var` | `HOME` | See below. |

#### `data_dir_env_var`: OpenCode has a config-dir variable, and it is not enough

`OPENCODE_CONFIG_DIR` exists but only points at a config *file*. Setting it left `.config/opencode`, `.local/share/opencode`, `.local/state/opencode` and `.cache/opencode` all under `HOME`. OpenCode's state follows `XDG_{DATA,CONFIG,CACHE}_HOME` (each verified to relocate independently, with `XDG_STATE_HOME` also honoured), and every one falls back to `HOME`. **`HOME` is the only single lever that moves all of them** — the same situation as `gemini-cli`, and recorded on #4639 as the issue asks.

## Preinstall decision: registry-only

`opencode-ai` is a 7.8 KB shim whose postinstall pulls a per-platform compiled binary of ~184 MB unpacked. Measured image delta, same target built twice, compressed layer totals summed from an `--output type=oci` export:

| Platform | providers layer, without | with | **delta** | image total |
|---|---|---|---|---|
| linux/amd64 | 324.40 MB | 447.89 MB | **+123.49 MB** | 680.27 → 803.76 MB (+18.2%) |
| linux/arm64 | 315.89 MB | 378.11 MB | **+62.22 MB** | 659.72 → 721.95 MB (+9.4%) |

Every other layer is byte-identical between the two builds. Against #4643's shrink effort, that is not a cost to put on every user, so OpenCode is registry-only and the #4805 `npx` fallback covers it. #4832's `DEFAULT_PREINSTALLED_ACP_PROVIDERS` is where that decision is recorded, and its test pins the default image contents to today's three.

**Why amd64 costs twice as much as arm64** (worth knowing before anyone considers preinstalling it): `opencode-linux-x64` and `opencode-linux-x64-baseline` both declare `os: linux, cpu: x64` with **no `libc` field**, so npm installs *both*, and the on-disk payload is 353 MB rather than 184 MB. On arm64 only `opencode-linux-arm64` matches and the binary is hardlinked, so it lands in the layer once.

**No musl mismatch on either arch.** The `-musl` variants declare `libc: ["musl"]` and npm correctly skipped them on the glibc `python:3.13-bookworm` builder. Verified by size: the arm64 image ships a 184,133,776-byte binary — exactly `opencode-linux-arm64`, not the 193.64 MB musl build.

One build-host caveat: the postinstall picks `-baseline` when `/proc/cpuinfo` reports no `avx2`. My amd64 build is QEMU-emulated, so it hardlinked `opencode-linux-x64-baseline`; a real x86_64 runner with avx2 hardlinks `opencode-linux-x64`. Both are glibc x64 builds and both work — this is OpenCode's own postinstall design, not something this change controls.

## Validation

Full pasted output is in the PR comment below. Headlines:

- `ruff check` / `ruff format --check`: clean over `openhands-sdk openhands-agent-server tests clients`.
- `pytest`, per directory as CI runs them: `tests/sdk` **6064 passed** (19 `acp_live` deselected), `tests/agent_server` **2083 passed**, `tests/cross` 419 passed with 2 failures. Both failures are in `test_remote_conversation_live_server.py` and reproduce identically in a clean worktree at `origin/main` — one needs a live LLM gateway, the other asserts a live server's secret list is empty and finds an ambient `OPENHANDS_AUTOMATION_API_KEY`.
- `check-acp-drift.py`: `OK: src/models/acp-providers.json matches openhands-sdk (4 providers).`
- TS client: `npm run build`, `npm test` (310 passed), `lint` (0 errors), `format:check` all pass. The generated `agent-server-schema.ts` is produced from the last *released* `openapi.json`, so it is unaffected and `check:agent-server-api` still reports current; it picks `opencode` up at the next release bump.
- **Image builds re-run against an unmodified Dockerfile**, both arches, OpenCode selected: `/usr/local/bin/opencode` present, executable, `opencode --version` → `1.18.23` (the pinned version), correct platform binary resolved.
- **Default image and `-python-slim`**: 0 filesystem matches for `*opencode*`; default still carries `claude-agent-acp`, `codex-acp`, `gemini`.
- **Live ACP conversation, twice.** In-image on linux/arm64 through the pinned wrapper: read `ledger.py` → wrote `ledger_total.txt` → `cat` returned `120` (45+12+63), reply returned, 0 permission requests. And through the real `ACPAgent`/`Conversation` SDK path on the host, exercising the `npx` fallback end to end. **Reported agent identity: `agent_name='OpenCode'`, `agent_version='1.18.23'`**, matching `pinned_version='1.18.23'`.
- **npx fallback timings** — the cold download is **not** on the 90 s clock. `_start_acp_server` warms the cache (`_ACP_NPX_CACHE_WARM_TIMEOUT`, 300 s) *before* submitting `_init` under `acp_startup_timeout`. Measured in a container with no OpenCode preinstalled:

  | | warm step (budget 300 s) | startup (budget 90 s) | total |
  |---|---|---|---|
  | arm64 cold | 4.5 s | 1.3 s | 5.9 s |
  | arm64 warm | 0.2 s | 1.2 s | 1.5 s |
  | amd64 cold | 10.7 s | 5.4 s | 16.1 s |
  | amd64 warm | 1.3 s | 5.3 s | 6.6 s |

  A cold start downloads ~60 MB packed on arm64 and ~120 MB on amd64 (both x64 packages). Staying inside the 300 s warm budget needs ≥1.6 Mbit/s (arm64) / ≥3.2 Mbit/s (amd64). **If the warm step fails or times out**, the download falls to the launch inside the 90 s deadline, which needs ≥5.3 Mbit/s / ≥10.7 Mbit/s. That is the real exposure: a link slower than roughly 10 Mbit/s can miss a cold amd64 start whenever the warm step has already failed. The warm failure path only logs a warning, so this degrades to a startup timeout rather than a clear error.

  The warm runs reused a cache written by an earlier container on a mounted volume, so the cache does survive container replacement. Note the path is `<persistence_dir>/../npm-cache` — under the agent-server default that is `workspace/conversations/npm-cache`, and `<working_dir>/.openhands/npm-cache` only when no persistence dir is set.
- **Isolation.** Two conversations sharing one persistence root, `acp_isolate_data_dir=True`: each got its own complete OpenCode tree under `<persistence_dir>/<conv_id>/acp/opencode/` — `.config/opencode` (including its plugin `node_modules`/`package.json`), `.local/share/opencode` (auth + `opencode.db`), `.local/state/opencode`, `.cache/opencode` (`models.json`, `bin/`). Each `opencode.db` holds exactly **one** session with a distinct id and cwd, and the ambient host `~/.local/share/opencode/` gained no `opencode.db` at all.

## How to Test

Everything below runs without OpenCode credentials — OpenCode's free OpenCode Zen tier is offered with no key, which is what the live turns use.

```bash
# registry, mirror and pin gates
uv run --frozen ruff check openhands-sdk openhands-agent-server tests clients
uv run --frozen pytest tests/sdk/settings/test_acp_install_catalog.py \
    tests/sdk/settings/test_acp_providers.py tests/agent_server/test_docker_build.py \
    tests/cross/test_agent_server_build_metadata.py \
    tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py -q

# the catalog CLI exactly as the Dockerfile invokes it
(cd openhands-sdk/openhands/sdk/settings && python3 -S acp_install_catalog.py opencode)
#   -> PACKAGES="opencode-ai@1.18.23"
#      WRAPPER_BINS="opencode"

uv run --package openhands-sdk python clients/typescript/scripts/check-acp-drift.py  # 4 providers

# image: OpenCode is selectable...
docker buildx build --platform linux/arm64 --target base-image-minimal \
  --build-arg INSTALL_ACP_PROVIDERS=opencode \
  -f openhands-agent-server/openhands/agent_server/docker/Dockerfile -t oc:sel --load .
docker run --rm oc:sel opencode --version                       # expect: 1.18.23

# ...and absent by default
docker buildx build --platform linux/arm64 --target base-image-minimal \
  -f openhands-agent-server/openhands/agent_server/docker/Dockerfile -t oc:def --load .
docker run --rm oc:def bash -lc 'command -v opencode || echo "absent (expected)"'
```

A live turn through the SDK (no key needed; uses a free Zen model):

```python
from openhands.sdk.conversation import Conversation
from openhands.sdk.settings.model import ACPAgentSettings

settings = ACPAgentSettings(
    acp_server="opencode", acp_model="opencode/nemotron-3.5-lightning-free"
)
agent = settings.create_agent().model_copy(update={"acp_isolate_data_dir": True})
conv = Conversation(agent=agent, workspace="/some/repo", persistence_dir="/tmp/p")
conv.send_message("Read README.md with your tools and summarise it in one line.")
conv.run()
agent.close()
```

Expect `agent_name='OpenCode'`, `agent_version='1.18.23'` in the logs, a real tool call, and the CLI's state confined to `/tmp/p/<conv_id>/acp/opencode/`.

## Notes for review

- **Not validated: an authenticated OpenCode Zen account.** I had no `OPENCODE_API_KEY`, so every live turn ran on the free public Zen tier (`opencode/nemotron-3.5-lightning-free`, `opencode/mimo-v2.5-free`), which the server offers with no credential. That is enough to substantiate every registry field — the model list, both `supports_*` flags, `_meta` behaviour and session mode were all exercised against the live server. What a real key would add is confirmation that the 62-model authenticated catalogue behaves identically; the 6-vs-62 model-count difference was verified with a dummy key, which is sufficient to establish which env var gates the catalogue but not that a *valid* key completes a turn.
- The SDK logs `ACP server offers auth methods ['opencode-login'] but no matching credential is available` at startup. This is benign and needs no SDK change: `_select_auth_method` returns `None` for `opencode-login`, so no `authenticate()` call is attempted, and `session/new` succeeds — OpenCode reads credentials from env/auth.json rather than through the ACP auth handshake.
- `available_models` is a curated 7 out of a catalogue that is both large (62 Zen ids) and auth-dependent. Consistent with the other providers, it is a suggestion list, not an access check.
- **Pin choice.** `1.18.23` (published 2026-08-25), not the newest `1.18.26` (2026-09-01). The review bot's 7-day supply-chain window is mandatory and `1.18.26` was <1 day old; `1.18.23` and all six of its native packages were already 8 days old. Every registry claim was re-verified against `1.18.23` and is identical — same `agentInfo`, `build`/`plan` modes, `model` configOptions select, `opencode/big-pickle` default, ignored `_meta`, same auth and data-dir behaviour. A later bump to `1.18.26`+ is routine once it ages out.
- The benchmark/evaluation wiring #4639 also lists for #4627 is deliberately **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPWWARoj7phKZUSB5sNaY4

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:81eecb8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-81eecb8-python \
  ghcr.io/openhands/agent-server:81eecb8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:81eecb8-golang-amd64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-golang-amd64
ghcr.io/openhands/agent-server:acp-opencode-provider-golang-amd64
ghcr.io/openhands/agent-server:81eecb8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:81eecb8-golang-arm64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-golang-arm64
ghcr.io/openhands/agent-server:acp-opencode-provider-golang-arm64
ghcr.io/openhands/agent-server:81eecb8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:81eecb8-java-amd64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-java-amd64
ghcr.io/openhands/agent-server:acp-opencode-provider-java-amd64
ghcr.io/openhands/agent-server:81eecb8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:81eecb8-java-arm64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-java-arm64
ghcr.io/openhands/agent-server:acp-opencode-provider-java-arm64
ghcr.io/openhands/agent-server:81eecb8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:81eecb8-python-amd64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python-amd64
ghcr.io/openhands/agent-server:acp-opencode-provider-python-amd64
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:81eecb8-python-arm64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python-arm64
ghcr.io/openhands/agent-server:acp-opencode-provider-python-arm64
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:81eecb8-python-slim-amd64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python-slim-amd64
ghcr.io/openhands/agent-server:acp-opencode-provider-python-slim-amd64
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:81eecb8-python-slim-arm64
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python-slim-arm64
ghcr.io/openhands/agent-server:acp-opencode-provider-python-slim-arm64
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:81eecb8-golang
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-golang
ghcr.io/openhands/agent-server:acp-opencode-provider-golang
ghcr.io/openhands/agent-server:81eecb8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:81eecb8-java
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-java
ghcr.io/openhands/agent-server:acp-opencode-provider-java
ghcr.io/openhands/agent-server:81eecb8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:81eecb8-python-slim
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python-slim
ghcr.io/openhands/agent-server:acp-opencode-provider-python-slim
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:81eecb8-python
ghcr.io/openhands/agent-server:81eecb86dabbb4eaee7d80498ee8bbfcbd75cf4d-python
ghcr.io/openhands/agent-server:acp-opencode-provider-python
ghcr.io/openhands/agent-server:81eecb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `81eecb8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `81eecb8-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->