### PR TITLE
feat: persist conversation read state

### DIFF
--- a/.pr/design.html
+++ b/.pr/design.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Conversation read state: server contract</title>
+<style>
+body{font:17px/1.6 system-ui,sans-serif;max-width:850px;margin:48px auto;padding:0 24px;color:#17212b;background:#fafbfc}
+h1,h2{line-height:1.2}code,pre{background:#eaf0f5;border-radius:4px}pre{padding:16px;overflow:auto}
+table{border-collapse:collapse;width:100%}td,th{border:1px solid #ccd5df;padding:12px;text-align:left}
+</style>
+<h1>Conversation read state: server contract</h1>
+<p>This PR provides a persisted, conversation-scoped read marker in the Agent Server
+and its TypeScript client. It supports the backend portion of
+<a href="https://github.com/OpenHands/OpenHands/issues/17140">OpenHands#17140</a>;
+it does not complete that issue's UI, per-user, or cross-window requirements.</p>
+<h2>Before and after</h2>
+<table>
+<tr><th>Surface</th><th>Before</th><th>After</th></tr>
+<tr><td>PATCH /api/conversations/{id}</td><td>title, tags</td><td>Also accepts optional unread: false to mark read, true to reset the read marker</td></tr>
+<tr><td>GET detail and /api/conversations/search</td><td>No read marker</td><td>last_read_at and derived unread on each ConversationInfo</td></tr>
+<tr><td>Metadata edits</td><td>Advance updated_at</td><td>Title, automatic title and tag edits preserve the activity timestamp</td></tr>
+</table>
+<h2>Semantics and compatibility</h2>
+<pre>unread = status in {finished, error, stuck}
+         and (last_read_at is null or updated_at &gt; last_read_at)</pre>
+<p>The timestamp comparison is strict: activity at the read timestamp is read.
+Running, idle, paused, waiting-for-confirmation and deleting conversations are not
+unread. Old metadata without last_read_at loads with null, so old terminal
+conversations initially appear unread. No persisted shape rewrite is required.
+The REST fields are additive; preserving updated_at on metadata edits is an
+intentional behavior change that downstream sort consumers should review.</p>
+<p>Read changes invalidate the cached conversation summary, persist meta.json,
+and invoke the existing conversation webhook path with the complete read state.
+That webhook is not a browser WebSocket broadcast, and this PR does not claim
+immediate cross-window synchronization.</p>
+<h2>Remaining application work</h2>
+<ul>
+<li>The stored marker is shared by callers of a conversation, not keyed by user.
+A multi-user application must define its ownership/read-state policy before
+claiming independent per-user read state.</li>
+<li>Canvas must consume a released server/client contract, mark conversations read
+on opening, and update all relevant windows through its push/state layer.</li>
+<li>Canvas owns the distinct unread badge, per-item read/unread actions, mark-all-read,
+unread sorting, and the issue-required screenshot or video.</li>
+</ul>
+<h2>Regression coverage</h2>
+<p>The model tests cover every execution status against absent, older, equal and
+newer read timestamps. Service tests check persisted read state across restart,
+metadata timestamp stability and webhook payloads. The live HTTP test exercises
+new output, read/unread toggles, title/tag edits, list/detail consistency and a
+second completed response becoming unread. LLM calls use the existing deterministic
+fixture; no live model credentials are needed.</p>
+</html>

--- a/clients/typescript/src/__tests__/api-clients.test.ts
+++ b/clients/typescript/src/__tests__/api-clients.test.ts
@@ -2285,6 +2285,7 @@ describe('Auxiliary API clients', () => {
     await client.respondToConfirmation('c1', { accept: true });
     await client.deleteConversation('c1');
     await client.updateConversation('c1', { title: 'New title' });
+    await client.updateConversation('c1', { unread: false });
 
     expect(global.fetch).toHaveBeenNthCalledWith(
       1,
@@ -2313,6 +2314,11 @@ describe('Auxiliary API clients', () => {
       8,
       'http://example.com/api/conversations/c1',
       expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ title: 'New title' }) })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      9,
+      'http://example.com/api/conversations/c1',
+      expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ unread: false }) })
     );
   });
 

--- a/clients/typescript/src/models/conversation.ts
+++ b/clients/typescript/src/models/conversation.ts
@@ -51,6 +51,8 @@ export interface ConversationInfo {
   title?: string;
   created_at?: string;
   updated_at?: string;
+  last_read_at?: string | null;
+  unread?: boolean;
   tags?: Record<string, string>;
   /**
    * HEAD of the conversation tree: the parent of the next appended event.
@@ -120,6 +122,7 @@ export interface CreateACPConversationRequest {
 export interface UpdateConversationRequest {
   title?: string;
   tags?: Record<string, string>;
+  unread?: boolean;
 }
 
 export interface StaticSecret {

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -512,12 +512,17 @@ def _compose_conversation_info(
     supports_runtime_model_switch = bool(
         agent_state.get("acp_supports_runtime_model_switch", False)
     )
+    unread = state.execution_status.is_terminal() and (
+        stored.last_read_at is None or stored.updated_at > stored.last_read_at
+    )
     return ConversationInfo(
         **state.model_dump(mode="json"),
         title=stored.title,
         metrics=stored.metrics,
         created_at=stored.created_at,
         updated_at=stored.updated_at,
+        last_read_at=stored.last_read_at,
+        unread=unread,
         forked_from_conversation_id=stored.forked_from_conversation_id,
         forked_from_event_id=stored.forked_from_event_id,
         parent_conversation_id=stored.parent_conversation_id,
@@ -622,6 +627,7 @@ def _stored_metadata_signature(stored: StoredConversation) -> int:
             "metrics",
             "created_at",
             "updated_at",
+            "last_read_at",
             "forked_from_conversation_id",
             "forked_from_event_id",
             "parent_conversation_id",
@@ -1882,7 +1888,8 @@ class ConversationService:
             state = await loop.run_in_executor(
                 None, _update_state_tags_sync, state, request.tags
             )
-        event_service.stored.updated_at = utc_now()
+        if request.unread is not None:
+            event_service.stored.last_read_at = None if request.unread else utc_now()
         record = self._conversation_records.get(conversation_id)
         if record is not None:
             record.stored = event_service.stored
@@ -1903,6 +1910,8 @@ class ConversationService:
             updated_fields.append("title")
         if request.tags is not None:
             updated_fields.append("tags")
+        if request.unread is not None:
+            updated_fields.append("unread")
         logger.info(
             "Successfully updated conversation %s (%s)",
             conversation_id,
@@ -2569,7 +2578,6 @@ class AutoTitleSubscriber(Subscriber):
                 )
                 if title and self.service.stored.title is None:
                     self.service.stored.title = title
-                    self.service.stored.updated_at = utc_now()
                     await self.service.save_meta()
             except Exception:
                 logger.warning(

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -94,6 +94,10 @@ class StoredConversation(ConversationConfig):
     metrics: MetricsSnapshot | None = None
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
+    last_read_at: datetime | None = Field(
+        default=None,
+        description="Most recent time the user marked this conversation as read",
+    )
     forked_from_conversation_id: OpenHandsUUID | None = Field(
         default=None,
         description=(
@@ -220,6 +224,16 @@ class _ConversationInfoBase(BaseModel):
     metrics: MetricsSnapshot | None = None
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
+    last_read_at: datetime | None = Field(
+        default=None,
+        description="Most recent time the user marked this conversation as read",
+    )
+    unread: bool = Field(
+        default=False,
+        description=(
+            "Whether terminal agent output is newer than the user's last read time"
+        ),
+    )
     # Plain ``UUID`` (not ``OpenHandsUUID``) so it JSON-serializes dashed, exactly
     # like the ``id`` field above — clients must be able to correlate the two.
     forked_from_conversation_id: UUID | None = Field(
@@ -483,6 +497,13 @@ class UpdateConversationRequest(BaseModel):
             "Key-value tags to set on the conversation. Keys must be lowercase "
             "alphanumeric. Values are arbitrary strings up to 256 characters. "
             "Replaces all existing tags when provided."
+        ),
+    )
+    unread: bool | None = Field(
+        default=None,
+        description=(
+            "Set the conversation read state. False marks it read; true marks it "
+            "unread."
         ),
     )
 

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -77,6 +77,27 @@ def test_current_model_id_is_lifted_from_acp_agent():
     assert info.current_model_id == "claude-opus-4-1"
 
 
+@pytest.mark.parametrize(
+    ("status", "was_read", "expected"),
+    [
+        (ConversationExecutionStatus.RUNNING, None, False),
+        (ConversationExecutionStatus.FINISHED, None, True),
+        (ConversationExecutionStatus.FINISHED, True, False),
+    ],
+)
+def test_unread_requires_terminal_output_newer_than_last_read(
+    status, was_read, expected
+):
+    state = _make_state(ACPAgent(acp_command=["echo", "test"]))
+    state.execution_status = status
+    stored = _make_stored(state)
+    stored.last_read_at = utc_now() if was_read else None
+
+    info = _compose_conversation_info(stored, state)
+
+    assert info.unread is expected
+
+
 def test_current_model_id_is_none_when_acp_agent_has_no_model():
     """Older ACP servers don't surface the field — we propagate ``None``."""
     agent = ACPAgent(acp_command=["echo", "test"])

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -18,6 +18,7 @@ routes them into the response model.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -77,25 +78,26 @@ def test_current_model_id_is_lifted_from_acp_agent():
     assert info.current_model_id == "claude-opus-4-1"
 
 
-@pytest.mark.parametrize(
-    ("status", "was_read", "expected"),
-    [
-        (ConversationExecutionStatus.RUNNING, None, False),
-        (ConversationExecutionStatus.FINISHED, None, True),
-        (ConversationExecutionStatus.FINISHED, True, False),
-    ],
-)
-def test_unread_requires_terminal_output_newer_than_last_read(
-    status, was_read, expected
-):
+@pytest.mark.parametrize("status", list(ConversationExecutionStatus))
+@pytest.mark.parametrize("read_offset", [None, -1, 0, 1])
+def test_unread_requires_terminal_output_newer_than_last_read(status, read_offset):
     state = _make_state(ACPAgent(acp_command=["echo", "test"]))
     state.execution_status = status
     stored = _make_stored(state)
-    stored.last_read_at = utc_now() if was_read else None
+    stored.last_read_at = (
+        None
+        if read_offset is None
+        else stored.updated_at + timedelta(seconds=read_offset)
+    )
 
     info = _compose_conversation_info(stored, state)
 
-    assert info.unread is expected
+    terminal = status in {
+        ConversationExecutionStatus.FINISHED,
+        ConversationExecutionStatus.ERROR,
+        ConversationExecutionStatus.STUCK,
+    }
+    assert info.unread is (terminal and read_offset in (None, -1))
 
 
 def test_current_model_id_is_none_when_acp_agent_has_no_model():

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1620,7 +1620,7 @@ def test_update_conversation_success(
     )
 
     try:
-        request_data = {"title": "Updated Conversation Title"}
+        request_data = {"title": "Updated Conversation Title", "unread": False}
 
         response = client.patch(
             f"/api/conversations/{sample_conversation_id}", json=request_data
@@ -1635,6 +1635,7 @@ def test_update_conversation_success(
         call_args = mock_conversation_service.update_conversation.call_args
         assert call_args[0][0] == sample_conversation_id
         assert call_args[0][1].title == "Updated Conversation Title"
+        assert call_args[0][1].unread is False
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2708,15 +2708,10 @@ class TestConversationServiceUpdateConversation:
         assert mock_service.save_meta.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_update_conversation_sets_updated_at(
+    async def test_metadata_update_preserves_activity_timestamp(
         self, conversation_service, sample_stored_conversation
     ):
-        """Test that update_conversation advances updated_at.
-
-        Renaming a conversation is a meaningful change; the timestamp must
-        reflect when it happened rather than staying at the value set at
-        conversation creation time.
-        """
+        """Renaming must not make an already-read conversation unread."""
         mock_service = AsyncMock(spec=EventService)
         mock_service.stored = sample_stored_conversation
         mock_state = ConversationState(
@@ -2736,7 +2731,38 @@ class TestConversationServiceUpdateConversation:
         request = UpdateConversationRequest(title="New Title")
         await conversation_service.update_conversation(conversation_id, request)
 
-        assert mock_service.stored.updated_at > original_updated_at
+        assert mock_service.stored.updated_at == original_updated_at
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_sets_read_state(
+        self, conversation_service, sample_stored_conversation
+    ):
+        mock_service = AsyncMock(spec=EventService)
+        mock_service.stored = sample_stored_conversation
+        mock_state = ConversationState(
+            id=sample_stored_conversation.id,
+            agent=_sample_agent(),
+            workspace=sample_stored_conversation.workspace,
+            execution_status=ConversationExecutionStatus.FINISHED,
+            confirmation_policy=sample_stored_conversation.confirmation_policy,
+        )
+        mock_service.get_state.return_value = mock_state
+        conversation_id = sample_stored_conversation.id
+        conversation_service._event_services[conversation_id] = mock_service
+
+        await conversation_service.update_conversation(
+            conversation_id, UpdateConversationRequest(unread=False)
+        )
+
+        assert mock_service.stored.last_read_at is not None
+        read_at = mock_service.stored.last_read_at
+
+        await conversation_service.update_conversation(
+            conversation_id, UpdateConversationRequest(unread=True)
+        )
+
+        assert read_at is not None
+        assert mock_service.stored.last_read_at is None
 
 
 class TestConversationServiceDeleteConversation:
@@ -3199,6 +3225,7 @@ class TestAutoTitle:
     async def test_autotitle_sets_title_on_first_user_message(self):
         """Title is generated and saved when the first user message arrives."""
         service = self._make_service()
+        original_updated_at = service.stored.updated_at
 
         with patch(self._GENERATE_TITLE_PATH, return_value="✨ Generated Title"):
             subscriber = AutoTitleSubscriber(service=service)
@@ -3206,6 +3233,7 @@ class TestAutoTitle:
             await self._drain_title_task(lambda: service.stored.title is not None)
 
         assert service.stored.title == "✨ Generated Title"
+        assert service.stored.updated_at == original_updated_at
         service.save_meta.assert_called_once()
 
     @pytest.mark.asyncio
@@ -3836,6 +3864,27 @@ class TestConversationTreeForkAndNavigate:
             assert reloaded_fork is not None
             assert reloaded_fork.forked_from_conversation_id == src_id
             assert reloaded_fork.forked_from_event_id == branch_point
+
+    @pytest.mark.asyncio
+    async def test_read_state_persists_across_restart(self, tmp_path):
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        conversations_dir = tmp_path / "conversations"
+
+        async with ConversationService(conversations_dir=conversations_dir) as svc:
+            info, _, _ = await self._start_with_events(svc, workspace_dir, ["first"])
+            await svc.update_conversation(
+                info.id, UpdateConversationRequest(unread=False)
+            )
+            marked = await svc.get_conversation(info.id)
+            assert marked is not None
+            read_at = marked.last_read_at
+
+        async with ConversationService(conversations_dir=conversations_dir) as svc2:
+            reloaded = await svc2.get_conversation(info.id)
+
+            assert reloaded is not None
+            assert reloaded.last_read_at == read_at
 
 
 class TestConversationSearchScaling:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2734,8 +2734,9 @@ class TestConversationServiceUpdateConversation:
         assert mock_service.stored.updated_at == original_updated_at
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("unread", [False, True])
     async def test_update_conversation_sets_read_state(
-        self, conversation_service, sample_stored_conversation
+        self, conversation_service, sample_stored_conversation, unread
     ):
         mock_service = AsyncMock(spec=EventService)
         mock_service.stored = sample_stored_conversation
@@ -2750,19 +2751,22 @@ class TestConversationServiceUpdateConversation:
         conversation_id = sample_stored_conversation.id
         conversation_service._event_services[conversation_id] = mock_service
 
-        await conversation_service.update_conversation(
-            conversation_id, UpdateConversationRequest(unread=False)
-        )
+        mock_service.stored.last_read_at = mock_service.stored.updated_at
+        original_updated_at = mock_service.stored.updated_at
+        with patch.object(
+            conversation_service, "_notify_conversation_webhooks", new=AsyncMock()
+        ) as notify:
+            assert await conversation_service.update_conversation(
+                conversation_id, UpdateConversationRequest(unread=unread)
+            )
 
-        assert mock_service.stored.last_read_at is not None
-        read_at = mock_service.stored.last_read_at
-
-        await conversation_service.update_conversation(
-            conversation_id, UpdateConversationRequest(unread=True)
-        )
-
-        assert read_at is not None
-        assert mock_service.stored.last_read_at is None
+        mock_service.save_meta.assert_awaited_once()
+        assert (mock_service.stored.last_read_at is None) is unread
+        assert mock_service.stored.updated_at == original_updated_at
+        notify.assert_awaited_once()
+        info = notify.call_args.args[0]
+        assert info.unread is unread
+        assert info.last_read_at == mock_service.stored.last_read_at
 
 
 class TestConversationServiceDeleteConversation:

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -678,6 +678,57 @@ def test_remote_conversation_over_real_server(server_env, patched_llm):
         shutil.rmtree(cwd_conversations)
 
 
+def test_conversation_read_state_over_real_server(server_env, patched_llm):
+    """Read state survives REST reads and new output becomes unread again."""
+    agent = Agent(llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")), tools=[])
+    workspace = RemoteWorkspace(
+        host=server_env["host"], working_dir=str(server_env["workspace_path"])
+    )
+    conversation = Conversation(agent=agent, workspace=workspace)
+    try:
+        conversation.send_message("Say hello")
+        conversation.run()
+        with httpx.Client(base_url=server_env["host"]) as client:
+            path = f"/api/conversations/{conversation.id}"
+            initial_response = client.get(path)
+            initial_response.raise_for_status()
+            initial = initial_response.json()
+            assert initial["unread"] is True
+            assert initial["last_read_at"] is None
+
+            client.patch(path, json={"unread": False}).raise_for_status()
+            read = client.get(path).json()
+            assert read["unread"] is False
+            assert read["last_read_at"] is not None
+            assert read["updated_at"] == initial["updated_at"]
+
+            client.patch(
+                path, json={"title": "Read conversation", "tags": {"test": "read"}}
+            ).raise_for_status()
+            metadata = client.get(path).json()
+            assert metadata["unread"] is False
+            assert metadata["updated_at"] == read["updated_at"]
+            assert metadata["last_read_at"] == read["last_read_at"]
+
+            page = client.get("/api/conversations/search").json()
+            listed = next(item for item in page["items"] if item["id"] == read["id"])
+            assert listed["unread"] is False
+            assert listed["last_read_at"] == read["last_read_at"]
+
+            client.patch(path, json={"unread": True}).raise_for_status()
+            unread = client.get(path).json()
+            assert unread["unread"] is True
+            assert unread["last_read_at"] is None
+            assert unread["updated_at"] == read["updated_at"]
+
+            client.patch(path, json={"unread": False}).raise_for_status()
+            conversation.send_message("Say hello again")
+            conversation.run()
+            assert client.get(path).json()["unread"] is True
+    finally:
+        conversation.close()
+
+
 def test_openai_chat_completions_gateway_over_real_server(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, patched_llm
 ):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Agent Canvas cannot distinguish completed output the user has read from new output. This PR adds the canonical Agent Server and TypeScript-client read-state contract supporting OpenHands/OpenHands#17140.

[Design, API before/after, and remaining application work](https://htmlpreview.github.io/?https://github.com/justavibedev/software-agent-sdk/blob/feat-conversation-read-state/.pr/design.html)

## Summary

- Persist `last_read_at` and derive `unread` for finished, error or stuck conversations with activity strictly newer than the read timestamp.
- Extend the metadata PATCH request and TypeScript client with `unread` to mark read/unread; list and detail responses include read state.
- Preserve the activity timestamp across manual/automatic title changes and tag edits.
- Verify every execution status and timestamp boundary, persistence after restart, webhook payloads, and a live HTTP lifecycle with deterministic LLM responses.

## Scope and remaining work

This PR is the server/client portion, not completion of OpenHands/OpenHands#17140. The marker is conversation-scoped and shared by callers; it does not implement independently keyed per-user state. Read updates use existing conversation webhooks, not browser WebSocket broadcasts.

Canvas still needs a released server/client contract, opening-to-mark-read behavior, cross-window push synchronization, distinct unread markers, item read/unread actions, mark-all-read, unread sorting and visual evidence. Multi-user ownership/read-state semantics also need resolution before the issue's per-user criterion can be claimed. The PR remains draft pending the human contribution note and review of this scoped rollout.

## How to Test

Validation for the latest follow-up commit used a disposable Python 3.13 container with only this checkout mounted, no host secrets and networking disconnected for the final test run:

- `uv run --no-sync pytest -q tests/agent_server/test_conversation_info_model.py tests/agent_server/test_conversation_service.py tests/agent_server/test_conversation_router.py tests/agent_server/test_openapi_contract.py tests/agent_server/test_openapi_discriminator.py tests/cross/test_remote_conversation_live_server.py::test_conversation_read_state_over_real_server` — **268 passed**.
- Ruff lint and format checks for all three changed test files — passed.
- Pyright for all three changed test files — **0 errors, 0 warnings**.

The initial implementation also validated the TypeScript client: 86 API-client tests passed; lint, build and format checks passed with eight pre-existing lint warnings. That package is unchanged by this follow-up and was not rerun here.

## Video/Screenshots

No UI is changed in this server/client PR. The dependent Canvas work must provide the visual evidence required by the issue.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Compatibility

The REST fields are additive. Existing metadata loads with `last_read_at = null`, so existing terminal conversations initially appear unread. Keeping metadata-only edits from advancing `updated_at` intentionally changes timestamp behavior; downstream consumers that sort on it should review this change.
