### PR TITLE
fix(conversation): pick up a user message that arrives mid-step

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1993,15 +1993,17 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
-                    # State lock released for the step, so intake is not stuck
-                    # behind it; the step re-takes it per event.
+                    # Mark the step as holding the state lock so state-mutating
+                    # tools (e.g. switch_llm) running on worker threads skip
+                    # re-acquiring it instead of deadlocking (#3485).
+                    self._step_holds_state_lock = True
                     last_user_message_id_before_step = self._state.last_user_message_id
-                    with self._state.agent_step():
+                    try:
                         self.agent.step(
-                            self,
-                            on_event=self._on_event_with_state_lock,
-                            on_token=self._on_token,
+                            self, on_event=self._on_event, on_token=self._on_token
                         )
+                    finally:
+                        self._step_holds_state_lock = False
                     self._resume_for_message_sent_during_step(
                         last_user_message_id_before_step
                     )
@@ -2238,21 +2240,34 @@ class LocalConversation(BaseConversation):
                             else None
                         )
                     else:
-                        # State lock released for the step, so intake is not
-                        # stuck behind it; the step re-takes it per event. The
-                        # agent lock held across this await is thread- (not
-                        # task-) reentrant, so a step awaited from another
-                        # coroutine on this thread would re-enter it: dispatch
-                        # such callers via run_in_executor.
+                        # The state lock is held across this await. Mutations
+                        # performed inside astep() (including native async
+                        # Agent.astep / ACPAgent.astep that mutate on the
+                        # event-loop thread) are intentional and part of this
+                        # critical section. The invariant is only that no
+                        # *unrelated* state mutator may run concurrently while
+                        # the lock is held: because FIFOLock is thread- (not
+                        # task-) reentrant, any unrelated state-mutating
+                        # coroutine awaited on this event-loop thread would
+                        # silently re-enter the lock and corrupt history. Such
+                        # unrelated mutators must be dispatched via
+                        # run_in_executor onto a worker thread.
+                        # Mark the step as holding the state lock so
+                        # state-mutating tools (e.g. switch_llm) running on
+                        # worker threads skip re-acquiring it instead of
+                        # deadlocking while this await holds it (#3485).
+                        self._step_holds_state_lock = True
                         last_user_message_id_before_step = (
                             self._state.last_user_message_id
                         )
-                        with self._state.agent_step():
+                        try:
                             await self.agent.astep(
                                 self,
-                                on_event=self._on_event_with_state_lock,
+                                on_event=self._on_event,
                                 on_token=self._on_token,
                             )
+                        finally:
+                            self._step_holds_state_lock = False
                         self._resume_for_message_sent_during_step(
                             last_user_message_id_before_step
                         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1870,6 +1870,25 @@ class LocalConversation(BaseConversation):
         with self._state:
             self._on_event(event)
 
+    def _resume_for_message_sent_during_step(
+        self, last_user_message_id_before_step: EventID | None
+    ) -> None:
+        """Keep the run alive for a user message that landed mid-step.
+
+        Intake no longer waits out the step (#4674), so a message can arrive
+        after the agent has built its prompt. The agent's FINISHED would then
+        close the run over input it never read — the mechanism behind
+        OpenHands/OpenHands#15432. Clearing FINISHED here makes pickup on the
+        next step deterministic instead of a lock race. Call while holding the
+        state lock.
+        """
+        if self._state.last_user_message_id == last_user_message_id_before_step:
+            return
+        if self._state.execution_status != ConversationExecutionStatus.FINISHED:
+            return
+        logger.info("User message arrived during step; continuing run")
+        self._state.execution_status = ConversationExecutionStatus.RUNNING
+
     @contextlib.asynccontextmanager
     async def _released_state_lock_during_io(self):
         """Release the run loop's state lock across an awaited LLM network call.
@@ -1979,16 +1998,21 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
-                    # Mark the step as holding the state lock so state-mutating
-                    # tools (e.g. switch_llm) running on worker threads skip
-                    # re-acquiring it instead of deadlocking (#3485).
-                    self._step_holds_state_lock = True
-                    try:
+                    # The step runs under the agent lock with the state lock
+                    # released (#4674), so message intake is not stuck behind
+                    # it and switch_llm can take the state lock normally rather
+                    # than skipping it to dodge a deadlock (#3485). Mutations
+                    # made by the step re-take the state lock per event.
+                    last_user_message_id_before_step = self._state.last_user_message_id
+                    with self._state.agent_step():
                         self.agent.step(
-                            self, on_event=self._on_event, on_token=self._on_token
+                            self,
+                            on_event=self._on_event_with_state_lock,
+                            on_token=self._on_token,
                         )
-                    finally:
-                        self._step_holds_state_lock = False
+                    self._resume_for_message_sent_during_step(
+                        last_user_message_id_before_step
+                    )
                     iteration += 1
 
                     # Check for non-finished terminal conditions
@@ -2222,31 +2246,29 @@ class LocalConversation(BaseConversation):
                             else None
                         )
                     else:
-                        # The state lock is held across this await. Mutations
-                        # performed inside astep() (including native async
-                        # Agent.astep / ACPAgent.astep that mutate on the
-                        # event-loop thread) are intentional and part of this
-                        # critical section. The invariant is only that no
-                        # *unrelated* state mutator may run concurrently while
-                        # the lock is held: because FIFOLock is thread- (not
-                        # task-) reentrant, any unrelated state-mutating
-                        # coroutine awaited on this event-loop thread would
-                        # silently re-enter the lock and corrupt history. Such
-                        # unrelated mutators must be dispatched via
-                        # run_in_executor onto a worker thread.
-                        # Mark the step as holding the state lock so
-                        # state-mutating tools (e.g. switch_llm) running on
-                        # worker threads skip re-acquiring it instead of
-                        # deadlocking while this await holds it (#3485).
-                        self._step_holds_state_lock = True
-                        try:
+                        # The agent lock, not the state lock, is held across
+                        # this await. It is still thread- (not task-) reentrant,
+                        # so a step awaited from another coroutine on this
+                        # event-loop thread would silently re-enter it; dispatch
+                        # such callers via run_in_executor onto a worker thread.
+                        # The step runs under the agent lock with the state
+                        # lock released (#4674), so message intake is not stuck
+                        # behind it and switch_llm can take the state lock
+                        # normally rather than skipping it to dodge a deadlock
+                        # (#3485). Mutations made by the step re-take the state
+                        # lock per event.
+                        last_user_message_id_before_step = (
+                            self._state.last_user_message_id
+                        )
+                        with self._state.agent_step():
                             await self.agent.astep(
                                 self,
-                                on_event=self._on_event,
+                                on_event=self._on_event_with_state_lock,
                                 on_token=self._on_token,
                             )
-                        finally:
-                            self._step_holds_state_lock = False
+                        self._resume_for_message_sent_during_step(
+                            last_user_message_id_before_step
+                        )
                         iteration += 1
 
                         if (

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1873,14 +1873,9 @@ class LocalConversation(BaseConversation):
     def _resume_for_message_sent_during_step(
         self, last_user_message_id_before_step: EventID | None
     ) -> None:
-        """Keep the run alive for a user message that landed mid-step.
+        """Don't let FINISHED close the run over input the step never read.
 
-        Intake no longer waits out the step (#4674), so a message can arrive
-        after the agent has built its prompt. The agent's FINISHED would then
-        close the run over input it never read — the mechanism behind
-        OpenHands/OpenHands#15432. Clearing FINISHED here makes pickup on the
-        next step deterministic instead of a lock race. Call while holding the
-        state lock.
+        Call while holding the state lock.
         """
         if self._state.last_user_message_id == last_user_message_id_before_step:
             return
@@ -1998,11 +1993,8 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
-                    # The step runs under the agent lock with the state lock
-                    # released (#4674), so message intake is not stuck behind
-                    # it and switch_llm can take the state lock normally rather
-                    # than skipping it to dodge a deadlock (#3485). Mutations
-                    # made by the step re-take the state lock per event.
+                    # State lock released for the step, so intake is not stuck
+                    # behind it; the step re-takes it per event.
                     last_user_message_id_before_step = self._state.last_user_message_id
                     with self._state.agent_step():
                         self.agent.step(
@@ -2246,17 +2238,12 @@ class LocalConversation(BaseConversation):
                             else None
                         )
                     else:
-                        # The agent lock, not the state lock, is held across
-                        # this await. It is still thread- (not task-) reentrant,
-                        # so a step awaited from another coroutine on this
-                        # event-loop thread would silently re-enter it; dispatch
-                        # such callers via run_in_executor onto a worker thread.
-                        # The step runs under the agent lock with the state
-                        # lock released (#4674), so message intake is not stuck
-                        # behind it and switch_llm can take the state lock
-                        # normally rather than skipping it to dodge a deadlock
-                        # (#3485). Mutations made by the step re-take the state
-                        # lock per event.
+                        # State lock released for the step, so intake is not
+                        # stuck behind it; the step re-takes it per event. The
+                        # agent lock held across this await is thread- (not
+                        # task-) reentrant, so a step awaited from another
+                        # coroutine on this thread would re-enter it: dispatch
+                        # such callers via run_in_executor.
                         last_user_message_id_before_step = (
                             self._state.last_user_message_id
                         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1871,18 +1871,28 @@ class LocalConversation(BaseConversation):
             self._on_event(event)
 
     def _resume_for_message_sent_during_step(
-        self, last_user_message_id_before_step: EventID | None
-    ) -> None:
+        self,
+        last_user_message_id_before_step: EventID | None,
+        *,
+        at_iteration_cap: bool,
+    ) -> bool:
         """Don't let FINISHED close the run over input the step never read.
 
-        Call while holding the state lock.
+        Returns whether the caller should break. Out of iterations, go idle for
+        a follow-up run rather than fall through to MaxIterationsReached. Call
+        while holding the state lock.
         """
         if self._state.last_user_message_id == last_user_message_id_before_step:
-            return
+            return False
         if self._state.execution_status != ConversationExecutionStatus.FINISHED:
-            return
+            return False
+        if at_iteration_cap:
+            logger.info("User message arrived during step; leaving run idle")
+            self._state.execution_status = ConversationExecutionStatus.IDLE
+            return True
         logger.info("User message arrived during step; continuing run")
         self._state.execution_status = ConversationExecutionStatus.RUNNING
+        return False
 
     @contextlib.asynccontextmanager
     async def _released_state_lock_during_io(self):
@@ -2004,10 +2014,12 @@ class LocalConversation(BaseConversation):
                         )
                     finally:
                         self._step_holds_state_lock = False
-                    self._resume_for_message_sent_during_step(
-                        last_user_message_id_before_step
-                    )
                     iteration += 1
+                    if self._resume_for_message_sent_during_step(
+                        last_user_message_id_before_step,
+                        at_iteration_cap=iteration >= self.max_iteration_per_run,
+                    ):
+                        break
 
                     # Check for non-finished terminal conditions
                     # Note: We intentionally do NOT check for FINISHED status here.
@@ -2268,10 +2280,12 @@ class LocalConversation(BaseConversation):
                             )
                         finally:
                             self._step_holds_state_lock = False
-                        self._resume_for_message_sent_during_step(
-                            last_user_message_id_before_step
-                        )
                         iteration += 1
+                        if self._resume_for_message_sent_during_step(
+                            last_user_message_id_before_step,
+                            at_iteration_cap=(iteration >= self.max_iteration_per_run),
+                        ):
+                            break
 
                         if (
                             self.state.execution_status

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -250,16 +250,9 @@ class ConversationState(OpenHandsModel):
     _write_guard: Callable[[], AbstractContextManager[None]] | None = PrivateAttr(
         default=None
     )
-    # ===== Locks, in acquisition order =====
-    # One lock used to guard every concern at once, so message intake contended
-    # with the run loop at every step boundary (#4674). They are now split by
-    # responsibility and must be acquired outer -> inner, never the reverse:
-    #   1. _agent_lock - the agent and the step it is running. Held for a whole
-    #      step by `agent_step()`, which releases `_lock` for that duration.
-    #   2. _lock - everything else: the event log, execution_status, the secret
-    #      registry, stats, HEAD, and the persistence writes they trigger.
-    _agent_lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)
-    _lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)
+    # Acquire outer -> inner, never the reverse.
+    _agent_lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)  # the agent step
+    _lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)  # everything else
     _save_depth: int = PrivateAttr(default=0)  # context-manager nesting depth
     _dirty: bool = PrivateAttr(default=False)  # pending unsaved field changes
 
@@ -752,7 +745,7 @@ class ConversationState(OpenHandsModel):
         return self
 
     def _flush_deferred_save(self) -> None:
-        """Persist the mutations a context-manager block batched, if any."""
+        """Persist what a context-manager block batched, if anything."""
         if not self._dirty:
             return
         fs = getattr(self, "_fs", None)
@@ -773,21 +766,13 @@ class ConversationState(OpenHandsModel):
     def agent_step(self) -> Generator[None]:
         """Run an agent step under ``_agent_lock``, with ``_lock`` released.
 
-        The run loop enters a step already holding the state lock and used to
-        keep it for the whole step, so message intake had to wait out the step
-        and pickup came down to a lock race (#4674). Hand the state lock back
-        for the duration instead: the step re-takes it per emitted event, and
-        concurrent steps are serialized on the dedicated agent lock.
-
-        A no-op beyond the agent lock when the caller does not hold ``_lock``
-        (a direct ``step()``/``astep()`` call).
+        Steps serialize on the agent lock; the state lock stays free so intake
+        does not wait out a step. The step re-takes it per emitted event.
         """
         depth = 0
         save_depth = 0
         if self._lock.owned():
-            # Batched mutations must not stay pending while the lock is open to
-            # other threads, and their `_save_depth` must not swallow the flush
-            # of a block another thread opens meanwhile.
+            # Don't leave batched mutations pending while others hold the lock.
             save_depth = self._save_depth
             self._save_depth = 0
             self._flush_deferred_save()

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -1,8 +1,8 @@
 # state.py
 import json
 import threading
-from collections.abc import Callable, Sequence
-from contextlib import AbstractContextManager
+from collections.abc import Callable, Generator, Sequence
+from contextlib import AbstractContextManager, contextmanager
 from enum import Enum
 from pathlib import Path
 from typing import Any, Self
@@ -250,9 +250,16 @@ class ConversationState(OpenHandsModel):
     _write_guard: Callable[[], AbstractContextManager[None]] | None = PrivateAttr(
         default=None
     )
-    _lock: FIFOLock = PrivateAttr(
-        default_factory=FIFOLock
-    )  # FIFO lock for thread safety
+    # ===== Locks, in acquisition order =====
+    # One lock used to guard every concern at once, so message intake contended
+    # with the run loop at every step boundary (#4674). They are now split by
+    # responsibility and must be acquired outer -> inner, never the reverse:
+    #   1. _agent_lock - the agent and the step it is running. Held for a whole
+    #      step by `agent_step()`, which releases `_lock` for that duration.
+    #   2. _lock - everything else: the event log, execution_status, the secret
+    #      registry, stats, HEAD, and the persistence writes they trigger.
+    _agent_lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)
+    _lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)
     _save_depth: int = PrivateAttr(default=0)  # context-manager nesting depth
     _dirty: bool = PrivateAttr(default=False)  # pending unsaved field changes
 
@@ -744,18 +751,54 @@ class ConversationState(OpenHandsModel):
         self._save_depth += 1
         return self
 
+    def _flush_deferred_save(self) -> None:
+        """Persist the mutations a context-manager block batched, if any."""
+        if not self._dirty:
+            return
+        fs = getattr(self, "_fs", None)
+        if getattr(self, "_autosave_enabled", False) and fs is not None:
+            self._save_base_state(fs)
+        self._dirty = False
+
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Context manager exit — flushes any deferred save."""
         try:
             self._save_depth -= 1
-            if self._save_depth == 0 and self._dirty:
-                fs = getattr(self, "_fs", None)
-                autosave_enabled = getattr(self, "_autosave_enabled", False)
-                if autosave_enabled and fs is not None:
-                    self._save_base_state(fs)
-                self._dirty = False
+            if self._save_depth == 0:
+                self._flush_deferred_save()
         finally:
             self._lock.release()
+
+    @contextmanager
+    def agent_step(self) -> Generator[None]:
+        """Run an agent step under ``_agent_lock``, with ``_lock`` released.
+
+        The run loop enters a step already holding the state lock and used to
+        keep it for the whole step, so message intake had to wait out the step
+        and pickup came down to a lock race (#4674). Hand the state lock back
+        for the duration instead: the step re-takes it per emitted event, and
+        concurrent steps are serialized on the dedicated agent lock.
+
+        A no-op beyond the agent lock when the caller does not hold ``_lock``
+        (a direct ``step()``/``astep()`` call).
+        """
+        depth = 0
+        save_depth = 0
+        if self._lock.owned():
+            # Batched mutations must not stay pending while the lock is open to
+            # other threads, and their `_save_depth` must not swallow the flush
+            # of a block another thread opens meanwhile.
+            save_depth = self._save_depth
+            self._save_depth = 0
+            self._flush_deferred_save()
+            depth = self._lock.release_all()
+        try:
+            with self._agent_lock:
+                yield
+        finally:
+            if depth:
+                self._lock.reacquire(depth)
+                self._save_depth = save_depth
 
     def locked(self) -> bool:
         """

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -1,8 +1,8 @@
 # state.py
 import json
 import threading
-from collections.abc import Callable, Generator, Sequence
-from contextlib import AbstractContextManager, contextmanager
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
 from enum import Enum
 from pathlib import Path
 from typing import Any, Self
@@ -250,9 +250,9 @@ class ConversationState(OpenHandsModel):
     _write_guard: Callable[[], AbstractContextManager[None]] | None = PrivateAttr(
         default=None
     )
-    # Acquire outer -> inner, never the reverse.
-    _agent_lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)  # the agent step
-    _lock: FIFOLock = PrivateAttr(default_factory=FIFOLock)  # everything else
+    _lock: FIFOLock = PrivateAttr(
+        default_factory=FIFOLock
+    )  # FIFO lock for thread safety
     _save_depth: int = PrivateAttr(default=0)  # context-manager nesting depth
     _dirty: bool = PrivateAttr(default=False)  # pending unsaved field changes
 
@@ -744,46 +744,18 @@ class ConversationState(OpenHandsModel):
         self._save_depth += 1
         return self
 
-    def _flush_deferred_save(self) -> None:
-        """Persist what a context-manager block batched, if anything."""
-        if not self._dirty:
-            return
-        fs = getattr(self, "_fs", None)
-        if getattr(self, "_autosave_enabled", False) and fs is not None:
-            self._save_base_state(fs)
-        self._dirty = False
-
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Context manager exit — flushes any deferred save."""
         try:
             self._save_depth -= 1
-            if self._save_depth == 0:
-                self._flush_deferred_save()
+            if self._save_depth == 0 and self._dirty:
+                fs = getattr(self, "_fs", None)
+                autosave_enabled = getattr(self, "_autosave_enabled", False)
+                if autosave_enabled and fs is not None:
+                    self._save_base_state(fs)
+                self._dirty = False
         finally:
             self._lock.release()
-
-    @contextmanager
-    def agent_step(self) -> Generator[None]:
-        """Run an agent step under ``_agent_lock``, with ``_lock`` released.
-
-        Steps serialize on the agent lock; the state lock stays free so intake
-        does not wait out a step. The step re-takes it per emitted event.
-        """
-        depth = 0
-        save_depth = 0
-        if self._lock.owned():
-            # Don't leave batched mutations pending while others hold the lock.
-            save_depth = self._save_depth
-            self._save_depth = 0
-            self._flush_deferred_save()
-            depth = self._lock.release_all()
-        try:
-            with self._agent_lock:
-                yield
-        finally:
-            if depth:
-                self._lock.reacquire(depth)
-                self._save_depth = save_depth
 
     def locked(self) -> bool:
         """

--- a/tests/sdk/conversation/local/test_message_sent_during_step.py
+++ b/tests/sdk/conversation/local/test_message_sent_during_step.py
@@ -17,6 +17,7 @@ from openhands.sdk.conversation.types import (
     ConversationCallbackType,
     ConversationTokenCallbackType,
 )
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.event.llm_convertible import (
     ActionEvent,
     MessageEvent,
@@ -123,6 +124,32 @@ async def test_arun_picks_up_message_sent_during_the_llm_call(tmp_path):
     assert agent.steps[0] == ["first"]
     assert agent.steps[1] == ["first", MID_STEP_MESSAGE]
     assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+
+@pytest.mark.asyncio
+async def test_message_at_the_iteration_cap_leaves_the_run_idle(tmp_path):
+    """Out of iterations, go idle for a follow-up run, not MaxIterationsReached."""
+    agent = _LLMWindowAgent()
+    conversation = Conversation(
+        agent=agent, workspace=str(tmp_path), max_iteration_per_run=1
+    )
+    assert isinstance(conversation, LocalConversation)
+    conversation.send_message("first")
+
+    await conversation.arun()
+
+    assert len(agent.steps) == 1
+    assert conversation.state.execution_status == ConversationExecutionStatus.IDLE
+    codes = [
+        event.code
+        for event in conversation.state.events
+        if isinstance(event, ConversationErrorEvent)
+    ]
+    assert codes == [], f"unexpected error events: {codes}"
+
+    # The follow-up run consumes the message that did not fit.
+    await conversation.arun()
+    assert agent.steps[1] == ["first", MID_STEP_MESSAGE]
 
 
 class _ToolCallAction(Action):

--- a/tests/sdk/conversation/local/test_message_sent_during_step.py
+++ b/tests/sdk/conversation/local/test_message_sent_during_step.py
@@ -1,12 +1,4 @@
-"""A user message sent while a step is in flight must be picked up.
-
-Regression for OpenHands/OpenHands#15432: the run loop held the single
-conversation state lock across the whole agent step, so message intake had to
-wait the step out and whether the message was seen came down to a lock race.
-The step now runs under a dedicated agent lock with the state lock released
-(#4674), and the loop refuses to close on the agent's FINISHED when a user
-message arrived after the step began.
-"""
+"""A user message sent while a step is in flight must be picked up."""
 
 import asyncio
 import threading
@@ -32,11 +24,10 @@ SECOND_MESSAGE = "sent while the step was in flight"
 
 
 class _MessageDuringStepAgent(AgentBase):
-    """Finishes on every step, but sends a user message from the first one.
+    """Finishes on every step; sends a user message from inside the first.
 
-    The message is sent from a *separate* thread and joined inside the step, so
-    the test never sleeps: if intake were still serialized behind the step, the
-    join would time out and ``intake_completed_during_step`` stays False.
+    Sent from a separate thread and joined, so the test never sleeps: if intake
+    were serialized behind the step, the join would time out.
     """
 
     def __init__(self) -> None:
@@ -49,7 +40,7 @@ class _MessageDuringStepAgent(AgentBase):
 
     @property
     def steps(self) -> list[list[str]]:
-        """User-message texts visible to the agent at the start of each step."""
+        """User-message texts seen at the start of each step."""
         return self._steps
 
     @property
@@ -110,13 +101,7 @@ class _MessageDuringStepAgent(AgentBase):
 
 
 class _MessageDuringLLMCallAgent(_MessageDuringStepAgent):
-    """Sends the message from inside the released-lock LLM window.
-
-    This is what ``Agent.astep`` really does: it hands the state lock back
-    around the provider round-trip via ``_released_state_lock_during_io``. A
-    message arriving there lands while the status is still RUNNING, so nothing
-    reset the FINISHED the step went on to set — OpenHands/OpenHands#15432.
-    """
+    """Sends the message from the released-lock window ``Agent.astep`` uses."""
 
     async def astep(
         self,
@@ -192,7 +177,7 @@ def test_state_lock_is_free_while_a_step_runs(tmp_path):
 
 @pytest.mark.asyncio
 async def test_arun_picks_up_message_sent_during_the_llm_call(tmp_path):
-    """The reported OpenHands/OpenHands#15432 symptom must not reproduce."""
+    """A message landing during the LLM round-trip must not be dropped."""
     conversation, agent = _make_conversation(tmp_path, _MessageDuringLLMCallAgent)
     await conversation.arun()
     _assert_picked_up(agent)

--- a/tests/sdk/conversation/local/test_message_sent_during_step.py
+++ b/tests/sdk/conversation/local/test_message_sent_during_step.py
@@ -1,0 +1,198 @@
+"""A user message sent while a step is in flight must be picked up.
+
+Regression for OpenHands/OpenHands#15432: the run loop held the single
+conversation state lock across the whole agent step, so message intake had to
+wait the step out and whether the message was seen came down to a lock race.
+The step now runs under a dedicated agent lock with the state lock released
+(#4674), and the loop refuses to close on the agent's FINISHED when a user
+message arrived after the step began.
+"""
+
+import asyncio
+import threading
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.conversation import Conversation, LocalConversation
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
+from openhands.sdk.conversation.types import (
+    ConversationCallbackType,
+    ConversationTokenCallbackType,
+)
+from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.sdk.llm import LLM, Message, TextContent
+
+
+SECOND_MESSAGE = "sent while the step was in flight"
+
+
+class _MessageDuringStepAgent(AgentBase):
+    """Finishes on every step, but sends a user message from the first one.
+
+    The message is sent from a *separate* thread and joined inside the step, so
+    the test never sleeps: if intake were still serialized behind the step, the
+    join would time out and ``intake_completed_during_step`` stays False.
+    """
+
+    def __init__(self) -> None:
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"
+        )
+        super().__init__(llm=llm, tools=[])
+        self._steps: list[list[str]] = []
+        self._intake_completed_during_step = False
+
+    @property
+    def steps(self) -> list[list[str]]:
+        """User-message texts visible to the agent at the start of each step."""
+        return self._steps
+
+    @property
+    def intake_completed_during_step(self) -> bool:
+        return self._intake_completed_during_step
+
+    def init_state(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        on_event(
+            SystemPromptEvent(
+                source="agent", system_prompt=TextContent(text="dummy"), tools=[]
+            )
+        )
+
+    def _record_step(self, conversation: LocalConversation) -> None:
+        self._steps.append(
+            [
+                event.llm_message.content[0].text  # type: ignore[union-attr]
+                for event in conversation.state.events
+                if isinstance(event, MessageEvent) and event.source == "user"
+            ]
+        )
+
+    def _send_from_another_thread(self, conversation: LocalConversation) -> None:
+        thread = threading.Thread(
+            target=conversation.send_message, args=(SECOND_MESSAGE,)
+        )
+        thread.start()
+        thread.join(timeout=10.0)
+        self._intake_completed_during_step = not thread.is_alive()
+
+    def step(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+    ) -> None:
+        self._record_step(conversation)
+        if len(self._steps) == 1:
+            self._send_from_another_thread(conversation)
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            )
+        )
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+    async def astep(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+        prompt_message: MessageEvent | None = None,
+    ) -> None:
+        await asyncio.to_thread(self.step, conversation, on_event, on_token)
+
+
+class _MessageDuringLLMCallAgent(_MessageDuringStepAgent):
+    """Sends the message from inside the released-lock LLM window.
+
+    This is what ``Agent.astep`` really does: it hands the state lock back
+    around the provider round-trip via ``_released_state_lock_during_io``. A
+    message arriving there lands while the status is still RUNNING, so nothing
+    reset the FINISHED the step went on to set — OpenHands/OpenHands#15432.
+    """
+
+    async def astep(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+        prompt_message: MessageEvent | None = None,
+    ) -> None:
+        self._record_step(conversation)
+        async with conversation._released_state_lock_during_io():
+            if len(self._steps) == 1:
+                await asyncio.to_thread(self._send_from_another_thread, conversation)
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            )
+        )
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+
+def _make_conversation(
+    tmp_path, agent_cls: type[_MessageDuringStepAgent] = _MessageDuringStepAgent
+) -> tuple[LocalConversation, _MessageDuringStepAgent]:
+    agent = agent_cls()
+    conversation = Conversation(
+        agent=agent, workspace=str(tmp_path), max_iteration_per_run=5
+    )
+    assert isinstance(conversation, LocalConversation)
+    conversation.send_message("first")
+    return conversation, agent
+
+
+def _assert_picked_up(agent: _MessageDuringStepAgent) -> None:
+    assert agent.intake_completed_during_step, (
+        "send_message() blocked until the step finished; intake is still "
+        "serialized behind the run loop"
+    )
+    assert len(agent.steps) == 2, (
+        f"expected a second step for the mid-step message, saw {agent.steps}"
+    )
+    assert agent.steps[0] == ["first"]
+    assert agent.steps[1] == ["first", SECOND_MESSAGE]
+
+
+def test_sync_run_picks_up_message_sent_during_step(tmp_path):
+    conversation, agent = _make_conversation(tmp_path)
+    conversation.run()
+    _assert_picked_up(agent)
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+
+@pytest.mark.asyncio
+async def test_arun_picks_up_message_sent_during_step(tmp_path):
+    conversation, agent = _make_conversation(tmp_path)
+    await conversation.arun()
+    _assert_picked_up(agent)
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+
+def test_state_lock_is_free_while_a_step_runs(tmp_path):
+    """``agent_step()`` hands the state lock back for the step's duration."""
+    conversation, _ = _make_conversation(tmp_path)
+    state = conversation._state
+    with state:
+        assert state.owned()
+        with state.agent_step():
+            assert not state.owned()
+            assert state._agent_lock.owned()
+        assert state.owned()
+    assert not state.locked()
+
+
+@pytest.mark.asyncio
+async def test_arun_picks_up_message_sent_during_the_llm_call(tmp_path):
+    """The reported OpenHands/OpenHands#15432 symptom must not reproduce."""
+    conversation, agent = _make_conversation(tmp_path, _MessageDuringLLMCallAgent)
+    await conversation.arun()
+    _assert_picked_up(agent)

--- a/tests/sdk/conversation/local/test_message_sent_during_step.py
+++ b/tests/sdk/conversation/local/test_message_sent_during_step.py
@@ -1,6 +1,7 @@
 """A user message sent while a step is in flight must be picked up."""
 
 import asyncio
+import json
 import threading
 
 import pytest
@@ -16,36 +17,54 @@ from openhands.sdk.conversation.types import (
     ConversationCallbackType,
     ConversationTokenCallbackType,
 )
-from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
-from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.event.llm_convertible import (
+    ActionEvent,
+    MessageEvent,
+    ObservationEvent,
+    SystemPromptEvent,
+)
+from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
+from openhands.sdk.tool import Action, Observation
 
 
-SECOND_MESSAGE = "sent while the step was in flight"
+MID_STEP_MESSAGE = "sent while the step was in flight"
 
 
-class _MessageDuringStepAgent(AgentBase):
-    """Finishes on every step; sends a user message from inside the first.
+def _llm() -> LLM:
+    return LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
 
-    Sent from a separate thread and joined, so the test never sleeps: if intake
-    were serialized behind the step, the join would time out.
+
+def _user_messages(conversation: LocalConversation) -> list[str]:
+    return [
+        event.llm_message.content[0].text  # type: ignore[union-attr]
+        for event in conversation.state.events
+        if isinstance(event, MessageEvent) and event.source == "user"
+    ]
+
+
+def _send_and_wait(conversation: LocalConversation, text: str) -> bool:
+    """Send from another thread and join; True if it completed."""
+    thread = threading.Thread(target=conversation.send_message, args=(text,))
+    thread.start()
+    thread.join(timeout=10.0)
+    return not thread.is_alive()
+
+
+class _LLMWindowAgent(AgentBase):
+    """Sends a user message from the window ``Agent.astep`` releases the lock in.
+
+    ``Agent.astep`` hands the state lock back around the provider round-trip, so
+    a message can be appended there. It lands while the status is still RUNNING,
+    which is why nothing resets the FINISHED the step goes on to set.
     """
 
     def __init__(self) -> None:
-        llm = LLM(
-            model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"
-        )
-        super().__init__(llm=llm, tools=[])
+        super().__init__(llm=_llm(), tools=[])
         self._steps: list[list[str]] = []
-        self._intake_completed_during_step = False
 
     @property
     def steps(self) -> list[list[str]]:
-        """User-message texts seen at the start of each step."""
         return self._steps
-
-    @property
-    def intake_completed_during_step(self) -> bool:
-        return self._intake_completed_during_step
 
     def init_state(
         self, state: ConversationState, on_event: ConversationCallbackType
@@ -56,22 +75,87 @@ class _MessageDuringStepAgent(AgentBase):
             )
         )
 
-    def _record_step(self, conversation: LocalConversation) -> None:
-        self._steps.append(
-            [
-                event.llm_message.content[0].text  # type: ignore[union-attr]
-                for event in conversation.state.events
-                if isinstance(event, MessageEvent) and event.source == "user"
-            ]
-        )
+    def step(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+    ) -> None:
+        raise NotImplementedError
 
-    def _send_from_another_thread(self, conversation: LocalConversation) -> None:
-        thread = threading.Thread(
-            target=conversation.send_message, args=(SECOND_MESSAGE,)
+    async def astep(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+        prompt_message: MessageEvent | None = None,
+    ) -> None:
+        self._steps.append(_user_messages(conversation))
+        async with conversation._released_state_lock_during_io():
+            if len(self._steps) == 1:
+                assert await asyncio.to_thread(
+                    _send_and_wait, conversation, MID_STEP_MESSAGE
+                )
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            )
         )
-        thread.start()
-        thread.join(timeout=10.0)
-        self._intake_completed_during_step = not thread.is_alive()
+        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+
+@pytest.mark.asyncio
+async def test_arun_picks_up_message_sent_during_the_llm_call(tmp_path):
+    """A message landing during the LLM round-trip must not be dropped."""
+    agent = _LLMWindowAgent()
+    conversation = Conversation(
+        agent=agent, workspace=str(tmp_path), max_iteration_per_run=5
+    )
+    assert isinstance(conversation, LocalConversation)
+    conversation.send_message("first")
+
+    await conversation.arun()
+
+    assert len(agent.steps) == 2, (
+        f"expected a second step for the mid-step message, saw {agent.steps}"
+    )
+    assert agent.steps[0] == ["first"]
+    assert agent.steps[1] == ["first", MID_STEP_MESSAGE]
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+
+
+class _ToolCallAction(Action):
+    command: str
+
+
+class _ToolCallObservation(Observation):
+    result: str
+
+    @property
+    def to_llm_content(self):
+        return [TextContent(text=self.result)]
+
+
+class _ToolCallAgent(AgentBase):
+    """Emits one action, waits as a tool would, then emits its observation."""
+
+    def __init__(self) -> None:
+        super().__init__(llm=_llm(), tools=[])
+        self._intake_completed_mid_tool_call = False
+
+    @property
+    def intake_completed_mid_tool_call(self) -> bool:
+        return self._intake_completed_mid_tool_call
+
+    def init_state(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        on_event(
+            SystemPromptEvent(
+                source="agent", system_prompt=TextContent(text="dummy"), tools=[]
+            )
+        )
 
     def step(
         self,
@@ -79,105 +163,59 @@ class _MessageDuringStepAgent(AgentBase):
         on_event: ConversationCallbackType,
         on_token: ConversationTokenCallbackType | None = None,
     ) -> None:
-        self._record_step(conversation)
-        if len(self._steps) == 1:
-            self._send_from_another_thread(conversation)
-        on_event(
-            MessageEvent(
-                source="agent",
-                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
-            )
+        action = ActionEvent(
+            source="agent",
+            thought=[TextContent(text="t")],
+            action=_ToolCallAction(command="sleep"),
+            tool_name="bash",
+            tool_call_id="call_1",
+            tool_call=MessageToolCall(
+                id="call_1",
+                name="bash",
+                arguments=json.dumps({"command": "sleep"}),
+                origin="completion",
+            ),
+            llm_response_id="resp_1",
         )
-        conversation.state.execution_status = ConversationExecutionStatus.FINISHED
-
-    async def astep(
-        self,
-        conversation: LocalConversation,
-        on_event: ConversationCallbackType,
-        on_token: ConversationTokenCallbackType | None = None,
-        prompt_message: MessageEvent | None = None,
-    ) -> None:
-        await asyncio.to_thread(self.step, conversation, on_event, on_token)
-
-
-class _MessageDuringLLMCallAgent(_MessageDuringStepAgent):
-    """Sends the message from the released-lock window ``Agent.astep`` uses."""
-
-    async def astep(
-        self,
-        conversation: LocalConversation,
-        on_event: ConversationCallbackType,
-        on_token: ConversationTokenCallbackType | None = None,
-        prompt_message: MessageEvent | None = None,
-    ) -> None:
-        self._record_step(conversation)
-        async with conversation._released_state_lock_during_io():
-            if len(self._steps) == 1:
-                await asyncio.to_thread(self._send_from_another_thread, conversation)
+        on_event(action)
+        # The tool is "executing" here.
+        self._intake_completed_mid_tool_call = _send_and_wait(
+            conversation, MID_STEP_MESSAGE
+        )
         on_event(
-            MessageEvent(
-                source="agent",
-                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            ObservationEvent(
+                source="environment",
+                observation=_ToolCallObservation(result="done"),
+                action_id=action.id,
+                tool_name="bash",
+                tool_call_id="call_1",
             )
         )
         conversation.state.execution_status = ConversationExecutionStatus.FINISHED
 
 
-def _make_conversation(
-    tmp_path, agent_cls: type[_MessageDuringStepAgent] = _MessageDuringStepAgent
-) -> tuple[LocalConversation, _MessageDuringStepAgent]:
-    agent = agent_cls()
+def test_user_message_never_splits_a_tool_call(tmp_path):
+    """Intake must not append between an action and its observation.
+
+    Providers require a tool result to follow its tool call directly. A user
+    message spliced in between yields assistant(tool_calls) -> user -> tool.
+    """
+    agent = _ToolCallAgent()
     conversation = Conversation(
-        agent=agent, workspace=str(tmp_path), max_iteration_per_run=5
+        agent=agent, workspace=str(tmp_path), max_iteration_per_run=1
     )
     assert isinstance(conversation, LocalConversation)
-    conversation.send_message("first")
-    return conversation, agent
+    conversation.send_message("go")
 
-
-def _assert_picked_up(agent: _MessageDuringStepAgent) -> None:
-    assert agent.intake_completed_during_step, (
-        "send_message() blocked until the step finished; intake is still "
-        "serialized behind the run loop"
-    )
-    assert len(agent.steps) == 2, (
-        f"expected a second step for the mid-step message, saw {agent.steps}"
-    )
-    assert agent.steps[0] == ["first"]
-    assert agent.steps[1] == ["first", SECOND_MESSAGE]
-
-
-def test_sync_run_picks_up_message_sent_during_step(tmp_path):
-    conversation, agent = _make_conversation(tmp_path)
     conversation.run()
-    _assert_picked_up(agent)
-    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
 
-
-@pytest.mark.asyncio
-async def test_arun_picks_up_message_sent_during_step(tmp_path):
-    conversation, agent = _make_conversation(tmp_path)
-    await conversation.arun()
-    _assert_picked_up(agent)
-    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
-
-
-def test_state_lock_is_free_while_a_step_runs(tmp_path):
-    """``agent_step()`` hands the state lock back for the step's duration."""
-    conversation, _ = _make_conversation(tmp_path)
-    state = conversation._state
-    with state:
-        assert state.owned()
-        with state.agent_step():
-            assert not state.owned()
-            assert state._agent_lock.owned()
-        assert state.owned()
-    assert not state.locked()
-
-
-@pytest.mark.asyncio
-async def test_arun_picks_up_message_sent_during_the_llm_call(tmp_path):
-    """A message landing during the LLM round-trip must not be dropped."""
-    conversation, agent = _make_conversation(tmp_path, _MessageDuringLLMCallAgent)
-    await conversation.arun()
-    _assert_picked_up(agent)
+    assert not agent.intake_completed_mid_tool_call, (
+        "send_message() completed while a tool call was in flight; it can now "
+        "split the action/observation pair"
+    )
+    order = [type(event).__name__ for event in conversation.state.events]
+    action_at = order.index("ActionEvent")
+    observation_at = order.index("ObservationEvent")
+    assert observation_at == action_at + 1, (
+        f"an event was appended between the action and its observation: {order}"
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`Agent.astep` hands the conversation state lock back around the provider round-trip. A `send_message()` that lands in that window appends while the execution status is still `RUNNING`, so nothing resets the `FINISHED` the step goes on to set. The run loop breaks and the agent never reads the message. That is OpenHands/OpenHands#15432, "messages sent during streaming are not always seen by the agent".

Pickup was decided by which thread won the lock, not by whether new input existed.

## Summary

- The run loop now records `last_user_message_id` before each step and compares it after. If a user message arrived while the step was in flight, the agent's `FINISHED` no longer ends the run.
- When that happens on the final permitted iteration, the run goes idle for a follow-up run instead of falling through to `MaxIterationsReached`. This mirrors what the ACP branch of `arun()` already does for the same situation.
- 38 lines in `local_conversation.py`, applied to both the sync and async loops. Nothing else changes.

## Issue Number

Fixes #4674
Closes OpenHands/OpenHands#15432

## How to Test

```
uv run pytest tests/sdk/conversation/local/test_message_sent_during_step.py -q
```

`test_arun_picks_up_message_sent_during_the_llm_call` fails on `main`:

```
AssertionError: expected a second step for the mid-step message, saw [['first']]
```

End-to-end, driving the real `arun()` with an agent that releases the lock around a simulated 3s provider call exactly as `Agent.astep` does, while another thread sends a message into that window:

| | `main` | this branch |
| --- | --- | --- |
| steps taken | 1 | 2 |
| second step saw | n/a | `['first', 'mid-step message']` |
| outcome | MESSAGE LOST | message picked up |

Regression runs on this branch:

```
uv run pytest tests/sdk -q           ->  6027 passed, 9 skipped, 10 xfailed
uv run pytest tests/agent_server -q  ->  2083 passed
uv run pre-commit run --files <changed files>  ->  all hooks pass
```

## Video/Screenshots

Not applicable. Concurrency change with no user interface surface; the before/after table above is the observable evidence.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**On the lock split #4674 asks for.** I first implemented it: a separate `_agent_lock` for the step, with the state lock released for the step's duration so intake never waits. It is on this branch's history (`c381b67`) and it is wrong. Releasing the state lock across the step lets a user message append **between an `ActionEvent` and its `ObservationEvent`**, because tool execution sits between those two `on_event` calls and holds no lock. The LLM history then reads:

```
assistant(tool_calls=[call_1])
user("stop!")
tool(tool_call_id=call_1)
```

The tool result no longer directly follows its call. Anthropic requires `tool_result` to open the very next user turn, and `View.enforce_properties` does not repair the ordering — it keeps all three events. Verified with a probe on both versions:

| | intake completes mid tool call | event order |
| --- | --- | --- |
| `main` | no | Action -> Observation |
| lock-split attempt | yes | Action -> **user message** -> Observation |
| this branch | no | Action -> Observation |

So narrowing the run loop's hold is not safe on its own. It needs the intake queue that #4671 covers, so a message arriving mid-tool-loop can be parked and spliced at a turn boundary rather than appended where it lands. This PR therefore does the half that is safe and that #4674 says closes the bug by itself: it makes pickup deterministic. The lock is still one lock.

`test_user_message_never_splits_a_tool_call` pins the invariant, so whoever does the split next gets a failing test instead of malformed histories. It passes on `main` and here, and fails on the lock-split attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LW36SdS3D1r4xfdjGTUDix

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0536343-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0536343-python \
  ghcr.io/openhands/agent-server:0536343-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0536343-golang-amd64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-golang-amd64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-golang-amd64
ghcr.io/openhands/agent-server:0536343-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0536343-golang-arm64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-golang-arm64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-golang-arm64
ghcr.io/openhands/agent-server:0536343-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0536343-java-amd64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-java-amd64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-java-amd64
ghcr.io/openhands/agent-server:0536343-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0536343-java-arm64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-java-arm64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-java-arm64
ghcr.io/openhands/agent-server:0536343-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0536343-python-amd64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python-amd64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python-amd64
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0536343-python-arm64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python-arm64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python-arm64
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0536343-python-slim-amd64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python-slim-amd64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python-slim-amd64
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:0536343-python-slim-arm64
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python-slim-arm64
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python-slim-arm64
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:0536343-golang
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-golang
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-golang
ghcr.io/openhands/agent-server:0536343-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0536343-java
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-java
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-java
ghcr.io/openhands/agent-server:0536343-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0536343-python-slim
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python-slim
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python-slim
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:0536343-python
ghcr.io/openhands/agent-server:0536343a3a805ab35308c44ff3964a6c6b86ac8c-python
ghcr.io/openhands/agent-server:vasco-state-4674-split-state-locks-python
ghcr.io/openhands/agent-server:0536343-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0536343-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0536343-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->