### PR TITLE
ci: verify ACP wrapper targets exist instead of guessing from package names

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -146,6 +146,14 @@ RUN set -eux; \
     "$ACP_NODE_DIR/bin/node" --version; \
     PATH="$ACP_NODE_DIR/bin:$PATH" "$ACP_NODE_DIR/bin/npm" install -g $PACKAGES; \
     for bin in $WRAPPER_BINS; do \
+      # Fail the build rather than ship a wrapper that execs a missing target:
+      # a wrong binary_name is otherwise invisible until someone launches the
+      # provider, since the wrapper is only a shell script we chmod +x.
+      [ -x "$ACP_NODE_DIR/bin/$bin" ] || { \
+        echo "ACP wrapper target not installed: $ACP_NODE_DIR/bin/$bin" >&2; \
+        echo "(check binary_name in acp_install_catalog.py against the package's npm bin)" >&2; \
+        exit 1; \
+      }; \
       printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
         "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \
         > "$ACP_WRAPPER_DIR/$bin"; \

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -109,45 +109,6 @@ class TestACPInstallCatalogMatchesACPProviders:
         assert GEMINI_CLI_VERSION == "0.46.0"
 
 
-# Single-package providers whose CLI binary name deliberately differs from
-# their npm package's basename. Keeps a real, permanent mismatch (rather than
-# a typo) from being confused with the general rule below.
-_BINARY_NAME_BASENAME_EXEMPTIONS = {
-    # @google/gemini-cli's bin is "gemini", not the package basename
-    # "gemini-cli".
-    "gemini-cli",
-}
-
-
-class TestBinaryNameMatchesPackageBasename:
-    """For a single-package provider, `npx -y <pkg>@<ver>` resolves the
-    package's OWN bin — so binary_name (the pre-installed wrapper the image
-    ships and resolve_acp_command() rewrites to) should normally just be that
-    package's basename, unless explicitly exempted. Multi-package specs are
-    exempt by construction: binary_name there is the entry command npx is
-    told to run, independent of any one package's own name."""
-
-    def test_binary_name_is_package_basename_or_exempted(self):
-        for key, spec in ACP_INSTALL_CATALOG.items():
-            if len(spec.packages) != 1:
-                continue
-            basename = spec.packages[0].name.rsplit("/", 1)[-1]
-            if key in _BINARY_NAME_BASENAME_EXEMPTIONS:
-                assert spec.binary_name != basename, (
-                    f"{key}: binary_name now matches the package basename "
-                    "— remove it from _BINARY_NAME_BASENAME_EXEMPTIONS"
-                )
-            else:
-                assert spec.binary_name == basename, (
-                    f"{key}: binary_name {spec.binary_name!r} does not match "
-                    f"package basename {basename!r}; add it to "
-                    "_BINARY_NAME_BASENAME_EXEMPTIONS if intentional"
-                )
-
-    def test_every_exemption_is_a_real_catalog_key(self):
-        assert _BINARY_NAME_BASENAME_EXEMPTIONS <= set(ACP_INSTALL_CATALOG)
-
-
 class TestDefaultPreinstalledACPProviders:
     def test_preserves_todays_default_image_contents(self):
         assert DEFAULT_PREINSTALLED_ACP_PROVIDERS == (


### PR DESCRIPTION
HUMAN:

Noticed this while adding Kimi (#4714) — the basename test made me add a third entry to an exemption list that's outgrowing the rule, and the thing it's a proxy for isn't actually checked anywhere.

---

AGENT:

## Why

`binary_name` is the wrapper the agent-server image ships and `resolve_acp_command()` rewrites to. The image builds it like this:

```sh
for bin in $WRAPPER_BINS; do
  printf '#!/bin/sh\n... exec "%s/bin/%s" "$@"\n' "$ACP_NODE_DIR" "$bin" > "$ACP_WRAPPER_DIR/$bin";
  chmod +x "$ACP_WRAPPER_DIR/$bin";
done
```

Nothing checks `$ACP_NODE_DIR/bin/$bin` exists. A wrong `binary_name` writes an executable wrapper pointing at nothing: the build succeeds, the image ships, and it fails only when a user launches that provider.

`TestBinaryNameMatchesPackageBasename` was the proxy for this — assert `binary_name` equals the npm package basename unless exempted. Three problems:

**1. The exemption list is becoming the rule.** Real npm `bin` fields:

| Provider | package basename | actual bin | |
|---|---|---|---|
| claude-code | `claude-agent-acp` | `claude-agent-acp` | ✅ |
| codex | `codex-acp` | `codex-acp` | ✅ |
| gemini-cli | `gemini-cli` | `gemini` | ❌ exempt |
| kimi-code (#4714) | `kimi-code` | `kimi` | ❌ exempt |
| opencode (#4827) | `opencode-ai` | `opencode` | ❌ would exempt |
| pi (#4419) | — | `pi` | ❌ exempt (multi-package) |

Once the in-flight provider PRs land it holds for **2 of 6**. npm has no rule that a bin matches its package name.

**2. Its failure mode is a rubber stamp** — *"add it to `_BINARY_NAME_BASENAME_EXEMPTIONS` if intentional"* asks the author to confirm the value they just wrote.

**3. It passes on the typo it exists to catch.** For an exempted provider the assertion is `binary_name != basename`. Set `binary_name="gemnii"` and `"gemnii" != "gemini-cli"` holds, so:

```
$ pytest -k BinaryName          # old test, catalog says binary_name="gemnii"
2 passed
```

That typo produces a completely broken image.

## Summary

- **Add** a `[ -x "$ACP_NODE_DIR/bin/$bin" ]` guard to the wrapper loop, right after `npm install -g`, failing the build with the offending path and a pointer to `acp_install_catalog.py`. It checks the package's *actually installed* bin, so no exemption list is needed — `gemini` and `kimi` pass because they genuinely exist.
- **Remove** `TestBinaryNameMatchesPackageBasename`, `_BINARY_NAME_BASENAME_EXEMPTIONS` and `test_every_exemption_is_a_real_catalog_key`, now superseded.

**8 insertions, 39 deletions.**

### Honest limitation

This only covers providers actually installed in a given build, so a registry-only provider (Kimi today) isn't exercised by a default image build. That's partial coverage — but the comparison is *a real check with partial coverage* versus *a heuristic that verifies nothing and passes on typos*, so I'd rather have the former than both.

## Issue Number

Part of #4830

## How to Test

Built `--target acp-providers` both ways:

```
# legitimate mismatch — gemini-cli's bin is "gemini"
docker build --target acp-providers --build-arg INSTALL_ACP_PROVIDERS=gemini-cli ...
=> DONE, exit 0

# injected typo — binary_name="gemnii"
=> ACP wrapper target not installed: /acp-node/bin/gemnii
   (check binary_name in acp_install_catalog.py against the package's npm bin)
   exit 1
```

Plus `uv run pytest tests/sdk/settings/ tests/agent_server/test_docker_build.py tests/cross/test_agent_server_build_metadata.py -q` → 141 passed, and all pre-commit hooks pass.

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Touches a test added in #4832. Sequencing with #4714: that PR currently adds `kimi-code` to the exemption set this PR deletes — whichever merges second drops those three lines, which is a trivial conflict either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:aaa4415-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-aaa4415-python \
  ghcr.io/openhands/agent-server:aaa4415-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:aaa4415-golang-amd64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-golang-amd64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-golang-amd64
ghcr.io/openhands/agent-server:aaa4415-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:aaa4415-golang-arm64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-golang-arm64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-golang-arm64
ghcr.io/openhands/agent-server:aaa4415-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:aaa4415-java-amd64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-java-amd64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-java-amd64
ghcr.io/openhands/agent-server:aaa4415-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:aaa4415-java-arm64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-java-arm64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-java-arm64
ghcr.io/openhands/agent-server:aaa4415-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:aaa4415-python-amd64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python-amd64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python-amd64
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:aaa4415-python-arm64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python-arm64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python-arm64
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:aaa4415-python-slim-amd64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python-slim-amd64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python-slim-amd64
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:aaa4415-python-slim-arm64
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python-slim-arm64
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python-slim-arm64
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:aaa4415-golang
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-golang
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-golang
ghcr.io/openhands/agent-server:aaa4415-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:aaa4415-java
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-java
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-java
ghcr.io/openhands/agent-server:aaa4415-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:aaa4415-python-slim
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python-slim
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python-slim
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:aaa4415-python
ghcr.io/openhands/agent-server:aaa441535796c2e5017779e0d78ac0fa80a3e5e9-python
ghcr.io/openhands/agent-server:fix-verify-acp-wrapper-targets-python
ghcr.io/openhands/agent-server:aaa4415-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `aaa4415-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `aaa4415-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->