### PR TITLE
[DRAFT/test] Attach authoritative cache-aware cost to LLM span (#4817, Option A)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -16,11 +16,17 @@ from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
 logger = getLogger(__name__)
 
 
-# Fields copied from the underlying model's pricing entry into a proxy alias
-# registration so the alias becomes priceable in litellm's global `model_cost`
-# map (which the cost instrumentation reads). Cache buckets are included even
-# when zero so litellm resolves providers such as `bedrock` that key cache
-# pricing off their presence (companion issue #4817 handles cache accuracy).
+def _merge_raw_model_metadata(model_info: Mapping[str, Any]) -> dict[str, Any]:
+    """Preserve raw LiteLLM capability fields."""
+    key = model_info.get("key")
+    raw = model_cost.get(key) if isinstance(key, str) else None
+    if not isinstance(raw, dict):
+        return dict(model_info)
+    return {**raw, **model_info}
+
+
+# Pricing fields copied from the underlying model so a custom proxy alias
+# becomes priceable in litellm's global `model_cost` map (#4816).
 _PRICING_FIELDS: tuple[str, ...] = (
     "input_cost_per_token",
     "output_cost_per_token",
@@ -33,89 +39,43 @@ _PRICING_FIELDS: tuple[str, ...] = (
 )
 
 
-def _merge_raw_model_metadata(model_info: Mapping[str, Any]) -> dict[str, Any]:
-    """Preserve raw LiteLLM capability fields."""
-    key = model_info.get("key")
-    raw = model_cost.get(key) if isinstance(key, str) else None
-    if not isinstance(raw, dict):
-        return dict(model_info)
-    return {**raw, **model_info}
-
-
-def _is_already_priceable(model: str) -> bool:
-    """True if litellm can already price `model` without SDK registration.
-
-    Covers both direct `model_cost` keys and provider-prefixed names that
-    litellm resolves by parsing the provider segment (e.g.
-    `anthropic/claude-sonnet-4-5-20250929`).
-    """
-    if model in model_cost:
-        return True
-    try:
-        litellm.cost_per_token(model=model, prompt_tokens=1, completion_tokens=1)
-        return True
-    except Exception:
-        return False
-
-
 def _register_proxy_alias_pricing(
     alias: str,
     underlying_model_info: Mapping[str, Any] | None,
     proxy_model_info: Mapping[str, Any] | None,
 ) -> None:
-    """Register a `litellm_proxy/*` alias into litellm's global `model_cost`.
+    """Register a `litellm_proxy/*` alias into litellm's `model_cost` (#4816).
 
-    A custom proxy model whose public name is not a litellm-known model id
-    (e.g. `prod/claude-sonnet-4-5-bedrock`) is silently priced `$0` by the
-    cost instrumentation: litellm strips the `litellm_proxy/` prefix, fails
-    to parse the first path segment as a provider, and `cost_per_token`
-    raises. Registering the alias with pricing derived from the underlying
-    model makes it priceable without renaming the proxy model. See #4816.
+    litellm strips the `litellm_proxy/` prefix and parses the first segment as
+    the provider, so a custom name like `prod/claude-sonnet-4-5-bedrock` makes
+    `cost_per_token` raise and the span is silently priced $0. Registering the
+    alias with the underlying model's pricing makes it priceable without
+    renaming the proxy model.
     """
-    if not alias or _is_already_priceable(alias):
+    if not alias or alias in model_cost:
         return
+    try:
+        litellm.cost_per_token(model=alias, prompt_tokens=1, completion_tokens=1)
+        return
+    except Exception:
+        pass
 
     entry: dict[str, Any] = {}
-    if isinstance(underlying_model_info, Mapping):
-        entry.update(
-            {
-                f: underlying_model_info[f]
-                for f in _PRICING_FIELDS
-                if f in underlying_model_info
-            }
-        )
-    # Proxy-side overrides win when present (e.g. operator-set pricing).
-    if isinstance(proxy_model_info, Mapping):
-        entry.update(
-            {f: proxy_model_info[f] for f in _PRICING_FIELDS if f in proxy_model_info}
-        )
+    for src in (underlying_model_info, proxy_model_info):
+        if isinstance(src, Mapping):
+            entry.update({f: src[f] for f in _PRICING_FIELDS if f in src})
 
-    has_pricing = (
-        entry.get("input_cost_per_token") is not None
-        or entry.get("output_cost_per_token") is not None
-    )
-    if not has_pricing:
-        logger.debug(
-            "Could not derive pricing for litellm_proxy alias %r "
-            "(no underlying model pricing found); span cost will stay $0.",
-            alias,
-        )
+    if (
+        entry.get("input_cost_per_token") is None
+        and entry.get("output_cost_per_token") is None
+    ):
         return
 
     entry.setdefault("mode", "chat")
     try:
         litellm.register_model({alias: entry})
-        logger.debug(
-            "Registered litellm_proxy alias %r into model_cost (provider=%s).",
-            alias,
-            entry.get("litellm_provider"),
-        )
     except Exception as e:
-        logger.debug(
-            "Failed to register litellm_proxy alias %r into model_cost: %s",
-            alias,
-            e,
-        )
+        logger.debug("Failed to register litellm_proxy alias %r: %s", alias, e)
 
 
 @lru_cache
@@ -156,8 +116,8 @@ def _get_model_info_from_litellm_proxy(
             model_info = current.get("model_info")
             logger.debug(f"Got model info from litellm proxy: {model_info}")
 
-            # Make custom proxy aliases priceable in litellm's global model_cost
-            # map so the cost instrumentation does not silently record $0 (#4816).
+            # Make custom proxy aliases priceable so cost instrumentation does
+            # not silently record $0 (#4816).
             underlying_model = current.get("litellm_params", {}).get("model")
             underlying_model_info = None
             if isinstance(underlying_model, str) and underlying_model != stripped:

--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import Any
 
 import httpx
+import litellm
 from litellm import model_cost
 from litellm.utils import get_model_info
 from pydantic import SecretStr
@@ -15,6 +16,23 @@ from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
 logger = getLogger(__name__)
 
 
+# Fields copied from the underlying model's pricing entry into a proxy alias
+# registration so the alias becomes priceable in litellm's global `model_cost`
+# map (which the cost instrumentation reads). Cache buckets are included even
+# when zero so litellm resolves providers such as `bedrock` that key cache
+# pricing off their presence (companion issue #4817 handles cache accuracy).
+_PRICING_FIELDS: tuple[str, ...] = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
+    "max_input_tokens",
+    "max_output_tokens",
+    "litellm_provider",
+    "mode",
+)
+
+
 def _merge_raw_model_metadata(model_info: Mapping[str, Any]) -> dict[str, Any]:
     """Preserve raw LiteLLM capability fields."""
     key = model_info.get("key")
@@ -22,6 +40,82 @@ def _merge_raw_model_metadata(model_info: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(raw, dict):
         return dict(model_info)
     return {**raw, **model_info}
+
+
+def _is_already_priceable(model: str) -> bool:
+    """True if litellm can already price `model` without SDK registration.
+
+    Covers both direct `model_cost` keys and provider-prefixed names that
+    litellm resolves by parsing the provider segment (e.g.
+    `anthropic/claude-sonnet-4-5-20250929`).
+    """
+    if model in model_cost:
+        return True
+    try:
+        litellm.cost_per_token(model=model, prompt_tokens=1, completion_tokens=1)
+        return True
+    except Exception:
+        return False
+
+
+def _register_proxy_alias_pricing(
+    alias: str,
+    underlying_model_info: Mapping[str, Any] | None,
+    proxy_model_info: Mapping[str, Any] | None,
+) -> None:
+    """Register a `litellm_proxy/*` alias into litellm's global `model_cost`.
+
+    A custom proxy model whose public name is not a litellm-known model id
+    (e.g. `prod/claude-sonnet-4-5-bedrock`) is silently priced `$0` by the
+    cost instrumentation: litellm strips the `litellm_proxy/` prefix, fails
+    to parse the first path segment as a provider, and `cost_per_token`
+    raises. Registering the alias with pricing derived from the underlying
+    model makes it priceable without renaming the proxy model. See #4816.
+    """
+    if not alias or _is_already_priceable(alias):
+        return
+
+    entry: dict[str, Any] = {}
+    if isinstance(underlying_model_info, Mapping):
+        entry.update(
+            {
+                f: underlying_model_info[f]
+                for f in _PRICING_FIELDS
+                if f in underlying_model_info
+            }
+        )
+    # Proxy-side overrides win when present (e.g. operator-set pricing).
+    if isinstance(proxy_model_info, Mapping):
+        entry.update(
+            {f: proxy_model_info[f] for f in _PRICING_FIELDS if f in proxy_model_info}
+        )
+
+    has_pricing = (
+        entry.get("input_cost_per_token") is not None
+        or entry.get("output_cost_per_token") is not None
+    )
+    if not has_pricing:
+        logger.debug(
+            "Could not derive pricing for litellm_proxy alias %r "
+            "(no underlying model pricing found); span cost will stay $0.",
+            alias,
+        )
+        return
+
+    entry.setdefault("mode", "chat")
+    try:
+        litellm.register_model({alias: entry})
+        logger.debug(
+            "Registered litellm_proxy alias %r into model_cost (provider=%s).",
+            alias,
+            entry.get("litellm_provider"),
+        )
+    except Exception as e:
+        logger.debug(
+            "Failed to register litellm_proxy alias %r into model_cost: %s",
+            alias,
+            e,
+        )
 
 
 @lru_cache
@@ -61,6 +155,24 @@ def _get_model_info_from_litellm_proxy(
         if current:
             model_info = current.get("model_info")
             logger.debug(f"Got model info from litellm proxy: {model_info}")
+
+            # Make custom proxy aliases priceable in litellm's global model_cost
+            # map so the cost instrumentation does not silently record $0 (#4816).
+            underlying_model = current.get("litellm_params", {}).get("model")
+            underlying_model_info = None
+            if isinstance(underlying_model, str) and underlying_model != stripped:
+                try:
+                    underlying_model_info = get_model_info(underlying_model)
+                except Exception as e:
+                    logger.debug(
+                        f"get_model_info(underlying={underlying_model}) failed: {e}"
+                    )
+            _register_proxy_alias_pricing(
+                alias=stripped,
+                underlying_model_info=underlying_model_info,
+                proxy_model_info=model_info,
+            )
+
             return model_info
     except Exception as e:
         logger.debug(

--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -65,6 +65,13 @@ def _register_proxy_alias_pricing(
         if isinstance(src, Mapping):
             entry.update({f: src[f] for f in _PRICING_FIELDS if f in src})
 
+    # litellm's `get_llm_provider` cannot resolve `bedrock_converse` as a
+    # provider label for an unknown alias id (only ``bedrock`` is accepted), so
+    # normalize it before registering or `cost_per_token` keeps raising.
+
+    if entry.get("litellm_provider") == "bedrock_converse":
+        entry["litellm_provider"] = "bedrock"
+
     if (
         entry.get("input_cost_per_token") is None
         and entry.get("output_cost_per_token") is None

--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -50,6 +50,8 @@ class Telemetry(BaseModel):
         default=None
     )
     _stats_update_callback: Callable[[], None] | None = PrivateAttr(default=None)
+    _span_cm: Any = PrivateAttr(default=None)
+    _span: Any = PrivateAttr(default=None)
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid", arbitrary_types_allowed=True
@@ -79,6 +81,7 @@ class Telemetry(BaseModel):
     def on_request(self, telemetry_ctx: dict | None) -> None:
         self._req_start = time.time()
         self._req_ctx = telemetry_ctx or {}
+        self._open_span()
 
     def on_response(
         self,
@@ -115,7 +118,11 @@ class Telemetry(BaseModel):
         if self.log_enabled:
             self.log_llm_call(resp, cost, raw_resp=raw_resp)
 
-        # 5) notify about stats update
+        # 5) authoritative cost + cache buckets onto the span, before it closes
+        self._annotate_span(cost, usage)
+        self._close_span()
+
+        # 6) notify about stats update
         if self._stats_update_callback is not None:
             try:
                 self._stats_update_callback()
@@ -128,6 +135,7 @@ class Telemetry(BaseModel):
         # Best-effort logging for failed requests (so we can debug malformed
         # request payloads, e.g. orphaned Responses reasoning items).
         self._last_latency = time.time() - (self._req_start or time.time())
+        self._close_span(_err)
 
         if not self.log_enabled:
             return
@@ -217,16 +225,7 @@ class Telemetry(BaseModel):
             or 0
         )
 
-        cache_read = 0
-        p_details = getattr(usage, "prompt_tokens_details", None) or getattr(
-            usage, "input_tokens_details", None
-        )
-        if p_details is not None:
-            cache_read = int(getattr(p_details, "cached_tokens", 0) or 0)
-
-        # Kimi-K2-thinking populate usage.cached_tokens field
-        if not cache_read and hasattr(usage, "cached_tokens"):
-            cache_read = int(getattr(usage, "cached_tokens", 0) or 0)
+        cache_read, cache_write = self._cache_buckets(usage)
 
         reasoning_tokens = 0
         c_details = getattr(usage, "completion_tokens_details", None) or getattr(
@@ -234,9 +233,6 @@ class Telemetry(BaseModel):
         )
         if c_details is not None:
             reasoning_tokens = int(getattr(c_details, "reasoning_tokens", 0) or 0)
-
-        # Chat-specific: litellm may set a hidden cache write field
-        cache_write = int(getattr(usage, "_cache_creation_input_tokens", 0) or 0)
 
         self.metrics.add_token_usage(
             prompt_tokens=prompt_tokens,
@@ -247,6 +243,88 @@ class Telemetry(BaseModel):
             context_window=context_window,
             response_id=response_id,
         )
+
+    @staticmethod
+    def _cache_buckets(usage: Usage | ResponseAPIUsage) -> tuple[int, int]:
+        """Return ``(cache_read, cache_write)`` for either usage shape.
+
+        Single source of truth for both ``metrics`` and the span, so the trace
+        and the app's cost cannot disagree about the buckets.
+        """
+        cache_read = 0
+        p_details = getattr(usage, "prompt_tokens_details", None) or getattr(
+            usage, "input_tokens_details", None
+        )
+        if p_details is not None:
+            cache_read = int(getattr(p_details, "cached_tokens", 0) or 0)
+        # Kimi-K2-thinking populates usage.cached_tokens instead.
+        if not cache_read:
+            cache_read = int(getattr(usage, "cached_tokens", 0) or 0)
+        if not cache_read:
+            cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+
+        # litellm mirrors this onto a private attr; the public one and the
+        # details dict are both populated on some provider shapes only.
+        cache_write = int(getattr(usage, "_cache_creation_input_tokens", 0) or 0)
+        if not cache_write:
+            cache_write = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+        if not cache_write and p_details is not None:
+            cache_write = int(getattr(p_details, "cache_creation_tokens", 0) or 0)
+        return cache_read, cache_write
+
+    # ---------- Observability span ----------
+    # These bracket one LLM call: ``on_request`` -> transport -> ``on_response``
+    # all run inside a single retry attempt, so the span is current while
+    # litellm executes and still open when the cost is known.
+    def _open_span(self) -> None:
+        self._close_span()  # a retry re-enters on_request; never leak the old one
+        try:
+            # Imported lazily: openhands.sdk.observability pulls in
+            # openhands.sdk.event, which imports this module.
+            from openhands.sdk.observability.laminar import llm_call_span
+
+            cm = llm_call_span(f"llm.{self.model_name}")
+            self._span = cm.__enter__()
+            self._span_cm = cm
+        except Exception:
+            logger.debug("Failed to open LLM span", exc_info=True)
+            self._span = self._span_cm = None
+
+    def _annotate_span(
+        self, cost: float | None, usage: Usage | ResponseAPIUsage | None
+    ) -> None:
+        span = self._span
+        if span is None:
+            return
+        try:
+            if cost:
+                # Authoritative: _compute_cost prefers the proxy's
+                # x-litellm-response-cost header, which is already cache-aware
+                # and priced by the real backend rather than by a name lookup.
+                span.set_attribute("gen_ai.usage.cost", float(cost))
+            if usage is not None:
+                cache_read, cache_write = self._cache_buckets(usage)
+                # Emitted unconditionally: lmnr only reports these when
+                # prompt_tokens_details is populated, which not every provider
+                # shape does.
+                span.set_attribute("gen_ai.usage.cache_read_input_tokens", cache_read)
+                span.set_attribute(
+                    "gen_ai.usage.cache_creation_input_tokens", cache_write
+                )
+        except Exception:
+            logger.debug("Failed to annotate LLM span", exc_info=True)
+
+    def _close_span(self, err: BaseException | None = None) -> None:
+        cm, self._span_cm, self._span = self._span_cm, None, None
+        if cm is None:
+            return
+        try:
+            if err is not None:
+                cm.__exit__(type(err), err, err.__traceback__)
+            else:
+                cm.__exit__(None, None, None)
+        except Exception:
+            logger.debug("Failed to close LLM span", exc_info=True)
 
     def _compute_cost(
         self,

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -404,6 +404,34 @@ def start_child_span(
         logger.debug("Failed to create observability child span", exc_info=True)
 
 
+@contextlib.contextmanager
+def llm_call_span(name: str) -> Iterator[Any]:
+    """Open a span that stays current for the duration of one LLM call.
+
+    lmnr's LiteLLM instrumentation builds its span with ``Laminar.start_span``
+    (detached from the OTel context) and ends it in a ``finally`` before
+    ``litellm.completion`` returns, so attributes cannot be attached to it
+    afterwards -- OTel silently drops writes to an ended span. This span is
+    *current* while the call runs, so lmnr's span nests underneath it, and it
+    stays open long enough for Telemetry to attach the authoritative cost.
+
+    Yields ``None`` when observability is disabled, so callers stay branch-free.
+    """
+    if not should_enable_observability():
+        yield None
+        return
+    try:
+        from lmnr import Laminar
+
+        cm = Laminar.start_as_current_span(name=name, span_type="LLM")
+    except Exception:
+        logger.debug("Failed to open LLM observability span", exc_info=True)
+        yield None
+        return
+    with cm as span:
+        yield span
+
+
 # Trace-metadata key set by software-agent-sdk#4010 on the parent's `task`
 # TOOL span; copied onto a detached delegate trace when present so the
 # originating tool call is visible from the delegate's trace alone.

--- a/tests/sdk/llm/test_llm_span_cost.py
+++ b/tests/sdk/llm/test_llm_span_cost.py
@@ -1,0 +1,109 @@
+"""Span cost must be authoritative and cache-aware (issue #4817)."""
+
+import contextlib
+
+import pytest
+from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openhands.sdk.llm.utils.metrics import Metrics
+from openhands.sdk.llm.utils.telemetry import Telemetry
+
+
+PROXY_COST = 0.084930
+
+
+def _usage(cache_creation=20281, cache_read=0, prompt=20291, completion=83):
+    return Usage(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cache_read),
+        cache_creation_input_tokens=cache_creation,
+        cache_read_input_tokens=cache_read,
+    )
+
+
+def _response(usage, cost=PROXY_COST):
+    resp = ModelResponse(model="litellm_proxy/claude-sonnet-4-5-20250929", usage=usage)
+    resp._hidden_params = {
+        "additional_headers": {"llm_provider-x-litellm-response-cost": cost}
+    }
+    return resp
+
+
+@pytest.fixture
+def exporter(monkeypatch):
+    exp = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    tracer = provider.get_tracer("test")
+
+    @contextlib.contextmanager
+    def fake_span(name):
+        with tracer.start_as_current_span(name) as span:
+            yield span
+
+    monkeypatch.setattr("openhands.sdk.observability.laminar.llm_call_span", fake_span)
+    return exp
+
+
+def _attrs(exporter):
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, f"expected one span, got {len(spans)}"
+    return dict(spans[0].attributes)
+
+
+def test_span_cost_uses_authoritative_proxy_cost(exporter):
+    t = Telemetry(
+        model_name="litellm_proxy/claude-sonnet-4-5-20250929", metrics=Metrics()
+    )
+    t.on_request(telemetry_ctx={})
+    t.on_response(_response(_usage()))
+
+    attrs = _attrs(exporter)
+    assert attrs["gen_ai.usage.cost"] == pytest.approx(PROXY_COST)
+    # Not the flat token recompute that loses the cache buckets.
+    flat = 20291 * 3e-6 + 83 * 15e-6
+    assert attrs["gen_ai.usage.cost"] != pytest.approx(flat)
+
+
+def test_span_carries_cache_buckets(exporter):
+    t = Telemetry(model_name="m", metrics=Metrics())
+    t.on_request(telemetry_ctx={})
+    t.on_response(_response(_usage(cache_creation=20281, cache_read=7)))
+
+    attrs = _attrs(exporter)
+    assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 20281
+    assert attrs["gen_ai.usage.cache_read_input_tokens"] == 7
+
+
+def test_span_cost_agrees_with_metrics(exporter):
+    t = Telemetry(model_name="m", metrics=Metrics())
+    t.on_request(telemetry_ctx={})
+    t.on_response(_response(_usage()))
+
+    attrs = _attrs(exporter)
+    assert attrs["gen_ai.usage.cost"] == pytest.approx(t.metrics.accumulated_cost)
+
+
+def test_cache_buckets_survive_absent_prompt_tokens_details():
+    usage = Usage(prompt_tokens=100, completion_tokens=5)
+    object.__setattr__(usage, "cache_creation_input_tokens", 42)
+    assert Telemetry._cache_buckets(usage)[1] == 42
+
+
+def test_span_closed_on_error(exporter):
+    t = Telemetry(model_name="m", metrics=Metrics())
+    t.on_request(telemetry_ctx={})
+    t.on_error(RuntimeError("boom"))
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_retry_does_not_leak_spans(exporter):
+    t = Telemetry(model_name="m", metrics=Metrics())
+    t.on_request(telemetry_ctx={})
+    t.on_request(telemetry_ctx={})  # retry re-enters without a response
+    t.on_response(_response(_usage()))
+    assert len(exporter.get_finished_spans()) == 2

--- a/tests/sdk/llm/test_model_info_proxy_lookup.py
+++ b/tests/sdk/llm/test_model_info_proxy_lookup.py
@@ -174,6 +174,7 @@ def test_register_proxy_alias_makes_alias_priceable():
         underlying_model_info=underlying,
         proxy_model_info=None,
     )
+    cost = (0.0, 0.0)
     try:
         cost = litellm.cost_per_token(
             model=alias, prompt_tokens=100, completion_tokens=50
@@ -218,6 +219,50 @@ def test_register_proxy_proxy_overrides_win():
     assert entry["output_cost_per_token"] == 2.0
     # Underlying cache/max/provider fields still carried over.
     assert entry["litellm_provider"] == underlying["litellm_provider"]
+    _pop(alias)
+
+
+def test_register_proxy_alias_bedrock_converse_provider_normalized():
+    """A bedrock_converse provider label must be normalized to bedrock.
+
+    ``get_llm_provider`` resolves ``bedrock_converse`` only for model ids already
+    present in litellm's builtin bedrock_converse set; an unknown alias id with that
+    label raises, leaving the span priced $0. Registering with ``bedrock`` makes
+    ``cost_per_token`` resolve without an explicit ``custom_llm_provider`` (#4836).
+    """
+    alias = "prod/claude-sonnet-4-5-bedrock-e"
+    _pop(alias)
+    # Sanity: the alias is not priceable before registration.
+
+    try:
+        litellm.cost_per_token(model=alias, prompt_tokens=1, completion_tokens=1)
+        pre_raises = False
+    except Exception:
+        pre_raises = True
+    assert pre_raises
+
+    # The proxy advertises ``bedrock_converse`` (the Anthropic-on-Bedrock route),
+    # which would otherwise override the underlying provider in the merged entry.
+
+    underlying = model_cost["us.anthropic.claude-sonnet-4-5-20250929-v1:0"]
+    assert underlying["litellm_provider"] == "bedrock_converse"
+    _register_proxy_alias_pricing(
+        alias=alias,
+        underlying_model_info=underlying,
+        proxy_model_info={"litellm_provider": "bedrock_converse"},
+    )
+    assert model_cost[alias]["litellm_provider"] == "bedrock"
+    cost = (0.0, 0.0)
+    try:
+        cost = litellm.cost_per_token(
+            model=alias, prompt_tokens=100, completion_tokens=50
+        )
+        post_raises = False
+    except Exception:
+        post_raises = True
+    assert not post_raises
+    assert cost[0] > 0
+    assert cost[1] > 0
     _pop(alias)
 
 

--- a/tests/sdk/llm/test_model_info_proxy_lookup.py
+++ b/tests/sdk/llm/test_model_info_proxy_lookup.py
@@ -13,9 +13,13 @@ aliases (claude-opus-4-8 vision still off).
 
 from unittest.mock import patch
 
+import litellm
+from litellm import model_cost
+
 from openhands.sdk.llm.utils.model_info import (
     _get_model_info_from_litellm_proxy,
     _merge_raw_model_metadata,
+    _register_proxy_alias_pricing,
     get_litellm_model_info,
 )
 
@@ -52,8 +56,8 @@ def _patched_httpx_get(*_a, **_kw):
 
 
 def setup_function(_):
-    # Both functions are lru_cache'd; clear between tests so cache_key reuse
-    # across tests does not mask behavior.
+    # `_get_model_info_from_litellm_proxy` is lru_cache'd; clear between tests
+    # so cache_key reuse across tests does not mask behavior.
     _get_model_info_from_litellm_proxy.cache_clear()
 
 
@@ -138,3 +142,127 @@ def test_raw_registry_capabilities_survive_typed_model_info_projection():
     assert info["supports_reasoning"] is True
     assert info["supports_adaptive_thinking"] is True
     assert info["supports_sampling_params"] is False
+
+
+# --- alias pricing registration (issue #4816) ---
+
+# Each test uses a distinct custom alias so litellm's internal caches (which
+# remember a previously-registered alias as priceable even after it is popped
+# out of `model_cost`) cannot pollute a later test's priceability check.
+_UNDERLYING = "claude-sonnet-4-5-20250929"
+
+
+def _pop(alias):
+    model_cost.pop(alias, None)
+
+
+def test_register_proxy_alias_makes_alias_priceable():
+    """Registering a custom alias flips cost_per_token from raising to a value."""
+    alias = "prod/claude-sonnet-4-5-bedrock-a"
+    _pop(alias)
+    # Sanity: the alias is not priceable before registration.
+    try:
+        litellm.cost_per_token(model=alias, prompt_tokens=1, completion_tokens=1)
+        pre_raises = False
+    except Exception:
+        pre_raises = True
+    assert pre_raises
+
+    underlying = model_cost[_UNDERLYING]
+    _register_proxy_alias_pricing(
+        alias=alias,
+        underlying_model_info=underlying,
+        proxy_model_info=None,
+    )
+    try:
+        cost = litellm.cost_per_token(
+            model=alias, prompt_tokens=100, completion_tokens=50
+        )
+        post_raises = False
+    except Exception:
+        post_raises = True
+
+    assert not post_raises
+    # (prompt_cost, completion_cost); both must be non-zero.
+    assert cost[0] > 0
+    assert cost[1] > 0
+    _pop(alias)
+
+
+def test_register_proxy_alias_skips_already_priceable_models():
+    """A provider-prefixed real model is priceable natively; do not clobber."""
+    alias = "anthropic/claude-sonnet-4-5-20250929"
+    before = dict(model_cost.get(alias, {}))
+    _register_proxy_alias_pricing(
+        alias=alias,
+        underlying_model_info=model_cost[_UNDERLYING],
+        proxy_model_info={"input_cost_per_token": 999},
+    )
+    # Entry unchanged: registration was skipped.
+    assert model_cost.get(alias, {}) == before
+
+
+def test_register_proxy_proxy_overrides_win():
+    """Proxy-side pricing overrides take precedence over the underlying model."""
+    alias = "prod/claude-sonnet-4-5-bedrock-b"
+    _pop(alias)
+    underlying = model_cost[_UNDERLYING]
+    override = {"input_cost_per_token": 1.0, "output_cost_per_token": 2.0}
+    _register_proxy_alias_pricing(
+        alias=alias,
+        underlying_model_info=underlying,
+        proxy_model_info=override,
+    )
+    entry = model_cost[alias]
+    assert entry["input_cost_per_token"] == 1.0
+    assert entry["output_cost_per_token"] == 2.0
+    # Underlying cache/max/provider fields still carried over.
+    assert entry["litellm_provider"] == underlying["litellm_provider"]
+    _pop(alias)
+
+
+def test_register_proxy_alias_no_pricing_logs_and_skips():
+    """When no pricing can be derived, the alias stays unregistered (no $0 entry)."""
+    alias = "prod/claude-sonnet-4-5-bedrock-c"
+    _pop(alias)
+    _register_proxy_alias_pricing(
+        alias=alias,
+        underlying_model_info=None,
+        proxy_model_info={"supports_vision": True},
+    )
+    assert alias not in model_cost
+
+
+def test_get_model_info_from_proxy_registers_alias_pricing():
+    """End-to-end: fetching proxy model info registers the alias into model_cost."""
+    alias = "prod/claude-sonnet-4-5-bedrock-d"
+    _pop(alias)
+    proxy_response = {
+        "data": [
+            {
+                "model_name": alias,
+                "litellm_params": {"model": _UNDERLYING},
+                "model_info": {"supports_vision": True},
+            }
+        ]
+    }
+    with patch(
+        "openhands.sdk.llm.utils.model_info.httpx.get",
+        lambda *_a, **_kw: _FakeResponse(proxy_response),
+    ):
+        _get_model_info_from_litellm_proxy.cache_clear()
+        _get_model_info_from_litellm_proxy(
+            secret_api_key="k",
+            base_url="https://proxy.example",
+            model=f"litellm_proxy/{alias}",
+            cache_key=42,
+        )
+    assert alias in model_cost
+    try:
+        cost = litellm.cost_per_token(
+            model=alias, prompt_tokens=100, completion_tokens=50
+        )
+    except Exception:
+        cost = None
+    assert cost is not None and cost[0] > 0
+    _pop(alias)


### PR DESCRIPTION
## Summary

Draft PR to **test @VascoSch92's Option A fix** for #4817 (LLM span cost is `$0` for custom `litellm_proxy/*` models and cache-blind for priceable ones) end-to-end on a live self-hosted Laminar deployment.

This reconstructs the working patch Vasco posted in [this comment](https://github.com/OpenHands/software-agent-sdk/issues/4817#issuecomment-5529909667) verbatim, so CI produces a deployable `agent-server` image tagged by commit.

## What it does

- `Telemetry.on_request` opens an observability span (`llm.<model>`, span_type `LLM`) via a new `laminar.llm_call_span` context manager; `on_response` stamps the authoritative, cache-aware `gen_ai.usage.cost` (from the proxy's `x-litellm-response-cost` header, which `_compute_cost` already prefers) plus `gen_ai.usage.cache_read_input_tokens` / `cache_creation_input_tokens`, then closes it; `on_error` closes it too. Because the SDK span is *current* while litellm runs, lmnr's detached `litellm.completion` span nests underneath it and is still open when the cost is known.
- `_cache_buckets` becomes the single source of truth for both `metrics` and the span.

## Why this approach works (empirically confirmed)

I verified on the target self-hosted Laminar (lmnr ~0.7.60, ClickHouse) that **Laminar honors a client-supplied `gen_ai.usage.cost` for `total_cost`** — a sentinel `$7.77` on an unpriceable model landed as `total_cost = 7.77` (details in [this issue comment](https://github.com/OpenHands/software-agent-sdk/issues/4817#issuecomment-5530255997)). The registration approach in #4816/#4836 does **not** move the span, because Laminar prices server-side from the model name, not from the client's litellm `model_cost` map.

## Known trade-off (maintainer decision — see #4817)

- Reparents `litellm.completion` under `llm.<model>`, so `tests/sdk/conversation/test_utility_llm_span_metadata.py::test_operation_metadata_reaches_the_exported_llm_span` **fails** (parent chain is an asserted contract). Left failing intentionally so the trade-off is visible.
- Open question this PR is meant to answer live: does Laminar **double-count** cost on the parent `llm.<model>` + child `litellm.completion`? For our custom-alias case the child derives `$0`, so no double-count is expected; priceable models may differ.

## Tests

`tests/sdk/llm/test_llm_span_cost.py` (6 cases, green): authoritative cost preferred over the flat recompute, cache buckets present, span cost == `llm.metrics`, buckets recovered when `prompt_tokens_details` absent, span closed on error, no leak on retry.

## Status

**Draft, for testing only.** Not for merge as-is — the trace-shape trade-off and the Option A vs Option C decision are for maintainers (both are laid out on #4817).

---
_This PR was created by an AI agent (OpenHands) on behalf of the user, reconstructing @VascoSch92's patch from #4817 for deployment testing._


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:28b20a4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-28b20a4-python \
  ghcr.io/openhands/agent-server:28b20a4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:28b20a4-golang-amd64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-golang-amd64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-golang-amd64
ghcr.io/openhands/agent-server:28b20a4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:28b20a4-golang-arm64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-golang-arm64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-golang-arm64
ghcr.io/openhands/agent-server:28b20a4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:28b20a4-java-amd64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-java-amd64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-java-amd64
ghcr.io/openhands/agent-server:28b20a4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:28b20a4-java-arm64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-java-arm64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-java-arm64
ghcr.io/openhands/agent-server:28b20a4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:28b20a4-python-amd64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python-amd64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python-amd64
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:28b20a4-python-arm64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python-arm64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python-arm64
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:28b20a4-python-slim-amd64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python-slim-amd64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python-slim-amd64
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:28b20a4-python-slim-arm64
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python-slim-arm64
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python-slim-arm64
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:28b20a4-golang
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-golang
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-golang
ghcr.io/openhands/agent-server:28b20a4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:28b20a4-java
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-java
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-java
ghcr.io/openhands/agent-server:28b20a4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:28b20a4-python-slim
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python-slim
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python-slim
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:28b20a4-python
ghcr.io/openhands/agent-server:28b20a41f43914b2f79262f11a22bfedd0dc301d-python
ghcr.io/openhands/agent-server:test-issue-4817-span-cost-python
ghcr.io/openhands/agent-server:28b20a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `28b20a4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `28b20a4-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->