### PR TITLE
ci(typescript-client): run integration tests against the branch's agent-server

### DIFF
--- a/.github/workflows/typescript-client-integration-tests.yml
+++ b/.github/workflows/typescript-client-integration-tests.yml
@@ -17,6 +17,10 @@ env:
     AGENT_SERVER_PORT: 8010
     HOST_WORKSPACE_DIR: /tmp/agent-workspace
     AGENT_WORKSPACE_DIR: /workspace
+    # integration-test builds this from the branch and loads it straight into the
+    # runner's daemon, never pushing, so fork PRs need no registry credentials.
+    # smoke-test deliberately stays on the pinned release image.
+    BRANCH_AGENT_SERVER_IMAGE: agent-server:branch-build
 
 defaults:
     run:
@@ -25,7 +29,8 @@ defaults:
 jobs:
     integration-test:
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        # Raised from 30: this job now builds the agent-server image itself.
+        timeout-minutes: 45
 
         steps:
             - name: Checkout code
@@ -38,12 +43,17 @@ jobs:
                   cache: npm
                   cache-dependency-path: clients/typescript/package-lock.json
 
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  version: latest
+                  python-version: '3.13'
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
             - name: Install dependencies
               run: npm ci
-
-            - name: Resolve agent-server image
-              run: |
-                  echo "AGENT_SERVER_IMAGE=$(node -p 'require("./package.json").config.agentServerImage')" >> "$GITHUB_ENV"
 
             - name: Build package
               run: npm run build
@@ -53,10 +63,38 @@ jobs:
                   mkdir -p ${{ env.HOST_WORKSPACE_DIR }}
                   chmod 777 ${{ env.HOST_WORKSPACE_DIR }}
 
-            - name: Pull agent-server Docker image
+            - name: Prepare agent-server build context
+              id: agent_server_ctx
+              working-directory: .
               run: |
-                  docker pull ${{ env.AGENT_SERVER_IMAGE }}
-                  docker images
+                  uv sync --frozen
+                  uv run ./openhands-agent-server/openhands/agent_server/docker/build.py \
+                      --build-ctx-only --arch amd64 \
+                      --base-image nikolaik/python-nodejs:python3.13-nodejs22-slim
+
+            - name: Build agent-server image from this branch
+              uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+              with:
+                  context: ${{ steps.agent_server_ctx.outputs.build_context }}
+                  file: ${{ steps.agent_server_ctx.outputs.dockerfile }}
+                  # `source` skips the pyinstaller stage that `binary` needs. Every
+                  # layer beneath it is shared, so the cache below still applies.
+                  target: source
+                  platforms: linux/amd64
+                  push: false
+                  load: true
+                  tags: ${{ env.BRANCH_AGENT_SERVER_IMAGE }}
+                  # Scope server.yml populates with mode=max on push to main.
+                  cache-from: type=gha,scope=agent-server-python-amd64
+                  build-args: |
+                      BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22-slim
+                      OPENHANDS_BUILD_GIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+                      OPENHANDS_BUILD_GIT_REF=${{ github.head_ref != '' && format('refs/heads/{0}', github.head_ref) || github.ref }}
+                      INSTALL_ACP_PROVIDERS=claude-code,codex,gemini-cli
+                      INSTALL_CAPABILITIES=vscode,browser,docker
+
+            - name: Show built image
+              run: docker images ${{ env.BRANCH_AGENT_SERVER_IMAGE }}
 
             - name: Start agent-server container
               run: |
@@ -65,7 +103,7 @@ jobs:
                     -p 127.0.0.1:${{ env.AGENT_SERVER_PORT }}:8000 \
                     -v ${{ env.HOST_WORKSPACE_DIR }}:${{ env.AGENT_WORKSPACE_DIR }} \
                     -e LOG_JSON=true \
-                    ${{ env.AGENT_SERVER_IMAGE }} --host 0.0.0.0
+                    ${{ env.BRANCH_AGENT_SERVER_IMAGE }} --host 0.0.0.0
 
                   # Wait for container to start
                   sleep 5


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Make integration test of typescript-client run against agent-server build by the branch.

---

AGENT:

## Why

The TypeScript client's integration job never tested the agent-server it ships
beside. It read `config.agentServerImage` from `clients/typescript/package.json`,
pulled that exact published tag from the registry and ran the suite against it.
Today that pin is `ghcr.io/openhands/agent-server:1.44.0-python`, cut on
2026-08-27, while the tree is at 1.44.1 with unreleased server changes on top.

So a PR touching both `openhands-agent-server/` and `clients/typescript/` in one
commit had its client tested against the last release, and the pairing it
actually changed was never exercised. Nothing else covered that gap either. The
`Check OpenAPI Schema` job runs `make test-server-schema`, which despite the step
name exports the in-tree schema twice, diffs them for determinism, runs a quality
script and validates the JSON. It never builds or checks the TypeScript client.

The same pin also means a client change that depends on a new server endpoint
cannot be tested at all until a release exists and the pin is bumped, which is a
real ordering constraint for the streaming epic's endpoint switch.

## Summary

- `integration-test` now builds the agent-server from the checkout with
  `build.py --build-ctx-only` plus `docker/build-push-action`, and loads the
  result into the runner's Docker daemon. Nothing is pushed, so fork PRs need no
  registry credentials.
- The build uses the `source` target rather than `binary`, skipping the
  pyinstaller stage. Every layer beneath it is shared with the published variant,
  so `cache-from: type=gha,scope=agent-server-python-amd64`, the scope
  `server.yml` already fills with `mode=max` on pushes to main, still applies.
- `smoke-test` deliberately keeps pulling the pinned release image, so the
  "client still works against what is deployed" check is not lost.
- Job timeout raised from 30 to 45 minutes, since the job now builds rather than
  pulls.

## Issue Number

Related to #4671. Not a fix for it, so no closing keyword: this came out of
reviewing how the client is tested after it moved into this repository, and it
unblocks testing that epic's endpoint switch against a server that actually has
the endpoint. Happy to file a dedicated issue instead if reviewers prefer.

## How to Test

CI on this PR is the test: `integration-test` should build the image from this
branch and go green, and `smoke-test` should still pull the pinned release.
Confirm from the logs that `Build agent-server image from this branch` runs and
that `Show built image` lists `agent-server:branch-build`.

The build-context step also runs locally, which is how the base-image mismatch
below was caught:

```
GITHUB_OUTPUT=/tmp/out.txt uv run \
  ./openhands-agent-server/openhands/agent_server/docker/build.py \
  --build-ctx-only --arch amd64 \
  --base-image nikolaik/python-nodejs:python3.13-nodejs22-slim
cat /tmp/out.txt
```

It writes `build_context`, `dockerfile`, `tags_csv` and `base_image_slug`, and
the generated Dockerfile contains the `source` stage this workflow targets.

## Video/Screenshots

N/A, CI-only change with no UI surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- `build.py` defaults to a python3.12 base image while the published `python`
  variant is built on python3.13. The local run above surfaced that, so the base
  image is now passed explicitly to both `build.py` and the build action rather
  than being inherited from the default.
- `config.agentServerImage` is deliberately left in place. It still drives
  generated types via `scripts/agent-server-openapi.mjs` and the `smoke-test`
  job, so only the integration job stops reading it.
- Build time is the thing to watch in review. The cache scope should cover the
  expensive base-image layers, but if a cold build proves too slow, the cheaper
  options are the `source-minimal` target or dropping
  `INSTALL_CAPABILITIES`/`INSTALL_ACP_PROVIDERS`. Both trade fidelity with the
  published image for speed, so I kept fidelity by default.

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4ab7971-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4ab7971-python \
  ghcr.io/openhands/agent-server:4ab7971-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4ab7971-golang-amd64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-golang-amd64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-golang-amd64
ghcr.io/openhands/agent-server:4ab7971-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4ab7971-golang-arm64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-golang-arm64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-golang-arm64
ghcr.io/openhands/agent-server:4ab7971-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4ab7971-java-amd64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-java-amd64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-java-amd64
ghcr.io/openhands/agent-server:4ab7971-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4ab7971-java-arm64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-java-arm64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-java-arm64
ghcr.io/openhands/agent-server:4ab7971-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4ab7971-python-amd64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python-amd64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python-amd64
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4ab7971-python-arm64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python-arm64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python-arm64
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4ab7971-python-slim-amd64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python-slim-amd64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python-slim-amd64
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:4ab7971-python-slim-arm64
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python-slim-arm64
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python-slim-arm64
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:4ab7971-golang
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-golang
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-golang
ghcr.io/openhands/agent-server:4ab7971-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4ab7971-java
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-java
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-java
ghcr.io/openhands/agent-server:4ab7971-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4ab7971-python-slim
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python-slim
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python-slim
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:4ab7971-python
ghcr.io/openhands/agent-server:4ab7971c12e78c2afab18190ed2c1213d88350d4-python
ghcr.io/openhands/agent-server:vasco-ts-itests-branch-server-python
ghcr.io/openhands/agent-server:4ab7971-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4ab7971-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4ab7971-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->