### PR TITLE
feat(acp): add Cursor as a built-in ACP provider

### DIFF
--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -41,6 +41,7 @@ describe('ACP provider credential descriptors', () => {
     // opencode's own gateway (OpenCode Zen) resolves its endpoint from the
     // model catalogue, so it has no base-URL override var either.
     ['opencode', 'OPENCODE_API_KEY', null],
+    ['cursor', 'CURSOR_API_KEY', 'CURSOR_API_ENDPOINT'],
   ])('%s declares its api_key/base_url env vars', (key, apiKeyEnvVar, baseUrlEnvVar) => {
     const provider = ACP_PROVIDERS[key];
     expect(provider.api_key_env_var).toBe(apiKeyEnvVar);
@@ -73,6 +74,16 @@ describe('ACP provider credential descriptors', () => {
     ]);
     expect(opencode.default_session_mode).toBe('build');
     expect(opencode.file_secrets).toEqual([]);
+  });
+
+  it('cursor launches the preinstalled agent binary in ACP mode', () => {
+    const cursor = ACP_PROVIDERS.cursor;
+    expect(cursor.default_command).toEqual(['agent', 'acp']);
+    expect(cursor.binary_name).toBe('agent');
+    expect(cursor.default_session_mode).toBe('agent');
+    expect(cursor.default_model).toBe('default[]');
+    expect(cursor.file_secrets).toEqual([]);
+    expect(cursor.data_dir_env_var).toBeNull();
   });
 
   it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {

--- a/clients/typescript/src/models/acp-providers.json
+++ b/clients/typescript/src/models/acp-providers.json
@@ -108,6 +108,71 @@
     "supports_runtime_model_switch": true,
     "supports_set_session_model": true
   },
+  "cursor": {
+    "agent_name_patterns": [
+      "cursor-agent",
+      "agent"
+    ],
+    "api_key_env_var": "CURSOR_API_KEY",
+    "available_models": [
+      {
+        "id": "default[]",
+        "label": "Auto"
+      },
+      {
+        "id": "composer-2.5[fast=true]",
+        "label": "Composer 2.5"
+      },
+      {
+        "id": "grok-4.6[effort=high,fast=true]",
+        "label": "Grok 4.6"
+      },
+      {
+        "id": "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
+        "label": "Claude Opus 5"
+      },
+      {
+        "id": "claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]",
+        "label": "Claude Opus 4.8"
+      },
+      {
+        "id": "claude-sonnet-5[thinking=true,context=300k,effort=high]",
+        "label": "Claude Sonnet 5"
+      },
+      {
+        "id": "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]",
+        "label": "GPT-5.6 Sol"
+      },
+      {
+        "id": "gpt-5.5[context=272k,reasoning=medium,fast=false]",
+        "label": "GPT-5.5"
+      },
+      {
+        "id": "gpt-5.3-codex[reasoning=medium,fast=false]",
+        "label": "GPT-5.3 Codex"
+      },
+      {
+        "id": "gemini-3.8-flash[reasoning_effort=high]",
+        "label": "Gemini 3.8 Flash"
+      }
+    ],
+    "base_url_env_var": "CURSOR_API_ENDPOINT",
+    "binary_name": "agent",
+    "data_dir_env_var": null,
+    "default_command": [
+      "agent",
+      "acp"
+    ],
+    "default_model": "default[]",
+    "default_session_mode": "agent",
+    "display_name": "Cursor",
+    "env_conflicts": [],
+    "file_secrets": [],
+    "key": "cursor",
+    "session_meta_key": null,
+    "supports_runtime_model_switch": true,
+    "supports_set_session_model": true
+  },
   "gemini-cli": {
     "agent_name_patterns": [
       "gemini-cli"

--- a/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py
@@ -1,6 +1,14 @@
-"""ACP npm installation catalog — the single source of truth for each
-built-in provider's pinned npm package(s), CLI entry point, and any launch
-arguments needed to invoke it.
+"""ACP installation catalog — the single source of truth for each built-in
+provider's pinned distribution, CLI entry point, and any launch arguments
+needed to invoke it.
+
+Two install flavours are described:
+
+- :class:`ACPInstallSpec` — one or more pinned npm packages, launched with
+  ``npx`` and preinstallable into the agent-server image.
+- :class:`ACPPreinstalledBinaryInstallSpec` — a first-party CLI that is not
+  an npm package. The binary must already be on ``PATH``;
+  :func:`render_docker_install_plan` rejects it.
 
 Deliberately dependency-free (stdlib only, no pydantic): the agent-server
 Dockerfile's ``acp-providers`` stage builds from a bare ``python:*-bookworm``
@@ -23,6 +31,7 @@ import argparse
 import sys
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from typing import TypeGuard
 
 
 @dataclass(frozen=True)
@@ -97,6 +106,54 @@ class ACPInstallSpec:
             *self.trailing_args,
         )
 
+    def launch_command(self) -> tuple[str, ...]:
+        """Alias of :meth:`npx_command`, shared with
+        :class:`ACPPreinstalledBinaryInstallSpec`."""
+        return self.npx_command()
+
+
+@dataclass(frozen=True)
+class ACPPreinstalledBinaryInstallSpec:
+    """A first-party CLI that is not distributed as an npm package.
+
+    Cursor is the motivating case: its ACP server is the official ``agent acp``
+    binary, installed by a curl/PowerShell script
+    (https://cursor.com/docs/cli/installation), not published on npm. There is
+    no download-on-demand path — ``_prefer_pinned_binary`` leaves a non-npx
+    command unchanged, and launch fails if ``binary_name`` is absent from
+    ``PATH``.
+
+    Nothing here reaches the published agent-server images —
+    :func:`render_docker_install_plan` rejects this flavour, and joining
+    :data:`DEFAULT_PREINSTALLED_ACP_PROVIDERS` is a separate decision that
+    this spec cannot satisfy (there is no npm package to bake in).
+    """
+
+    key: str
+    """Provider key, matching
+    :class:`~openhands.sdk.settings.acp_providers.ACPProviderInfo.key`."""
+
+    binary_name: str
+    """CLI entry point resolved off ``PATH`` at launch (e.g. ``agent``)."""
+
+    trailing_args: tuple[str, ...] = field(default=())
+    """Args appended after the binary (e.g. Cursor's ``acp`` subcommand)."""
+
+    min_node_version: str | None = None
+    """Always ``None`` — this flavour is not a Node package."""
+
+    def launch_command(self) -> tuple[str, ...]:
+        """The on-PATH binary plus any trailing args that enter ACP mode."""
+        return (self.binary_name, *self.trailing_args)
+
+
+ACPInstallCatalogEntry = ACPInstallSpec | ACPPreinstalledBinaryInstallSpec
+
+
+def is_npm_install_spec(spec: ACPInstallCatalogEntry) -> TypeGuard[ACPInstallSpec]:
+    """True when *spec* can be baked into the image via npm."""
+    return isinstance(spec, ACPInstallSpec)
+
 
 # Pinned npm versions for the built-in ACP launchers. A bump here is the only
 # edit needed — ACP_PROVIDERS, the Dockerfile install stage, and the
@@ -115,7 +172,7 @@ PI_CODING_AGENT_VERSION = "0.83.0"
 OPENCODE_VERSION = "1.18.23"
 
 
-ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
+ACP_INSTALL_CATALOG: Mapping[str, ACPInstallCatalogEntry] = {
     "claude-code": ACPInstallSpec(
         key="claude-code",
         packages=(
@@ -176,11 +233,20 @@ ACP_INSTALL_CATALOG: Mapping[str, ACPInstallSpec] = {
         # No `engines` field on opencode-ai or its platform packages: the CLI
         # is a compiled Bun binary and only its postinstall runs on Node.
     ),
+    "cursor": ACPPreinstalledBinaryInstallSpec(
+        key="cursor",
+        # Official Cursor CLI entry point. The installer places ``agent`` on
+        # PATH as a symlink to ``cursor-agent`` under
+        # ``~/.local/share/cursor-agent/versions/<calver>/``.
+        binary_name="agent",
+        trailing_args=("acp",),
+    ),
 }
-"""Every ACP provider installable via npm. Registry membership only makes a
-provider *selectable* (``INSTALL_ACP_PROVIDERS``) — see
+"""Every built-in ACP provider's install recipe. Registry membership only
+makes a provider *selectable* — see
 :data:`DEFAULT_PREINSTALLED_ACP_PROVIDERS` for what actually ships in the
-default image."""
+default image. npm specs can join that default; preinstalled-binary specs
+cannot (there is nothing to bake in)."""
 
 
 DEFAULT_PREINSTALLED_ACP_PROVIDERS: tuple[str, ...] = (
@@ -197,13 +263,15 @@ deliberate decision per provider (see OpenHands/software-agent-sdk#4820)."""
 
 def render_docker_install_plan(
     keys: Iterable[str],
-    catalog: Mapping[str, ACPInstallSpec] = ACP_INSTALL_CATALOG,
+    catalog: Mapping[str, ACPInstallCatalogEntry] = ACP_INSTALL_CATALOG,
 ) -> tuple[list[str], list[str]]:
     """Resolve provider ``keys`` to (npm packages, wrapper bin names).
 
     Packages are deduplicated (first-seen order preserved) so two providers
     sharing a dependency only install it once. Raises :class:`ValueError`
-    listing the valid keys when ``keys`` contains one not in ``catalog``.
+    listing the valid keys when ``keys`` contains one not in ``catalog``, or
+    when a key names a preinstalled-binary provider that cannot be baked
+    into the image.
     """
     packages: list[str] = []
     wrapper_bins: list[str] = []
@@ -215,6 +283,11 @@ def render_docker_install_plan(
             raise ValueError(
                 f"Unknown ACP provider {key!r} in INSTALL_ACP_PROVIDERS "
                 f"(expected one of: {valid})"
+            )
+        if not is_npm_install_spec(spec):
+            raise ValueError(
+                f"ACP provider {key!r} is a preinstalled binary and cannot "
+                "be added to INSTALL_ACP_PROVIDERS (no npm package to bake in)"
             )
         for pkg in spec.packages:
             if pkg.pinned not in seen:

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -436,6 +436,46 @@ _OPENCODE_MODELS: tuple[ACPModelOption, ...] = (
     ),
 )
 
+# Model IDs accepted by ``agent acp`` (Cursor CLI), taken from the
+# ``models.availableModels`` list ``session/new`` reports. The CLI's
+# ``--list-models`` names (e.g. ``composer-2.5``) are a different namespace —
+# the ACP server wants the bracketed runtime ids. Curated to the Auto router
+# plus a stable subset; the live session advertises more, and a user may still
+# set any id the server lists. Verified against Cursor CLI 2026.09.02-c22c1a3.
+_CURSOR_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="default[]", label="Auto"),
+    ACPModelOption(id="composer-2.5[fast=true]", label="Composer 2.5"),
+    ACPModelOption(id="grok-4.6[effort=high,fast=true]", label="Grok 4.6"),
+    ACPModelOption(
+        id="claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
+        label="Claude Opus 5",
+    ),
+    ACPModelOption(
+        id="claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]",
+        label="Claude Opus 4.8",
+    ),
+    ACPModelOption(
+        id="claude-sonnet-5[thinking=true,context=300k,effort=high]",
+        label="Claude Sonnet 5",
+    ),
+    ACPModelOption(
+        id="gpt-5.6-sol[context=272k,reasoning=medium,fast=false]",
+        label="GPT-5.6 Sol",
+    ),
+    ACPModelOption(
+        id="gpt-5.5[context=272k,reasoning=medium,fast=false]",
+        label="GPT-5.5",
+    ),
+    ACPModelOption(
+        id="gpt-5.3-codex[reasoning=medium,fast=false]",
+        label="GPT-5.3 Codex",
+    ),
+    ACPModelOption(
+        id="gemini-3.8-flash[reasoning_effort=high]",
+        label="Gemini 3.8 Flash",
+    ),
+)
+
 
 # ---------------------------------------------------------------------------
 # Reserved file-content credential secrets for the built-in providers.
@@ -508,7 +548,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "claude-code": ACPProviderInfo(
             key="claude-code",
             display_name="Claude Code",
-            default_command=ACP_INSTALL_CATALOG["claude-code"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["claude-code"].launch_command(),
             api_key_env_var="ANTHROPIC_API_KEY",
             base_url_env_var="ANTHROPIC_BASE_URL",
             default_session_mode="bypassPermissions",
@@ -544,7 +584,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "codex": ACPProviderInfo(
             key="codex",
             display_name="Codex",
-            default_command=ACP_INSTALL_CATALOG["codex"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["codex"].launch_command(),
             api_key_env_var="OPENAI_API_KEY",
             base_url_env_var="OPENAI_BASE_URL",
             default_session_mode="agent-full-access",
@@ -561,7 +601,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
             display_name="Gemini CLI",
-            default_command=ACP_INSTALL_CATALOG["gemini-cli"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["gemini-cli"].launch_command(),
             api_key_env_var="GEMINI_API_KEY",
             base_url_env_var="GEMINI_BASE_URL",
             # gemini-cli 0.46.0 rejects ``set_session_mode("yolo")`` at session
@@ -589,7 +629,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "kimi-code": ACPProviderInfo(
             key="kimi-code",
             display_name="Kimi Code",
-            default_command=ACP_INSTALL_CATALOG["kimi-code"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["kimi-code"].launch_command(),
             # No env-var API key: ``KIMI_API_KEY`` is read only from inside
             # config.toml, so exporting it authenticates nothing (verified on
             # 0.38.0, with and without a config file present). The credential
@@ -634,7 +674,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # ``pi-acp`` as the positional npx runs — which is also the only
             # token ``_prefer_pinned_binary`` and
             # ``detect_acp_provider_by_command`` can match on.
-            default_command=ACP_INSTALL_CATALOG["pi"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["pi"].launch_command(),
             api_key_env_var="ANTHROPIC_API_KEY",
             # pi resolves each provider's base URL from its own catalogue;
             # ANTHROPIC_BASE_URL reaches only the vendored Anthropic SDK, which
@@ -657,7 +697,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "opencode": ACPProviderInfo(
             key="opencode",
             display_name="OpenCode",
-            default_command=ACP_INSTALL_CATALOG["opencode"].npx_command(),
+            default_command=ACP_INSTALL_CATALOG["opencode"].launch_command(),
             # OpenCode Zen, the CLI's own gateway and the provider its model
             # ids are namespaced under. Third-party keys (ANTHROPIC_API_KEY,
             # OPENAI_API_KEY, ...) also enable their providers inside OpenCode,
@@ -695,6 +735,42 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # XDG_{DATA,CONFIG,CACHE,STATE}_HOME, which all fall back to HOME.
             # Relocating HOME is the only single lever that moves all of them.
             data_dir_env_var="HOME",
+        ),
+        "cursor": ACPProviderInfo(
+            key="cursor",
+            display_name="Cursor",
+            default_command=ACP_INSTALL_CATALOG["cursor"].launch_command(),
+            # ``--api-key`` / CURSOR_API_KEY. Login also works via the ACP
+            # ``cursor_login`` auth method after ``agent login``, with no key.
+            api_key_env_var="CURSOR_API_KEY",
+            base_url_env_var="CURSOR_API_ENDPOINT",
+            # Verified against Cursor CLI 2026.09.02-c22c1a3: ``session/new``
+            # reports modes ``agent`` / ``plan`` / ``ask``. ``agent`` is the
+            # tool-executing default. There is no permission-bypass mode;
+            # the ACP bridge auto-approves request_permission.
+            default_session_mode="agent",
+            # ``initialize`` currently omits ``agentInfo.name``. Command-time
+            # detection matches the official ``agent`` binary (and the
+            # unwrapped ``cursor-agent`` basename the installer places under
+            # ``~/.local/share/cursor-agent/``).
+            agent_name_patterns=("cursor-agent", "agent"),
+            # Verified: ``session/set_model`` and ``session/set_config_option``
+            # (configId=model) both succeed after session/new. The session
+            # advertises a ``model`` configOptions select, so the SDK's
+            # auto-detect prefers that path when present.
+            supports_set_session_model=True,
+            supports_runtime_model_switch=True,
+            session_meta_key=None,
+            available_models=_CURSOR_MODELS,
+            # The CLI's own default (models.currentModelId / configOptions
+            # currentValue) — the Auto router, not a pinned snapshot.
+            default_model="default[]",
+            binary_name=ACP_INSTALL_CATALOG["cursor"].binary_name,
+            # Login state, ACP sessions and cli-config live under ``~/.cursor``.
+            # There is no dedicated config-dir env that moves sessions without
+            # also dropping the login; relocating HOME would unauthenticate
+            # the subprocess. Isolation is therefore skipped.
+            data_dir_env_var=None,
         ),
     }
 )

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1203,12 +1203,19 @@ class ConversationSettings(BaseModel):
 AgentKind = Literal["openhands", "llm", "acp"]
 
 ACPServerKind = Literal[
-    "claude-code", "codex", "gemini-cli", "kimi-code", "pi", "opencode", "custom"
+    "claude-code",
+    "codex",
+    "gemini-cli",
+    "kimi-code",
+    "pi",
+    "opencode",
+    "cursor",
+    "custom",
 ]
 """Known ACP backend servers the GUI can pick from.
 
 ``custom`` means the user supplies the raw ``acp_command`` themselves;
-the other choices map to a default npx command stored in
+the other choices map to a default launch command stored in
 :data:`~openhands.sdk.settings.acp_providers.ACP_PROVIDERS`.
 """
 

--- a/tests/cross/test_agent_server_build_metadata.py
+++ b/tests/cross/test_agent_server_build_metadata.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from openhands.sdk.settings.acp_install_catalog import (
     ACP_INSTALL_CATALOG,
     DEFAULT_PREINSTALLED_ACP_PROVIDERS,
+    is_npm_install_spec,
 )
 
 
@@ -126,6 +127,8 @@ def test_agent_server_dockerfile_has_no_hardcoded_acp_packages() -> None:
         "acp-providers stage should no longer branch on a hardcoded provider-key list"
     )
     for spec in ACP_INSTALL_CATALOG.values():
+        if not is_npm_install_spec(spec):
+            continue
         for pkg in spec.packages:
             assert pkg.pinned not in acp_stage, (
                 f"{AGENT_SERVER_DOCKERFILE}: found hardcoded package pin "
@@ -148,7 +151,7 @@ def test_agent_server_node_pin_clears_every_declared_engine_floor() -> None:
     pinned = tuple(int(part) for part in match.group(1).split("."))
 
     for spec in ACP_INSTALL_CATALOG.values():
-        if spec.min_node_version is None:
+        if not is_npm_install_spec(spec) or spec.min_node_version is None:
             continue
         required = tuple(int(part) for part in spec.min_node_version.split("."))
         assert pinned >= required, (

--- a/tests/sdk/agent/test_acp_conformance.py
+++ b/tests/sdk/agent/test_acp_conformance.py
@@ -203,6 +203,11 @@ def test_acp_conformance_probe(
     provider_key: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     provider = ACP_PROVIDERS[provider_key]
+    if provider_key == "cursor":
+        pytest.skip(
+            "Cursor ACP authenticates via cursor_login (existing CLI login), "
+            "not a bogus env-var key; the credential-free probe cannot run it"
+        )
     _skip_if_node_below_floor(provider_key)
     _isolate_env(monkeypatch, tmp_path)
 

--- a/tests/sdk/settings/test_acp_install_catalog.py
+++ b/tests/sdk/settings/test_acp_install_catalog.py
@@ -18,7 +18,9 @@ from openhands.sdk.settings.acp_install_catalog import (
     PI_CODING_AGENT_VERSION,
     ACPInstallSpec,
     ACPPackagePin,
+    ACPPreinstalledBinaryInstallSpec,
     _main,
+    is_npm_install_spec,
     render_docker_install_plan,
 )
 from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
@@ -131,7 +133,7 @@ class TestACPInstallCatalogMatchesACPProviders:
 
     def test_default_commands_are_derived_from_catalog(self):
         for key, info in ACP_PROVIDERS.items():
-            assert info.default_command == ACP_INSTALL_CATALOG[key].npx_command()
+            assert info.default_command == ACP_INSTALL_CATALOG[key].launch_command()
 
     def test_binary_names_are_derived_from_catalog(self):
         for key, info in ACP_PROVIDERS.items():
@@ -141,6 +143,13 @@ class TestACPInstallCatalogMatchesACPProviders:
         assert CLAUDE_AGENT_ACP_VERSION == "0.63.0"
         assert CODEX_ACP_VERSION == "1.10.0"
         assert GEMINI_CLI_VERSION == "0.46.0"
+
+    def test_cursor_is_a_preinstalled_binary(self):
+        spec = ACP_INSTALL_CATALOG["cursor"]
+        assert isinstance(spec, ACPPreinstalledBinaryInstallSpec)
+        assert not is_npm_install_spec(spec)
+        assert spec.launch_command() == ("agent", "acp")
+        assert spec.binary_name == "agent"
 
 
 class TestDefaultPreinstalledACPProviders:
@@ -183,6 +192,10 @@ class TestRenderDockerInstallPlan:
         assert "claude-code" in message
         assert "codex" in message
         assert "gemini-cli" in message
+
+    def test_preinstalled_binary_cannot_join_image_plan(self):
+        with pytest.raises(ValueError, match="preinstalled binary"):
+            render_docker_install_plan(["cursor"])
 
     def test_dedupes_shared_packages_preserving_first_seen_order(self):
         shared = ACPPackagePin("@acme/shared-engine", "9.9.9")

--- a/tests/sdk/settings/test_acp_install_catalog_pins_live.py
+++ b/tests/sdk/settings/test_acp_install_catalog_pins_live.py
@@ -22,7 +22,10 @@ import subprocess
 
 import pytest
 
-from openhands.sdk.settings.acp_install_catalog import ACP_INSTALL_CATALOG
+from openhands.sdk.settings.acp_install_catalog import (
+    ACP_INSTALL_CATALOG,
+    is_npm_install_spec,
+)
 
 
 def _npm_registry_reachable(timeout: float = 3.0) -> bool:
@@ -40,9 +43,11 @@ requires_npm = pytest.mark.skipif(
 
 pytestmark = pytest.mark.acp_live
 
+_NPM_SPECS = [spec for spec in ACP_INSTALL_CATALOG.values() if is_npm_install_spec(spec)]
+
 _ALL_PINS = [
     pytest.param(spec.key, pkg.name, pkg.version, id=f"{spec.key}:{pkg.pinned}")
-    for spec in ACP_INSTALL_CATALOG.values()
+    for spec in _NPM_SPECS
     for pkg in spec.packages
 ]
 
@@ -121,7 +126,7 @@ def _npm_view_bins(pinned: str) -> set[str]:
 
 @requires_npm
 @pytest.mark.parametrize(
-    "spec", ACP_INSTALL_CATALOG.values(), ids=list(ACP_INSTALL_CATALOG)
+    "spec", _NPM_SPECS, ids=[spec.key for spec in _NPM_SPECS]
 )
 def test_binary_name_is_declared_by_one_of_the_pinned_packages(spec) -> None:
     """``binary_name`` must be a bin some pinned package actually declares.

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -8,8 +8,10 @@ from typing import get_args
 import pytest
 
 from openhands.sdk.settings.acp_install_catalog import (
+    ACP_INSTALL_CATALOG,
     PI_ACP_VERSION,
     PI_CODING_AGENT_VERSION,
+    is_npm_install_spec,
 )
 from openhands.sdk.settings.acp_providers import (
     ACP_PROVIDERS,
@@ -39,7 +41,9 @@ class TestACPProviderInfo:
             assert isinstance(info, ACPProviderInfo)
 
     def test_default_commands_prefer_offline_cache(self):
-        for info in ACP_PROVIDERS.values():
+        for key, info in ACP_PROVIDERS.items():
+            if not is_npm_install_spec(ACP_INSTALL_CATALOG[key]):
+                continue
             assert info.default_command[:3] == ("npx", "-y", "--prefer-offline")
 
     def test_claude_code_metadata(self):
@@ -213,6 +217,29 @@ class TestACPProviderInfo:
         # credential file to materialise.
         assert info.file_secrets == ()
 
+    def test_cursor_metadata(self):
+        info = ACP_PROVIDERS["cursor"]
+        assert info.key == "cursor"
+        assert info.display_name == "Cursor"
+        # Preinstalled binary, not an npx package.
+        assert info.default_command == ("agent", "acp")
+        assert info.binary_name == "agent"
+        assert info.api_key_env_var == "CURSOR_API_KEY"
+        assert info.base_url_env_var == "CURSOR_API_ENDPOINT"
+        assert info.default_session_mode == "agent"
+        assert "cursor-agent" in info.agent_name_patterns
+        assert "agent" in info.agent_name_patterns
+        assert info.supports_set_session_model is True
+        assert info.supports_runtime_model_switch is True
+        assert info.session_meta_key is None
+        assert info.default_model == "default[]"
+        model_ids = [m.id for m in info.available_models]
+        assert "default[]" in model_ids
+        assert "composer-2.5[fast=true]" in model_ids
+        # Login lives under ~/.cursor; no dedicated relocation lever.
+        assert info.data_dir_env_var is None
+        assert info.file_secrets == ()
+
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
         with pytest.raises((AttributeError, TypeError)):
@@ -272,12 +299,19 @@ class TestDetectACPProviderByAgentName:
         assert info is not None
         assert info.key == "opencode"
 
+    def test_detects_cursor_by_agent_name(self):
+        # initialize currently omits agentInfo.name; the unwrapped binary
+        # basename is still ``cursor-agent``.
+        info = detect_acp_provider_by_agent_name("cursor-agent")
+        assert info is not None
+        assert info.key == "cursor"
+
     def test_case_insensitive_detection(self):
         assert detect_acp_provider_by_agent_name("CLAUDE-AGENT-ACP") is not None
         assert detect_acp_provider_by_agent_name("Gemini-CLI") is not None
 
     def test_returns_none_for_unknown_agent_name(self):
-        assert detect_acp_provider_by_agent_name("some-unknown-agent") is None
+        assert detect_acp_provider_by_agent_name("some-unknown-cli") is None
 
     def test_returns_none_for_empty_string(self):
         assert detect_acp_provider_by_agent_name("") is None
@@ -316,6 +350,16 @@ class TestDetectACPProviderByCommand:
         info = detect_acp_provider_by_command(["/opt/acp-wrappers/kimi", "acp"])
         assert info is not None
         assert info.key == "kimi-code"
+
+    def test_detects_cursor_by_command(self):
+        info = detect_acp_provider_by_command(["agent", "acp"])
+        assert info is not None
+        assert info.key == "cursor"
+        info = detect_acp_provider_by_command(
+            ["/Users/me/.local/share/cursor-agent/versions/2026.09.02/cursor-agent", "acp"]
+        )
+        assert info is not None
+        assert info.key == "cursor"
 
     def test_returns_none_for_custom_command(self):
         assert detect_acp_provider_by_command(["my-custom-acp", "serve"]) is None

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -395,6 +395,7 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
         "kimi-code",
         "pi",
         "opencode",
+        "cursor",
         "custom",
     }
 
@@ -1422,6 +1423,7 @@ def test_acp_create_agent_carries_provider_key() -> None:
         "kimi-code",
         "pi",
         "opencode",
+        "cursor",
         "custom",
     ):
         kwargs: dict[str, Any] = {"acp_server": server}
@@ -1451,6 +1453,9 @@ def test_acp_resolve_command_for_known_servers(
         cmd = settings.resolve_acp_command()
         assert cmd, f"expected default command for {server}, got empty"
         assert cmd[0] == "npx", f"expected npx-based default, got {cmd}"
+
+    cursor_cmd = ACPAgentSettings(acp_server="cursor").resolve_acp_command()
+    assert cursor_cmd == ["agent", "acp"]
 
 
 def test_acp_create_agent_explicit_command_overrides_default() -> None:
@@ -1525,6 +1530,8 @@ def _which_returning(*available: str):
         # opencode's trailing arg is an ``acp`` subcommand, preserved the same
         # way as gemini's ``--acp`` flag.
         ("opencode", "opencode", ["opencode", "acp"]),
+        # Cursor's default is already the on-PATH binary; rewrite is a no-op.
+        ("cursor", "agent", ["agent", "acp"]),
     ],
 )
 def test_acp_resolve_command_rewrites_default_to_pinned_binary(
@@ -2257,6 +2264,7 @@ def test_acp_resolve_command_uses_registry_defaults(
         "kimi-code",
         "pi",
         "opencode",
+        "cursor",
     ):
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)


### PR DESCRIPTION
HUMAN:

Cursor CLI already speaks ACP via `agent acp`; this registers it as a first-class SDK provider without growing the default image.

---

AGENT:

Live-verified the Cursor ACP handshake on Cursor CLI `2026.09.02-c22c1a3` before writing the registry record. `initialize` / `authenticate(cursor_login)` / `session/new` / `session/set_mode` / `session/set_model` / `session/set_config_option` all succeeded. Unit tests: `uv run pytest tests/sdk/settings/test_acp_providers.py tests/sdk/settings/test_acp_install_catalog.py tests/sdk/test_settings.py tests/cross/test_agent_server_build_metadata.py` — 235 passed. TypeScript mirror regenerated with `uv run python clients/typescript/scripts/check-acp-drift.py --write`. Credential-free `acp_live` conformance is skipped for Cursor because its only advertised auth method is `cursor_login`.

## Why

OpenHands has no Cursor ACP provider. Cursor's official server is the first-party `agent acp` binary (curl installer, not npm). #4820's npm catalog cannot represent it, and #4823 was closed because Antigravity's 650 MiB archive was not worth a runtime fetcher. Cursor is the cheap binary case: already on PATH, `agent acp`, no image growth.

## Summary

- Add `cursor` to `ACP_PROVIDERS` / `ACPServerKind` with fields taken from the live handshake.
- Introduce `ACPPreinstalledBinaryInstallSpec`; `render_docker_install_plan` rejects it; default image preinstall list is unchanged.
- Mirror the record into `clients/typescript` and extend provider/settings tests.

## Issue Number

Closes #4873

## How to Test

1. Install Cursor CLI and log in (`agent login`).
2. From this branch: `uv run pytest tests/sdk/settings/test_acp_providers.py tests/sdk/settings/test_acp_install_catalog.py tests/sdk/test_settings.py tests/cross/test_agent_server_build_metadata.py`
3. Confirm `ACPAgentSettings(acp_server="cursor").resolve_acp_command() == ["agent", "acp"]`.
4. Confirm `render_docker_install_plan(["cursor"])` raises.

## Video/Screenshots

N/A — registry/metadata change. Handshake evidence is in #4873.

## Design Doc

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Not added to `DEFAULT_PREINSTALLED_ACP_PROVIDERS`. Agent Canvas onboarding branding is downstream (#4833 / #4841).

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.61s · commit 7f332a4  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 33/40 hunks, 11/11 files (context budget: 33, hunk budget: 7).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 9.0% | No direct hunk selected |
| Weakened authentication | 9.0% | [F004H008 · openhands-sdk/openhands/sdk/settings/acp\_providers.py:736–777](https://github.com/OpenHands/software-agent-sdk/blob/7f332a430cec10428d6b75ce6a64bee7a8f20160/openhands-sdk/openhands/sdk/settings/acp_providers.py#L736-L777) |
| Weakened authorization | 8.0% | [F004H008 · openhands-sdk/openhands/sdk/settings/acp\_providers.py:736–777](https://github.com/OpenHands/software-agent-sdk/blob/7f332a430cec10428d6b75ce6a64bee7a8f20160/openhands-sdk/openhands/sdk/settings/acp_providers.py#L736-L777) |
| Contract regression | 32.0% | [F003H007 · openhands-sdk/openhands/sdk/settings/acp\_install\_catalog.py:284–294](https://github.com/OpenHands/software-agent-sdk/blob/7f332a430cec10428d6b75ce6a64bee7a8f20160/openhands-sdk/openhands/sdk/settings/acp_install_catalog.py#L284-L294) |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 5.0% | No direct hunk selected |
| Credential misuse | 11.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 4.0% | No direct hunk selected |
| Privileged environment access | 7.0% | No direct hunk selected |
| Security assessment bypass | 7.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 73.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 895ebf076e6d19fd5ca2ee00890581a5eacb1df555135b7df741bb2a31fc3558 -->
<!-- jev-fast-audit:end -->
