### PR TITLE
perf(sdk): make EventLog.append flat against conversation length

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -22,6 +22,12 @@ logger = get_logger(__name__)
 LOCK_FILE_NAME = ".eventlog.lock"
 LOCK_TIMEOUT_SECONDS = 30
 
+# Marker naming the number of events on disk. The count is in the name rather than
+# the contents because FileStore.read is cached (LocalFileStore states that the cache
+# assumes exclusive access) while FileStore.exists goes to the filesystem, and this
+# has to see writes from other processes.
+COUNT_MARKER_PATTERN = ".eventlog-count-{count}.marker"
+
 # ROOT_PARENT_ID now lives in event.types (single source of truth); it is used
 # below in _effective_parent_id and re-exported here so existing
 # ``from event_store import ROOT_PARENT_ID`` importers keep working.
@@ -196,10 +202,14 @@ class EventLog(EventsListBase):
 
         try:
             with self._fs.lock(self._lock_path, timeout=LOCK_TIMEOUT_SECONDS):
-                # Sync with disk in case another process wrote while we waited
-                disk_length = self._count_events_on_disk()
-                if disk_length > self._length:
-                    self._sync_from_disk(disk_length)
+                # Sync with disk in case another process wrote while we waited.
+                # Counting means listing the whole directory, which grows with the
+                # conversation, so skip it when the marker proves the count is still
+                # what we think it is.
+                if not self._disk_length_is_known():
+                    disk_length = self._count_events_on_disk()
+                    if disk_length > self._length:
+                        self._sync_from_disk(disk_length)
 
                 if evt_id in self._id_to_idx:
                     existing_idx = self._id_to_idx[evt_id]
@@ -229,6 +239,7 @@ class EventLog(EventsListBase):
                 self._id_to_idx[evt_id] = idx
                 self._event_cache[idx] = event
                 self._length += 1
+                self._advance_count_marker(idx, self._length)
                 return idx
         except TimeoutError:
             logger.error(
@@ -236,6 +247,36 @@ class EventLog(EventsListBase):
                 f"for event {evt_id}"
             )
             raise
+
+    def _count_marker_path(self, count: int) -> str:
+        return f"{self._dir}/{COUNT_MARKER_PATTERN.format(count=count)}"
+
+    def _disk_length_is_known(self) -> bool:
+        """True when the marker proves nothing has been appended since we last looked.
+
+        Only the exact match is a proof. Every other outcome -- no marker, a marker for
+        a different count, a store that cannot answer -- returns False and leaves the
+        caller on the authoritative counting path.
+        """
+        try:
+            return self._fs.exists(self._count_marker_path(self._length))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Error probing event count marker in %s: %s", self._dir, e)
+            return False
+
+    def _advance_count_marker(self, previous: int, current: int) -> None:
+        """Move the marker from ``previous`` to ``current``.
+
+        Called with the lock held, after the event file is written. An append
+        interrupted anywhere in the critical section leaves no marker at all, which
+        costs the next writer a full count rather than letting it trust a stale one.
+        """
+        try:
+            self._fs.write(self._count_marker_path(current), "")
+            if previous != current:
+                self._fs.delete(self._count_marker_path(previous))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Error updating event count marker in %s: %s", self._dir, e)
 
     def _count_events_on_disk(self) -> int:
         """Count event files on disk."""
@@ -296,6 +337,10 @@ class EventLog(EventsListBase):
         by_idx: dict[int, EventID] = {}
         for p in paths:
             name = posix_path_name(p)
+            if name.startswith("."):
+                # Bookkeeping files (the lock, the count marker) live alongside the
+                # events and are not malformed event files.
+                continue
             m = EVENT_NAME_RE.match(name)
             if m:
                 idx = int(m.group("idx"))

--- a/openhands-sdk/openhands/sdk/io/local.py
+++ b/openhands-sdk/openhands/sdk/io/local.py
@@ -110,7 +110,12 @@ class LocalFileStore(FileStore):
 
             if os.path.isfile(full_path):
                 os.remove(full_path)
-                del self.cache[full_path]
+                # The cache only holds what this process read or wrote, so a file
+                # written by anyone else is not in it. Deleting one used to raise
+                # KeyError here, after the removal had already succeeded, and the
+                # handler below logged it as a failure.
+                if full_path in self.cache:
+                    del self.cache[full_path]
                 logger.debug(f"Removed local file: {full_path}")
             elif os.path.isdir(full_path):
                 shutil.rmtree(full_path)

--- a/tests/sdk/conversation/test_event_store.py
+++ b/tests/sdk/conversation/test_event_store.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.event_store import LOCK_FILE_NAME, EventLog
 from openhands.sdk.conversation.persistence_const import (
     EVENT_FILE_PATTERN,
     EVENT_NAME_RE,
@@ -14,6 +14,7 @@ from openhands.sdk.conversation.persistence_const import (
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.io.memory import InMemoryFileStore
 from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.utils.path import posix_path_name
 
 
 def create_test_event(event_id: str, content: str = "Test content") -> MessageEvent:
@@ -424,7 +425,9 @@ def test_event_log_concurrent_writes_serialized():
         assert log1._length == 1
         assert log2._length == 2
 
-        files = [f for f in fs.list("events") if not f.endswith(".lock")]
+        # The events directory also holds bookkeeping files -- the lock and the
+        # append count marker -- which are dotfiles rather than event files.
+        files = [f for f in fs.list("events") if not posix_path_name(f).startswith(".")]
         assert len(files) == 2
 
 
@@ -555,3 +558,116 @@ def test_event_log_cold_reload_past_100k_events():
     # Appending after reload keeps length accounting consistent.
     log.append(create_test_event("after-reload", "after"))
     assert len(log) == n + 1
+
+
+# --- append count marker -------------------------------------------------------
+#
+# append() used to list the whole events directory on every call to notice writes
+# from other processes, so its cost grew with the conversation. The marker names the
+# count in its filename -- FileStore.read is cached, FileStore.exists is not -- and is
+# only ever trusted as proof that nothing changed.
+
+
+def test_append_does_not_count_the_directory_on_the_fast_path():
+    """The listing is what made append cost grow; the marker has to remove it."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+    log.append(create_test_event("00000000-0000-0000-0000-000000000001"))
+
+    calls = 0
+    real_count = log._count_events_on_disk
+
+    def counting(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_count(*args, **kwargs)
+
+    log._count_events_on_disk = counting  # type: ignore[method-assign]
+    for i in range(2, 12):
+        log.append(create_test_event(f"00000000-0000-0000-0000-{i:012d}"))
+
+    assert calls == 0, f"append counted the directory {calls} times on the fast path"
+    assert len(log) == 11
+
+
+def test_a_second_instance_still_sees_events_written_by_the_first():
+    """The marker must not cost us the multi-writer sync it replaces."""
+    fs = InMemoryFileStore()
+    first = EventLog(fs)
+    second = EventLog(fs)
+
+    first.append(create_test_event("00000000-0000-0000-0000-000000000001"))
+    first.append(create_test_event("00000000-0000-0000-0000-000000000002"))
+
+    # `second` was opened when the log was empty and has no marker of its own to
+    # trust, so it must fall back to counting and pick both events up.
+    second.append(create_test_event("00000000-0000-0000-0000-000000000003"))
+
+    assert len(second) == 3
+    assert [e.id for e in second][-1].endswith("3")
+
+
+def test_a_missing_marker_falls_back_to_counting():
+    """An append interrupted mid-critical-section leaves no marker."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+    log.append(create_test_event("00000000-0000-0000-0000-000000000001"))
+
+    for path in [p for p in fs.list(EVENTS_DIR) if "count" in p]:
+        fs.delete(path)
+
+    counted = False
+    real_count = log._count_events_on_disk
+
+    def counting(*args, **kwargs):
+        nonlocal counted
+        counted = True
+        return real_count(*args, **kwargs)
+
+    log._count_events_on_disk = counting  # type: ignore[method-assign]
+    log.append(create_test_event("00000000-0000-0000-0000-000000000002"))
+
+    assert counted, "a missing marker must not be treated as proof"
+    assert len(log) == 2
+
+
+def test_a_stale_marker_is_not_treated_as_proof():
+    """Only the marker for our own length is a proof; any other value is not."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+    log.append(create_test_event("00000000-0000-0000-0000-000000000001"))
+
+    # Someone else appended and moved the marker past us.
+    for path in [p for p in fs.list(EVENTS_DIR) if "count" in p]:
+        fs.delete(path)
+    fs.write(f"{EVENTS_DIR}/.eventlog-count-7.marker", "")
+
+    assert not log._disk_length_is_known()
+
+
+def test_marker_names_do_not_prefix_one_another():
+    """InMemoryFileStore.delete matches by prefix, so 1 must not delete 10."""
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+
+    for i in range(1, 13):
+        log.append(create_test_event(f"00000000-0000-0000-0000-{i:012d}"))
+
+    markers = [p for p in fs.list(EVENTS_DIR) if "count" in p]
+    assert markers == [f"{EVENTS_DIR}/.eventlog-count-12.marker"], markers
+
+
+def test_bookkeeping_files_are_not_reported_as_malformed(caplog):
+    """The lock and the marker sit in the events directory by design."""
+    import logging
+
+    fs = InMemoryFileStore()
+    log = EventLog(fs)
+    log.append(create_test_event("00000000-0000-0000-0000-000000000001"))
+    fs.write(f"{EVENTS_DIR}/{LOCK_FILE_NAME}", "")
+
+    with caplog.at_level(logging.WARNING):
+        reopened = EventLog(fs)
+
+    assert len(reopened) == 1
+    assert "Unrecognized event file name" not in caplog.text

--- a/tests/sdk/io/test_filestore_cache.py
+++ b/tests/sdk/io/test_filestore_cache.py
@@ -312,3 +312,53 @@ def test_cache_with_evict_correct():
     total_len = len(cache["key2"]) + len(cache["key3"])
     # Verify memory statistics match the total size of key2 and key3
     assert total_len == cache.current_memory
+
+
+def test_delete_does_not_report_a_failure_for_an_uncached_file(tmp_path, caplog):
+    """The cache only holds what this process read or wrote.
+
+    Deleting a file written by anyone else removed it and then raised KeyError on
+    the cache eviction, which the handler logged as "Error clearing local file
+    store" even though the delete itself had already succeeded.
+    """
+    import logging
+
+    store = LocalFileStore(str(tmp_path))
+    external = tmp_path / "written-by-someone-else.json"
+    external.write_text("{}")
+
+    with caplog.at_level(logging.ERROR):
+        store.delete("written-by-someone-else.json")
+
+    assert not external.exists()
+    assert "Error clearing local file store" not in caplog.text
+
+
+def test_delete_still_evicts_a_cached_file(tmp_path):
+    """The guard must not skip eviction for files the store does hold."""
+    store = LocalFileStore(str(tmp_path))
+    store.write("cached.json", '{"a": 1}')
+    full = store.get_full_path("cached.json")
+    assert full in store.cache
+
+    store.delete("cached.json")
+
+    assert full not in store.cache
+    assert store.cache.current_memory == 0
+
+
+def test_exists_sees_an_external_write_but_read_does_not(tmp_path):
+    """Pins the asymmetry the event log's append marker relies on.
+
+    ``read`` is served from the cache, which the class documents as assuming
+    exclusive access, so it cannot be used to detect another writer. ``exists`` goes
+    to the filesystem, so a marker that carries its value in the filename can.
+    """
+    store = LocalFileStore(str(tmp_path))
+    store.write("marker.json", "written-by-this-process")
+
+    (tmp_path / "marker.json").write_text("written-by-someone-else")
+    (tmp_path / "appeared.json").write_text("{}")
+
+    assert store.read("marker.json") == "written-by-this-process"
+    assert store.exists("appeared.json")


### PR DESCRIPTION
HUMAN:

Ran a long conversation against a local file store and watched the per-append time stop climbing; 3200 appends went from 22s to 1.3s.

---

AGENT:

## Why

Closes #4676 (step 1 of #4671).

`EventLog.append` listed the whole events directory on every call, inside the lock, to notice writes from another process:

```python
with self._fs.lock(self._lock_path, timeout=LOCK_TIMEOUT_SECONDS):
    disk_length = self._count_events_on_disk()   # self._fs.list(self._dir)
```

`LocalFileStore.list()` is worse than a listing. It stats every entry to decide whether to append a trailing `/`:

```python
files = [os.path.join(path, f) for f in os.listdir(full_path)]
files = [f + "/" if os.path.isdir(self.get_full_path(f)) else f for f in files]
```

So appending event N costs N `stat` calls on the run loop's critical path, while holding the lock. At 1600 entries the listing is 0.416 ms and the stats take it to 3.031 ms — 86% of the cost is for a decoration the counter does not read.

## Summary

- `append` counts the directory only when a marker file cannot prove the count is unchanged.
- The count is in the marker's **filename**, not its contents. `FileStore.read` is served from a cache the class documents as assuming exclusive access, so it cannot see another writer; `FileStore.exists` goes to the filesystem. Measured below.
- `LocalFileStore.delete` no longer logs a failure when evicting a cache entry that was never there, and `_scan_and_build_index` no longer reports bookkeeping dotfiles as malformed event files.

### Why this cannot lose a concurrent write

Only an exact match with our own `_length` is treated as proof. A missing marker, a marker naming a different count, or a store that cannot answer all fall through to `_count_events_on_disk()` + `_sync_from_disk()` **unchanged**, so the authoritative path is exactly what it is today and the new fast path only ever skips work when nothing has changed.

The marker is written after the event, inside the lock. An append interrupted anywhere in the critical section therefore leaves no marker at all, which costs the next writer a full count rather than letting it trust a stale one. Over-trusting is not reachable.

## How to Test

```bash
uv run pytest tests/sdk/conversation/test_event_store.py tests/sdk/io/ -q
```

Full suite:

```
$ uv run pytest tests/sdk/ -q
6070 passed, 9 skipped, 16 deselected, 10 xfailed in 157.44s
```

`ruff check` and `ruff format --check` are clean on the four changed files.

### The measurement the issue asks for

`EventLog` over `LocalFileStore`, real `MessageEvent`s with generated ids, mean ms per append by bucket:

| events so far | before | after |
| ---: | ---: | ---: |
| 400 | 1.066 | 0.396 |
| 800 | 2.565 | 0.428 |
| 1200 | 4.135 | 0.388 |
| 1600 | 5.701 | 0.425 |
| 2000 | 7.107 | 0.394 |
| 2400 | 9.192 | 0.432 |
| 2800 | 11.863 | 0.401 |
| 3200 | 12.827 | 0.385 |
| **last / first bucket** | **12.0x** | **1.0x** |
| **total for 3200 appends** | **21.78 s** | **1.30 s** |

Flat, which is the acceptance criterion. 17x on the total, 33x on the last append.

### End-to-end across two real processes

Unit tests share a `FileStore` object, so they cannot exercise the thing the marker exists for. Parent appends 1, a spawned child process appends 3, parent appends again:

```
parent wrote 1, len=1
child wrote 3 in a separate process
parent's marker for its own length still valid? False
after parent appends again: len=5   (expect 5)
```

The parent's probe correctly fails, it re-counts, and the child's events are picked up.

And the asymmetry the design rests on, on the same store:

```
FileStore.read after an external write:  'written-by-parent'    <- stale, from cache
os.path.exists (what the marker uses):   True
```

A contents-based marker would have been silently wrong across processes. `tests/sdk/io/test_filestore_cache.py::test_exists_sees_an_external_write_but_read_does_not` pins that property so the reason for the filename encoding does not get refactored away.

### Tests

Six cases in `test_event_store.py` and three in `test_filestore_cache.py`. Four of them fail on the parent commit and pass here:

```
FAILED test_append_does_not_count_the_directory_on_the_fast_path
FAILED test_a_stale_marker_is_not_treated_as_proof
FAILED test_marker_names_do_not_prefix_one_another
FAILED test_bookkeeping_files_are_not_reported_as_malformed
```

The other two — a second instance still seeing the first's events, and a missing marker falling back to counting — pass either way on purpose: they guard the multi-writer behaviour this change must not cost.

`test_marker_names_do_not_prefix_one_another` is there because `InMemoryFileStore.delete` matches by prefix, so `.eventlog-count-1` would have deleted `.eventlog-count-10`. The names carry a `.marker` suffix so no one is a prefix of another at any count.

### The two incidental fixes

Both were found by this change and both reproduce on `main`:

```python
store = LocalFileStore(tmp)
(tmp / "external.txt").write_text("hi")     # not written through the store
store.delete("external.txt")
# ERROR Error clearing local file store: '.../external.txt'
# ...and the file is gone. The removal succeeded; the KeyError came from evicting
# a cache entry that was never there.
```

and every `EventLog` open logs `Unrecognized event file name: .eventlog.lock`.

## Issue Number

Closes #4676

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
