### PR TITLE
fix(extensions): compose local source with repo_path

### DIFF
--- a/openhands-agent-server/openhands/agent_server/canvas_extensions_router.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions_router.py
@@ -24,8 +24,12 @@ from openhands.agent_server.canvas_extensions.installed import (
     list_installed_canvas_extensions,
     uninstall_canvas_extension,
 )
-from openhands.agent_server.canvas_extensions.manifest import CanvasExtensionManifest
+from openhands.agent_server.canvas_extensions.manifest import (
+    MANIFEST_FILENAME,
+    CanvasExtensionManifest,
+)
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 canvas_extensions_router = APIRouter(
@@ -173,12 +177,24 @@ def install_canvas_extension_endpoint(
             status_code=409,
             detail="Canvas extension already installed. Use force=true to overwrite.",
         )
-    except ExtensionFetchError:
+    except ExtensionFetchError as e:
+        # Pass the specific reason through -- which of source/ref/repo_path is
+        # wrong is the whole diagnostic, and a generic message misattributes a
+        # bad repo_path to the source. Redacted in case a URL carried a token.
         raise HTTPException(
             status_code=400,
             detail=(
-                "Failed to fetch canvas extension source. "
-                "Check that the source is valid."
+                "Failed to fetch canvas extension source: "
+                f"{redact_url_credentials(str(e))}"
+            ),
+        )
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"No {MANIFEST_FILENAME} found at the resolved location. "
+                "Source plus Path must point at the extension's own "
+                "directory, not the repository root."
             ),
         )
     except (ValidationError, ValueError, OSError):

--- a/openhands-agent-server/openhands/agent_server/canvas_extensions_router.py
+++ b/openhands-agent-server/openhands/agent_server/canvas_extensions_router.py
@@ -148,7 +148,7 @@ class UninstallCanvasExtensionResponse(BaseModel):
     "/install",
     response_model=InstalledCanvasExtensionResponse,
     responses={
-        400: {"description": "Failed to fetch canvas extension source"},
+        400: {"description": "Could not read canvas extension source"},
         409: {"description": "Canvas extension already installed (use force=true)"},
         422: {"description": "Invalid canvas extension (bad manifest, etc.)"},
     },
@@ -181,10 +181,13 @@ def install_canvas_extension_endpoint(
         # Pass the specific reason through -- which of source/ref/repo_path is
         # wrong is the whole diagnostic, and a generic message misattributes a
         # bad repo_path to the source. Redacted in case a URL carried a token.
+        # Deliberately not worded "failed to fetch": the canvas client treats
+        # that phrase as a network outage and hides the reason behind a
+        # "Disconnected, check your network" toast.
         raise HTTPException(
             status_code=400,
             detail=(
-                "Failed to fetch canvas extension source: "
+                "Could not read canvas extension source: "
                 f"{redact_url_credentials(str(e))}"
             ),
         )

--- a/openhands-sdk/openhands/sdk/extensions/fetch.py
+++ b/openhands-sdk/openhands/sdk/extensions/fetch.py
@@ -109,7 +109,7 @@ def _resolve_local_source(url: str) -> Path:
 
 
 def _apply_subpath(base_path: Path, subpath: str | None, context: str) -> Path:
-    """Apply a subpath to a base path, validating it exists.
+    """Apply a subpath to a base path, validating it exists and stays inside.
 
     Args:
         base_path: The root path.
@@ -120,12 +120,16 @@ def _apply_subpath(base_path: Path, subpath: str | None, context: str) -> Path:
         The final path (base_path if no subpath, otherwise base_path/subpath).
 
     Raises:
-        ExtensionFetchError: If subpath doesn't exist.
+        ExtensionFetchError: If subpath escapes base_path or doesn't exist.
     """
     if not subpath:
         return base_path
 
     final_path = base_path / subpath.strip("/")
+    # Containment: a subpath must not climb out of the base via ".." or a symlink.
+    resolved_base = base_path.resolve()
+    if not final_path.resolve().is_relative_to(resolved_base):
+        raise ExtensionFetchError(f"Subdirectory '{subpath}' escapes {context}")
     if not final_path.exists():
         raise ExtensionFetchError(f"Subdirectory '{subpath}' not found in {context}")
     return final_path
@@ -191,13 +195,8 @@ def fetch_with_resolution(
     source_type, url = parse_extension_source(source)
 
     if source_type == SourceType.LOCAL:
-        if repo_path is not None:
-            raise ExtensionFetchError(
-                f"repo_path is not supported for local extension sources. "
-                f"Specify the full path directly instead of "
-                f"source='{source}' + repo_path='{repo_path}'"
-            )
-        return _resolve_local_source(url), None
+        base_path = _resolve_local_source(url)
+        return _apply_subpath(base_path, repo_path, f"local source '{source}'"), None
 
     git = git_helper if git_helper is not None else GitHelper()
 

--- a/tests/agent_server/test_canvas_extensions_router.py
+++ b/tests/agent_server/test_canvas_extensions_router.py
@@ -393,9 +393,6 @@ def test_list_installed_empty_and_multiple(client: TestClient, tmp_path: Path):
     assert names == {"ext-one", "ext-two"}
 
 
-# -- OSS-10405: Source + Path composition for local sources -------------------
-
-
 @pytest.mark.parametrize(
     "source_suffix,repo_path",
     [

--- a/tests/agent_server/test_canvas_extensions_router.py
+++ b/tests/agent_server/test_canvas_extensions_router.py
@@ -450,6 +450,10 @@ def test_install_reports_which_field_is_wrong_for_bad_repo_path(
     assert install.status_code == 400
     assert "demo-extensio" in install.json()["detail"]
     assert "not found" in install.json()["detail"]
+    # The canvas client classifies any message containing "failed to fetch" as
+    # a network outage and replaces it with a "Disconnected" toast, which would
+    # hide the reason we just went to the trouble of reporting.
+    assert "failed to fetch" not in install.json()["detail"].lower()
 
 
 def test_install_reports_missing_manifest_at_resolved_location(

--- a/tests/agent_server/test_canvas_extensions_router.py
+++ b/tests/agent_server/test_canvas_extensions_router.py
@@ -391,3 +391,98 @@ def test_list_installed_empty_and_multiple(client: TestClient, tmp_path: Path):
         for e in client.get("/canvas-extensions/installed").json()["canvas_extensions"]
     }
     assert names == {"ext-one", "ext-two"}
+
+
+# -- OSS-10405: Source + Path composition for local sources -------------------
+
+
+@pytest.mark.parametrize(
+    "source_suffix,repo_path",
+    [
+        ("", "demo-extension"),
+        ("", "/demo-extension"),
+        ("/", "demo-extension"),
+        ("/", "/demo-extension"),
+    ],
+)
+def test_install_composes_local_source_and_repo_path(
+    client: TestClient, tmp_path: Path, source_suffix: str, repo_path: str
+):
+    """A parent directory as Source plus the extension dir as Path installs."""
+    repo = tmp_path / "canvas-extensions"
+    write_extension(repo / "demo-extension", name="demo-extension")
+    # A sibling that must not be picked up.
+    write_extension(repo / "other-extension", name="other-extension")
+
+    install = client.post(
+        "/canvas-extensions/install",
+        json={"source": str(repo) + source_suffix, "repo_path": repo_path},
+    )
+
+    assert install.status_code == 200, install.json()
+    body = install.json()
+    assert body["name"] == "demo-extension"
+    assert body["repo_path"] == repo_path
+    assert body["enabled"] is False
+
+
+def test_install_with_full_extension_dir_as_source_still_works(
+    client: TestClient, tmp_path: Path
+):
+    """The pre-existing single-field flow is unchanged."""
+    src = write_extension(tmp_path / "src" / "demo-extension", name="demo-extension")
+
+    install = client.post("/canvas-extensions/install", json={"source": str(src)})
+
+    assert install.status_code == 200
+    assert install.json()["name"] == "demo-extension"
+
+
+def test_install_reports_which_field_is_wrong_for_bad_repo_path(
+    client: TestClient, tmp_path: Path
+):
+    """A bad Path blames Path, not the source (the old message misattributed)."""
+    repo = tmp_path / "canvas-extensions"
+    write_extension(repo / "demo-extension", name="demo-extension")
+
+    install = client.post(
+        "/canvas-extensions/install",
+        json={"source": str(repo), "repo_path": "demo-extensio"},
+    )
+
+    assert install.status_code == 400
+    assert "demo-extensio" in install.json()["detail"]
+    assert "not found" in install.json()["detail"]
+
+
+def test_install_reports_missing_manifest_at_resolved_location(
+    client: TestClient, tmp_path: Path
+):
+    """Pointing Source/Path at a directory with no manifest says so."""
+    repo = tmp_path / "canvas-extensions"
+    (repo / "not-an-extension").mkdir(parents=True)
+
+    install = client.post(
+        "/canvas-extensions/install",
+        json={"source": str(repo), "repo_path": "not-an-extension"},
+    )
+
+    assert install.status_code == 422
+    assert "canvas-extension.json" in install.json()["detail"]
+
+
+def test_install_rejects_repo_path_escaping_the_source(
+    client: TestClient, tmp_path: Path
+):
+    """A traversing Path is rejected rather than resolving outside Source."""
+    repo = tmp_path / "canvas-extensions"
+    write_extension(repo / "demo-extension", name="demo-extension")
+    write_extension(tmp_path / "outside-extension", name="outside-extension")
+
+    install = client.post(
+        "/canvas-extensions/install",
+        json={"source": str(repo), "repo_path": "../outside-extension"},
+    )
+
+    assert install.status_code == 400
+    assert "escapes" in install.json()["detail"]

--- a/tests/sdk/extensions/test_fetch.py
+++ b/tests/sdk/extensions/test_fetch.py
@@ -393,20 +393,64 @@ def test_fetch_with_resolution_falls_back_to_head(tmp_path: Path):
 # -- repo_path parameter ------------------------------------------------------
 
 
-def test_fetch_local_with_repo_path_raises_error(tmp_path: Path):
+def test_fetch_local_with_repo_path_resolves_subdirectory(tmp_path: Path):
+    """A local source plus repo_path composes into the subdirectory (OSS-10405)."""
     ext_dir = tmp_path / "monorepo"
     ext_dir.mkdir()
     (ext_dir / "extensions" / "my-ext").mkdir(parents=True)
 
-    with pytest.raises(
-        ExtensionFetchError,
-        match="repo_path is not supported for local",
-    ):
-        fetch(
-            str(ext_dir),
-            cache_dir=tmp_path,
-            repo_path="extensions/my-ext",
-        )
+    path, resolved_ref = fetch_with_resolution(
+        str(ext_dir),
+        cache_dir=tmp_path,
+        repo_path="extensions/my-ext",
+    )
+
+    assert path == (ext_dir / "extensions" / "my-ext").resolve()
+    assert resolved_ref is None
+
+
+@pytest.mark.parametrize(
+    "source_suffix,repo_path",
+    [
+        ("", "extensions/my-ext"),
+        ("", "/extensions/my-ext"),
+        ("/", "extensions/my-ext"),
+        ("/", "/extensions/my-ext"),
+    ],
+)
+def test_fetch_local_repo_path_tolerates_slashes(
+    tmp_path: Path, source_suffix: str, repo_path: str
+):
+    """Leading/trailing slashes on either field resolve the same way."""
+    ext_dir = tmp_path / "monorepo"
+    ext_dir.mkdir()
+    (ext_dir / "extensions" / "my-ext").mkdir(parents=True)
+
+    path = fetch(
+        str(ext_dir) + source_suffix,
+        cache_dir=tmp_path,
+        repo_path=repo_path,
+    )
+
+    assert path == (ext_dir / "extensions" / "my-ext").resolve()
+
+
+def test_fetch_local_with_missing_repo_path_raises_error(tmp_path: Path):
+    ext_dir = tmp_path / "monorepo"
+    ext_dir.mkdir()
+
+    with pytest.raises(ExtensionFetchError, match="not found in local source"):
+        fetch(str(ext_dir), cache_dir=tmp_path, repo_path="extensions/my-ext")
+
+
+def test_fetch_local_repo_path_cannot_escape_source(tmp_path: Path):
+    """A traversing repo_path is rejected rather than silently escaping."""
+    ext_dir = tmp_path / "monorepo"
+    ext_dir.mkdir()
+    (tmp_path / "outside").mkdir()
+
+    with pytest.raises(ExtensionFetchError, match="escapes local source"):
+        fetch(str(ext_dir), cache_dir=tmp_path, repo_path="../outside")
 
 
 def test_fetch_github_with_repo_path(tmp_path: Path):

--- a/tests/sdk/plugin/test_plugin_fetch.py
+++ b/tests/sdk/plugin/test_plugin_fetch.py
@@ -50,14 +50,24 @@ def test_fetch_generic_error_raises_plugin_fetch_error(tmp_path: Path):
         )
 
 
-def test_fetch_local_with_repo_path_raises_plugin_fetch_error(
+def test_fetch_local_with_repo_path_resolves_subdirectory(tmp_path: Path):
+    """A local monorepo source plus repo_path resolves to the subdirectory."""
+    plugin_dir = tmp_path / "monorepo"
+    (plugin_dir / "plugins" / "my-plugin").mkdir(parents=True)
+
+    result = fetch_plugin(str(plugin_dir), repo_path="plugins/my-plugin")
+
+    assert result == (plugin_dir / "plugins" / "my-plugin").resolve()
+
+
+def test_fetch_local_with_missing_repo_path_raises_plugin_fetch_error(
     tmp_path: Path,
 ):
-    """repo_path rejection for local sources surfaces as PluginFetchError."""
+    """A repo_path that does not exist surfaces as PluginFetchError."""
     plugin_dir = tmp_path / "monorepo"
     plugin_dir.mkdir()
 
-    with pytest.raises(PluginFetchError, match="repo_path is not supported for local"):
+    with pytest.raises(PluginFetchError, match="not found in local source"):
         fetch_plugin(str(plugin_dir), repo_path="plugins/my-plugin")
 
 
@@ -91,10 +101,11 @@ def test_plugin_fetch_delegates(tmp_path: Path):
     assert result == plugin_dir.resolve()
 
 
-def test_plugin_fetch_local_with_repo_path_raises_error(tmp_path: Path):
-    """Plugin.fetch() raises PluginFetchError for local + repo_path."""
+def test_plugin_fetch_local_with_repo_path_resolves_subdirectory(tmp_path: Path):
+    """Plugin.fetch() composes a local source with repo_path."""
     plugin_dir = tmp_path / "monorepo"
-    plugin_dir.mkdir()
+    (plugin_dir / "plugins" / "my-plugin").mkdir(parents=True)
 
-    with pytest.raises(PluginFetchError, match="repo_path is not supported for local"):
-        Plugin.fetch(str(plugin_dir), repo_path="plugins/my-plugin")
+    result = Plugin.fetch(str(plugin_dir), repo_path="plugins/my-plugin")
+
+    assert result == (plugin_dir / "plugins" / "my-plugin").resolve()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

BE needed to install extensions from local path
Edit: this will apply the paths to any client applications 

---

AGENT:

## Why

Installing a canvas extension by pointing Source at a repository and Path at the
extension's subdirectory always fails. `fetch_with_resolution()` rejects
`repo_path` outright for `SourceType.LOCAL` before the subpath is ever applied,
so the composition that already works for git and GitHub sources is unreachable
for a local checkout.

The failure is also unreadable. The install route catches `ExtensionFetchError`
and replaces it with one fixed sentence about the source, so a typo in Path is
reported as a bad Source. On `origin/main` six of seven distinct mistakes return
the exact same message.

Reported as OSS-10405 and as OpenHands/OpenHands#17048.

## Summary

- `fetch.py`: local sources now compose with `repo_path` the same way git sources
  do, via `_apply_subpath()`, instead of raising.
- `_apply_subpath()` gained containment. A subpath that climbs out of the base
  through `..` or a symlink is rejected rather than resolved.
- `canvas_extensions_router.py`: the install route forwards the specific fetch
  reason (credential-redacted) and answers a missing manifest with its own 422
  telling the user that Source plus Path must name the extension's own directory.
- That 400 is worded "Could not read", not "Failed to fetch". The canvas client
  treats any message containing "failed to fetch" as a network outage and
  replaces it with a "Disconnected, check your network" toast, which hid the
  reason. A test asserts the phrase stays out.

## Issue Number

OpenHands/OpenHands#17048, Linear OSS-10405.

## How to Test

The ticket's own reproduction, run end to end against the real installer
(`install_canvas_extension`), with a fixture repository holding
`canvas-extensions/canvas-pulse/canvas-extension.json`:

```
$ uv run --frozen python evidence.py
```

On `origin/main` (e26683288):

```
  FAIL  Source=/path/canvas-extensions/  Path=/canvas-pulse
          ExtensionFetchError: repo_path is not supported for local extension sources...
  FAIL  Source=/path/canvas-extensions/  Path=canvas-pulse
          ExtensionFetchError: repo_path is not supported for local extension sources...
  FAIL  Source=/path/canvas-extensions   Path=/canvas-pulse
          ExtensionFetchError: repo_path is not supported for local extension sources...
  FAIL  Source=/path/canvas-extensions   Path=canvas-pulse
          ExtensionFetchError: repo_path is not supported for local extension sources...
  PASS  Source=/path/canvas-extensions/canvas-pulse  (no Path)
          installed 'canvas-pulse' v0.1.0
```

On this branch:

```
  PASS  Source=/path/canvas-extensions/  Path=/canvas-pulse
          installed 'canvas-pulse' v0.1.0
  PASS  Source=/path/canvas-extensions/  Path=canvas-pulse
          installed 'canvas-pulse' v0.1.0
  PASS  Source=/path/canvas-extensions   Path=/canvas-pulse
          installed 'canvas-pulse' v0.1.0
  PASS  Source=/path/canvas-extensions   Path=canvas-pulse
          installed 'canvas-pulse' v0.1.0
  PASS  Source=/path/canvas-extensions/canvas-pulse  (no Path)
          installed 'canvas-pulse' v0.1.0
```

Installed content was checked, not just the return value: only the named
subdirectory is copied (a sibling `other-extension/` in the same repository is
not), `repo_path` is recorded on the installed record, and the extension stays
`enabled=False` as before.

Second, what the HTTP API says for each realistic mistake, driven through
`TestClient` against `canvas_extensions_router`.

On `origin/main`:

```
400  happy: parent + subdir            -> Failed to fetch canvas extension source. Check that the source is valid.
400  happy: parent/ + /subdir          -> Failed to fetch canvas extension source. Check that the source is valid.
400  typo in Path                      -> Failed to fetch canvas extension source. Check that the source is valid.
400  Path at dir without manifest      -> Failed to fetch canvas extension source. Check that the source is valid.
422  Path left empty, Source=repo root -> Invalid canvas extension. Ensure the manifest is well-formed.
400  Source typo                       -> Failed to fetch canvas extension source. Check that the source is valid.
400  traversal                         -> Failed to fetch canvas extension source. Check that the source is valid.
```

On this branch:

```
200  happy: parent + subdir            -> installed
409  happy: parent/ + /subdir          -> Canvas extension already installed. Use force=true to overwrite.
400  typo in Path                      -> Could not read canvas extension source: Subdirectory 'canvas-puls' not found in local source '/tmp/.../canvas-extensions'
422  Path at dir without manifest      -> No canvas-extension.json found at the resolved location. Source plus Path must point at the extension's own directory, not the repository root.
422  Path left empty, Source=repo root -> No canvas-extension.json found at the resolved location. Source plus Path must point at the extension's own directory, not the repository root.
400  Source typo                       -> Could not read canvas extension source: Local extension path does not exist: /tmp/.../nope
400  traversal                         -> Could not read canvas extension source: Subdirectory '../..' escapes local source '/tmp/.../canvas-extensions'
```

The 409 on the second row is the store rejecting a duplicate name, because the
first row already installed `canvas-pulse` into the shared fixture store. Slash
tolerance is covered on its own by the parametrized router test.

Test suites:

```
$ uv run --frozen pytest tests/agent_server          # 2068 passed
$ uv run --frozen pytest tests/sdk/extensions tests/sdk/plugin tests/sdk/skill
                                                     # 677 passed, 2 skipped
$ pre-commit run --all-files                          # all hooks pass
```

Each new regression test was confirmed to fail with its fix reverted.

### Browser verification

Ran the Canvas dev stack against this branch's agent-server:

```
OH_AGENT_SERVER_LOCAL_PATH=<this checkout> npm run dev   # from OpenHands/OpenHands
```

with a fixture at `/tmp/repository-name/demo-extension` plus a sibling
`other-extension`. Installing through the UI with Source `/tmp/repository-name`
and Path `demo-extension` succeeded, and the resulting record proves the
composition rather than a full-path install:

```
name=demo-extension  source=/tmp/repository-name  repo_path=demo-extension  enabled=false
install dir contains: demo-extension        # the sibling was not copied
```

The agent-server log for the failure cases, taken from the same session:

```
HTTPException 400 on POST /api/canvas-extensions/install: Could not read canvas extension source: Subdirectory 'demo-extensio' not found in local source '/tmp/repository-name'
HTTPException 422 on POST /api/canvas-extensions/install: No canvas-extension.json found at the resolved location. Source plus Path must point at the extension's own directory, not the repository root.
HTTPException 400 on POST /api/canvas-extensions/install: Could not read canvas extension source: Subdirectory '../..' escapes local source '/tmp/repository-name'
```

This browser run is what surfaced the "failed to fetch" wording collision: the
server logged the correct 400 while the UI showed a network-outage toast. The
unit test did not catch it because it used a stand-in for the client's error
class.

## Video/Screenshots

Terminal output above is the reproduction evidence: the four failing ticket cases
on `origin/main`, the same four passing here, and the before/after API messages.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Caught while testing this in the browser, not by the unit tests: with the old
  wording the improved 400 was still displayed as a network outage, because
  `isCorsOrNetworkErrorMessage()` in the canvas frontend matches the substring
  "failed to fetch". Reworded here so every consumer benefits, not just the one
  hook the companion PR touches.
- `fetch.py` is shared by Plugins, Skills and Canvas Extensions, so Plugins and
  Skills gain the same local Source + Path composition. Two plugin tests that
  asserted the old rejection were rewritten to the new contract.
- The containment check in `_apply_subpath()` also tightens git and GitHub
  sources, which previously accepted a traversing `repo_path`.
- The Canvas UI change that actually renders these messages is a separate PR in
  OpenHands/OpenHands#17120. It shows the improved text only once this lands.

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:423fbe6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-423fbe6-python \
  ghcr.io/openhands/agent-server:423fbe6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:423fbe6-golang-amd64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-golang-amd64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-golang-amd64
ghcr.io/openhands/agent-server:423fbe6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:423fbe6-golang-arm64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-golang-arm64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-golang-arm64
ghcr.io/openhands/agent-server:423fbe6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:423fbe6-java-amd64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-java-amd64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-java-amd64
ghcr.io/openhands/agent-server:423fbe6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:423fbe6-java-arm64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-java-arm64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-java-arm64
ghcr.io/openhands/agent-server:423fbe6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:423fbe6-python-amd64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python-amd64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python-amd64
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:423fbe6-python-arm64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python-arm64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python-arm64
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:423fbe6-python-slim-amd64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python-slim-amd64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python-slim-amd64
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:423fbe6-python-slim-arm64
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python-slim-arm64
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python-slim-arm64
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:423fbe6-golang
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-golang
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-golang
ghcr.io/openhands/agent-server:423fbe6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:423fbe6-java
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-java
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-java
ghcr.io/openhands/agent-server:423fbe6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:423fbe6-python-slim
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python-slim
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python-slim
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:423fbe6-python
ghcr.io/openhands/agent-server:423fbe6a3e43f0c904374d5711e3169661d759ca-python
ghcr.io/openhands/agent-server:vasco-oss-10405-local-repo-path-python
ghcr.io/openhands/agent-server:423fbe6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `423fbe6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `423fbe6-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->