### PR TITLE
test(acp): live conformance + model-acceptance probes for built-in providers (#4830 P0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,53 @@ jobs:
                   path: coverage-sdk.dat
                   if-no-files-found: warn
 
+    # Deliberately NOT a required status check: these tests launch real npx
+    # subprocesses and hit the live npm registry (see the `acp_live` marker
+    # and tests/sdk/agent/test_acp_conformance.py's docstring). sdk-tests IS
+    # required, so a registry blip must not be able to block unrelated PRs;
+    # this job carries that live-network risk instead, gated to only run
+    # when ACP registry/catalog files actually change (OpenHands/
+    # software-agent-sdk#4830 P0-1/2/3).
+    acp-live-tests:
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+              with: {fetch-depth: 0}
+
+            - name: Detect ACP registry/catalog changes
+              id: changed
+              uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+              with:
+                  files: |
+                      openhands-sdk/openhands/sdk/settings/acp_providers.py
+                      openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+                      tests/sdk/agent/test_acp_conformance.py
+                      tests/sdk/settings/test_acp_install_catalog_pins_live.py
+                      pyproject.toml
+                      uv.lock
+                      .github/workflows/tests.yml
+
+            - name: Install uv
+              if: steps.changed.outputs.any_changed == 'true'
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  enable-cache: true
+                  python-version: '3.13'
+
+            - name: Install deps
+              if: steps.changed.outputs.any_changed == 'true'
+              run: uv sync --frozen --group dev
+
+            - name: Run live ACP conformance + pin-installability tests
+              if: steps.changed.outputs.any_changed == 'true'
+              run: |
+                  CI=true uv run python -m pytest -vvs \
+                    -m acp_live \
+                    tests/sdk/agent/test_acp_conformance.py \
+                    tests/sdk/settings/test_acp_install_catalog_pins_live.py
+
     tools-tests:
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 15

--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -49,7 +49,7 @@ describe('ACP provider credential descriptors', () => {
     ]);
     expect(codex.default_session_mode).toBe('agent-full-access');
     expect(codex.available_models.map((model) => model.id)).toEqual(
-      expect.arrayContaining(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
+      expect.arrayContaining(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
     );
   });
 

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -51,10 +51,6 @@
     "api_key_env_var": "OPENAI_API_KEY",
     "available_models": [
       {
-        "id": "gpt-5.6",
-        "label": "GPT-5.6"
-      },
-      {
         "id": "gpt-5.6-sol",
         "label": "GPT-5.6 Sol"
       },
@@ -69,14 +65,6 @@
       {
         "id": "gpt-5.5",
         "label": "GPT-5.5"
-      },
-      {
-        "id": "gpt-5.4",
-        "label": "GPT-5.4"
-      },
-      {
-        "id": "gpt-5.4-mini",
-        "label": "GPT-5.4 Mini"
       }
     ],
     "base_url_env_var": "OPENAI_BASE_URL",

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -324,14 +324,16 @@ _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
 # separate ``reasoning_effort`` configOption, not part of the model id, so it is
 # not encoded here. GPT-5.6 variants are rollout/account-dependent suggestions;
 # the adapter's live model list remains authoritative.
+#
+# ``gpt-5.6`` (bare), ``gpt-5.4``, and ``gpt-5.4-mini`` are dead entries the
+# live server's ``set_config_option`` rejects with "Invalid params" (#4830
+# P0-2 model-acceptance probe caught this) and have been removed; only the
+# GPT-5.6 tier's suffixed variants are live.
 _CODEX_MODELS: tuple[ACPModelOption, ...] = (
-    ACPModelOption(id="gpt-5.6", label="GPT-5.6"),
     ACPModelOption(id="gpt-5.6-sol", label="GPT-5.6 Sol"),
     ACPModelOption(id="gpt-5.6-terra", label="GPT-5.6 Terra"),
     ACPModelOption(id="gpt-5.6-luna", label="GPT-5.6 Luna"),
     ACPModelOption(id="gpt-5.5", label="GPT-5.5"),
-    ACPModelOption(id="gpt-5.4", label="GPT-5.4"),
-    ACPModelOption(id="gpt-5.4-mini", label="GPT-5.4 Mini"),
 )
 
 # Model IDs accepted by ``@google/gemini-cli --acp``. Mirrors the

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"
 dependencies = [
-    "agent-client-protocol>=0.10.1",
+    "agent-client-protocol>=0.10.1,<0.11.0",  # 0.11.0 reordered prompt() args, broke the client (#4830)
     "deprecation>=2.1.0",
     "fakeredis[lua]>=2.32.1",  # Explicit dependency for docket/fastmcp background tasks
     "fastmcp>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,11 @@ testpaths = [
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short -m 'not stress'"
+addopts = "-v --tb=short -m 'not stress and not acp_live'"
 asyncio_mode = "auto"
 markers = [
     "stress: stress / scale tests, deselected by default. Run with `pytest -m stress` (see tests/agent_server/stress/__init__.py for details).",
+    "acp_live: live ACP conformance/pin-installability tests that launch real npx subprocesses and hit the npm registry, deselected by default. Run with `pytest -m acp_live` (see tests/sdk/agent/test_acp_conformance.py).",
 ]
 
 # Pyright configuration for PEP 420 namespace packages

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -131,7 +131,6 @@ def test_openai_subscription_models_endpoint_integration(client):
     assert response.status_code == 200
     data = response.json()
     assert data == {"vendor": "openai", "models": sorted(OPENAI_CODEX_MODELS)}
-    assert "gpt-5.6" in data["models"]
     assert "gpt-5.6-sol" in data["models"]
     assert "gpt-5.6-terra" in data["models"]
     assert "gpt-5.6-luna" in data["models"]

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -1,0 +1,257 @@
+"""Live, credential-free conformance probes for the built-in ACP providers.
+
+For each entry in ``ACP_PROVIDERS``, launches ``info.default_command``
+verbatim (through ``npx``) with a bogus credential and an isolated data dir,
+then asserts what the live server reports back rather than what the registry
+assumes it reports. Every historical drift this catches (#3772, #3654,
+#4629, #4812) was silent precisely because nothing read state back from the
+server — see OpenHands/software-agent-sdk#4830 P0-1/P0-2.
+
+No API key, subscription, or network credential is required: every built-in
+provider's handshake (initialize / authenticate / new_session /
+set_session_mode / model selection) succeeds with a syntactically-present but
+invalid key, which is what makes this suite safe to run unauthenticated in
+fork PRs. Needs ``npx`` (Node.js) and network access to the npm registry;
+skipped when unavailable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from acp.client.connection import ClientSideConnection
+from acp.exceptions import RequestError as ACPRequestError
+
+from openhands.sdk.agent.acp_agent import (
+    ACPAgent,
+    _apply_acp_model,
+    _select_auth_method,
+)
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.settings.acp_install_catalog import ACP_INSTALL_CATALOG
+from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+from openhands.sdk.utils.async_executor import AsyncExecutor
+from openhands.sdk.workspace.local import LocalWorkspace
+
+
+requires_npx = pytest.mark.skipif(
+    shutil.which("npx") is None, reason="npx (Node.js) not available"
+)
+
+# Syntactically valid-looking but non-functional credentials. Enough for each
+# provider's auth-method selection to pick an env-var-backed method and clear
+# the handshake; real inference would reject them, but no turn is ever sent.
+_BOGUS_KEY = "sk-acp-conformance-probe-0000000000000000000000000000"
+
+# Per-call deadline for the model-acceptance probe's set_config_option /
+# set_session_model round-trips — these are metadata writes, not inference
+# calls, so they should return in well under a second even cold.
+_MODEL_CALL_TIMEOUT = 15.0
+
+
+def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Give the probe its own HOME and bogus keys so it never touches host
+    credentials (subscription logins, real API keys) or a real proxy."""
+    isolated_home = tmp_path / "home"
+    isolated_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(isolated_home))
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+        "GEMINI_API_KEY",
+    ):
+        monkeypatch.setenv(var, _BOGUS_KEY)
+    for var in (
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_BASE_URL",
+        "GEMINI_BASE_URL",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "CODEX_HOME",
+        "CLAUDE_CONFIG_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _spy(monkeypatch: pytest.MonkeyPatch, obj: Any, name: str) -> dict[str, Any]:
+    """Wrap an async attribute of ``obj`` to record its args/return, while
+    still calling through to the real implementation."""
+    original = getattr(obj, name)
+    captured: dict[str, Any] = {}
+
+    async def _wrapped(*args, **kwargs):
+        result = await original(*args, **kwargs)
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        captured["result"] = result
+        return result
+
+    monkeypatch.setattr(obj, name, _wrapped)
+    return captured
+
+
+def _launch(agent: ACPAgent, tmp_path: Path) -> ConversationState:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    state = ConversationState.create(
+        id=uuid.uuid4(),
+        agent=agent,
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+    )
+    agent._executor = AsyncExecutor()
+    agent._start_acp_server(state)
+    return state
+
+
+@requires_npx
+@pytest.mark.parametrize("provider_key", list(ACP_PROVIDERS))
+def test_acp_conformance_probe(
+    provider_key: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = ACP_PROVIDERS[provider_key]
+    _isolate_env(monkeypatch, tmp_path)
+
+    init_captured = _spy(monkeypatch, ClientSideConnection, "initialize")
+    auth_method_calls: list[tuple[list[Any], str | None]] = []
+    original_select = _select_auth_method
+
+    def _spy_select_auth_method(auth_methods, env):
+        picked = original_select(auth_methods, env)
+        auth_method_calls.append((list(auth_methods), picked))
+        return picked
+
+    monkeypatch.setattr(
+        "openhands.sdk.agent.acp_agent._select_auth_method", _spy_select_auth_method
+    )
+
+    agent = ACPAgent(
+        acp_command=list(provider.default_command),
+        acp_server=provider.key,
+        acp_isolate_data_dir=True,
+        acp_model=provider.default_model,
+    )
+    start = time.monotonic()
+    try:
+        _launch(agent, tmp_path)
+        cold_start = time.monotonic() - start
+
+        init_response = init_captured["result"]
+        print(
+            f"[acp-conformance] provider={provider.key} "
+            f"cold_start={cold_start:.2f}s "
+            f"protocol_version={init_response.protocol_version}"
+        )
+        assert 0 < init_response.protocol_version < 65536
+
+        # agent_name matches agent_name_patterns.
+        assert agent.agent_name, "server did not report an agent name"
+        lowered_name = agent.agent_name.lower()
+        assert any(pat in lowered_name for pat in provider.agent_name_patterns), (
+            f"agent_name={agent.agent_name!r} does not match any pattern in "
+            f"{provider.agent_name_patterns!r} (upstream renamed the agent?)"
+        )
+
+        # agent_version equals the pin.
+        pinned_version = ACP_INSTALL_CATALOG[provider.key].packages[0].version
+        assert agent.agent_version == pinned_version, (
+            f"agent_version={agent.agent_version!r} != pinned {pinned_version!r} — "
+            "npx resolved a different version than default_command pins"
+        )
+
+        # authMethods contains what _select_auth_method picked. Some
+        # providers (claude-code, per #4830's baseline) require no auth
+        # handshake at all, in which case _select_auth_method is never
+        # called — only assert when the server actually offered methods.
+        offered_ids = {m.id for m in init_response.auth_methods or []}
+        if offered_ids:
+            assert auth_method_calls, (
+                f"server offered authMethods {sorted(offered_ids)!r} but "
+                "_select_auth_method was never invoked"
+            )
+            _, picked_method_id = auth_method_calls[0]
+            if picked_method_id is not None:
+                assert picked_method_id in offered_ids, (
+                    f"_select_auth_method picked {picked_method_id!r}, not "
+                    f"present in the server's own authMethods "
+                    f"{sorted(offered_ids)!r}"
+                )
+
+        # set_session_mode(default_session_mode) succeeded implicitly: a
+        # rejection raises inside _start_acp_server and _launch would have
+        # propagated before this line.
+
+        # The session advertised *some* model-selection mechanism, matching
+        # supports_set_session_model's premise that one exists.
+        if provider.supports_set_session_model:
+            assert agent._available_models is not None, (
+                f"provider={provider.key} claims supports_set_session_model "
+                "but the session response carried neither configOptions nor "
+                "the models capability"
+            )
+
+        # The model reads back as requested.
+        if provider.default_model:
+            assert agent.current_model_id == provider.default_model, (
+                f"requested default_model={provider.default_model!r} but the "
+                f"live session reports current_model_id={agent.current_model_id!r} "
+                "(the id may no longer be accepted — see the model-acceptance "
+                "probe below)"
+            )
+
+        # Mid-session set_model works when supports_runtime_model_switch.
+        if provider.supports_runtime_model_switch:
+            candidates = [
+                m.id
+                for m in provider.available_models
+                if m.id != agent.current_model_id
+            ]
+            if candidates:
+                target = candidates[0]
+                agent.set_acp_model(target)
+                assert agent.current_model_id == target, (
+                    f"set_acp_model({target!r}) reported success but "
+                    f"current_model_id is {agent.current_model_id!r}"
+                )
+
+        # Model-acceptance probe (#4830 P0-2): every curated available_models
+        # id and default_model must be *accepted* by the live protocol call,
+        # not merely appear in our own curated list.
+        session_id = agent._session_id
+        conn = agent._conn
+        assert session_id is not None
+        assert conn is not None
+        candidate_ids = list(
+            dict.fromkeys(
+                [m.id for m in provider.available_models]
+                + ([provider.default_model] if provider.default_model else [])
+            )
+        )
+        rejected: dict[str, str] = {}
+        for model_id in candidate_ids:
+            try:
+                agent._executor.run_async(
+                    _apply_acp_model(
+                        conn,
+                        session_id,
+                        model_id,
+                        agent_name=agent.agent_name,
+                        via_config_option=agent._model_via_config_option,
+                    ),
+                    timeout=_MODEL_CALL_TIMEOUT,
+                )
+            except (ACPRequestError, ValueError) as exc:
+                rejected[model_id] = str(exc)
+        assert not rejected, (
+            f"provider={provider.key} rejected curated model id(s) via the "
+            f"live protocol call (dead catalog entries — fix _CODEX_MODELS / "
+            f"_GEMINI_MODELS / _CLAUDE_MODELS or default_model in "
+            f"acp_providers.py): {rejected}"
+        )
+    finally:
+        agent.close()

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -18,6 +18,7 @@ skipped when unavailable.
 from __future__ import annotations
 
 import shutil
+import socket
 import time
 import uuid
 from pathlib import Path
@@ -39,8 +40,17 @@ from openhands.sdk.utils.async_executor import AsyncExecutor
 from openhands.sdk.workspace.local import LocalWorkspace
 
 
+def _npm_registry_reachable(timeout: float = 3.0) -> bool:
+    try:
+        socket.create_connection(("registry.npmjs.org", 443), timeout=timeout).close()
+        return True
+    except OSError:
+        return False
+
+
 requires_npx = pytest.mark.skipif(
-    shutil.which("npx") is None, reason="npx (Node.js) not available"
+    shutil.which("npx") is None or not _npm_registry_reachable(),
+    reason="npx (Node.js) not available, or npm registry unreachable",
 )
 
 # Syntactically valid-looking but non-functional credentials. Enough for each

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -13,6 +13,15 @@ set_session_mode / model selection) succeeds with a syntactically-present but
 invalid key, which is what makes this suite safe to run unauthenticated in
 fork PRs. Needs ``npx`` (Node.js) and network access to the npm registry;
 skipped when unavailable.
+
+Deselected from the default run via the ``acp_live`` marker (``addopts = -m
+'not stress and not acp_live'`` in pyproject.toml): the SDK's default test
+job is a *required* merge check, and an npm-registry blip or upstream ACP
+handshake hiccup — a real risk distinct from "registry unreachable," which
+the skip above already covers — must not be able to block unrelated PRs. Run
+explicitly with ``pytest -m acp_live``; CI runs it in the separate, non-
+required ``acp-live-tests`` job, gated on changes to ACP registry/catalog
+files (see ``.github/workflows/tests.yml``).
 """
 
 from __future__ import annotations
@@ -52,6 +61,8 @@ requires_npx = pytest.mark.skipif(
     shutil.which("npx") is None or not _npm_registry_reachable(),
     reason="npx (Node.js) not available, or npm registry unreachable",
 )
+
+pytestmark = pytest.mark.acp_live
 
 # Syntactically valid-looking but non-functional credentials. Enough for each
 # provider's auth-method selection to pick an env-var-backed method and clear

--- a/tests/sdk/llm/auth/test_openai.py
+++ b/tests/sdk/llm/auth/test_openai.py
@@ -180,7 +180,7 @@ def test_openai_subscription_auth_create_llm_no_credentials(tmp_path):
     auth = OpenAISubscriptionAuth(credential_store=store)
 
     with pytest.raises(ValueError, match="No credentials available"):
-        auth.create_llm(model="gpt-5.6")
+        auth.create_llm(model="gpt-5.6-sol")
 
 
 def test_openai_subscription_auth_create_llm_success(tmp_path):
@@ -197,9 +197,9 @@ def test_openai_subscription_auth_create_llm_success(tmp_path):
     )
     store.save(creds)
 
-    llm = auth.create_llm(model="gpt-5.6")
+    llm = auth.create_llm(model="gpt-5.6-sol")
 
-    assert llm.model == "openai/gpt-5.6"
+    assert llm.model == "openai/gpt-5.6-sol"
     assert llm.api_key is None
     assert llm._get_litellm_api_key_value() == "test_access_token"
     assert llm.auth_type == "subscription"

--- a/tests/sdk/settings/test_acp_install_catalog_pins_live.py
+++ b/tests/sdk/settings/test_acp_install_catalog_pins_live.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import socket
 import subprocess
 
 import pytest
@@ -18,8 +19,17 @@ import pytest
 from openhands.sdk.settings.acp_install_catalog import ACP_INSTALL_CATALOG
 
 
+def _npm_registry_reachable(timeout: float = 3.0) -> bool:
+    try:
+        socket.create_connection(("registry.npmjs.org", 443), timeout=timeout).close()
+        return True
+    except OSError:
+        return False
+
+
 requires_npm = pytest.mark.skipif(
-    shutil.which("npm") is None, reason="npm not available"
+    shutil.which("npm") is None or not _npm_registry_reachable(),
+    reason="npm not available, or npm registry unreachable",
 )
 
 _ALL_PINS = [

--- a/tests/sdk/settings/test_acp_install_catalog_pins_live.py
+++ b/tests/sdk/settings/test_acp_install_catalog_pins_live.py
@@ -1,0 +1,72 @@
+"""Live installability checks for ACP_INSTALL_CATALOG's pinned npm versions.
+
+Runs ``npm view <pkg>@<version>`` against the real npm registry so a yanked
+version or a security deprecation is caught here instead of breaking the next
+agent-server image build. Credential-free; needs ``npm`` and network access to
+the registry (skipped when unavailable). See OpenHands/software-agent-sdk#4830
+P0-3.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from openhands.sdk.settings.acp_install_catalog import ACP_INSTALL_CATALOG
+
+
+requires_npm = pytest.mark.skipif(
+    shutil.which("npm") is None, reason="npm not available"
+)
+
+_ALL_PINS = [
+    pytest.param(spec.key, pkg.name, pkg.version, id=f"{spec.key}:{pkg.pinned}")
+    for spec in ACP_INSTALL_CATALOG.values()
+    for pkg in spec.packages
+]
+
+
+def _npm_view_version_deprecated(pinned: str) -> tuple[str, str | None]:
+    """Return ``(resolved_version, deprecation_message_or_None)`` for a
+    ``name@version`` npm spec, raising ``AssertionError`` if it doesn't
+    resolve (yanked, typo'd, never published)."""
+    result = subprocess.run(
+        ["npm", "view", pinned, "version", "deprecated", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError(
+            f"npm view {pinned!r} produced unparseable output "
+            f"(exit={result.returncode}): stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        ) from None
+    if isinstance(data, dict) and "error" in data:
+        raise AssertionError(f"npm view {pinned!r} failed: {data['error']}")
+    if isinstance(data, str):
+        return data, None
+    return data["version"], data.get("deprecated")
+
+
+@requires_npm
+@pytest.mark.parametrize("provider_key,package_name,pinned_version", _ALL_PINS)
+def test_pinned_version_resolves_and_is_not_deprecated(
+    provider_key: str, package_name: str, pinned_version: str
+) -> None:
+    pinned = f"{package_name}@{pinned_version}"
+    resolved_version, deprecated = _npm_view_version_deprecated(pinned)
+    assert resolved_version == pinned_version, (
+        f"npm resolved {pinned!r} to version {resolved_version!r}, expected "
+        f"{pinned_version!r} — the registry's tag resolution disagrees with "
+        "the exact pin"
+    )
+    assert deprecated is None, (
+        f"{pinned!r} (provider={provider_key}) is deprecated on npm: "
+        f"{deprecated!r} — bump ACP_INSTALL_CATALOG to a non-deprecated version"
+    )

--- a/tests/sdk/settings/test_acp_install_catalog_pins_live.py
+++ b/tests/sdk/settings/test_acp_install_catalog_pins_live.py
@@ -5,6 +5,12 @@ version or a security deprecation is caught here instead of breaking the next
 agent-server image build. Credential-free; needs ``npm`` and network access to
 the registry (skipped when unavailable). See OpenHands/software-agent-sdk#4830
 P0-3.
+
+Deselected from the default run via the ``acp_live`` marker (see
+``tests/sdk/agent/test_acp_conformance.py`` for why): the SDK's default test
+job is a required merge check, and a live registry dependency must not be
+able to block unrelated PRs. Run explicitly with ``pytest -m acp_live``; CI
+runs it in the separate, non-required ``acp-live-tests`` job.
 """
 
 from __future__ import annotations
@@ -31,6 +37,8 @@ requires_npm = pytest.mark.skipif(
     shutil.which("npm") is None or not _npm_registry_reachable(),
     reason="npm not available, or npm registry unreachable",
 )
+
+pytestmark = pytest.mark.acp_live
 
 _ALL_PINS = [
     pytest.param(spec.key, pkg.name, pkg.version, id=f"{spec.key}:{pkg.pinned}")

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -70,7 +70,6 @@ class TestACPProviderInfo:
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key is None
         assert info.default_model == "gpt-5.5"
-        assert any(m.id == "gpt-5.6" for m in info.available_models)
         assert any(m.id == "gpt-5.6-sol" for m in info.available_models)
         assert any(m.id == "gpt-5.6-terra" for m in info.available_models)
         assert any(m.id == "gpt-5.6-luna" for m in info.available_models)

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -2382,7 +2382,7 @@ def test_llm_from_persisted_rebuilds_serialized_subscription_runtime(
     )
 
     source = OpenAISubscriptionAuth().create_llm(
-        model="gpt-5.6",
+        model="gpt-5.6-sol",
         credentials=credentials,
     )
     persisted = source.to_persisted()
@@ -2393,7 +2393,7 @@ def test_llm_from_persisted_rebuilds_serialized_subscription_runtime(
     loaded = LLM.from_persisted(persisted)
 
     assert loaded is not source
-    assert loaded.model == "openai/gpt-5.6"
+    assert loaded.model == "openai/gpt-5.6-sol"
     assert loaded.base_url == "https://chatgpt.com/backend-api/codex"
     assert loaded.is_subscription is True
     assert loaded.extra_headers is not None
@@ -2492,7 +2492,7 @@ def test_openai_subscription_create_llm_serializes_subscription_auth(
     monkeypatch.setattr(openai_auth, "_extract_chatgpt_account_id", lambda _: None)
 
     llm = OpenAISubscriptionAuth().create_llm(
-        model="gpt-5.6",
+        model="gpt-5.6-sol",
         credentials=OAuthCredentials(
             vendor="openai",
             access_token="access-token",

--- a/uv.lock
+++ b/uv.lock
@@ -2796,7 +2796,7 @@ vertex = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.10.1" },
+    { name = "agent-client-protocol", specifier = ">=0.10.1,<0.11.0" },
     { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.35.0" },
     { name = "deprecation", specifier = ">=2.1.0" },
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.32.1" },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Landing the SDK-scoped P0 items from #4830 now, ahead of the Kimi/OpenCode/Pi
provider PRs, so new providers land against a registry that's already
conformance-tested for real.

---

AGENT:

## Why

#4830 documents that the ACP registry's *behavioral* fields (`default_session_mode`,
model mechanism, `authMethods`, `agent_name_patterns`, `available_models`) drift
silently against upstream releases — every historical instance (#3772, #3654, the
0.44 `configOptions` move, #4629, #4812) was caught by a human noticing broken
behavior, not by CI. Nothing in the test suite launches the real `npx` command and
reads state back from the live server.

## Summary

- P0-1: `tests/sdk/agent/test_acp_conformance.py` — for every `ACP_PROVIDERS` entry,
  launches `info.default_command` verbatim via `ACPAgent._start_acp_server` (the real
  code path, not a reimplementation) with a bogus credential and an isolated
  `HOME`/`CODEX_HOME`/`CLAUDE_CONFIG_DIR`, then asserts `agent_name` matches
  `agent_name_patterns`, `agent_version` equals the pin, `authMethods` (when offered)
  contains what `_select_auth_method` picked, `set_session_mode` succeeded, the
  session exposed a model-selection mechanism, the requested `default_model` reads
  back as the live `current_model_id`, and `set_acp_model` works mid-session.
- P0-2: same test also probes model acceptance — every curated `available_models`/
  `default_model` id is applied via the live `set_config_option`/`set_session_model`
  call (not just checked for list membership).
- P0-3: `tests/sdk/settings/test_acp_install_catalog_pins_live.py` — `npm view
  <pkg>@<pin> version deprecated --json` against the real registry for every
  `ACP_INSTALL_CATALOG` pin.
- P0-5: bounded `agent-client-protocol` to `<0.11.0` in `openhands-sdk/pyproject.toml`
  (0.11.0 reordered `prompt()` args and broke the client per #4830).
- P0-4 (benchmarks' `tests/test_acp.py` keys/`_ACP_COMMANDS`/`_ACP_ENV_VARS`) lives in
  `OpenHands/benchmarks`, not this repo — left for a PR there.
- Running the new P0-1/P0-2 probe for real reproduced the exact codex drift #4830
  measured: `_CODEX_MODELS`' bare `"gpt-5.6"`, `"gpt-5.4"`, and `"gpt-5.4-mini"` are
  dead entries — the live `codex-acp` server rejects them with `Invalid params`; only
  `gpt-5.6-sol`/`-terra`/`-luna` and `gpt-5.5` are still live. Trimmed
  `_CODEX_MODELS` in `acp_providers.py`, regenerated the TypeScript mirror via
  `check-acp-drift.py --write`, and updated the tests that hardcoded the removed id —
  including `OPENAI_CODEX_MODELS` (`openhands/sdk/llm/auth/openai.py`), which derives
  from this same catalog, so the drift fix also fixes 4 pre-existing test failures it
  was silently causing.

## Issue Number

Addresses the SDK-scoped P0 items (1, 2, 3, 5) of #4830.

## How to Test

All commands run from the repo root with `uv sync --frozen --group dev`.

- New live/real tests (need `npx`/`npm` + network, no credentials):
  `uv run python -m pytest -vvs tests/sdk/agent/test_acp_conformance.py tests/sdk/settings/test_acp_install_catalog_pins_live.py`
  — 6 passed. This is a genuine e2e run: each of the 3 built-in providers
  (claude-code, codex, gemini-cli) is launched for real via `npx`, initialized,
  authenticated (bogus key), session-moded, and model-switched against the live
  upstream server — no mocks. Sample real output for codex:
  ```
  ACP server initialized: agent_name='@agentclientprotocol/codex-acp', agent_version='1.1.7'
  Authenticating with ACP method: api-key
  Setting ACP session mode: agent-full-access
  Switched ACP session model to gpt-5.6-sol (provider=codex, session=...0c84a8b4)
  [acp-conformance] provider=codex cold_start=5.62s protocol_version=1
  PASSED
  ```
  Before the `_CODEX_MODELS` fix, this same test failed for real with
  `ValueError: ACP server rejected set_config_option(model)(model='gpt-5.6'):
  Invalid params` — confirming the probe actually catches live drift, not just a
  hypothetical.
- Full SDK suite: `CI=true uv run python -m pytest -q -n auto tests/sdk` — 6029
  passed (1 unrelated pre-existing flake in `test_truncate.py` under `-n auto` only,
  verified to pass in isolation and to also fail identically on `origin/main` without
  this branch's changes).
- Cross + agent-server docker-build suites:
  `CI=true uv run python -m pytest -q tests/cross tests/agent_server/test_docker_build.py`
  — 482 passed (2 pre-existing failures in
  `test_remote_conversation_live_server.py` reproduced identically on `origin/main`
  without this branch's changes — unrelated to ACP, environment-dependent).
- TypeScript client: `cd clients/typescript && npm ci && npm test` — 309 passed
  (18 suites), including the updated `acp-providers.test.ts`. Also reran
  `uv run --package openhands-sdk python clients/typescript/scripts/check-acp-drift.py`
  — clean, no drift after `--write`.
- `uv run pre-commit run --files <all changed files>` — ruff format/lint, pycodestyle,
  pyright, import-dependency-rules, and Tool-subclass-registration hooks all pass.

## Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

P0-4 (`OpenHands/benchmarks` `tests/test_acp.py`) is out of scope for this repo and
left for a follow-up PR there. P1 items (6-8: adversarial mock-ACP scenarios,
turn-level golden tests, cold-cache timing) are intentionally not included — #4830
ranks them P1 and they need either a scenario-flagged mock server (a bigger,
separable change) or real credentials (non-blocking, nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cANmHnmzATeUbx2P14Fsu




<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:57a274a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-57a274a-python \
  ghcr.io/openhands/agent-server:57a274a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:57a274a-golang-amd64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-golang-amd64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-golang-amd64
ghcr.io/openhands/agent-server:57a274a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:57a274a-golang-arm64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-golang-arm64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-golang-arm64
ghcr.io/openhands/agent-server:57a274a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:57a274a-java-amd64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-java-amd64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-java-amd64
ghcr.io/openhands/agent-server:57a274a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:57a274a-java-arm64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-java-arm64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-java-arm64
ghcr.io/openhands/agent-server:57a274a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:57a274a-python-amd64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python-amd64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python-amd64
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:57a274a-python-arm64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python-arm64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python-arm64
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:57a274a-python-slim-amd64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python-slim-amd64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python-slim-amd64
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:57a274a-python-slim-arm64
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python-slim-arm64
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python-slim-arm64
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:57a274a-golang
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-golang
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-golang
ghcr.io/openhands/agent-server:57a274a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:57a274a-java
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-java
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-java
ghcr.io/openhands/agent-server:57a274a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:57a274a-python-slim
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python-slim
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python-slim
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:57a274a-python
ghcr.io/openhands/agent-server:57a274a26f6b1ecedf65ef319758f2ba3b22ade1-python
ghcr.io/openhands/agent-server:acp-ci-hardening-p0-python
ghcr.io/openhands/agent-server:57a274a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `57a274a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `57a274a-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->