### PR TITLE
feat(agent-server): add reversible conversation archiving

### DIFF
--- a/clients/typescript/src/__tests__/api-clients.test.ts
+++ b/clients/typescript/src/__tests__/api-clients.test.ts
@@ -1,5 +1,6 @@
 import {
   Agent,
+  ConversationArchiveFilter,
   ConversationExecutionStatus,
   ConversationManager,
   HttpClient,
@@ -2313,6 +2314,44 @@ describe('Auxiliary API clients', () => {
       8,
       'http://example.com/api/conversations/c1',
       expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ title: 'New title' }) })
+    );
+  });
+
+  it('ConversationClient wraps conversation archive endpoints and filters', async () => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, items: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    ) as typeof fetch;
+
+    const client = new ConversationClient({ host: 'http://example.com' });
+    await client.searchConversations({ archive_filter: ConversationArchiveFilter.ALL });
+    await client.countConversations({ archive_filter: ConversationArchiveFilter.ARCHIVED });
+    await client.archiveConversation('c1');
+    await client.unarchiveConversation('c1');
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://example.com/api/conversations/search?archive_filter=ALL',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://example.com/api/conversations/count?archive_filter=ARCHIVED',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://example.com/api/conversations/c1/archive',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ confirmed: true }) })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      4,
+      'http://example.com/api/conversations/c1/unarchive',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({}) })
     );
   });
 

--- a/clients/typescript/src/client/conversation-client.ts
+++ b/clients/typescript/src/client/conversation-client.ts
@@ -1,9 +1,10 @@
 import { HttpClient, HttpError } from './http-client';
-import { ConversationExecutionStatus, LLM, Success } from '../types/base';
+import { LLM, Success } from '../types/base';
 import type {
   AgentResponseResult,
   AskAgentResponse,
   ConfirmationResponseRequest,
+  ConversationCountRequest,
   ConversationEvent,
   ConversationEventCountOptions,
   ConversationEventPage,
@@ -83,9 +84,7 @@ export class ConversationClient {
     return response.data;
   }
 
-  async countConversations(
-    options: { status?: ConversationExecutionStatus } = {}
-  ): Promise<number> {
+  async countConversations(options: ConversationCountRequest = {}): Promise<number> {
     const response = await this.client.get<number>('/api/conversations/count', {
       params: options as Record<string, unknown>,
     });
@@ -368,6 +367,22 @@ export class ConversationClient {
     await this.client.post<Success>(`/api/conversations/${conversationId}/switch_acp_model`, {
       model,
     });
+  }
+
+  async archiveConversation(conversationId: string): Promise<Success> {
+    const response = await this.client.post<Success>(
+      `/api/conversations/${conversationId}/archive`,
+      { confirmed: true }
+    );
+    return response.data;
+  }
+
+  async unarchiveConversation(conversationId: string): Promise<Success> {
+    const response = await this.client.post<Success>(
+      `/api/conversations/${conversationId}/unarchive`,
+      {}
+    );
+    return response.data;
   }
 
   async deleteConversation(conversationId: string): Promise<void> {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -182,7 +182,7 @@ export type {
 export type { AgentOptions } from './agent/agent';
 
 export { EventSortOrder, AgentExecutionStatus, ConversationExecutionStatus } from './types/base';
-export { ConversationSortOrder } from './models/conversation';
+export { ConversationArchiveFilter, ConversationSortOrder } from './models/conversation';
 
 // Workspace models
 export type {
@@ -267,6 +267,7 @@ export type {
   LookupSecret,
   SecretObject,
   ConversationSearchRequest,
+  ConversationCountRequest,
   ConversationSearchResponse,
   ACPConversationSearchResponse,
   AskAgentRequest,

--- a/clients/typescript/src/models/conversation.ts
+++ b/clients/typescript/src/models/conversation.ts
@@ -23,6 +23,12 @@ export enum ConversationSortOrder {
   UPDATED_AT_DESC = 'UPDATED_AT_DESC',
 }
 
+export enum ConversationArchiveFilter {
+  ACTIVE = 'ACTIVE',
+  ARCHIVED = 'ARCHIVED',
+  ALL = 'ALL',
+}
+
 export interface ConversationInfo {
   id: ConversationID;
   /**
@@ -51,6 +57,7 @@ export interface ConversationInfo {
   title?: string;
   created_at?: string;
   updated_at?: string;
+  archived_at?: string | null;
   tags?: Record<string, string>;
   /**
    * HEAD of the conversation tree: the parent of the next appended event.
@@ -155,6 +162,12 @@ export interface ConversationSearchRequest {
   status?: ConversationExecutionStatus;
   sort_order?: ConversationSortOrder;
   tag?: string[];
+  archive_filter?: ConversationArchiveFilter;
+}
+
+export interface ConversationCountRequest {
+  status?: ConversationExecutionStatus;
+  archive_filter?: ConversationArchiveFilter;
 }
 
 export interface AskAgentRequest {

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -27,8 +27,10 @@ from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.models import (
     INCLUDE_SKILLS_PARAM_TITLE,
     AgentResponseResult,
+    ArchiveConversationRequest,
     AskAgentRequest,
     AskAgentResponse,
+    ConversationArchiveFilter,
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
@@ -105,14 +107,23 @@ async def search_conversations(
         Query(title="Sort order for conversations"),
     ] = ConversationSortOrder.CREATED_AT_DESC,
     include_skills: Annotated[bool, Query(title=INCLUDE_SKILLS_PARAM_TITLE)] = False,
+    archive_filter: Annotated[
+        ConversationArchiveFilter,
+        Query(title="Filter conversations by archive state"),
+    ] = ConversationArchiveFilter.ACTIVE,
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ConversationPage:
     """Search / List conversations"""
     assert limit > 0
     assert limit <= 100
-    page = await conversation_service.search_conversations(
-        page_id, limit, status, sort_order
-    )
+    if archive_filter == ConversationArchiveFilter.ACTIVE:
+        page = await conversation_service.search_conversations(
+            page_id, limit, status, sort_order
+        )
+    else:
+        page = await conversation_service.search_conversations(
+            page_id, limit, status, sort_order, archive_filter
+        )
     if not include_skills:
         # ``model_copy`` rather than in-place mutation so we never
         # write back into whatever the upstream service handed us
@@ -134,10 +145,17 @@ async def count_conversations(
         ConversationExecutionStatus | None,
         Query(title="Optional filter by conversation execution status"),
     ] = None,
+    archive_filter: Annotated[
+        ConversationArchiveFilter,
+        Query(title="Filter conversations by archive state"),
+    ] = ConversationArchiveFilter.ACTIVE,
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> int:
     """Count conversations matching the given filters"""
-    count = await conversation_service.count_conversations(status)
+    if archive_filter == ConversationArchiveFilter.ACTIVE:
+        count = await conversation_service.count_conversations(status)
+    else:
+        count = await conversation_service.count_conversations(status, archive_filter)
     return count
 
 
@@ -264,6 +282,39 @@ async def interrupt_conversation(
     interrupted = await conversation_service.interrupt_conversation(conversation_id)
     if not interrupted:
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
+    return Success()
+
+
+@conversation_router.post(
+    "/{conversation_id}/archive", responses={404: {"description": "Item not found"}}
+)
+async def archive_conversation(
+    conversation_id: UUID,
+    _request: ArchiveConversationRequest,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Reversibly hide a conversation after explicit confirmation."""
+    archived = await conversation_service.set_conversation_archived(
+        conversation_id, archived=True
+    )
+    if not archived:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    return Success()
+
+
+@conversation_router.post(
+    "/{conversation_id}/unarchive", responses={404: {"description": "Item not found"}}
+)
+async def unarchive_conversation(
+    conversation_id: UUID,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Restore an archived conversation to normal listings."""
+    unarchived = await conversation_service.set_conversation_archived(
+        conversation_id, archived=False
+    )
+    if not unarchived:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
     return Success()
 
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1840,9 +1840,11 @@ class ConversationService:
             if record is None and event_service is None:
                 return False
 
-            stored = (
-                event_service.stored if event_service is not None else record.stored
-            )
+            if event_service is not None:
+                stored = event_service.stored
+            else:
+                assert record is not None
+                stored = record.stored
             if (stored.archived_at is not None) == archived:
                 return True
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -26,6 +26,7 @@ from openhands.agent_server.event_service import (
     _without_agent_context_secret,
 )
 from openhands.agent_server.models import (
+    ConversationArchiveFilter,
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
@@ -71,6 +72,7 @@ from openhands.sdk.observability import OPERATION_METADATA_KEY, observe
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.files import atomic_write_text
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -527,6 +529,7 @@ def _compose_conversation_info(
         supports_runtime_model_switch=supports_runtime_model_switch,
         client_tools=stored.client_tools,
         launched_agent_profile=stored.launched_agent_profile,
+        archived_at=stored.archived_at,
     )
 
 
@@ -627,6 +630,7 @@ def _stored_metadata_signature(stored: StoredConversation) -> int:
             "parent_conversation_id",
             "client_tools",
             "launched_agent_profile",
+            "archived_at",
         },
     )
     return hash(json.dumps(metadata, sort_keys=True, default=str))
@@ -1230,12 +1234,14 @@ class ConversationService:
         limit: int = 100,
         execution_status: ConversationExecutionStatus | None = None,
         sort_order: ConversationSortOrder = ConversationSortOrder.CREATED_AT_DESC,
+        archive_filter: ConversationArchiveFilter = ConversationArchiveFilter.ACTIVE,
     ) -> ConversationPage:
         items, next_page_id = await self._search_conversations(
             page_id=page_id,
             limit=limit,
             execution_status=execution_status,
             sort_order=sort_order,
+            archive_filter=archive_filter,
         )
         return ConversationPage(
             items=items,
@@ -1248,12 +1254,14 @@ class ConversationService:
         limit: int = 100,
         execution_status: ConversationExecutionStatus | None = None,
         sort_order: ConversationSortOrder = ConversationSortOrder.CREATED_AT_DESC,
+        archive_filter: ConversationArchiveFilter = ConversationArchiveFilter.ACTIVE,
     ) -> ConversationPage:
         items, next_page_id = await self._search_conversations(
             page_id=page_id,
             limit=limit,
             execution_status=execution_status,
             sort_order=sort_order,
+            archive_filter=archive_filter,
         )
         return ConversationPage(
             items=items,
@@ -1266,6 +1274,7 @@ class ConversationService:
         limit: int,
         execution_status: ConversationExecutionStatus | None,
         sort_order: ConversationSortOrder,
+        archive_filter: ConversationArchiveFilter,
     ) -> tuple[list[ConversationInfo], str | None]:
         if self._event_services is None:
             raise ValueError("inactive_service")
@@ -1281,7 +1290,18 @@ class ConversationService:
         records = [
             (conversation_id, record)
             for conversation_id, record in self._conversation_records.items()
-            if execution_status is None or record.execution_status == execution_status
+            if (execution_status is None or record.execution_status == execution_status)
+            and (
+                archive_filter == ConversationArchiveFilter.ALL
+                or (
+                    archive_filter == ConversationArchiveFilter.ARCHIVED
+                    and record.stored.archived_at is not None
+                )
+                or (
+                    archive_filter == ConversationArchiveFilter.ACTIVE
+                    and record.stored.archived_at is None
+                )
+            )
         ]
         if sort_order in (
             ConversationSortOrder.CREATED_AT,
@@ -1322,26 +1342,39 @@ class ConversationService:
     async def count_conversations(
         self,
         execution_status: ConversationExecutionStatus | None = None,
+        archive_filter: ConversationArchiveFilter = ConversationArchiveFilter.ACTIVE,
     ) -> int:
-        return await self._count_conversations(execution_status=execution_status)
+        return await self._count_conversations(
+            execution_status=execution_status, archive_filter=archive_filter
+        )
 
     async def _count_conversations(
         self,
         execution_status: ConversationExecutionStatus | None,
+        archive_filter: ConversationArchiveFilter,
     ) -> int:
         """Count conversations matching the given filters."""
         if self._event_services is None:
             raise ValueError("inactive_service")
         await self._reconcile_active_records()
 
-        if execution_status is None:
-            return len(self._conversation_records)
-
-        await self._refresh_execution_statuses()
+        if execution_status is not None:
+            await self._refresh_execution_statuses()
         return sum(
             1
             for record in self._conversation_records.values()
-            if record.execution_status == execution_status
+            if (execution_status is None or record.execution_status == execution_status)
+            and (
+                archive_filter == ConversationArchiveFilter.ALL
+                or (
+                    archive_filter == ConversationArchiveFilter.ARCHIVED
+                    and record.stored.archived_at is not None
+                )
+                or (
+                    archive_filter == ConversationArchiveFilter.ACTIVE
+                    and record.stored.archived_at is None
+                )
+            )
         )
 
     async def batch_get_conversations(
@@ -1795,6 +1828,53 @@ class ConversationService:
 
     async def resume_conversation(self, conversation_id: UUID) -> bool:
         return bool(await self._get_or_load_event_service(conversation_id))
+
+    async def set_conversation_archived(
+        self, conversation_id: UUID, *, archived: bool
+    ) -> bool:
+        if self._event_services is None:
+            raise ValueError("inactive_service")
+        async with self._conversation_lifecycle(conversation_id):
+            record = self._conversation_records.get(conversation_id)
+            event_service = self._event_services.get(conversation_id)
+            if record is None and event_service is None:
+                return False
+
+            stored = (
+                event_service.stored if event_service is not None else record.stored
+            )
+            if (stored.archived_at is not None) == archived:
+                return True
+
+            previous_archived_at = stored.archived_at
+            stored.archived_at = utc_now() if archived else None
+            try:
+                if event_service is not None:
+                    await event_service.save_meta()
+                else:
+                    context = {"cipher": self.cipher}
+                    meta_file = (
+                        self.conversations_dir / conversation_id.hex / "meta.json"
+                    )
+                    await asyncio.to_thread(
+                        atomic_write_text,
+                        meta_file,
+                        stored.model_dump_json(context=context),
+                    )
+            except Exception:
+                stored.archived_at = previous_archived_at
+                raise
+
+            if record is not None:
+                record.stored = stored
+                record.cached_info = None
+                record.stored_signature = None
+            logger.info(
+                "%s conversation %s",
+                "Archived" if archived else "Unarchived",
+                conversation_id,
+            )
+            return True
 
     async def delete_conversation(self, conversation_id: UUID) -> bool:
         event_services = self._event_services

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
@@ -67,6 +67,14 @@ class ConversationSortOrder(StrEnum):
     UPDATED_AT_DESC = "UPDATED_AT_DESC"
 
 
+class ConversationArchiveFilter(StrEnum):
+    """Select conversations by archive state."""
+
+    ACTIVE = "ACTIVE"
+    ARCHIVED = "ARCHIVED"
+    ALL = "ALL"
+
+
 class EventSortOrder(StrEnum):
     """Enum for event sorting options."""
 
@@ -94,6 +102,10 @@ class StoredConversation(ConversationConfig):
     metrics: MetricsSnapshot | None = None
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
+    archived_at: datetime | None = Field(
+        default=None,
+        description="When this conversation was archived; null while active",
+    )
     forked_from_conversation_id: OpenHandsUUID | None = Field(
         default=None,
         description=(
@@ -149,6 +161,9 @@ class _ConversationInfoBase(BaseModel):
     )
     execution_status: ConversationExecutionStatus = Field(
         default=ConversationExecutionStatus.IDLE
+    )
+    archived_at: datetime | None = Field(
+        default=None, description="When this conversation was archived"
     )
     confirmation_policy: ConfirmationPolicyBase = Field(default=NeverConfirm())
     security_analyzer: SecurityAnalyzerBase | None = Field(
@@ -465,6 +480,14 @@ class SetSecurityAnalyzerRequest(BaseModel):
 
     security_analyzer: SecurityAnalyzerBase | None = Field(
         description="The security analyzer to set"
+    )
+
+
+class ArchiveConversationRequest(BaseModel):
+    """Explicit confirmation required before hiding a conversation."""
+
+    confirmed: Literal[True] = Field(
+        description="Must be true to confirm this reversible archive operation"
     )
 
 

--- a/tests/agent_server/test_conversation_archive.py
+++ b/tests/agent_server/test_conversation_archive.py
@@ -137,6 +137,17 @@ async def test_archive_unarchive_is_reversible_filtered_and_idempotent(
         str(archived.id),
     }
 
+    default_count = await client.get("/api/conversations/count")
+    archived_count = await client.get(
+        "/api/conversations/count", params={"archive_filter": "ARCHIVED"}
+    )
+    all_count = await client.get(
+        "/api/conversations/count", params={"archive_filter": "ALL"}
+    )
+    assert default_count.json() == 1
+    assert archived_count.json() == 1
+    assert all_count.json() == 2
+
     events_after = await client.get(f"/api/conversations/{archived.id}/events/search")
     assert events_after.status_code == 200
     assert events_after.json()["items"] == history_before

--- a/tests/agent_server/test_conversation_archive.py
+++ b/tests/agent_server/test_conversation_archive.py
@@ -14,8 +14,11 @@ from openhands.agent_server.conversation_router import conversation_router
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.event_router import event_router
-from openhands.agent_server.models import StartConversationRequest
-from openhands.sdk import LLM, Agent, Message
+from openhands.agent_server.models import (
+    StartConversationRequest,
+    UpdateConversationRequest,
+)
+from openhands.sdk import LLM, Agent, Message, TextContent
 from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -53,13 +56,15 @@ async def _create_conversation(
             workspace=LocalWorkspace(working_dir=str(workspace)),
             confirmation_policy=NeverConfirm(),
             autotitle=False,
-            title=title,
             tags={"owner": "agent-a", "purpose": "archive-test"},
         )
     )
+    await service.update_conversation(info.id, UpdateConversationRequest(title=title))
     event_service = await service.get_event_service(info.id)
     assert event_service is not None
-    await event_service.send_message(Message(role="user", content="keep this history"))
+    await event_service.send_message(
+        Message(role="user", content=[TextContent(text="keep this history")])
+    )
     return info
 
 

--- a/tests/agent_server/test_conversation_archive.py
+++ b/tests/agent_server/test_conversation_archive.py
@@ -1,0 +1,186 @@
+"""Integration tests for reversible conversation archiving."""
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from openhands.agent_server.config import Config
+from openhands.agent_server.conversation_router import conversation_router
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.dependencies import get_conversation_service
+from openhands.agent_server.event_router import event_router
+from openhands.agent_server.models import StartConversationRequest
+from openhands.sdk import LLM, Agent, Message
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.workspace import LocalWorkspace
+
+
+@pytest_asyncio.fixture
+async def conversation_service(tmp_path: Path) -> AsyncIterator[ConversationService]:
+    service = ConversationService(conversations_dir=tmp_path / "conversations")
+    async with service:
+        yield service
+
+
+@pytest_asyncio.fixture
+async def client(
+    conversation_service: ConversationService,
+) -> AsyncIterator[httpx.AsyncClient]:
+    app = FastAPI()
+    app.state.config = Config(
+        static_files_path=None, session_api_keys=[], secret_key=None
+    )
+    app.include_router(conversation_router, prefix="/api")
+    app.include_router(event_router, prefix="/api")
+    app.dependency_overrides[get_conversation_service] = lambda: conversation_service
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _create_conversation(
+    service: ConversationService, workspace: Path, *, title: str
+):
+    workspace.mkdir(exist_ok=True)
+    info, _ = await service.start_conversation(
+        StartConversationRequest(
+            agent=Agent(llm=LLM(model="test-model", usage_id="test"), tools=[]),
+            workspace=LocalWorkspace(working_dir=str(workspace)),
+            confirmation_policy=NeverConfirm(),
+            autotitle=False,
+            title=title,
+            tags={"owner": "agent-a", "purpose": "archive-test"},
+        )
+    )
+    event_service = await service.get_event_service(info.id)
+    assert event_service is not None
+    await event_service.send_message(Message(role="user", content="keep this history"))
+    return info
+
+
+@pytest.mark.asyncio
+async def test_archive_unarchive_is_reversible_filtered_and_idempotent(
+    client: httpx.AsyncClient,
+    conversation_service: ConversationService,
+    tmp_path: Path,
+):
+    archived = await _create_conversation(
+        conversation_service, tmp_path / "archived-workspace", title="Archive me"
+    )
+    active = await _create_conversation(
+        conversation_service, tmp_path / "active-workspace", title="Keep active"
+    )
+    updated = await client.patch(
+        f"/api/conversations/{archived.id}", json={"title": "Archive me"}
+    )
+    assert updated.status_code == 200
+
+    events_before = await client.get(f"/api/conversations/{archived.id}/events/search")
+    assert events_before.status_code == 200
+    history_before = events_before.json()["items"]
+    assert history_before
+
+    missing_confirmation = await client.post(
+        f"/api/conversations/{archived.id}/archive", json={}
+    )
+    assert missing_confirmation.status_code == 422
+
+    response = await client.post(
+        f"/api/conversations/{archived.id}/archive", json={"confirmed": True}
+    )
+    assert response.status_code == 200
+    first_archived_at = (await client.get(f"/api/conversations/{archived.id}")).json()[
+        "archived_at"
+    ]
+    response = await client.post(
+        f"/api/conversations/{archived.id}/archive", json={"confirmed": True}
+    )
+    assert response.status_code == 200
+
+    direct = await client.get(f"/api/conversations/{archived.id}")
+    assert direct.json()["archived_at"] == first_archived_at
+    assert direct.status_code == 200
+    assert direct.json()["archived_at"] is not None
+    assert direct.json()["title"] == "Archive me"
+    assert direct.json()["tags"] == {
+        "owner": "agent-a",
+        "purpose": "archive-test",
+    }
+    meta_file = conversation_service.conversations_dir / archived.id.hex / "meta.json"
+    persisted = json.loads(meta_file.read_text())
+    assert persisted["archived_at"] == first_archived_at
+    assert persisted["tags"] == direct.json()["tags"]
+
+    default_page = await client.get("/api/conversations/search")
+    assert [item["id"] for item in default_page.json()["items"]] == [str(active.id)]
+
+    archived_page = await client.get(
+        "/api/conversations/search", params={"archive_filter": "ARCHIVED"}
+    )
+    assert [item["id"] for item in archived_page.json()["items"]] == [str(archived.id)]
+
+    all_page = await client.get(
+        "/api/conversations/search", params={"archive_filter": "ALL"}
+    )
+    assert {item["id"] for item in all_page.json()["items"]} == {
+        str(active.id),
+        str(archived.id),
+    }
+
+    events_after = await client.get(f"/api/conversations/{archived.id}/events/search")
+    assert events_after.status_code == 200
+    assert events_after.json()["items"] == history_before
+
+    for _ in range(2):
+        response = await client.post(f"/api/conversations/{archived.id}/unarchive")
+        assert response.status_code == 200
+
+    restored = await client.get(f"/api/conversations/{archived.id}")
+    assert restored.status_code == 200
+    assert restored.json()["archived_at"] is None
+    assert restored.json()["tags"] == {
+        "owner": "agent-a",
+        "purpose": "archive-test",
+    }
+    default_page = await client.get("/api/conversations/search")
+    assert {item["id"] for item in default_page.json()["items"]} == {
+        str(active.id),
+        str(archived.id),
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_remains_permanent_and_separate_from_archive(
+    client: httpx.AsyncClient,
+    conversation_service: ConversationService,
+    tmp_path: Path,
+):
+    conversation = await _create_conversation(
+        conversation_service, tmp_path / "delete-workspace", title="Delete me"
+    )
+    conversation_dir = conversation_service.conversations_dir / conversation.id.hex
+
+    archived = await client.post(
+        f"/api/conversations/{conversation.id}/archive", json={"confirmed": True}
+    )
+    assert archived.status_code == 200
+    assert conversation_dir.is_dir()
+
+    deleted = await client.delete(f"/api/conversations/{conversation.id}")
+    assert deleted.status_code == 200
+    assert not conversation_dir.exists()
+    assert (
+        await client.get(f"/api/conversations/{conversation.id}")
+    ).status_code == 404
+    archived_page = await client.get(
+        "/api/conversations/search", params={"archive_filter": "ARCHIVED"}
+    )
+    assert archived_page.json()["items"] == []
+    assert (
+        await client.post(f"/api/conversations/{conversation.id}/unarchive")
+    ).status_code == 404


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

_This pull request was created by an AI agent (OpenHands) on behalf of Max Giraldo._

## Why

Agent Canvas currently stores archive state only in browser storage. The Agent Server needs a reversible, persisted archive contract so state follows the backend and remains available across clients.

## Summary

- Add persisted `archived_at` metadata plus idempotent archive and unarchive endpoints.
- Default search and count to active conversations, with `ARCHIVED` and `ALL` filters.
- Mirror the contract in `@openhands/typescript-client` and cover persistence, filtering, reversibility, history preservation, and deletion separation.

## Issue Number

No linked issue.

## How to Test

- Backend affected suite: 206 tests passed.
- Archive integration test: 2 tests passed, including active/archived/all search and count behavior.
- TypeScript client: lint and build passed; 310 coverage tests passed; formatting check passed.
- Local Agent Canvas stack was restarted against this branch and its live OpenAPI exposed `archive`, `unarchive`, and `archive_filter`.
- Mandatory final pair review completed with zero suggestions.

## Video/Screenshots

Not applicable; this PR provides backend and typed-client contracts.

## Design Doc

Not included.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is the backend and TypeScript-client dependency for the coordinated [Agent Canvas server-backed archiving branch](https://github.com/maxgiraldo/OpenHands/tree/openhands/server-conversation-archive). The frontend PR must wait for a released client version containing this contract.
