### PR TITLE
fix(llm): parse and normalize DeepSeek V4 DSML tool calls

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -111,6 +111,10 @@ from openhands.sdk.llm.streaming import (
     TokenCallbackType,
     _invoke_token_callback,
 )
+from openhands.sdk.llm.utils.dsml import (
+    DSMLStreamFilter,
+    normalize_deepseek_v4_response,
+)
 from openhands.sdk.llm.utils.image_inline import (
     amaybe_inline_image_urls,
     maybe_inline_image_urls,
@@ -1482,6 +1486,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 (Gemini sometimes returns empty choices; raising here
                 inside the retry boundary ensures it is retried).
         """
+        if self._model_features().supports_dsml_tool_calls:
+            resp = normalize_deepseek_v4_response(resp, model=self.model)
+
         raw_resp: ModelResponse | None = None
         if use_mock_tools:
             raw_resp = copy.deepcopy(resp)
@@ -2228,10 +2235,20 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
         )
         if enable_streaming and on_token is not None:
+            stream_filter = (
+                DSMLStreamFilter(on_token)
+                if self._model_features().supports_dsml_tool_calls
+                else None
+            )
             chunks: list[ModelResponseStream] = []
             stream = cast(Iterable[ModelResponseStream], ret)
             for chunk in stream:
-                on_token(chunk)
+                if stream_filter is not None:
+                    filtered_chunk = stream_filter.filter_chunk(chunk)
+                    if filtered_chunk is not None:
+                        on_token(filtered_chunk)
+                else:
+                    on_token(chunk)
                 chunks.append(chunk)
             ret = litellm.stream_chunk_builder(chunks, messages=messages)
 
@@ -2259,13 +2276,23 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
         )
         if enable_streaming and on_token is not None:
+            stream_filter = (
+                DSMLStreamFilter(on_token)
+                if self._model_features().supports_dsml_tool_calls
+                else None
+            )
             chunks: list[ModelResponseStream] = []
             # Some litellm wrappers (lmnr 0.7.47's instrumentor) hand
             # back a plain sync generator from ``litellm_acompletion``
             if hasattr(ret, "__aiter__"):
                 stream = cast(AsyncIterable[ModelResponseStream], ret)
                 async for chunk in stream:
-                    await _invoke_token_callback(on_token, chunk)
+                    if stream_filter is not None:
+                        filtered_chunk = stream_filter.filter_chunk(chunk)
+                        if filtered_chunk is not None:
+                            await _invoke_token_callback(on_token, filtered_chunk)
+                    else:
+                        await _invoke_token_callback(on_token, chunk)
                     chunks.append(chunk)
             else:
                 loop = asyncio.get_running_loop()
@@ -2273,7 +2300,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     None, list, cast(Iterable[ModelResponseStream], ret)
                 )
                 for chunk in synced_chunks:
-                    await _invoke_token_callback(on_token, chunk)
+                    if stream_filter is not None:
+                        filtered_chunk = stream_filter.filter_chunk(chunk)
+                        if filtered_chunk is not None:
+                            await _invoke_token_callback(on_token, filtered_chunk)
+                    else:
+                        await _invoke_token_callback(on_token, chunk)
                     chunks.append(chunk)
             ret = litellm.stream_chunk_builder(chunks, messages=messages)
 

--- a/openhands-sdk/openhands/sdk/llm/mixins/non_native_fc.py
+++ b/openhands-sdk/openhands/sdk/llm/mixins/non_native_fc.py
@@ -89,6 +89,8 @@ class NonNativeToolCallingMixin:
 
         # Preserve provider-specific reasoning fields before conversion
         orig_msg = resp.choices[0].message
+        if getattr(orig_msg, "tool_calls", None):
+            return resp
         non_fn_message: dict = orig_msg.model_dump()
         fn_msgs: list[dict] = convert_non_fncall_messages_to_fncall_messages(
             nonfncall_msgs + [non_fn_message],

--- a/openhands-sdk/openhands/sdk/llm/utils/dsml.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/dsml.py
@@ -1,0 +1,459 @@
+"""DeepSeek Markup Language (DSML) parsing and normalization for DeepSeek V4 models.
+
+DeepSeek V4 models may format tool calls using an XML-based markup syntax
+(`<｜DSML｜tool_calls>`, `<｜｜DSML｜｜r=...>`, etc.) instead of the standard OpenAI
+`tool_calls` structure, especially when tool calling is not natively bridged
+or when models fall back to internal tool calling markup.
+
+This module normalizes DSML markup from `content` into standard OpenAI-compatible
+`ChatCompletionMessageToolCall` structures, strips the markup from `content`, and
+provides a streaming filter to prevent DSML tokens from leaking to user-visible
+`on_token` callbacks.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+from litellm import (
+    ChatCompletionMessageToolCall,
+    ModelResponse,
+    ModelResponseStream,
+)
+from litellm.types.utils import Function
+
+
+logger = logging.getLogger(__name__)
+
+# Markers for DSML blocks. Covers both fullwidth (｜, U+FF5C) and standard ASCII (|)
+_DSML_MARKER_PATTERN = r"(?:\|\|DSML\|\||｜｜DSML｜｜|\|DSML\||｜DSML｜)"
+_DSML_DETECTION_RE = re.compile(_DSML_MARKER_PATTERN, re.IGNORECASE)
+
+_DEEPSEEK_V4_PATTERNS = ("deepseek-v4", "deepseek_v4")
+
+
+def is_deepseek_v4_model(model: str | None) -> bool:
+    """Check if the model string corresponds to a DeepSeek V4 model."""
+    if not model:
+        return False
+    raw = model.strip().lower()
+    return any(p in raw for p in _DEEPSEEK_V4_PATTERNS)
+
+
+def has_dsml_markers(text: str | None) -> bool:
+    """Check if the text contains any DSML markers."""
+    if not text:
+        return False
+    return bool(_DSML_DETECTION_RE.search(text))
+
+
+def _generate_call_id(tool_name: str, arguments: dict[str, Any], index: int) -> str:
+    """Generate a stable, unique OpenAI-style tool call ID."""
+    args_json = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+    h = hashlib.sha256(f"{tool_name}:{args_json}:{index}".encode()).hexdigest()[:20]
+    return f"call_dsml_{h}"
+
+
+def parse_dsml_tool_calls(
+    content: str,
+) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    """Parse DSML tool calls from assistant message content.
+
+    Returns:
+        (tool_calls, cleaned_content)
+        If no tool calls are parsed or DSML is unrecoverable, returns ([], content).
+    """
+    if not content or not has_dsml_markers(content):
+        return [], content
+
+    raw_calls: list[tuple[str, dict[str, Any]]] = []
+
+    # 1. First check standard DSML block:
+    # <[|]DSML[|]tool_calls> ... </[|]DSML[|]tool_calls>
+    std_block_re = re.compile(
+        rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)tool_calls\s*>\s*(.*?)(?:</(?:\s*{_DSML_MARKER_PATTERN}\s*)tool_calls\s*>|$)",
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    std_match = std_block_re.search(content)
+    if std_match:
+        block_content = std_match.group(1)
+        invoke_tag_re = re.compile(
+            rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)?invoke\s+(?:name\s*=\s*|\s*=\s*)?[\"']?([A-Za-z0-9_.-]+)[\"']?[^>]*>",
+            re.IGNORECASE,
+        )
+
+        invoke_splits = list(invoke_tag_re.finditer(block_content))
+        for i, inv_m in enumerate(invoke_splits):
+            tool_name = inv_m.group(1)
+            start_pos = inv_m.end()
+            end_pos = (
+                invoke_splits[i + 1].start()
+                if i + 1 < len(invoke_splits)
+                else len(block_content)
+            )
+            inv_body = block_content[start_pos:end_pos]
+            inv_body = re.sub(
+                rf"</(?:\s*{_DSML_MARKER_PATTERN}\s*)?invoke\s*>",
+                "",
+                inv_body,
+                flags=re.IGNORECASE,
+            )
+
+            param_tag_re = re.compile(
+                rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)?parameter\s+(?:name\s*=\s*|\s*=\s*)?[\"']?([A-Za-z0-9_.-]+)[\"']?(?:\s+string\s*=\s*[\"']?(true|false)[\"']?)?[^>]*>",
+                re.IGNORECASE,
+            )
+            param_splits = list(param_tag_re.finditer(inv_body))
+            params: dict[str, Any] = {}
+            for j, p_m in enumerate(param_splits):
+                pname = p_m.group(1)
+                is_str_val = p_m.group(2)
+                p_start = p_m.end()
+                p_end = (
+                    param_splits[j + 1].start()
+                    if j + 1 < len(param_splits)
+                    else len(inv_body)
+                )
+                pval_raw = inv_body[p_start:p_end]
+                pval_raw = re.sub(
+                    rf"</(?:\s*{_DSML_MARKER_PATTERN}\s*)?parameter\s*>",
+                    "",
+                    pval_raw,
+                    flags=re.IGNORECASE,
+                )
+                if is_str_val and is_str_val.lower() == "false":
+                    stripped = pval_raw.strip()
+                    try:
+                        parsed_val = json.loads(stripped)
+                    except Exception:
+                        parsed_val = stripped
+                else:
+                    parsed_val = pval_raw.strip("\r\n")
+
+                params[pname] = parsed_val
+
+            raw_calls.append((tool_name, params))
+
+        cleaned_content = std_block_re.sub("", content).strip()
+        cleaned_content = re.sub(
+            rf"</?(?:\s*{_DSML_MARKER_PATTERN}\s*)[^>]*>",
+            "",
+            cleaned_content,
+        ).strip()
+
+        if not raw_calls:
+            logger.warning(
+                "Malformed DeepSeek V4 DSML markup detected; "
+                "cannot safely recover tool calls."
+            )
+            return [], content
+
+        return _build_tool_calls(raw_calls), cleaned_content
+
+    # 2. Check compact / evaluation log variants: <||DSML||r=tool_name> ...
+    compact_tag_re = re.compile(
+        rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)(?:r|func|function|invoke)\s*=\s*[\"']?([A-Za-z0-9_.-]+)[\"']?[^>]*>",
+        re.IGNORECASE,
+    )
+    compact_splits = list(compact_tag_re.finditer(content))
+    if compact_splits:
+        for i, c_m in enumerate(compact_splits):
+            tool_name = c_m.group(1)
+            start_pos = c_m.end()
+            end_pos = (
+                compact_splits[i + 1].start()
+                if i + 1 < len(compact_splits)
+                else len(content)
+            )
+            body = content[start_pos:end_pos]
+
+            param_re = re.compile(
+                rf"<parameter\s*=\s*[\"']?([A-Za-z0-9_.-]+)[\"']?[^>]*>(.*?)(?:</parameter>|(?=<parameter|</{_DSML_MARKER_PATTERN}|$))",
+                re.DOTALL | re.IGNORECASE,
+            )
+            param_matches = list(param_re.finditer(body))
+            if param_matches:
+                params: dict[str, Any] = {
+                    pm.group(1): pm.group(2).strip("\r\n") for pm in param_matches
+                }
+                raw_calls.append((tool_name, params))
+            else:
+                m_re = re.compile(
+                    rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)m\s*>(.*?)(?:</(?:\s*{_DSML_MARKER_PATTERN}\s*)m\s*>|(?=<(?:\s*{_DSML_MARKER_PATTERN}\s*)m\s*>|</{_DSML_MARKER_PATTERN}|$))",
+                    re.DOTALL | re.IGNORECASE,
+                )
+                m_matches = list(m_re.finditer(body))
+                if m_matches:
+                    for mm in m_matches:
+                        val = mm.group(1).strip("\r\n")
+                        raw_calls.append((tool_name, {"command": val}))
+                else:
+                    unclosed_m = re.search(
+                        rf"(.*?)(?:</(?:\s*{_DSML_MARKER_PATTERN}\s*)[^>]*>|$)",
+                        body,
+                        re.DOTALL,
+                    )
+                    if unclosed_m and unclosed_m.group(1).strip():
+                        val = unclosed_m.group(1).strip("\r\n")
+                        raw_calls.append((tool_name, {"command": val}))
+
+        cleaned_content = compact_tag_re.sub("", content)
+        cleaned_content = re.sub(
+            r"<parameter\s*=\s*[^>]*>.*?(?:</parameter>|$)",
+            "",
+            cleaned_content,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        cleaned_content = re.sub(
+            rf"<(?:\s*{_DSML_MARKER_PATTERN}\s*)m\s*>.*?(?:</(?:\s*{_DSML_MARKER_PATTERN}\s*)m\s*>|$)",
+            "",
+            cleaned_content,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        cleaned_content = re.sub(
+            rf"</?(?:\s*{_DSML_MARKER_PATTERN}\s*)[^>]*>",
+            "",
+            cleaned_content,
+        ).strip()
+
+        if not raw_calls:
+            logger.warning(
+                "Malformed DeepSeek V4 DSML markup detected; "
+                "cannot safely recover tool calls."
+            )
+            return [], content
+
+        return _build_tool_calls(raw_calls), cleaned_content
+
+    logger.warning(
+        "Malformed DeepSeek V4 DSML markup detected; cannot safely recover tool calls."
+    )
+    return [], content
+
+
+def _build_tool_calls(
+    raw_calls: list[tuple[str, dict[str, Any]]],
+) -> list[ChatCompletionMessageToolCall]:
+    """Build list of ChatCompletionMessageToolCall with stable, unique IDs."""
+    tool_calls: list[ChatCompletionMessageToolCall] = []
+    for index, (tool_name, arguments) in enumerate(raw_calls):
+        call_id = _generate_call_id(tool_name, arguments, index)
+        tool_calls.append(
+            ChatCompletionMessageToolCall(
+                id=call_id,
+                type="function",
+                function=Function(
+                    name=tool_name,
+                    arguments=json.dumps(arguments, ensure_ascii=False),
+                ),
+            )
+        )
+    return tool_calls
+
+
+def normalize_deepseek_v4_response(
+    resp: ModelResponse,
+    model: str | None = None,
+) -> ModelResponse:
+    """Normalize DeepSeek V4 ModelResponse if DSML tool calls are in content.
+
+    Only applies when:
+    - The model belongs to DeepSeek V4
+    - Existing structured tool_calls is empty/None
+    - Content contains DSML markers
+    """
+    if not is_deepseek_v4_model(model):
+        return resp
+
+    if not resp.choices:
+        return resp
+
+    choice = resp.choices[0]
+    message = getattr(choice, "message", None)
+    if not message:
+        return resp
+
+    # Do not reprocess already structured tool calls
+    existing_tool_calls = getattr(message, "tool_calls", None)
+    if existing_tool_calls:
+        return resp
+
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or not has_dsml_markers(content):
+        return resp
+
+    parsed_calls, cleaned_content = parse_dsml_tool_calls(content)
+    if parsed_calls:
+        message.tool_calls = parsed_calls
+        message.content = cleaned_content
+        if getattr(choice, "finish_reason", None) in (None, "stop"):
+            choice.finish_reason = "tool_calls"
+
+    return resp
+
+
+class DSMLStreamFilter:
+    """Streaming token filter that suppresses DSML markup from token callbacks.
+
+    Plain conversational text (e.g. reasoning/thoughts before the DSML block)
+    is streamed immediately. When potential DSML markup prefixes are encountered,
+    tokens are held in an internal buffer. If a DSML marker is confirmed, the DSML
+    tokens are suppressed. If the candidate turns out not to be DSML (e.g. `x < y`),
+    the buffered characters are flushed to the callback.
+    """
+
+    def __init__(self, callback: Callable[[Any], Any]) -> None:
+        self.callback = callback
+        self.buffer = ""
+        self.in_dsml = False
+        self._marker_prefixes = [
+            "<",
+            "<|",
+            "<｜",
+            "<||",
+            "<｜｜",
+            "<|D",
+            "<｜D",
+            "<|DS",
+            "<｜DS",
+            "<|DSM",
+            "<｜DSM",
+            "<|DSML",
+            "<｜DSML",
+            "<||D",
+            "<｜｜D",
+            "<||DS",
+            "<｜｜DS",
+            "<||DSM",
+            "<｜｜DSM",
+            "<||DSML",
+            "<｜｜DSML",
+            "<|DSML|",
+            "<｜DSML｜",
+            "<||DSML||",
+            "<｜｜DSML｜｜",
+            "</",
+            "</|",
+            "</｜",
+            "</||",
+            "</｜｜",
+            "</|D",
+            "</｜D",
+            "</|DS",
+            "</｜DS",
+            "</|DSM",
+            "</｜DSM",
+            "</|DSML",
+            "</｜DSML",
+            "</||D",
+            "</｜｜D",
+            "</||DS",
+            "</｜｜DS",
+            "</||DSM",
+            "</｜｜DSM",
+            "</||DSML",
+            "</｜｜DSML",
+            "</|DSML|",
+            "</｜DSML｜",
+            "</||DSML||",
+            "</｜｜DSML｜｜",
+        ]
+
+    def _is_prefix_of_marker(self, text: str) -> bool:
+        return any(p.startswith(text) for p in self._marker_prefixes)
+
+    def _contains_marker(self, text: str) -> bool:
+        return any(
+            m in text
+            for m in (
+                "<|DSML|",
+                "<｜DSML｜",
+                "<||DSML||",
+                "<｜｜DSML｜｜",
+                "</|DSML|",
+                "</｜DSML｜",
+                "</||DSML||",
+                "</｜｜DSML｜｜",
+            )
+        )
+
+    def filter_chunk(self, chunk: ModelResponseStream) -> ModelResponseStream | None:
+        """Filter a ModelResponseStream chunk.
+
+        Returns a chunk with filtered delta content, or None if the chunk's content
+        is entirely suppressed.
+        """
+        if not chunk.choices:
+            return chunk
+
+        delta = getattr(chunk.choices[0], "delta", None)
+        if delta is None:
+            return chunk
+
+        content_str = getattr(delta, "content", None)
+        if content_str is None or not isinstance(content_str, str):
+            return chunk
+
+        emits = []
+        for char in content_str:
+            if self.in_dsml:
+                self.buffer += char
+                if re.search(
+                    rf"</(?:\s*{_DSML_MARKER_PATTERN}\s*)(?:tool_calls|r)[^>]*>",
+                    self.buffer,
+                ):
+                    self.in_dsml = False
+                    self.buffer = ""
+            elif self.buffer:
+                candidate = self.buffer + char
+                if self._is_prefix_of_marker(candidate):
+                    self.buffer = candidate
+                    if self._contains_marker(candidate):
+                        if re.search(
+                            rf"</(?:\s*{_DSML_MARKER_PATTERN}\s*)(?:tool_calls|r|m)?[^>]*>",
+                            self.buffer,
+                        ):
+                            self.in_dsml = False
+                            self.buffer = ""
+                        else:
+                            self.in_dsml = True
+                            self.buffer = ""
+                else:
+                    emits.append(self.buffer)
+                    self.buffer = ""
+                    if char == "<":
+                        self.buffer = "<"
+                    else:
+                        emits.append(char)
+            else:
+                if char == "<":
+                    self.buffer = "<"
+                else:
+                    emits.append(char)
+
+        emitted_text = "".join(emits)
+        if not emitted_text:
+            return None
+
+        new_chunk = copy.copy(chunk)
+        new_choice = copy.copy(chunk.choices[0])
+        new_delta = copy.copy(delta)
+        new_delta.content = emitted_text
+        new_choice.delta = new_delta
+        new_chunk.choices = [new_choice]
+        return new_chunk
+
+    def flush_remaining(self) -> str | None:
+        """Flush any pending non-DSML buffered text."""
+        if not self.in_dsml and self.buffer:
+            res = self.buffer
+            self.buffer = ""
+            return res
+        return None

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -63,6 +63,7 @@ class ModelFeatures:
     requires_inline_image_data: bool
     # Effective capability from LiteLLM metadata plus SDK overrides.
     supports_vision: bool
+    supports_dsml_tool_calls: bool
 
 
 LITELLM_PROXY_PREFIX = "litellm_proxy/"
@@ -402,5 +403,11 @@ def get_features(
             overrides=overrides,
             metadata=model_info,
             fallback=_model_supports_vision(model),
+        ),
+        supports_dsml_tool_calls=_resolved_bool(
+            "supports_dsml_tool_calls",
+            overrides=overrides,
+            metadata=model_info,
+            fallback=model_matches(model, ("deepseek-v4", "deepseek_v4")),
         ),
     )

--- a/tests/sdk/llm/test_dsml_normalization.py
+++ b/tests/sdk/llm/test_dsml_normalization.py
@@ -1,0 +1,643 @@
+"""Tests for DeepSeek V4 DSML markup normalization and stream filtering."""
+
+import glob
+import json
+import logging
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from litellm import (
+    ChatCompletionMessageToolCall,
+    CustomStreamWrapper,
+    ModelResponse,
+    ModelResponseStream,
+)
+from litellm.types.utils import (
+    Choices,
+    Delta,
+    Function,
+    Message as LiteLLMMessage,
+    StreamingChoices,
+)
+
+from openhands.sdk.agent.response_dispatch import LLMResponseType, classify_response
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm.utils.dsml import (
+    DSMLStreamFilter,
+    has_dsml_markers,
+    is_deepseek_v4_model,
+    normalize_deepseek_v4_response,
+    parse_dsml_tool_calls,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Model detection and marker checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("openai/deepseek-v4-flash", True),
+        ("deepseek/deepseek-v4-pro", True),
+        ("deepseek-v4", True),
+        ("DeepSeek-V4-Flash", True),
+        ("deepseek_v4", True),
+        ("deepseek/deepseek-chat", False),
+        ("deepseek/deepseek-reasoner", False),
+        ("openai/gpt-4o", False),
+        ("claude-3-5-sonnet", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_deepseek_v4_model(model, expected):
+    assert is_deepseek_v4_model(model) is expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("<｜DSML｜tool_calls>", True),
+        ("<|DSML|tool_calls>", True),
+        ("<｜｜DSML｜｜r=execute_bash>", True),
+        ("<||DSML||r=execute_bash>", True),
+        ("Some normal text without markup", False),
+        ("<function=execute_bash>", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_has_dsml_markers(text, expected):
+    assert has_dsml_markers(text) is expected
+
+
+# ---------------------------------------------------------------------------
+# 2. Standard DSML Parsing: types, parameters, and multiple invokes
+# ---------------------------------------------------------------------------
+
+
+def test_parse_standard_dsml_types_and_parameters():
+    content = """I will execute the inspection tool.
+
+<｜DSML｜tool_calls>
+<invoke name="inspect_env">
+<parameter name="command" string="true">ls -la /workspace && echo '<test>'</parameter>
+<parameter name="timeout" string="false">30</parameter>
+<parameter name="flag" string="false">true</parameter>
+<parameter name="neg_flag" string="false">false</parameter>
+<parameter name="ratio" string="false">3.14</parameter>
+<parameter name="items" string="false">["alpha", "beta"]</parameter>
+<parameter name="config" string="false">{"port": 8000, "debug": true}</parameter>
+<parameter name="empty_val" string="false">null</parameter>
+</invoke>
+</｜DSML｜tool_calls>
+
+Please review the output."""
+
+    calls, cleaned = parse_dsml_tool_calls(content)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.id.startswith("call_dsml_")
+    assert call.type == "function"
+    assert call.function.name == "inspect_env"
+
+    args = json.loads(call.function.arguments)
+    assert args["command"] == "ls -la /workspace && echo '<test>'"
+    assert args["timeout"] == 30
+    assert args["flag"] is True
+    assert args["neg_flag"] is False
+    assert args["ratio"] == 3.14
+    assert args["items"] == ["alpha", "beta"]
+    assert args["config"] == {"port": 8000, "debug": True}
+    assert args["empty_val"] is None
+
+    assert "I will execute the inspection tool." in cleaned
+    assert "Please review the output." in cleaned
+    assert "<｜DSML｜" not in cleaned
+
+
+def test_parse_standard_dsml_parallel_invokes_and_implicit_closures():
+    content = """<|DSML|tool_calls>
+<invoke name="read_file">
+<parameter name="path" string="true">/app/src/index.ts
+<parameter name="offset" string="false">100
+<invoke name="run_command">
+<parameter name="cmd" string="true">wc -l /app/src/index.ts</parameter>
+</invoke>
+</|DSML|tool_calls>"""
+
+    calls, cleaned = parse_dsml_tool_calls(content)
+
+    assert len(calls) == 2
+
+    # First invoke had implicit parameter closure and implicit invoke closure
+    assert calls[0].function.name == "read_file"
+    args1 = json.loads(calls[0].function.arguments)
+    assert args1["path"] == "/app/src/index.ts"
+    assert args1["offset"] == 100
+
+    # Second invoke
+    assert calls[1].function.name == "run_command"
+    args2 = json.loads(calls[1].function.arguments)
+    assert args2["cmd"] == "wc -l /app/src/index.ts"
+
+    assert cleaned == ""
+
+
+def test_parse_multiline_parameter_with_quotes_and_brackets():
+    multiline_script = """def test_func():
+    items = ["<one>", "<two>"]
+    if True:
+        print("Hello 'world'!")
+"""
+    content = f"""<｜DSML｜tool_calls>
+<invoke name="write_file">
+<parameter name="path" string="true">/tmp/script.py</parameter>
+<parameter name="content" string="true">{multiline_script}</parameter>
+</invoke>
+</｜DSML｜tool_calls>"""
+
+    calls, cleaned = parse_dsml_tool_calls(content)
+    assert len(calls) == 1
+    args = json.loads(calls[0].function.arguments)
+    assert args["path"] == "/tmp/script.py"
+    assert args["content"] == multiline_script.strip("\r\n")
+
+
+# ---------------------------------------------------------------------------
+# 3. Log Parity: Test against the 23 CVE benchmark completions
+# ---------------------------------------------------------------------------
+
+
+def test_all_cve_benchmark_completions_parse_successfully():
+    completions_dir = (
+        "/Users/aibot/Downloads/cyberSecurityBenchmark/902AILAB/eval-executor/repo/"
+        "runs/concurrent-cve-2026-19373-20260903T122344Z/model-cve-2026-19373-20260903T122443Z/agent/completions"
+    )
+    if not os.path.isdir(completions_dir):
+        pytest.skip("Completions directory not found on local path")
+
+    files = sorted(glob.glob(os.path.join(completions_dir, "*.json")))
+    assert len(files) > 0
+
+    dsml_tested = 0
+    for fpath in files:
+        with open(fpath, encoding="utf-8") as f:
+            data = json.load(f)
+        msg = data["response"]["choices"][0]["message"]
+        content = msg.get("content") or ""
+        if "DSML" in content:
+            dsml_tested += 1
+            calls, cleaned = parse_dsml_tool_calls(content)
+            assert len(calls) >= 1, f"Failed to parse DSML in {os.path.basename(fpath)}"
+            assert calls[0].function.name == "execute_bash"
+            args = json.loads(calls[0].function.arguments)
+            assert "command" in args
+            assert len(args["command"]) > 0
+
+    assert dsml_tested == 23
+
+
+# ---------------------------------------------------------------------------
+# 4. Guardrails & Safeguards
+# ---------------------------------------------------------------------------
+
+
+def test_non_deepseek_model_is_not_normalized():
+    model_response = ModelResponse(
+        id="resp-1",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(
+                    role="assistant",
+                    content=(
+                        "<｜DSML｜tool_calls><invoke name='bash'>"
+                        "<parameter name='cmd' string='true'>ls</parameter>"
+                        "</invoke></｜DSML｜tool_calls>"
+                    ),
+                ),
+            )
+        ],
+    )
+
+    result = normalize_deepseek_v4_response(model_response, model="gpt-4o")
+    assert result.choices[0].message.tool_calls is None
+    assert result.choices[0].message.content is not None
+    assert "<｜DSML｜" in result.choices[0].message.content
+
+
+def test_already_structured_tool_calls_are_untouched():
+    existing_call = ChatCompletionMessageToolCall(
+        id="call_orig_123",
+        type="function",
+        function=Function(name="existing_tool", arguments='{"param": "val"}'),
+    )
+    model_response = ModelResponse(
+        id="resp-2",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=LiteLLMMessage(
+                    role="assistant",
+                    content=(
+                        "<｜DSML｜tool_calls><invoke name='bash'>"
+                        "<parameter name='cmd' string='true'>ls</parameter>"
+                        "</invoke></｜DSML｜tool_calls>"
+                    ),
+                    tool_calls=[existing_call],
+                ),
+            )
+        ],
+    )
+
+    result = normalize_deepseek_v4_response(
+        model_response, model="openai/deepseek-v4-flash"
+    )
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].id == "call_orig_123"
+
+
+def test_malformed_unrecoverable_dsml_warns_and_avoids_partial_execution(caplog):
+    malformed_content = "<｜DSML｜tool_calls> <<<broken non-xml syntax without invoke"
+    with caplog.at_level(logging.WARNING):
+        calls, cleaned = parse_dsml_tool_calls(malformed_content)
+
+    assert len(calls) == 0
+    assert cleaned == malformed_content
+    assert any(
+        "Malformed DeepSeek V4 DSML markup detected" in r.message
+        for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Stream Filter
+# ---------------------------------------------------------------------------
+
+
+def test_dsml_stream_filter_suppresses_dsml_and_preserves_thoughts():
+    received_tokens = []
+
+    def on_token(chunk):
+        if chunk.choices and chunk.choices[0].delta.content:
+            received_tokens.append(chunk.choices[0].delta.content)
+
+    stream_filter = DSMLStreamFilter(on_token)
+
+    def make_chunk(text):
+        return ModelResponseStream(
+            id="stream-1",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content=text, role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+    # Simulating arbitrary character chunk streaming
+    chunks = [
+        make_chunk("Let me "),
+        make_chunk("inspect the directory.\n\n"),
+        make_chunk("<"),
+        make_chunk("｜"),
+        make_chunk("DSML"),
+        make_chunk("｜tool_calls>\n"),
+        make_chunk('<invoke name="execute_bash">\n'),
+        make_chunk('<parameter name="command" string="true">ls -la</parameter>\n'),
+        make_chunk("</invoke>\n"),
+        make_chunk("</｜DSML｜tool_calls>"),
+        make_chunk("\nExecution scheduled."),
+    ]
+
+    for c in chunks:
+        filtered = stream_filter.filter_chunk(c)
+        if filtered is not None:
+            on_token(filtered)
+
+    remaining = stream_filter.flush_remaining()
+    if remaining:
+        received_tokens.append(remaining)
+
+    combined_stream_output = "".join(received_tokens)
+    assert "Let me inspect the directory.\n\n" in combined_stream_output
+    assert "\nExecution scheduled." in combined_stream_output
+    assert "DSML" not in combined_stream_output
+    assert "execute_bash" not in combined_stream_output
+
+
+def test_dsml_stream_filter_non_dsml_angle_brackets():
+    received_tokens = []
+
+    def on_token(chunk):
+        if chunk.choices and chunk.choices[0].delta.content:
+            received_tokens.append(chunk.choices[0].delta.content)
+
+    stream_filter = DSMLStreamFilter(on_token)
+
+    def make_chunk(text):
+        return ModelResponseStream(
+            id="stream-2",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content=text, role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+    chunks = [
+        make_chunk("Condition: "),
+        make_chunk("a < b "),
+        make_chunk("and c > d. "),
+        make_chunk("<tag>inner</tag>"),
+    ]
+
+    for c in chunks:
+        filtered = stream_filter.filter_chunk(c)
+        if filtered is not None:
+            on_token(filtered)
+
+    remaining = stream_filter.flush_remaining()
+    if remaining:
+        received_tokens.append(remaining)
+
+    combined = "".join(received_tokens)
+    assert combined == "Condition: a < b and c > d. <tag>inner</tag>"
+
+
+# ---------------------------------------------------------------------------
+# 6. LLM Completion Layer & Agent Response Dispatch Integration
+# ---------------------------------------------------------------------------
+
+
+def test_llm_build_completion_result_normalizes_dsml():
+    raw_response = ModelResponse(
+        id="resp-cve-14",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(
+                    role="assistant",
+                    content=(
+                        "Let me examine the full compiled distribution code:\n\n"
+                        "<｜｜DSML｜｜r=execute_bash>\n"
+                        "<｜｜DSML｜｜m>cat /app/dist/index.js</｜｜DSML｜｜m>\n"
+                        "</｜｜DSML｜｜r>"
+                    ),
+                ),
+            )
+        ],
+    )
+
+    llm = LLM(
+        model="openai/deepseek-v4-flash",
+        api_key="sk-test",
+        stream=True,
+    )
+
+    # Validated chat response converts DSML before building LLMResponse
+    validated_resp = llm._validate_chat_response(
+        raw_response,
+        use_mock_tools=False,
+        formatted_messages=[],
+        cc_tools=[],
+        add_security_risk_prediction=False,
+    )
+
+    assert validated_resp.choices[0].finish_reason == "tool_calls"
+    assert validated_resp.choices[0].message.tool_calls is not None
+    assert len(validated_resp.choices[0].message.tool_calls) == 1
+
+    llm_response = llm._build_completion_result(validated_resp)
+    assert llm_response.message.tool_calls is not None
+    assert len(llm_response.message.tool_calls) == 1
+
+    tool_call = llm_response.message.tool_calls[0]
+    assert tool_call.name == "execute_bash"
+    assert json.loads(tool_call.arguments) == {"command": "cat /app/dist/index.js"}
+
+    # Classifies as TOOL_CALLS rather than CONTENT, preventing premature FINISHED
+    classification = classify_response(llm_response.message)
+    assert classification == LLMResponseType.TOOL_CALLS
+
+    # Text outside DSML is preserved in message content
+    assert len(llm_response.message.content) == 1
+    first_item = llm_response.message.content[0]
+    assert isinstance(first_item, TextContent)
+    assert first_item.text == "Let me examine the full compiled distribution code:"
+
+
+def test_llm_completion_and_streaming_end_to_end(monkeypatch):
+    dsml_text = (
+        "Thinking about command...\n\n"
+        "<｜DSML｜tool_calls>\n"
+        '<invoke name="execute_bash">\n'
+        '<parameter name="command" string="true">ls -la</parameter>\n'
+        "</invoke>\n"
+        "</｜DSML｜tool_calls>"
+    )
+
+    llm = LLM(
+        model="openai/deepseek-v4-flash",
+        api_key="sk-test",
+        stream=True,
+    )
+
+    # 1. Non-streaming mock
+    def mock_completion(*args, **kwargs):
+        return ModelResponse(
+            id="resp-test-sync",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=LiteLLMMessage(role="assistant", content=dsml_text),
+                )
+            ],
+        )
+
+    monkeypatch.setattr("openhands.sdk.llm.llm.litellm_completion", mock_completion)
+
+    resp = llm.completion(
+        messages=[Message(role="user", content=[TextContent(text="Run ls")])]
+    )
+    assert resp.message.tool_calls is not None
+    assert len(resp.message.tool_calls) == 1
+    assert resp.message.tool_calls[0].name == "execute_bash"
+    assert json.loads(resp.message.tool_calls[0].arguments) == {"command": "ls -la"}
+    first_item = resp.message.content[0]
+    assert isinstance(first_item, TextContent)
+    assert first_item.text == "Thinking about command..."
+
+    # 2. Streaming mock with on_token
+    token_feed = [
+        "Thinking about command...\n\n",
+        "<",
+        "｜DSML｜tool",
+        '_calls>\n<invoke name="execute_bash">\n',
+        '<parameter name="command" string="true">ls -la</parameter>\n',
+        "</invoke>\n</｜DSML｜tool_calls>",
+    ]
+
+    def mock_streaming_completion(*args, **kwargs):
+        def stream_gen():
+            for t in token_feed:
+                yield ModelResponseStream(
+                    id="stream-test",
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(content=t, role="assistant"),
+                            finish_reason=None,
+                        )
+                    ],
+                )
+
+        return CustomStreamWrapper(
+            completion_stream=stream_gen(),
+            model="openai/deepseek-v4-flash",
+            custom_llm_provider="openai",
+            logging_obj=MagicMock(),
+        )
+
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm_completion", mock_streaming_completion
+    )
+    final_resp = ModelResponse(
+        id="stream-final",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(role="assistant", content=dsml_text),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm.stream_chunk_builder",
+        lambda chunks, messages=None: final_resp,
+    )
+
+    seen_tokens = []
+
+    def on_token_cb(chunk):
+        if chunk.choices and chunk.choices[0].delta.content:
+            seen_tokens.append(chunk.choices[0].delta.content)
+
+    resp_streamed = llm.completion(
+        messages=[Message(role="user", content=[TextContent(text="Run ls")])],
+        on_token=on_token_cb,
+    )
+
+    # Streaming tokens never received DSML tags
+    streamed_combined = "".join(seen_tokens)
+    assert "Thinking about command..." in streamed_combined
+    assert "DSML" not in streamed_combined
+    assert "execute_bash" not in streamed_combined
+
+    # Aggregated response still has parsed tool_calls and identical result
+    # to non-streaming
+    assert resp_streamed.message.tool_calls is not None
+    assert len(resp_streamed.message.tool_calls) == 1
+    assert resp_streamed.message.tool_calls[0].name == "execute_bash"
+    assert json.loads(resp_streamed.message.tool_calls[0].arguments) == {
+        "command": "ls -la"
+    }
+    first_item = resp_streamed.message.content[0]
+    assert isinstance(first_item, TextContent)
+    assert first_item.text == "Thinking about command..."
+
+
+@pytest.mark.asyncio
+async def test_llm_acompletion_streaming_end_to_end(monkeypatch):
+    dsml_text = (
+        "Let me check:\n\n"
+        "<｜｜DSML｜｜r=execute_bash>\n"
+        "<｜｜DSML｜｜m>pwd</｜｜DSML｜｜m>\n"
+        "</｜｜DSML｜｜r>"
+    )
+
+    llm = LLM(
+        model="openai/deepseek-v4-flash",
+        api_key="sk-test",
+        stream=True,
+    )
+
+    token_feed = [
+        "Let me check:\n\n",
+        "<｜｜DSML｜｜r=execute_bash>\n",
+        "<｜｜DSML｜｜m>pwd</｜｜DSML｜｜m>\n",
+        "</｜｜DSML｜｜r>",
+    ]
+
+    async def mock_streaming_acompletion(*args, **kwargs):
+        async def astream_gen():
+            for t in token_feed:
+                yield ModelResponseStream(
+                    id="stream-test-async",
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(content=t, role="assistant"),
+                            finish_reason=None,
+                        )
+                    ],
+                )
+
+        return astream_gen()
+
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm_acompletion", mock_streaming_acompletion
+    )
+    final_resp_async = ModelResponse(
+        id="stream-final-async",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(role="assistant", content=dsml_text),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm.stream_chunk_builder",
+        lambda chunks, messages=None: final_resp_async,
+    )
+
+    seen_tokens = []
+
+    async def on_token_cb(chunk):
+        if chunk.choices and chunk.choices[0].delta.content:
+            seen_tokens.append(chunk.choices[0].delta.content)
+
+    resp_streamed = await llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="Check pwd")])],
+        on_token=on_token_cb,
+    )
+
+    streamed_combined = "".join(seen_tokens)
+    assert "Let me check:" in streamed_combined
+    assert "DSML" not in streamed_combined
+
+    assert resp_streamed.message.tool_calls is not None
+    assert len(resp_streamed.message.tool_calls) == 1
+    assert resp_streamed.message.tool_calls[0].name == "execute_bash"
+    assert json.loads(resp_streamed.message.tool_calls[0].arguments) == {
+        "command": "pwd"
+    }
+    first_item = resp_streamed.message.content[0]
+    assert isinstance(first_item, TextContent)
+    assert first_item.text == "Let me check:"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

DeepSeek V4 models (such as `deepseek-v4-flash` or `deepseek-v4-pro`) may emit tool calling markup using DeepSeek Markup Language (DSML, e.g. `<｜DSML｜tool_calls>`, `<｜｜DSML｜｜r=execute_bash>`, etc.) directly into `message.content` rather than OpenAI-compatible structured `tool_calls`. This commonly occurs when models fall back to their pre-trained DSML syntax or in non-native tool calling environments.

Previously, the OpenHands SDK did not parse DSML markup from message content when `tool_calls` was absent. As a consequence, `classify_response` classified the response as `LLMResponseType.CONTENT`, leading `_handle_content_response` to prematurely set `state.execution_status = ConversationExecutionStatus.FINISHED` before the requested tool call could be executed.

## Summary

- Added `openhands.sdk.llm.utils.dsml` supporting both standard DSML grammar (`<｜DSML｜tool_calls>` with `<invoke>` and typed `<parameter string="true|false">`) and compact evaluation formats (`<｜｜DSML｜｜r=...>` with `<parameter=...>` and `<｜｜DSML｜｜m>`).
- Implemented `normalize_deepseek_v4_response` to convert DSML markup into structured `ChatCompletionMessageToolCall` instances with stable, deterministic IDs, clean the markup from message content, and update `finish_reason = "tool_calls"`.
- Implemented `DSMLStreamFilter` to intercept streaming chunks during sync and async completions, preventing DSML markup tokens from leaking to user-visible `on_token` callbacks while ensuring aggregated responses match non-streaming results.
- Added capability detection via `supports_dsml_tool_calls` in `ModelFeatures`.
- Added comprehensive test coverage in `tests/sdk/llm/test_dsml_normalization.py` (31 tests) including all 23 DSML completion examples from the benchmark log, malformed DSML guardrails, and sync/async streaming validation.

## Issue Number

None

## How to Test

Run the test suite:
```bash
uv run pytest tests/sdk/llm/test_dsml_normalization.py -v
uv run pytest tests/sdk/llm/test_llm_completion.py -v
```

Execute an end-to-end agent task with DeepSeek V4:
```python
from openhands.sdk import LLM, Agent, Conversation, Tool
from openhands.tools.terminal import TerminalTool

llm = LLM(model="openai/deepseek-v4-flash", base_url="https://api.deepseek.com")
agent = Agent(llm=llm, tools=[Tool(name=TerminalTool.name)])
conv = Conversation(agent=agent, workspace="/tmp/test-workspace")
conv.send_message("Run echo 42 > answer.txt and say done.")
conv.run()
```

## Video/Screenshots

Live end-to-end run logs showing successful tool execution and completion:
```
Agent Action ───────────────────────────────────────────────────────────────────
Summary: Write 42 to answer.txt
$ echo 42 > answer.txt

Observation ────────────────────────────────────────────────────────────────────
Tool: terminal
Result:
📁 Working directory: /tmp/oh-dsml-live-0krjrrqv
🐍 Python interpreter: .../.venv/bin/python
✅ Exit code: 0

Message from Agent ─────────────────────────────────────────────────────────────
Done. I ran `echo 42 > answer.txt` and wrote `42` into `answer.txt`.
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Responses that already contain structured `tool_calls` are left untouched.
- Non-DeepSeek V4 models bypass normalization entirely.
- Unrecoverable malformed DSML logs a diagnostic warning without credentials and safely avoids partial execution.
