### PR TITLE
fix(sdk): re-check cancellation after acquiring resource lock in ParallelToolExecutor

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -308,6 +308,12 @@ class ParallelToolExecutor:
             if not lock_keys:
                 return tool_runner(action)
             with self._lock_manager.lock(*lock_keys):
+                if cancel_token is not None and cancel_token.is_cancelled:
+                    logger.info(
+                        "Skipping tool '%s' -- cancelled while waiting for lock",
+                        action.tool_name,
+                    )
+                    return self._cancelled_error(action, span_owner)
                 return tool_runner(action)
 
         except ValueError as e:

--- a/tests/sdk/agent/test_parallel_executor_cancel_wait.py
+++ b/tests/sdk/agent/test_parallel_executor_cancel_wait.py
@@ -1,0 +1,167 @@
+"""Regression tests for ParallelToolExecutor cancellation while lock-waiting.
+
+Reproduces #4777: a tool call that blocks acquiring a resource lock and is
+cancelled during that wait must not run once the lock becomes available.
+"""
+
+import asyncio
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhands.sdk.agent.parallel_executor import ParallelToolExecutor
+from openhands.sdk.conversation.cancellation import CancellationToken
+from openhands.sdk.conversation.resource_lock_manager import ResourceLockManager
+from openhands.sdk.event.llm_convertible import AgentErrorEvent
+from openhands.sdk.tool.tool import DeclaredResources
+
+
+def _make_action(
+    tool_name: str = "editor",
+    tool_call_id: str = "call_1",
+) -> Any:
+    """Create a mock ActionEvent."""
+    ae = MagicMock()
+    ae.tool_name = tool_name
+    ae.tool_call_id = tool_call_id
+    ae.action = MagicMock()
+    return ae
+
+
+def _ok_event() -> Any:
+    return MagicMock()
+
+
+@pytest.mark.parametrize(
+    ("resources", "lock_key", "use_async"),
+    [
+        pytest.param(
+            DeclaredResources(
+                keys=("file:/tmp/cancelled-waiter",),
+                declared=True,
+            ),
+            "file:/tmp/cancelled-waiter",
+            False,
+            id="sync-declared-resource",
+        ),
+        pytest.param(
+            DeclaredResources(keys=(), declared=False),
+            "tool:editor",
+            False,
+            id="sync-tool-mutex",
+        ),
+        pytest.param(
+            DeclaredResources(
+                keys=("file:/tmp/cancelled-async-waiter",),
+                declared=True,
+            ),
+            "file:/tmp/cancelled-async-waiter",
+            True,
+            id="async-declared-resource",
+        ),
+    ],
+)
+def test_cancellation_while_waiting_for_lock_skips_tool(
+    resources: DeclaredResources,
+    lock_key: str,
+    use_async: bool,
+):
+    lock_mgr = ResourceLockManager(timeouts={"file": 1.0, "tool": 1.0})
+    executor = ParallelToolExecutor(max_workers=2, lock_manager=lock_mgr)
+    action = _make_action("editor", "c0")
+    token = CancellationToken()
+    resources_resolved = threading.Event()
+    runner_called = threading.Event()
+
+    tool = MagicMock()
+    tool.name = "editor"
+
+    def declared_resources(_: Any) -> DeclaredResources:
+        resources_resolved.set()
+        return resources
+
+    tool.declared_resources = declared_resources
+
+    def runner(_: Any) -> list[Any]:
+        runner_called.set()
+        return [_ok_event()]
+
+    results: list[list[Any]] = []
+
+    def execute() -> None:
+        if use_async:
+            batch = asyncio.run(
+                executor.aexecute_batch(
+                    [action],
+                    runner,
+                    {"editor": tool},
+                    token,
+                )
+            )
+        else:
+            batch = executor.execute_batch(
+                [action],
+                runner,
+                {"editor": tool},
+                token,
+            )
+        results.extend(batch)
+
+    worker = threading.Thread(target=execute)
+    with lock_mgr.lock(lock_key):
+        worker.start()
+        assert resources_resolved.wait(timeout=1)
+        token.cancel()
+
+    worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    assert not runner_called.is_set()
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert isinstance(results[0][0], AgentErrorEvent)
+    assert results[0][0].error == "Tool call cancelled by interrupt."
+
+
+def test_uncancelled_tool_runs_after_resource_lock_wait():
+    lock_mgr = ResourceLockManager(timeouts={"file": 1.0})
+    executor = ParallelToolExecutor(max_workers=2, lock_manager=lock_mgr)
+    action = _make_action("editor", "c0")
+    token = CancellationToken()
+    resources_resolved = threading.Event()
+    started = threading.Event()
+    tool_output = _ok_event()
+    resource_key = "file:/tmp/sanity-waiter"
+
+    tool = MagicMock()
+    tool.name = "editor"
+
+    def declared_resources(_: Any) -> DeclaredResources:
+        resources_resolved.set()
+        return DeclaredResources(keys=(resource_key,), declared=True)
+
+    tool.declared_resources = declared_resources
+
+    def runner(_: Any) -> list[Any]:
+        started.set()
+        return [tool_output]
+
+    results: list[list[Any]] = []
+
+    def execute() -> None:
+        results.extend(
+            executor.execute_batch([action], runner, {"editor": tool}, token)
+        )
+
+    worker = threading.Thread(target=execute)
+    with lock_mgr.lock(resource_key):
+        worker.start()
+        assert resources_resolved.wait(timeout=1)
+
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert started.is_set()
+    assert results[0] == [tool_output]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
Hit this on my self-hosted agent-canvas deployment: a cancelled tool call kept running after interrupt. Validated the fix end-to-end on my live box before submitting, and reviewed the diff myself.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

``ParallelToolExecutor._run_safe`` checks ``cancel_token.is_cancelled`` once, before resolving resource locks. A tool call that blocks waiting for a ``ResourceLockManager`` lock and is cancelled during that wait still invokes ``tool_runner`` once the lock becomes available. This violates the documented contract that pending tool calls are skipped after cancellation, and lets a queued file/terminal/browser operation start after the user interrupted the run.

## Summary

- Re-check ``cancel_token.is_cancelled`` immediately after acquiring the resource lock, returning the existing synthetic cancellation error instead of running the tool.
- Add ``tests/sdk/agent/test_parallel_executor_cancel_wait.py``: parametrised regression test covering sync declared-resource, sync tool-mutex, and async paths, plus an uncancelled-path sanity test.

## Issue Number

Fixes #4777

## How to Test

Run the new regression tests:

```
uv run pytest tests/sdk/agent/test_parallel_executor_cancel_wait.py -v
```

End-to-end verification performed on a self-hosted agent-canvas deployment (SDK v1.44.1, ``ghcr.io/openhands/agent-canvas:main``):

1. Before the fix, a cancelled tool call still invoked ``tool_runner`` after the lock became available (reproduces on v1.44.1 and current ``main``).
2. After the fix, the cancelled call returns the synthetic ``AgentErrorEvent`` ("Tool call cancelled by interrupt.") and ``tool_runner`` is never invoked; the uncancelled path still returns normal tool output.
3. Live e2e on the running agent-server: created a conversation, the agent started a ``sleep 120`` terminal tool call, ``POST /api/conversations/{id}/interrupt`` moved the conversation from ``running`` to ``paused`` immediately. Server log: ``Skipping tool 'terminal' -- cancelled while waiting for lock``.

## Video/Screenshots

N/A - no UI change; behaviour is terminal-observable only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The same guard was independently proposed in #4780 (opened first); credit to @jstar0. This PR carries the same fix with additional coverage (the uncancelled path) and live end-to-end evidence.
- Residual gap, out of scope here: cancellation does not wake a lock waiter, so an interrupted call still blocks until the holder releases or the per-resource timeout fires (30s ``file``, 60s ``tool``, 300s ``terminal``/``browser``/``mcp``). A cancel-aware ``FIFOLock.acquire`` would be the proper follow-up.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.40s · commit 22e897e  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 7.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 98.0% | No primary concern to locate |

</details>


<!-- jev-input-signature ea1f7b687171dafa15cbbab09a7c9e32ee970ec93decaaedf8a17009b3d595aa -->
<!-- jev-fast-audit:end -->
