### PR TITLE
feat(acp): centralize ACP npm installation metadata

### DIFF
--- a/clients/typescript/scripts/check-acp-drift.py
+++ b/clients/typescript/scripts/check-acp-drift.py
@@ -9,11 +9,16 @@ Run locally:
     pip install -r scripts/requirements-acp-check.txt
     python scripts/check-acp-drift.py
 
+Pass --write to regenerate src/models/acp-providers.json from ACP_PROVIDERS
+instead of just checking for drift (e.g. after bumping a provider's pinned
+version or adding a new one to the SDK registry).
+
 CI runs this as the `validate-acp-providers` job on every PR + push to main.
 """
 
 from __future__ import annotations
 
+import argparse
 import dataclasses
 import difflib
 import json
@@ -38,7 +43,16 @@ def _dump_json(obj) -> str:
     return json.dumps(obj, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Regenerate src/models/acp-providers.json from ACP_PROVIDERS "
+        "instead of failing on drift.",
+    )
+    args = parser.parse_args(argv)
+
     try:
         from openhands.sdk.settings.acp_providers import (
             ACP_PROVIDERS,  # type: ignore[import-not-found]
@@ -54,11 +68,17 @@ def main() -> int:
 
     repo_root = pathlib.Path(__file__).resolve().parent.parent
     ts_json_path = repo_root / "src" / "models" / "acp-providers.json"
-    ts_data = _normalize(json.loads(ts_json_path.read_text()))
     py_data = _normalize(dict(ACP_PROVIDERS))
-
-    ts_text = _dump_json(ts_data)
     py_text = _dump_json(py_data)
+
+    if args.write:
+        ts_json_path.write_text(py_text)
+        n = len(py_data) if isinstance(py_data, dict) else 0
+        print(f"Wrote {ts_json_path} from openhands-sdk ACP_PROVIDERS ({n} providers).")
+        return 0
+
+    ts_data = _normalize(json.loads(ts_json_path.read_text()))
+    ts_text = _dump_json(ts_data)
 
     if ts_text == py_text:
         n = len(ts_data) if isinstance(ts_data, dict) else 0

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -1,14 +1,9 @@
 {
   "claude-code": {
-    "key": "claude-code",
-    "display_name": "Claude Code",
-    "default_command": ["npx", "-y", "--prefer-offline", "@agentclientprotocol/claude-agent-acp@0.63.0"],
+    "agent_name_patterns": [
+      "claude-agent"
+    ],
     "api_key_env_var": "ANTHROPIC_API_KEY",
-    "base_url_env_var": "ANTHROPIC_BASE_URL",
-    "default_session_mode": "bypassPermissions",
-    "agent_name_patterns": ["claude-agent"],
-    "supports_set_session_model": true,
-    "session_meta_key": "claudeCode",
     "available_models": [
       {
         "id": "default",
@@ -31,22 +26,29 @@
         "label": "Claude Haiku"
       }
     ],
-    "default_model": "opus[1m]",
-    "supports_runtime_model_switch": true,
-    "file_secrets": [],
+    "base_url_env_var": "ANTHROPIC_BASE_URL",
     "binary_name": "claude-agent-acp",
-    "data_dir_env_var": "CLAUDE_CONFIG_DIR"
+    "data_dir_env_var": "CLAUDE_CONFIG_DIR",
+    "default_command": [
+      "npx",
+      "-y",
+      "--prefer-offline",
+      "@agentclientprotocol/claude-agent-acp@0.63.0"
+    ],
+    "default_model": "opus[1m]",
+    "default_session_mode": "bypassPermissions",
+    "display_name": "Claude Code",
+    "file_secrets": [],
+    "key": "claude-code",
+    "session_meta_key": "claudeCode",
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
   },
   "codex": {
-    "key": "codex",
-    "display_name": "Codex",
-    "default_command": ["npx", "-y", "--prefer-offline", "@agentclientprotocol/codex-acp@1.1.7"],
+    "agent_name_patterns": [
+      "codex-acp"
+    ],
     "api_key_env_var": "OPENAI_API_KEY",
-    "base_url_env_var": "OPENAI_BASE_URL",
-    "default_session_mode": "agent-full-access",
-    "agent_name_patterns": ["codex-acp"],
-    "supports_set_session_model": true,
-    "session_meta_key": null,
     "available_models": [
       {
         "id": "gpt-5.6",
@@ -77,31 +79,38 @@
         "label": "GPT-5.4 Mini"
       }
     ],
+    "base_url_env_var": "OPENAI_BASE_URL",
+    "binary_name": "codex-acp",
+    "data_dir_env_var": "CODEX_HOME",
+    "default_command": [
+      "npx",
+      "-y",
+      "--prefer-offline",
+      "@agentclientprotocol/codex-acp@1.1.7"
+    ],
     "default_model": "gpt-5.5",
-    "supports_runtime_model_switch": true,
+    "default_session_mode": "agent-full-access",
+    "display_name": "Codex",
     "file_secrets": [
       {
-        "secret_name": "CODEX_AUTH_JSON",
-        "filename": "auth.json",
-        "env_var": "CODEX_HOME",
-        "subdir": "codex",
         "env_points_to": "dir",
+        "env_var": "CODEX_HOME",
+        "filename": "auth.json",
+        "secret_name": "CODEX_AUTH_JSON",
+        "subdir": "codex",
         "warn_if_unset": []
       }
     ],
-    "binary_name": "codex-acp",
-    "data_dir_env_var": "CODEX_HOME"
+    "key": "codex",
+    "session_meta_key": null,
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
   },
   "gemini-cli": {
-    "key": "gemini-cli",
-    "display_name": "Gemini CLI",
-    "default_command": ["npx", "-y", "--prefer-offline", "@google/gemini-cli@0.46.0", "--acp"],
+    "agent_name_patterns": [
+      "gemini-cli"
+    ],
     "api_key_env_var": "GEMINI_API_KEY",
-    "base_url_env_var": "GEMINI_BASE_URL",
-    "default_session_mode": "default",
-    "agent_name_patterns": ["gemini-cli"],
-    "supports_set_session_model": true,
-    "session_meta_key": null,
     "available_models": [
       {
         "id": "auto",
@@ -132,19 +141,35 @@
         "label": "Gemini 2.5 Flash"
       }
     ],
+    "base_url_env_var": "GEMINI_BASE_URL",
+    "binary_name": "gemini",
+    "data_dir_env_var": "HOME",
+    "default_command": [
+      "npx",
+      "-y",
+      "--prefer-offline",
+      "@google/gemini-cli@0.46.0",
+      "--acp"
+    ],
     "default_model": "auto",
-    "supports_runtime_model_switch": true,
+    "default_session_mode": "default",
+    "display_name": "Gemini CLI",
     "file_secrets": [
       {
-        "secret_name": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
-        "filename": "gcloud-credentials.json",
-        "env_var": "GOOGLE_APPLICATION_CREDENTIALS",
-        "subdir": "gemini-cli",
         "env_points_to": "file",
-        "warn_if_unset": ["GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"]
+        "env_var": "GOOGLE_APPLICATION_CREDENTIALS",
+        "filename": "gcloud-credentials.json",
+        "secret_name": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        "subdir": "gemini-cli",
+        "warn_if_unset": [
+          "GOOGLE_CLOUD_PROJECT",
+          "GOOGLE_CLOUD_LOCATION"
+        ]
       }
     ],
-    "binary_name": "gemini",
-    "data_dir_env_var": "HOME"
+    "key": "gemini-cli",
+    "session_meta_key": null,
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
   }
 }

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -13,11 +13,11 @@ ARG PORT=8000
 # to bundle google-cloud-aiplatform so the resulting binary supports
 # `vertex_ai/*` partner models (MiniMax, Qwen, Kimi MaaS endpoints).
 ARG ENABLE_VERTEX=0
-# Comma-separated ACP provider keys (see ACP_PROVIDERS in
-# openhands-sdk/openhands/sdk/settings/acp_providers.py) to bake into the
+# Comma-separated ACP provider keys (see ACP_INSTALL_CATALOG in
+# openhands-sdk/openhands/sdk/settings/acp_install_catalog.py) to bake into the
 # acp-providers stage below. The default reproduces the full provider set
-# shipped today; an unknown key fails the build rather than silently
-# installing nothing.
+# shipped today (DEFAULT_PREINSTALLED_ACP_PROVIDERS); an unknown key fails the
+# build rather than silently installing nothing.
 ARG INSTALL_ACP_PROVIDERS=claude-code,codex,gemini-cli
 # Comma-separated capability keys to include in the `base-image` stage below
 # (`base-image-minimal` is unaffected). The default reproduces today's full
@@ -112,23 +112,17 @@ ARG INSTALL_ACP_PROVIDERS
 # parent, mirroring /agent-server's own top-level placement in the builder
 # stage above.
 ENV ACP_NODE_DIR=/acp-node
+# The catalog module is dependency-free (stdlib only), so it can be COPYed
+# into this bare `python` image and run as-is — no pip install, and no need
+# to pull in the rest of the SDK source (which would break the zero-context
+# fast path `build.py` uses for the `base-image-minimal` target). Adding an
+# npm provider is a catalog edit only; this stage never needs to change.
+COPY openhands-sdk/openhands/sdk/settings/acp_install_catalog.py /tmp/acp_install_catalog.py
 RUN set -eux; \
     ACP_WRAPPER_DIR=/opt/acp-wrappers; \
     mkdir -p "$ACP_NODE_DIR" "$ACP_WRAPPER_DIR"; \
-    PACKAGES=""; \
-    WRAPPER_BINS=""; \
-    for provider in $(echo "$INSTALL_ACP_PROVIDERS" | tr ',' ' '); do \
-      case "$provider" in \
-        claude-code) PACKAGES="$PACKAGES @agentclientprotocol/claude-agent-acp@0.63.0"; \
-          WRAPPER_BINS="$WRAPPER_BINS claude-agent-acp";; \
-        codex) PACKAGES="$PACKAGES @agentclientprotocol/codex-acp@1.1.7"; \
-          WRAPPER_BINS="$WRAPPER_BINS codex-acp";; \
-        gemini-cli) PACKAGES="$PACKAGES @google/gemini-cli@0.46.0"; \
-          WRAPPER_BINS="$WRAPPER_BINS gemini";; \
-        *) echo "Unknown ACP provider '$provider' in INSTALL_ACP_PROVIDERS" \
-             "(expected one of: claude-code, codex, gemini-cli)" >&2; exit 1;; \
-      esac; \
-    done; \
+    PLAN=$(python3 /tmp/acp_install_catalog.py "$INSTALL_ACP_PROVIDERS") || exit 1; \
+    eval "$PLAN"; \
     if [ -z "$PACKAGES" ]; then \
       echo "INSTALL_ACP_PROVIDERS is empty; no ACP providers will be installed"; \
       exit 0; \

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -32,6 +32,9 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.logger import IN_CI, get_logger, rolling_log_view
+from openhands.sdk.settings.acp_install_catalog import (
+    DEFAULT_PREINSTALLED_ACP_PROVIDERS,
+)
 from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
 from openhands.sdk.workspace import PlatformType, TargetType
 
@@ -47,6 +50,13 @@ VALID_TARGETS = {
     "base-image",
     "builder",
 }
+# Relative path (from sdk_project_root) of the dependency-free ACP install
+# catalog the Dockerfile's `acp-providers` stage COPYs in directly. Mirrored
+# here so the empty-context fast path below (`is_base_only`) can stage just
+# this one file instead of pulling in the full SDK source tree.
+_ACP_INSTALL_CATALOG_RELPATH = Path(
+    "openhands-sdk/openhands/sdk/settings/acp_install_catalog.py"
+)
 # Capability keys accepted by the Dockerfile's INSTALL_CAPABILITIES build arg
 # (the `base-image` stage's VSCode Web, browser, and Docker blocks). Kept
 # local to this module since, unlike ACP_PROVIDERS, no other repo/runtime
@@ -442,7 +452,7 @@ class BuildOptions(BaseModel):
         ),
     )
     install_acp_providers: str = Field(
-        default="claude-code,codex,gemini-cli",
+        default=",".join(DEFAULT_PREINSTALLED_ACP_PROVIDERS),
         description=(
             "Comma-separated ACP provider keys (see ACP_PROVIDERS in "
             "openhands-sdk/openhands/sdk/settings/acp_providers.py) to bake "
@@ -879,6 +889,13 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
     if is_base_only:
         ctx = Path(tempfile.mkdtemp(prefix="agent-base-ctx-"))
         shutil.copy2(dockerfile_path, ctx / "Dockerfile")
+        # The acp-providers stage COPYs this one dependency-free catalog file
+        # (see the Dockerfile) — stage it at the same relative path the real
+        # sdist-extracted context uses, so the same COPY instruction works
+        # here without pulling in the rest of the SDK source.
+        catalog_dst = ctx / _ACP_INSTALL_CATALOG_RELPATH
+        catalog_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(opts.sdk_project_root / _ACP_INSTALL_CATALOG_RELPATH, catalog_dst)
     else:
         ctx = _make_build_context(opts.sdk_project_root, opts.prebuilt_sdist)
     telemetry.build_context_seconds = _round_seconds(
@@ -1131,7 +1148,9 @@ def main(argv: list[str]) -> int:
         "--install-acp-providers",
         # os.environ.get, not _env(): an explicit empty string here means
         # "install none" and must survive, but _env() treats blank as unset.
-        default=os.environ.get("INSTALL_ACP_PROVIDERS", "claude-code,codex,gemini-cli"),
+        default=os.environ.get(
+            "INSTALL_ACP_PROVIDERS", ",".join(DEFAULT_PREINSTALLED_ACP_PROVIDERS)
+        ),
         help=(
             "Comma-separated ACP provider keys to bake into the image "
             "(default from $INSTALL_ACP_PROVIDERS; empty string installs none)."

--- a/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
@@ -167,9 +167,12 @@ def render_docker_install_plan(
 def _main(argv: list[str] | None = None) -> int:
     """CLI entry point used by the Dockerfile's ``acp-providers`` build stage.
 
-    Prints a shell-``eval``-able plan (``PACKAGES=...`` / ``WRAPPER_BINS=...``)
+    Prints a shell-``eval``-able plan (``PACKAGES="..."`` / ``WRAPPER_BINS="..."``)
     for the comma-separated provider keys in ``providers`` (empty string installs
-    none).
+    none). Values are double-quoted: without quotes, ``eval`` re-tokenizes each
+    line on whitespace, so a multi-package ``PACKAGES=a b c`` would parse as
+    "assign PACKAGES=a, then run command b with arg c" instead of one
+    space-separated assignment. Package/bin names never contain a ``"``.
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -182,8 +185,8 @@ def _main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    print("PACKAGES=" + " ".join(packages))
-    print("WRAPPER_BINS=" + " ".join(wrapper_bins))
+    print(f'PACKAGES="{" ".join(packages)}"')
+    print(f'WRAPPER_BINS="{" ".join(wrapper_bins)}"')
     return 0
 
 

--- a/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
@@ -1,0 +1,191 @@
+"""ACP npm installation catalog — the single source of truth for each
+built-in provider's pinned npm package(s), CLI entry point, and any launch
+arguments needed to invoke it.
+
+Deliberately dependency-free (stdlib only, no pydantic): the agent-server
+Dockerfile's ``acp-providers`` stage builds from a bare ``python:*-bookworm``
+image with no OpenHands package installed, so this file is COPYed into that
+stage on its own and executed with the system ``python3`` to render the ACP
+payload's npm-install/wrapper plan (see :func:`render_docker_install_plan` and
+the ``acp-providers`` stage in
+``openhands-agent-server/openhands/agent_server/docker/Dockerfile``). It must
+keep working when imported (or run as a script) with nothing beyond the
+standard library on ``sys.path``.
+
+:data:`ACP_PROVIDERS` in ``acp_providers.py`` builds each provider's
+``default_command``/``binary_name`` from this catalog, so a package/version
+bump only needs to happen here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ACPPackagePin:
+    """One pinned npm package (name + exact version)."""
+
+    name: str
+    version: str
+
+    @property
+    def pinned(self) -> str:
+        """The ``name@version`` token passed to ``npm``/``npx``."""
+        return f"{self.name}@{self.version}"
+
+
+@dataclass(frozen=True)
+class ACPInstallSpec:
+    """Everything needed to install and launch one provider's ACP CLI via npm.
+
+    Supports one or more independently pinned packages (e.g. Pi's ``pi-acp``
+    adapter plus its ``@earendil-works/pi-coding-agent`` engine).
+    """
+
+    key: str
+    """Provider key, matching
+    :class:`~openhands.sdk.settings.acp_providers.ACPProviderInfo.key`."""
+
+    packages: tuple[ACPPackagePin, ...]
+    """One or more npm packages to pin and install. Never empty."""
+
+    binary_name: str
+    """CLI entry point: the agent-server's pre-installed ``PATH`` wrapper name,
+    and (when :attr:`packages` has more than one entry) the positional command
+    ``npx`` is told to run."""
+
+    trailing_args: tuple[str, ...] = field(default=())
+    """Args appended after the package spec in :meth:`npx_command` (e.g.
+    gemini-cli's ``--acp``, opencode's ``acp``). Empty for CLIs that need no
+    subcommand to enter ACP mode."""
+
+    def npx_command(self) -> tuple[str, ...]:
+        """The default ``npx``-based launch command for this provider.
+
+        A single package is invoked the ordinary way (``npx <pkg>@<ver>``); two
+        or more use ``npx --package=<pkg>@<ver> ... <binary_name>`` so ``npx``
+        knows which installed package's bin to run.
+        """
+        if len(self.packages) == 1:
+            package_tokens: tuple[str, ...] = (self.packages[0].pinned,)
+            entry: tuple[str, ...] = ()
+        else:
+            package_tokens = tuple(f"--package={p.pinned}" for p in self.packages)
+            entry = (self.binary_name,)
+        return (
+            "npx",
+            "-y",
+            "--prefer-offline",
+            *package_tokens,
+            *entry,
+            *self.trailing_args,
+        )
+
+
+# Pinned npm versions for the built-in ACP launchers. A bump here is the only
+# edit needed — ACP_PROVIDERS, the Dockerfile install stage, and the
+# TypeScript mirror (via check-acp-drift.py --write) all derive from
+# ACP_INSTALL_CATALOG below.
+CLAUDE_AGENT_ACP_VERSION = "0.63.0"
+CODEX_ACP_VERSION = "1.1.7"
+GEMINI_CLI_VERSION = "0.46.0"
+
+
+ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
+    "claude-code": ACPInstallSpec(
+        key="claude-code",
+        packages=(
+            ACPPackagePin(
+                "@agentclientprotocol/claude-agent-acp", CLAUDE_AGENT_ACP_VERSION
+            ),
+        ),
+        binary_name="claude-agent-acp",
+    ),
+    "codex": ACPInstallSpec(
+        key="codex",
+        packages=(ACPPackagePin("@agentclientprotocol/codex-acp", CODEX_ACP_VERSION),),
+        binary_name="codex-acp",
+    ),
+    "gemini-cli": ACPInstallSpec(
+        key="gemini-cli",
+        packages=(ACPPackagePin("@google/gemini-cli", GEMINI_CLI_VERSION),),
+        binary_name="gemini",
+        trailing_args=("--acp",),
+    ),
+}
+"""Every ACP provider installable via npm. Registry membership only makes a
+provider *selectable* (``INSTALL_ACP_PROVIDERS``) — see
+:data:`DEFAULT_PREINSTALLED_ACP_PROVIDERS` for what actually ships in the
+default image."""
+
+
+DEFAULT_PREINSTALLED_ACP_PROVIDERS: tuple[str, ...] = (
+    "claude-code",
+    "codex",
+    "gemini-cli",
+)
+"""Provider keys baked into the default agent-server image
+(``INSTALL_ACP_PROVIDERS`` default). Kept separate from
+:data:`ACP_INSTALL_CATALOG` so registering a new npm provider there does not,
+by itself, grow every published image — joining this default is a separate,
+deliberate decision per provider (see OpenHands/software-agent-sdk#4820)."""
+
+
+def render_docker_install_plan(
+    keys: Iterable[str],
+    catalog: Mapping[str, ACPInstallSpec] = ACP_INSTALL_CATALOG,
+) -> tuple[list[str], list[str]]:
+    """Resolve provider ``keys`` to (npm packages, wrapper bin names).
+
+    Packages are deduplicated (first-seen order preserved) so two providers
+    sharing a dependency only install it once. Raises :class:`ValueError`
+    listing the valid keys when ``keys`` contains one not in ``catalog``.
+    """
+    packages: list[str] = []
+    wrapper_bins: list[str] = []
+    seen: set[str] = set()
+    for key in keys:
+        spec = catalog.get(key)
+        if spec is None:
+            valid = ", ".join(catalog)
+            raise ValueError(
+                f"Unknown ACP provider {key!r} in INSTALL_ACP_PROVIDERS "
+                f"(expected one of: {valid})"
+            )
+        for pkg in spec.packages:
+            if pkg.pinned not in seen:
+                seen.add(pkg.pinned)
+                packages.append(pkg.pinned)
+        wrapper_bins.append(spec.binary_name)
+    return packages, wrapper_bins
+
+
+def _main(argv: list[str] | None = None) -> int:
+    """CLI entry point used by the Dockerfile's ``acp-providers`` build stage.
+
+    Prints a shell-``eval``-able plan (``PACKAGES=...`` / ``WRAPPER_BINS=...``)
+    for the comma-separated provider keys in ``providers`` (empty string installs
+    none).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "providers", help="Comma-separated ACP provider keys, or '' for none."
+    )
+    args = parser.parse_args(argv)
+    keys = [k for k in (p.strip() for p in args.providers.split(",")) if k]
+    try:
+        packages, wrapper_bins = render_docker_install_plan(keys)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print("PACKAGES=" + " ".join(packages))
+    print("WRAPPER_BINS=" + " ".join(wrapper_bins))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -40,6 +40,13 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from openhands.sdk.settings.acp_install_catalog import (
+    ACP_INSTALL_CATALOG,
+    CLAUDE_AGENT_ACP_VERSION as CLAUDE_AGENT_ACP_VERSION,
+    CODEX_ACP_VERSION as CODEX_ACP_VERSION,
+    GEMINI_CLI_VERSION as GEMINI_CLI_VERSION,
+)
+
 
 @dataclass(frozen=True)
 class ACPModelOption:
@@ -378,21 +385,16 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 )
 
 
-# Pinned npm versions for the built-in ACP launchers. Keep in sync with the
-# `npm install -g` line in
-# openhands-agent-server/openhands/agent_server/docker/Dockerfile — a bump must
-# edit both. The pin constrains the native (no pre-installed binary) path, where
-# the bare `npx -y <pkg>` would otherwise resolve npm `latest` at launch under a
-# permission-disabling session mode. In the image the binary rewrite in
-# `ACPAgentSettings.resolve_acp_command` runs the pinned `binary_name` instead,
-# so the `@version` suffix is a no-op there.
+# Pinned npm package/version and CLI-invocation shape for each built-in
+# launcher now lives in ACP_INSTALL_CATALOG (openhands.sdk.settings.
+# acp_install_catalog) — a dependency-free module also consumed directly by
+# the agent-server Dockerfile's `acp-providers` build stage. A version bump
+# only needs to happen there; `default_command`/`binary_name` below are
+# derived from it so both stay in sync automatically.
 #
 # claude-agent-acp 0.44+ / codex-acp select the model via a ``model``
 # ``configOptions`` entry (and retain the legacy ``session/set_model``
 # extension); the SDK detects which mechanism each session advertises.
-CLAUDE_AGENT_ACP_VERSION = "0.63.0"
-CODEX_ACP_VERSION = "1.1.7"
-GEMINI_CLI_VERSION = "0.46.0"
 
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
@@ -400,12 +402,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "claude-code": ACPProviderInfo(
             key="claude-code",
             display_name="Claude Code",
-            default_command=(
-                "npx",
-                "-y",
-                "--prefer-offline",
-                f"@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
-            ),
+            default_command=ACP_INSTALL_CATALOG["claude-code"].npx_command(),
             api_key_env_var="ANTHROPIC_API_KEY",
             base_url_env_var="ANTHROPIC_BASE_URL",
             default_session_mode="bypassPermissions",
@@ -424,18 +421,13 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             available_models=_CLAUDE_MODELS,
             # The CLI's own default (model configOptions ``currentValue``).
             default_model="opus[1m]",
-            binary_name="claude-agent-acp",
+            binary_name=ACP_INSTALL_CATALOG["claude-code"].binary_name,
             data_dir_env_var="CLAUDE_CONFIG_DIR",
         ),
         "codex": ACPProviderInfo(
             key="codex",
             display_name="Codex",
-            default_command=(
-                "npx",
-                "-y",
-                "--prefer-offline",
-                f"@agentclientprotocol/codex-acp@{CODEX_ACP_VERSION}",
-            ),
+            default_command=ACP_INSTALL_CATALOG["codex"].npx_command(),
             api_key_env_var="OPENAI_API_KEY",
             base_url_env_var="OPENAI_BASE_URL",
             default_session_mode="agent-full-access",
@@ -446,19 +438,13 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             available_models=_CODEX_MODELS,
             default_model="gpt-5.5",
             file_secrets=_CODEX_FILE_SECRETS,
-            binary_name="codex-acp",
+            binary_name=ACP_INSTALL_CATALOG["codex"].binary_name,
             data_dir_env_var="CODEX_HOME",
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
             display_name="Gemini CLI",
-            default_command=(
-                "npx",
-                "-y",
-                "--prefer-offline",
-                f"@google/gemini-cli@{GEMINI_CLI_VERSION}",
-                "--acp",
-            ),
+            default_command=ACP_INSTALL_CATALOG["gemini-cli"].npx_command(),
             api_key_env_var="GEMINI_API_KEY",
             base_url_env_var="GEMINI_BASE_URL",
             # gemini-cli 0.46.0 rejects ``set_session_mode("yolo")`` at session
@@ -478,7 +464,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # 0.46.0 ``availableModels``.
             default_model="auto",
             file_secrets=_GEMINI_FILE_SECRETS,
-            binary_name="gemini",
+            binary_name=ACP_INSTALL_CATALOG["gemini-cli"].binary_name,
             # Gemini CLI has no dedicated config-dir var; it hard-codes
             # ``~/.gemini`` (ignoring XDG), so only HOME relocates its state.
             data_dir_env_var="HOME",

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -889,6 +889,66 @@ def test_base_image_target_uses_real_build_context(
     assert mock_make_context.called == expect_real_context
 
 
+def test_base_image_minimal_stages_acp_install_catalog_without_full_context(
+    tmp_path: Path,
+):
+    """base-image-minimal's empty-context fast path must still stage the
+    dependency-free ACP install catalog the Dockerfile's acp-providers stage
+    COPies in — at the same relative path a real sdist-extracted context
+    would use — without falling back to the expensive full SDK build context.
+    """
+    from openhands.agent_server.docker.build import (
+        _ACP_INSTALL_CATALOG_RELPATH,
+        BuildOptions,
+        _default_sdk_project_root,
+        build,
+    )
+
+    fake_ctx = tmp_path / "base-ctx"
+
+    def fake_run(cmd, cwd=None):
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    sdk_project_root = _default_sdk_project_root()
+    opts = BuildOptions(
+        base_image="python:3.12",
+        custom_tags="python",
+        target="base-image-minimal",
+        git_sha="abc1234567890",
+        git_ref="refs/heads/main",
+        push=False,
+        sdk_project_root=sdk_project_root,
+    )
+
+    with (
+        patch(
+            "openhands.agent_server.docker.build.tempfile.mkdtemp",
+            return_value=str(fake_ctx),
+        ),
+        patch(
+            "openhands.agent_server.docker.build._make_build_context"
+        ) as mock_make_context,
+        patch("openhands.agent_server.docker.build._run", side_effect=fake_run),
+        patch(
+            "openhands.agent_server.docker.build._active_buildx_driver",
+            return_value="docker-container",
+        ),
+        patch(
+            "openhands.agent_server.docker.build._default_local_cache_dir",
+            return_value=tmp_path / "cache",
+        ),
+        patch("openhands.agent_server.docker.build.shutil.rmtree"),
+    ):
+        fake_ctx.mkdir()
+        build(opts)
+
+    assert not mock_make_context.called
+    staged = fake_ctx / _ACP_INSTALL_CATALOG_RELPATH
+    assert staged.read_text() == (
+        (sdk_project_root / _ACP_INSTALL_CATALOG_RELPATH).read_text()
+    )
+
+
 def test_build_with_prebuilt_sdist_preserves_tags_and_docker_args(tmp_path: Path):
     from openhands.agent_server.docker.build import (
         BuildOptions,

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -1,10 +1,9 @@
 import re
 from pathlib import Path
 
-from openhands.sdk.settings.acp_providers import (
-    CLAUDE_AGENT_ACP_VERSION,
-    CODEX_ACP_VERSION,
-    GEMINI_CLI_VERSION,
+from openhands.sdk.settings.acp_install_catalog import (
+    ACP_INSTALL_CATALOG,
+    DEFAULT_PREINSTALLED_ACP_PROVIDERS,
 )
 
 
@@ -25,17 +24,14 @@ AGENT_SERVER_SPEC = (
     / "agent_server"
     / "agent-server.spec"
 )
-
-_DOCKERFILE_ACP_PACKAGE = re.compile(
-    r'^\s*(?P<key>[\w-]+)\) PACKAGES="\$PACKAGES '
-    r'(?P<package>@[^@\s]+)@(?P<version>[^\s";]+)";',
-    re.MULTILINE,
+ACP_INSTALL_CATALOG_PY = (
+    REPO_ROOT
+    / "openhands-sdk"
+    / "openhands"
+    / "sdk"
+    / "settings"
+    / "acp_install_catalog.py"
 )
-_REGISTRY_ACP_PACKAGES = {
-    "claude-code": ("@agentclientprotocol/claude-agent-acp", CLAUDE_AGENT_ACP_VERSION),
-    "codex": ("@agentclientprotocol/codex-acp", CODEX_ACP_VERSION),
-    "gemini-cli": ("@google/gemini-cli", GEMINI_CLI_VERSION),
-}
 
 
 def test_server_workflow_passes_git_metadata_build_args() -> None:
@@ -117,33 +113,56 @@ def test_agent_server_binary_copies_openhands_distribution_metadata() -> None:
         assert f'*copy_metadata("{distribution}")' in spec_text
 
 
-def test_agent_server_dockerfile_acp_package_versions_match_registry() -> None:
+def test_agent_server_dockerfile_has_no_hardcoded_acp_packages() -> None:
+    """The acp-providers stage must resolve packages/versions from the
+    dependency-free catalog at build time, not from Dockerfile-baked arms.
+    """
     dockerfile_text = AGENT_SERVER_DOCKERFILE.read_text(encoding="utf-8")
-    case_arms = dockerfile_text.partition('case "$provider" in')[2].partition("esac")[0]
-    dockerfile_packages = list(_DOCKERFILE_ACP_PACKAGE.finditer(case_arms))
+    acp_stage = dockerfile_text.partition("FROM python:3.13-bookworm AS acp-providers")[
+        2
+    ].partition("####")[0]
 
-    assert dockerfile_packages, (
-        f"No ACP package versions found in {AGENT_SERVER_DOCKERFILE} "
-        "INSTALL_ACP_PROVIDERS case arms"
+    assert 'case "$provider"' not in acp_stage, (
+        "acp-providers stage should no longer branch on a hardcoded provider-key list"
     )
+    for spec in ACP_INSTALL_CATALOG.values():
+        for pkg in spec.packages:
+            assert pkg.pinned not in acp_stage, (
+                f"{AGENT_SERVER_DOCKERFILE}: found hardcoded package pin "
+                f"{pkg.pinned!r} in the acp-providers stage; it should come "
+                "from acp_install_catalog.py at build time instead"
+            )
 
-    for match in dockerfile_packages:
-        provider_key = match["key"]
-        registry_package = _REGISTRY_ACP_PACKAGES.get(provider_key)
-        if registry_package is None:
-            continue
-        expected_package, expected_version = registry_package
-        dockerfile_package = match["package"]
-        dockerfile_version = match["version"]
 
-        assert dockerfile_package == expected_package, (
-            f"{AGENT_SERVER_DOCKERFILE}: ACP provider {provider_key!r} uses package "
-            f"{dockerfile_package}, but acp_providers.py uses {expected_package}"
-        )
-        assert dockerfile_version == expected_version, (
-            f"{AGENT_SERVER_DOCKERFILE}: ACP package {dockerfile_package} has version "
-            f"{dockerfile_version}, but acp_providers.py pins {expected_version}"
-        )
+def test_agent_server_dockerfile_acp_stage_uses_install_catalog() -> None:
+    dockerfile_text = AGENT_SERVER_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert (
+        "COPY openhands-sdk/openhands/sdk/settings/acp_install_catalog.py "
+        "/tmp/acp_install_catalog.py" in dockerfile_text
+    )
+    assert "python3 /tmp/acp_install_catalog.py" in dockerfile_text
+    # The COPY path above is relative to the build context root; confirm it
+    # actually resolves, matching the relpath build.py stages for the
+    # empty-context `base-image-minimal` fast path.
+    assert ACP_INSTALL_CATALOG_PY.is_file()
+
+
+def test_default_preinstalled_acp_providers_matches_dockerfile_and_workflow() -> None:
+    """DEFAULT_PREINSTALLED_ACP_PROVIDERS is the single source for the
+    default `INSTALL_ACP_PROVIDERS` value baked into the Dockerfile ARG and
+    the server workflow's non-dispatch default; both are plain text (a
+    Dockerfile/workflow can't import Python), so this guards them from
+    drifting apart.
+    """
+    default_csv = ",".join(DEFAULT_PREINSTALLED_ACP_PROVIDERS)
+    assert default_csv == "claude-code,codex,gemini-cli"
+
+    dockerfile_text = AGENT_SERVER_DOCKERFILE.read_text(encoding="utf-8")
+    assert f"ARG INSTALL_ACP_PROVIDERS={default_csv}" in dockerfile_text
+
+    workflow_text = SERVER_WORKFLOW.read_text(encoding="utf-8")
+    assert f"'{default_csv}'" in workflow_text
 
 
 def test_server_workflow_publishes_python_slim_without_acp_providers() -> None:

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -173,17 +174,17 @@ class TestACPInstallCatalogCLI:
         assert code == 0
         out = capsys.readouterr().out
         assert out.splitlines() == [
-            "PACKAGES=@agentclientprotocol/claude-agent-acp@"
+            'PACKAGES="@agentclientprotocol/claude-agent-acp@'
             f"{CLAUDE_AGENT_ACP_VERSION} @agentclientprotocol/codex-acp@"
-            f"{CODEX_ACP_VERSION}",
-            "WRAPPER_BINS=claude-agent-acp codex-acp",
+            f'{CODEX_ACP_VERSION}"',
+            'WRAPPER_BINS="claude-agent-acp codex-acp"',
         ]
 
     def test_empty_string_installs_nothing(self, capsys):
         code = _main([""])
         assert code == 0
         out = capsys.readouterr().out
-        assert out.splitlines() == ["PACKAGES=", "WRAPPER_BINS="]
+        assert out.splitlines() == ['PACKAGES=""', 'WRAPPER_BINS=""']
 
     def test_unknown_provider_fails_clearly(self, capsys):
         code = _main(["bogus"])
@@ -204,6 +205,33 @@ class TestACPInstallCatalogCLI:
         )
         assert result.returncode == 0, result.stderr
         assert result.stdout.splitlines() == [
-            f"PACKAGES=@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
-            "WRAPPER_BINS=claude-agent-acp",
+            f'PACKAGES="@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}"',
+            'WRAPPER_BINS="claude-agent-acp"',
+        ]
+
+    def test_output_survives_a_real_shell_eval_multi_package(self):
+        """Regression test for the exact bug the Dockerfile hit: `eval`
+        re-tokenizes its argument on whitespace, so an unquoted multi-word
+        `PACKAGES=a b c` parses as "assign PACKAGES=a, then run command b
+        with arg c" (exit 127), not one space-separated assignment. Runs the
+        CLI's real stdout through `sh -c 'eval "$PLAN"; ...'`, exactly like
+        the Dockerfile's `PLAN=$(...) || exit 1; eval "$PLAN"`.
+        """
+        plan = subprocess.run(
+            [sys.executable, "-S", CATALOG_PY, "claude-code,codex,gemini-cli"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        result = subprocess.run(
+            ["sh", "-c", 'eval "$PLAN"; echo "$PACKAGES"; echo "$WRAPPER_BINS"'],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PLAN": plan},
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.splitlines() == [
+            f"@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION} "
+            f"@agentclientprotocol/codex-acp@{CODEX_ACP_VERSION} "
+            f"@google/gemini-cli@{GEMINI_CLI_VERSION}",
+            "claude-agent-acp codex-acp gemini",
         ]

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -1,0 +1,209 @@
+"""Tests for the dependency-free ACP npm installation catalog."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from openhands.sdk.settings.acp_install_catalog import (
+    ACP_INSTALL_CATALOG,
+    CLAUDE_AGENT_ACP_VERSION,
+    CODEX_ACP_VERSION,
+    DEFAULT_PREINSTALLED_ACP_PROVIDERS,
+    GEMINI_CLI_VERSION,
+    ACPInstallSpec,
+    ACPPackagePin,
+    _main,
+    render_docker_install_plan,
+)
+from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+
+
+CATALOG_PY = __import__(
+    "openhands.sdk.settings.acp_install_catalog", fromlist=["__file__"]
+).__file__
+
+
+class TestACPPackagePin:
+    def test_pinned_is_name_at_version(self):
+        pin = ACPPackagePin(name="@scope/pkg", version="1.2.3")
+        assert pin.pinned == "@scope/pkg@1.2.3"
+
+    def test_is_frozen(self):
+        pin = ACPPackagePin(name="pkg", version="1.0.0")
+        with pytest.raises((AttributeError, TypeError)):
+            pin.version = "2.0.0"  # type: ignore[misc]
+
+
+class TestACPInstallSpecNpxCommand:
+    def test_single_package_no_trailing_args(self):
+        spec = ACPInstallSpec(
+            key="codex",
+            packages=(ACPPackagePin("@agentclientprotocol/codex-acp", "1.1.7"),),
+            binary_name="codex-acp",
+        )
+        assert spec.npx_command() == (
+            "npx",
+            "-y",
+            "--prefer-offline",
+            "@agentclientprotocol/codex-acp@1.1.7",
+        )
+
+    def test_single_package_with_trailing_args(self):
+        spec = ACPInstallSpec(
+            key="gemini-cli",
+            packages=(ACPPackagePin("@google/gemini-cli", "0.46.0"),),
+            binary_name="gemini",
+            trailing_args=("--acp",),
+        )
+        assert spec.npx_command() == (
+            "npx",
+            "-y",
+            "--prefer-offline",
+            "@google/gemini-cli@0.46.0",
+            "--acp",
+        )
+
+    def test_multi_package_uses_package_flags_and_entry_binary(self):
+        # Mirrors the shape Pi needs: an ACP adapter plus its engine package,
+        # both pinned, with the adapter's bin invoked positionally.
+        spec = ACPInstallSpec(
+            key="pi",
+            packages=(
+                ACPPackagePin("pi-acp", "0.1.0"),
+                ACPPackagePin("@earendil-works/pi-coding-agent", "0.2.0"),
+            ),
+            binary_name="pi-acp",
+        )
+        assert spec.npx_command() == (
+            "npx",
+            "-y",
+            "--prefer-offline",
+            "--package=pi-acp@0.1.0",
+            "--package=@earendil-works/pi-coding-agent@0.2.0",
+            "pi-acp",
+        )
+
+
+class TestACPInstallCatalogMatchesACPProviders:
+    """ACP_PROVIDERS derives default_command/binary_name from this catalog;
+    verify the two stay in lockstep for every npm-installable provider."""
+
+    def test_catalog_keys_match_registered_npm_providers(self):
+        assert set(ACP_INSTALL_CATALOG) == set(ACP_PROVIDERS)
+
+    def test_default_commands_are_derived_from_catalog(self):
+        for key, info in ACP_PROVIDERS.items():
+            assert info.default_command == ACP_INSTALL_CATALOG[key].npx_command()
+
+    def test_binary_names_are_derived_from_catalog(self):
+        for key, info in ACP_PROVIDERS.items():
+            assert info.binary_name == ACP_INSTALL_CATALOG[key].binary_name
+
+    def test_pinned_versions_unchanged(self):
+        assert CLAUDE_AGENT_ACP_VERSION == "0.63.0"
+        assert CODEX_ACP_VERSION == "1.1.7"
+        assert GEMINI_CLI_VERSION == "0.46.0"
+
+
+class TestDefaultPreinstalledACPProviders:
+    def test_preserves_todays_default_image_contents(self):
+        assert DEFAULT_PREINSTALLED_ACP_PROVIDERS == (
+            "claude-code",
+            "codex",
+            "gemini-cli",
+        )
+
+    def test_every_default_provider_is_in_the_catalog(self):
+        for key in DEFAULT_PREINSTALLED_ACP_PROVIDERS:
+            assert key in ACP_INSTALL_CATALOG
+
+
+class TestRenderDockerInstallPlan:
+    def test_default_set(self):
+        packages, wrapper_bins = render_docker_install_plan(
+            DEFAULT_PREINSTALLED_ACP_PROVIDERS
+        )
+        assert packages == [
+            f"@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
+            f"@agentclientprotocol/codex-acp@{CODEX_ACP_VERSION}",
+            f"@google/gemini-cli@{GEMINI_CLI_VERSION}",
+        ]
+        assert wrapper_bins == ["claude-agent-acp", "codex-acp", "gemini"]
+
+    def test_empty_selection_installs_nothing(self):
+        assert render_docker_install_plan([]) == ([], [])
+
+    def test_subset_selection(self):
+        packages, wrapper_bins = render_docker_install_plan(["codex"])
+        assert packages == [f"@agentclientprotocol/codex-acp@{CODEX_ACP_VERSION}"]
+        assert wrapper_bins == ["codex-acp"]
+
+    def test_unknown_key_raises_with_valid_keys_listed(self):
+        with pytest.raises(ValueError, match="bogus") as exc_info:
+            render_docker_install_plan(["codex", "bogus"])
+        message = str(exc_info.value)
+        assert "claude-code" in message
+        assert "codex" in message
+        assert "gemini-cli" in message
+
+    def test_dedupes_shared_packages_preserving_first_seen_order(self):
+        shared = ACPPackagePin("@acme/shared-engine", "9.9.9")
+        catalog = {
+            "a": ACPInstallSpec(key="a", packages=(shared,), binary_name="a-bin"),
+            "b": ACPInstallSpec(
+                key="b",
+                packages=(ACPPackagePin("@acme/b-only", "1.0.0"), shared),
+                binary_name="b-bin",
+            ),
+        }
+        packages, wrapper_bins = render_docker_install_plan(["a", "b"], catalog=catalog)
+        assert packages == ["@acme/shared-engine@9.9.9", "@acme/b-only@1.0.0"]
+        assert wrapper_bins == ["a-bin", "b-bin"]
+
+
+class TestACPInstallCatalogCLI:
+    """The Dockerfile's acp-providers stage COPies this module in and runs it
+    directly with the system python3 — exercise that exact entry point."""
+
+    def test_prints_shell_eval_able_plan(self, capsys):
+        code = _main(["claude-code,codex"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert out.splitlines() == [
+            "PACKAGES=@agentclientprotocol/claude-agent-acp@"
+            f"{CLAUDE_AGENT_ACP_VERSION} @agentclientprotocol/codex-acp@"
+            f"{CODEX_ACP_VERSION}",
+            "WRAPPER_BINS=claude-agent-acp codex-acp",
+        ]
+
+    def test_empty_string_installs_nothing(self, capsys):
+        code = _main([""])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert out.splitlines() == ["PACKAGES=", "WRAPPER_BINS="]
+
+    def test_unknown_provider_fails_clearly(self, capsys):
+        code = _main(["bogus"])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "bogus" in err
+
+    def test_runs_standalone_with_no_dependencies(self):
+        """Regression guard for the Dockerfile's `python3 <file> ...`
+        invocation: this must work with nothing but the stdlib on
+        sys.path, since the acp-providers stage is a bare python image
+        with no OpenHands package (or pydantic) installed.
+        """
+        result = subprocess.run(
+            [sys.executable, "-S", CATALOG_PY, "claude-code"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.splitlines() == [
+            f"PACKAGES=@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
+            "WRAPPER_BINS=claude-agent-acp",
+        ]

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -109,6 +109,45 @@ class TestACPInstallCatalogMatchesACPProviders:
         assert GEMINI_CLI_VERSION == "0.46.0"
 
 
+# Single-package providers whose CLI binary name deliberately differs from
+# their npm package's basename. Keeps a real, permanent mismatch (rather than
+# a typo) from being confused with the general rule below.
+_BINARY_NAME_BASENAME_EXEMPTIONS = {
+    # @google/gemini-cli's bin is "gemini", not the package basename
+    # "gemini-cli".
+    "gemini-cli",
+}
+
+
+class TestBinaryNameMatchesPackageBasename:
+    """For a single-package provider, `npx -y <pkg>@<ver>` resolves the
+    package's OWN bin — so binary_name (the pre-installed wrapper the image
+    ships and resolve_acp_command() rewrites to) should normally just be that
+    package's basename, unless explicitly exempted. Multi-package specs are
+    exempt by construction: binary_name there is the entry command npx is
+    told to run, independent of any one package's own name."""
+
+    def test_binary_name_is_package_basename_or_exempted(self):
+        for key, spec in ACP_INSTALL_CATALOG.items():
+            if len(spec.packages) != 1:
+                continue
+            basename = spec.packages[0].name.rsplit("/", 1)[-1]
+            if key in _BINARY_NAME_BASENAME_EXEMPTIONS:
+                assert spec.binary_name != basename, (
+                    f"{key}: binary_name now matches the package basename "
+                    "— remove it from _BINARY_NAME_BASENAME_EXEMPTIONS"
+                )
+            else:
+                assert spec.binary_name == basename, (
+                    f"{key}: binary_name {spec.binary_name!r} does not match "
+                    f"package basename {basename!r}; add it to "
+                    "_BINARY_NAME_BASENAME_EXEMPTIONS if intentional"
+                )
+
+    def test_every_exemption_is_a_real_catalog_key(self):
+        assert _BINARY_NAME_BASENAME_EXEMPTIONS <= set(ACP_INSTALL_CATALOG)
+
+
 class TestDefaultPreinstalledACPProviders:
     def test_preserves_todays_default_image_contents(self):
         assert DEFAULT_PREINSTALLED_ACP_PROVIDERS == (

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
+from typing import get_args
 
 import pytest
 
@@ -15,6 +16,7 @@ from openhands.sdk.settings.acp_providers import (
     detect_acp_provider_by_command,
     get_acp_provider,
 )
+from openhands.sdk.settings.model import ACPServerKind
 
 
 class TestACPProviderInfo:
@@ -158,8 +160,9 @@ class TestDetectACPProviderByCommand:
     def test_detects_each_provider_from_default_command(self):
         for key, info in ACP_PROVIDERS.items():
             detected = detect_acp_provider_by_command(list(info.default_command))
-            assert detected is not None, key
-            assert detected.key == key
+            # Identity, not just a matching key: detect_acp_provider_by_command
+            # must resolve back to the very same ACP_PROVIDERS entry.
+            assert detected is info, key
 
     def test_tolerates_version_pin(self):
         info = detect_acp_provider_by_command(
@@ -228,6 +231,14 @@ class TestProviderRegistryConsistency:
                 assert detected.key == key, (
                     f"pattern {pattern!r} matched {detected.key!r}, expected {key!r}"
                 )
+
+    def test_acp_server_kind_matches_registry_keys(self):
+        # ACPServerKind (the ACPAgentSettings.acp_server discriminator) is a
+        # hand-maintained Literal, not derived from ACP_PROVIDERS — a provider
+        # added to one without the other would either be unselectable via
+        # settings (Literal missing it) or unrecognized at runtime (registry
+        # missing it). "custom" is the one non-registry value it also accepts.
+        assert set(get_args(ACPServerKind)) == set(ACP_PROVIDERS) | {"custom"}
 
 
 class TestProviderModelLists:
@@ -331,6 +342,15 @@ class TestACPFileSecrets:
             ACP_PROVIDERS["codex"].file_secrets
             + ACP_PROVIDERS["gemini-cli"].file_secrets
         )
+
+    def test_file_secret_subdirs_are_unique_across_providers(self):
+        # Each spec's subdir is a folder under the shared per-conversation
+        # acp/ root (see ACPFileSecretSpec.subdir); a collision would let two
+        # providers' credential files overwrite each other.
+        subdirs = [
+            spec.subdir for info in ACP_PROVIDERS.values() for spec in info.file_secrets
+        ]
+        assert len(subdirs) == len(set(subdirs)), subdirs
 
     def test_file_secret_spec_is_frozen(self):
         from pydantic import ValidationError


### PR DESCRIPTION
HUMAN:

Landing this ahead of the open Kimi/OpenCode/Pi provider PRs so they build on the shared catalog from the start.

---

AGENT:

## Why

ACP npm installation data (package names, pinned versions, executable/args) was repeated across `acp_providers.py`, the agent-server Dockerfile's shell case-arms, `_REGISTRY_ACP_PACKAGES` in the cross-repo test, and the TypeScript mirror. Each provider addition (Kimi #4714, OpenCode #4827, Pi #4419) had to touch the same values in several places, and Pi's two independently-pinned packages didn't fit the one-provider/one-package shape at all.

## Summary

- Add `ACP_INSTALL_CATALOG` (`openhands-sdk/openhands/sdk/settings/acp_install_catalog.py`), a small **dependency-free** (stdlib-only) catalog of each built-in provider's pinned npm package(s), CLI entry point and launch arguments. Supports one or more packages per provider via `ACPInstallSpec.npx_command()`.
- `ACP_PROVIDERS` now derives `default_command`/`binary_name` from this catalog instead of duplicating npx command construction; the three pinned version constants (`CLAUDE_AGENT_ACP_VERSION`, `CODEX_ACP_VERSION`, `GEMINI_CLI_VERSION`) now live in the catalog and are re-exported unchanged.
- The agent-server Dockerfile's `acp-providers` stage `COPY`s the catalog file in (it's dependency-free, so it runs with the bare stage's system `python3`, no pip install) and calls it directly to resolve `INSTALL_ACP_PROVIDERS` into an install plan — replacing the hardcoded shell `case` arms, package versions, and provider-key list. Adding an npm provider is now a catalog-only edit.
- `build.py`'s empty-build-context fast path for `base-image-minimal` stages just this one small file (at the same relative path the real sdist context uses) instead of pulling in the whole SDK source, so that fast path stays fast.
- `DEFAULT_PREINSTALLED_ACP_PROVIDERS = ("claude-code", "codex", "gemini-cli")` separates "registered/selectable" from "baked into the default image," preserving today's default image contents exactly.
- `check-acp-drift.py` gained `--write` to regenerate the committed TypeScript mirror from `ACP_PROVIDERS` deterministically; ran it once to reformat `acp-providers.json` into canonical (sorted-key) form — values are unchanged.
- Removed the regex-based `test_agent_server_dockerfile_acp_package_versions_match_registry` (parsed the now-deleted shell arms) and `_REGISTRY_ACP_PACKAGES`; added catalog/plan/Dockerfile-shape tests instead.
- Hardened four registry invariants flagged in #4830 that this PR's diff directly touches or supersedes (same "loop the registry, don't enumerate" spirit as the rest of this PR): `detect_acp_provider_by_command(default_command) is info` (identity, not just key equality); `file_secrets[*].subdir` uniqueness across *all* providers, not just per-provider; `ACPServerKind`'s `Literal` args equal `set(ACP_PROVIDERS) | {"custom"}` (it was a hand-maintained duplicate of the registry keys); and `binary_name` matches its pinned package's basename or is on an explicit exemption list (gemini-cli's real mismatch: package `@google/gemini-cli`, bin `gemini`). #4830's other items are cross-repo or unrelated to this diff and are left for that issue's own PR.

## Issue Number

Fixes #4828

## How to Test

- `uv run pytest tests/sdk/settings/test_acp_install_catalog.py tests/sdk/settings/test_acp_providers.py tests/agent_server/test_docker_build.py tests/cross/test_agent_server_build_metadata.py -q` — all pass, including new tests for `npx_command()` shapes (single package, package + trailing args, multi-package via `--package=`), `render_docker_install_plan` (default/subset/empty/unknown/dedup), the catalog's standalone-stdlib CLI (`python3 -S acp_install_catalog.py ...`, matching exactly how the Dockerfile invokes it), and that `base-image-minimal`'s empty-context path stages the catalog file without pulling in the full SDK source.
- Same command, updated: 143 tests pass across those four files, including the #4830 hardening tests above and a regression test that pipes the install-catalog CLI's real stdout through `sh -c 'eval "$PLAN"; ...'` — this is what caught a real CI failure (`eval` re-tokenizing an unquoted multi-package line as "assign PACKAGES=a, then run command b", exit 127) that a plain string-equality test on the printed output had missed; fixed by quoting the CLI's output.
- Full repo test suite (`uv run pytest tests/ -q`): 2609 passed.
- `uv run --package openhands-sdk python clients/typescript/scripts/check-acp-drift.py` — clean (no drift after `--write`).
- Verified `ACP_PROVIDERS[key].default_command`/`.binary_name` are byte-identical to the pre-refactor hardcoded values for all three providers (no behavior change).
- **Real end-to-end validation with local ACP credentials** (not just unit tests): ran `ACPAgent` with `acp_command=list(ACP_PROVIDERS[key].default_command)` — i.e. the exact catalog-derived command — against the real ACP servers using my local machine's stored credentials:
  - `claude-code`: launched `npx -y --prefer-offline @agentclientprotocol/claude-agent-acp@0.63.0`, sent a real message, got a correct reply, cost reported ($0.2501).
  - `codex`: launched `npx -y --prefer-offline @agentclientprotocol/codex-acp@1.1.7`, authenticated via local ChatGPT auth, sent a real message, got a correct reply.
  - `gemini-cli`: launched successfully (correct pinned command) but the request failed with a **Google-side** error ("This client is no longer supported for Gemini Code Assist for individuals... migrate to Antigravity") — this is the known, unrelated deprecation of personal Gemini OAuth, not a regression from this change.
  - Lint/type-check: `ruff check`/`ruff format --check`/`pyright`/`pycodestyle`/import-rules/tool-registration pre-commit hooks all pass.

## Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Out of scope (per the issue): non-npm acquisition (#4823), Antigravity (#4624), Renovate config, lockfiles, npx-fallback changes, and unrelated image refactors. This is intended to land before the open Kimi (#4714), OpenCode (#4827) and Pi (#4419) provider PRs rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xRP31CknHViePcfbXDuQ

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:96dd9f5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-96dd9f5-python \
  ghcr.io/openhands/agent-server:96dd9f5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:96dd9f5-golang-amd64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-golang-amd64
ghcr.io/openhands/agent-server:acp-install-catalog-golang-amd64
ghcr.io/openhands/agent-server:96dd9f5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:96dd9f5-golang-arm64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-golang-arm64
ghcr.io/openhands/agent-server:acp-install-catalog-golang-arm64
ghcr.io/openhands/agent-server:96dd9f5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:96dd9f5-java-amd64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-java-amd64
ghcr.io/openhands/agent-server:acp-install-catalog-java-amd64
ghcr.io/openhands/agent-server:96dd9f5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:96dd9f5-java-arm64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-java-arm64
ghcr.io/openhands/agent-server:acp-install-catalog-java-arm64
ghcr.io/openhands/agent-server:96dd9f5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:96dd9f5-python-amd64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python-amd64
ghcr.io/openhands/agent-server:acp-install-catalog-python-amd64
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:96dd9f5-python-arm64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python-arm64
ghcr.io/openhands/agent-server:acp-install-catalog-python-arm64
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:96dd9f5-python-slim-amd64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python-slim-amd64
ghcr.io/openhands/agent-server:acp-install-catalog-python-slim-amd64
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:96dd9f5-python-slim-arm64
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python-slim-arm64
ghcr.io/openhands/agent-server:acp-install-catalog-python-slim-arm64
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:96dd9f5-golang
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-golang
ghcr.io/openhands/agent-server:acp-install-catalog-golang
ghcr.io/openhands/agent-server:96dd9f5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:96dd9f5-java
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-java
ghcr.io/openhands/agent-server:acp-install-catalog-java
ghcr.io/openhands/agent-server:96dd9f5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:96dd9f5-python-slim
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python-slim
ghcr.io/openhands/agent-server:acp-install-catalog-python-slim
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:96dd9f5-python
ghcr.io/openhands/agent-server:96dd9f5ab3e10649a58bf33de9650259ef22a567-python
ghcr.io/openhands/agent-server:acp-install-catalog-python
ghcr.io/openhands/agent-server:96dd9f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `96dd9f5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `96dd9f5-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
