### PR TITLE
fix(agent-server): persist confirmation policy, analyzer and secrets to meta.json

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import cast
 from uuid import UUID, uuid4
 
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from openhands.agent_server.conversation_lease import (
     DEFAULT_LEASE_TTL_SECONDS,
@@ -75,6 +75,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.llm.streaming import LLMStreamChunk
 from openhands.sdk.mcp.utils import MCPToolProvider
+from openhands.sdk.secret import SecretSource, StaticSecret
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
 from openhands.sdk.utils.async_utils import AsyncCallbackWrapper
@@ -108,6 +109,22 @@ def _without_agent_context_secret(
     return agent.model_copy(
         update={"agent_context": context.model_copy(update={"secrets": secrets})}
     )
+
+
+def _as_secret_sources(
+    secrets: Mapping[str, SecretValue],
+) -> dict[str, SecretSource]:
+    """Normalise a SecretValue mapping for storage.
+
+    ``EventService.update_secrets`` accepts ``SecretValue`` (``str | SecretSource``)
+    while ``StoredConversation.secrets`` is ``dict[str, SecretSource]``, and
+    ``model_copy`` does not validate, so a plain string would only fail later when
+    meta.json is serialised.
+    """
+    return {
+        name: StaticSecret(value=SecretStr(value)) if isinstance(value, str) else value
+        for name, value in secrets.items()
+    }
 
 
 @dataclass
@@ -188,6 +205,16 @@ class EventService:
                     }
                 )
             )
+
+    async def _persist_stored(self, **updates) -> None:
+        """Apply updates to the stored conversation and write meta.json.
+
+        ``model_copy`` rather than in-place mutation, matching
+        ``apply_resume_secrets``. Rollback when ``save_meta`` itself fails is
+        tracked separately in #4800 and is not changed here.
+        """
+        self.stored = self.stored.model_copy(update=updates)
+        await self.save_meta()
 
     def _without_stored_secret(self, secret_name: str) -> StoredConversation:
         # meta.json (StoredConversation) no longer carries the agent, so there is
@@ -1679,6 +1706,12 @@ class EventService:
             secrets.pop(CODEX_AUTH_SECRET_NAME, None)
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.update_secrets, secrets)
+        # The conversation writes base_state.json, but startup reads these three
+        # fields off StoredConversation, so meta.json has to carry them too or the
+        # change is reverted on the next load.
+        await self._persist_stored(
+            secrets={**self.stored.secrets, **_as_secret_sources(secrets)}
+        )
 
     async def set_confirmation_policy(self, policy: ConfirmationPolicyBase):
         """Set the confirmation policy for the conversation."""
@@ -1688,6 +1721,7 @@ class EventService:
         await loop.run_in_executor(
             None, self._conversation.set_confirmation_policy, policy
         )
+        await self._persist_stored(confirmation_policy=policy)
 
     async def set_security_analyzer(
         self, security_analyzer: SecurityAnalyzerBase | None
@@ -1699,6 +1733,7 @@ class EventService:
         await loop.run_in_executor(
             None, self._conversation.set_security_analyzer, security_analyzer
         )
+        await self._persist_stored(security_analyzer=security_analyzer)
 
     async def load_plugin(self, plugin_ref: str) -> None:
         """Load a marketplace plugin into the active conversation."""

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -4207,6 +4207,7 @@ async def test_api_mutations_survive_a_server_restart(tmp_path):
         conversations_dir=conversations_dir, cipher=cipher
     ) as restarted:
         event_service = await restarted._get_or_load_event_service(conv_id)
+        assert event_service is not None
         stored = event_service.stored
 
         assert isinstance(stored.confirmation_policy, AlwaysConfirm)
@@ -4254,6 +4255,7 @@ async def test_a_plain_string_secret_is_stored_as_a_secret_source(tmp_path):
         conversations_dir=conversations_dir, cipher=Cipher("string-secret-test-key")
     ) as restarted:
         event_service = await restarted._get_or_load_event_service(conv_id)
+        assert event_service is not None
         source = event_service.stored.secrets["MY_TOKEN"]
 
     assert not isinstance(source, str)

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -50,7 +50,8 @@ from openhands.sdk.git.utils import run_git_command
 from openhands.sdk.llm import MessageToolCall, TextContent
 from openhands.sdk.mcp.config import dump_mcp_config
 from openhands.sdk.secret import SecretSource, StaticSecret
-from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm, NeverConfirm
+from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
@@ -4164,3 +4165,96 @@ async def test_search_live_conversation_does_not_wait_for_state_lock(tmp_path):
             holder.join(timeout=2)
 
     assert [item.id for item in page.items] == [conversation_info.id]
+
+
+# --- API mutations have to reach meta.json -------------------------------------
+#
+# set_confirmation_policy / set_security_analyzer / update_secrets write through
+# the conversation to base_state.json, but startup reads all three off
+# StoredConversation, so a mutation that never reaches meta.json is reverted on the
+# next load.
+
+
+async def _start_one(
+    conversations_dir: Path, workspace_dir: Path, cipher: Cipher | None
+):
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+    async with ConversationService(
+        conversations_dir=conversations_dir, cipher=cipher
+    ) as service:
+        info, _ = await service.start_conversation(request)
+        event_service = await service.get_event_service(info.id)
+        assert event_service is not None
+        await event_service.set_confirmation_policy(AlwaysConfirm())
+        await event_service.set_security_analyzer(LLMSecurityAnalyzer())
+        await event_service.update_secrets({"MY_TOKEN": "shh"})
+    return info.id
+
+
+async def test_api_mutations_survive_a_server_restart(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    cipher = Cipher("mutation-persistence-test-key")
+
+    conv_id = await _start_one(conversations_dir, workspace_dir, cipher)
+
+    async with ConversationService(
+        conversations_dir=conversations_dir, cipher=cipher
+    ) as restarted:
+        event_service = await restarted._get_or_load_event_service(conv_id)
+        stored = event_service.stored
+
+        assert isinstance(stored.confirmation_policy, AlwaysConfirm)
+        assert isinstance(stored.security_analyzer, LLMSecurityAnalyzer)
+        assert sorted(stored.secrets) == ["MY_TOKEN"]
+        assert stored.secrets["MY_TOKEN"].get_value() == "shh"
+
+
+async def test_mutations_are_written_to_meta_json(tmp_path):
+    """meta.json is what startup reads, so the assertion is on the file."""
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    conv_id = await _start_one(
+        conversations_dir, workspace_dir, Cipher("meta-json-test-key")
+    )
+
+    raw = (conversations_dir / conv_id.hex / "meta.json").read_text()
+    meta = json.loads(raw)
+
+    assert meta["confirmation_policy"]["kind"] == "AlwaysConfirm"
+    assert meta["security_analyzer"]["kind"] == "LLMSecurityAnalyzer"
+    assert sorted(meta["secrets"]) == ["MY_TOKEN"]
+    # Encrypted at rest, as the resume path already does.
+    assert "shh" not in raw
+    assert meta["secrets"]["MY_TOKEN"]["value"] not in (None, "shh")
+
+
+async def test_a_plain_string_secret_is_stored_as_a_secret_source(tmp_path):
+    """update_secrets takes SecretValue (str | SecretSource); stored takes the latter.
+
+    model_copy does not validate, so a raw string would only fail later, when
+    meta.json is serialised.
+    """
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    conv_id = await _start_one(
+        conversations_dir, workspace_dir, Cipher("string-secret-test-key")
+    )
+
+    async with ConversationService(
+        conversations_dir=conversations_dir, cipher=Cipher("string-secret-test-key")
+    ) as restarted:
+        event_service = await restarted._get_or_load_event_service(conv_id)
+        source = event_service.stored.secrets["MY_TOKEN"]
+
+    assert not isinstance(source, str)
+    assert source.get_value() == "shh"


### PR DESCRIPTION
HUMAN:

Turned on confirmation prompts and an analyzer through the API, restarted the server, and they were both back to what the conversation started with. They stick now.

---

AGENT:

## Why

Closes #4810.

`set_confirmation_policy`, `set_security_analyzer` and `update_secrets` delegate to the conversation, which writes `base_state.json`, and never touch `StoredConversation`:

```python
async def set_confirmation_policy(self, policy: ConfirmationPolicyBase):
    ...
    await loop.run_in_executor(None, self._conversation.set_confirmation_policy, policy)
    # nothing updates self.stored, nothing calls save_meta()
```

Startup reads all three off `StoredConversation` (`event_service.py:1105-1117`), so after eviction or a restart the conversation reverts to the values it was created with. For two of the three that means the **security analyzer and confirmation policy silently regress** to the creation-time setting.

It is worse than the issue describes: `stored` is stale in process as well, so it is not only a reload problem.

```
$ python repro.py
in-process confirmation_policy : NeverConfirm       <- set to AlwaysConfirm
in-process security_analyzer   : NoneType           <- set to LLMSecurityAnalyzer
in-process secrets keys        : []                 <- MY_TOKEN was set
meta.json confirmation_policy  : {'kind': 'NeverConfirm'}
meta.json security_analyzer    : None
after restart confirmation_policy: NeverConfirm
```

## Summary

- All three mutations write through to `meta.json`, via `model_copy` + `save_meta` — the same shape `apply_resume_secrets` already uses for the resume path, so there is one pattern rather than two.
- Plain-string secrets are normalised to `SecretSource` before they reach `stored`.
- Rollback when `save_meta` itself fails is deliberately untouched: that is #4800, and mixing it in here would collide with whoever takes it.

### Why the normalisation is not incidental

`update_secrets` is typed `dict[str, SecretValue]`, and `SecretValue = str | SecretSource`. `StoredConversation.secrets` is `dict[str, SecretSource]`. `model_copy(update=...)` **does not validate**, so merging a raw string in produces a model that looks fine and then fails at the point of writing meta.json:

```
PydanticSerializationError: Error calling function `_serialize_by_kind`:
AttributeError: 'str' object has no attribute '_is_handler_for_current_class'
```

The API route validates through `UpdateSecretsRequest`, so the HTTP path never hits this, but the method accepts strings and `apply_resume_secrets` merges the same way. `test_a_plain_string_secret_is_stored_as_a_secret_source` passes a bare string so this cannot regress.

## How to Test

```bash
uv run pytest tests/agent_server/test_conversation_service.py -k "mutation or plain_string" -q
```

Full suite:

```
$ uv run pytest tests/agent_server/ -q
2094 passed, 13 deselected in 180.44s
```

`ruff check` and `ruff format --check` clean on both changed files.

### End-to-end, not just unit tests

Start a conversation, mutate all three through the service, drop the `ConversationService` entirely, and bring a fresh one up against the same directory:

```
in-process confirmation_policy : AlwaysConfirm
in-process security_analyzer   : LLMSecurityAnalyzer
in-process secrets keys        : ['MY_TOKEN']
meta.json confirmation_policy  : {'kind': 'AlwaysConfirm'}
meta.json security_analyzer    : {'kind': 'LLMSecurityAnalyzer'}
meta.json secrets keys         : ['MY_TOKEN']
after restart confirmation_policy: AlwaysConfirm
after restart security_analyzer  : LLMSecurityAnalyzer
after restart secret value       : 'shh'
```

### What happens to the secret at rest

I checked this rather than assuming, since the change is what starts routing API secret updates into `meta.json`.

With a cipher configured, the value is encrypted and round-trips:

```json
{"MY_TOKEN": {"value": "gAAAAABqmvmIuMS90CqPhDCi_Xo-...", "kind": "StaticSecret"}}
```

`'shh' in meta.json` is `False`, and the reloaded source returns `'shh'`.

Without a cipher, the serialiser masks it, so the name persists and the value loads back as `None` — **not** as the `**********` placeholder, which would otherwise reach a tool call. Both behaviours are what `apply_resume_secrets` already produced; this change does not alter them.

### Tests

Three added. All three fail on the parent commit:

```
FAILED test_api_mutations_survive_a_server_restart
FAILED test_mutations_are_written_to_meta_json
FAILED test_a_plain_string_secret_is_stored_as_a_secret_source
```

`test_mutations_are_written_to_meta_json` asserts against the file rather than the object, because meta.json is what startup actually reads.

## Issue Number

Closes #4810

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
