### PR TITLE
fix(agent-server): proxy cloud runtime requests

### DIFF
--- a/.github/agent-server-openapi-weak-schema-allowlist.json
+++ b/.github/agent-server-openapi-weak-schema-allowlist.json
@@ -288,6 +288,12 @@
     "owner": "OpenHands OSS"
   },
   {
+    "pointer": "/components/schemas/JsonValue",
+    "kind": "empty-object-schema",
+    "reason": "Cloud proxy request bodies intentionally accept arbitrary JSON values for upstream runtime APIs.",
+    "owner": "OpenHands OSS"
+  },
+  {
     "pointer": "/components/schemas/MCPOAuthAuthentication-Input/properties/additional_client_metadata/anyOf/0/additionalProperties",
     "kind": "unrestricted-additional-properties",
     "reason": "The upstream MCP or OAuth payload intentionally preserves provider-defined extension fields.",

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -22,6 +22,7 @@ from openhands.agent_server.auth_router import auth_router
 from openhands.agent_server.bash_router import bash_router
 from openhands.agent_server.bash_service import get_default_bash_event_service
 from openhands.agent_server.canvas_extensions_router import canvas_extensions_router
+from openhands.agent_server.cloud_proxy_router import cloud_proxy_router
 from openhands.agent_server.config import (
     Config,
     get_default_config,
@@ -424,6 +425,7 @@ def _add_api_routes(app: FastAPI) -> None:
     api_router.include_router(sub_agents_router)
     api_router.include_router(plugins_router)
     api_router.include_router(canvas_extensions_router)
+    api_router.include_router(cloud_proxy_router)
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
     api_router.include_router(provider_connections_router)

--- a/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
+++ b/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
@@ -1,0 +1,196 @@
+"""Authenticated proxy for browser requests to OpenHands runtime hosts.
+
+Cloud Canvas cannot call a per-conversation runtime directly from the browser:
+the runtime host is not the same origin and may not expose CORS headers. The
+Canvas client therefore sends a request envelope to this agent-server, which
+forwards it to the runtime after validating the destination.
+
+This endpoint is intentionally limited to OpenHands-managed runtime hosts. A
+generic authenticated URL fetcher would be an SSRF primitive because session
+API keys are accepted by this server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from typing import Literal
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field, JsonValue, field_validator
+
+
+ALLOWED_RUNTIME_HOST_SUFFIXES = (
+    ".prod-runtime.all-hands.dev",
+    ".staging-runtime.all-hands.dev",
+)
+
+_REQUEST_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "content-length",
+        "content-encoding",
+        "host",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+_RESPONSE_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "content-encoding",
+        "content-length",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+class CloudProxyRequest(BaseModel):
+    """Request envelope for forwarding a browser call to a runtime host."""
+
+    host: str = Field(description="Absolute upstream OpenHands runtime host")
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+    path: str = Field(description="Upstream absolute path, including query string")
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: JsonValue | None = None
+    timeout_seconds: float | None = Field(default=None, gt=0)
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, value: str) -> str:
+        parsed = urlparse(value)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("host must not include an invalid port") from exc
+
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or port
+            or parsed.path not in ("", "/")
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("host must be an absolute https URL without a port")
+
+        hostname = parsed.hostname.lower().rstrip(".")
+        if not hostname.endswith(ALLOWED_RUNTIME_HOST_SUFFIXES):
+            raise ValueError("host is not an allowed OpenHands runtime host")
+
+        return f"https://{hostname}"
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        if (
+            not value.startswith("/")
+            or value.startswith("//")
+            or any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
+        ):
+            raise ValueError("path must be an absolute path")
+        return value
+
+
+cloud_proxy_router = APIRouter(prefix="/cloud-proxy", tags=["Cloud Proxy"])
+
+
+def _ensure_public_dns_target(host: str) -> None:
+    parsed = urlparse(host)
+    if not parsed.hostname:
+        raise HTTPException(status_code=400, detail="host is required")
+
+    try:
+        addresses = socket.getaddrinfo(
+            parsed.hostname,
+            443,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="host could not be resolved",
+        ) from exc
+
+    if not addresses:
+        raise HTTPException(status_code=400, detail="host could not be resolved")
+
+    for *_, sockaddr in addresses:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="host resolves to a non-public address",
+            )
+
+
+def _forward_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Keep end-to-end headers while letting httpx own transport headers."""
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in _REQUEST_HOP_BY_HOP_HEADERS
+    }
+
+
+@cloud_proxy_router.post(
+    "",
+    response_class=Response,
+    responses={200: {"description": "Upstream response"}},
+)
+async def proxy_cloud_request(request: CloudProxyRequest) -> Response:
+    """Forward an authenticated request to an allowed OpenHands runtime."""
+    await asyncio.to_thread(_ensure_public_dns_target, request.host)
+    url = f"{request.host}{request.path}"
+    timeout = request.timeout_seconds or 30.0
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
+            upstream = await client.request(
+                request.method,
+                url,
+                headers=_forward_headers(request.headers),
+                json=request.body if request.body is not None else None,
+            )
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail="upstream request failed") from exc
+
+    response_headers = {
+        key: value
+        for key, value in upstream.headers.items()
+        if key.lower() not in _RESPONSE_HOP_BY_HOP_HEADERS
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=response_headers,
+        media_type=upstream.headers.get("content-type"),
+    )

--- a/tests/agent_server/test_cloud_proxy_router.py
+++ b/tests/agent_server/test_cloud_proxy_router.py
@@ -1,0 +1,220 @@
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.cloud_proxy_router import cloud_proxy_router
+
+
+def make_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(cloud_proxy_router, prefix="/api")
+    return TestClient(app)
+
+
+def public_dns_result(ip: str = "93.184.216.34"):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 443))]
+
+
+def mock_upstream(status_code: int = 200):
+    response = httpx.Response(
+        status_code,
+        json={"success": True},
+        headers={"content-type": "application/json"},
+        request=httpx.Request(
+            "POST",
+            "https://abc123.prod-runtime.all-hands.dev/api/conversations/conv-1",
+        ),
+    )
+    async_client = MagicMock()
+    async_client.__aenter__ = AsyncMock(return_value=async_client)
+    async_client.__aexit__ = AsyncMock(return_value=None)
+    async_client.request = AsyncMock(return_value=response)
+    return async_client
+
+
+def test_cloud_proxy_forwards_confirmation_post():
+    client = make_client()
+    async_client = mock_upstream()
+
+    with (
+        patch("socket.getaddrinfo", return_value=public_dns_result()),
+        patch("httpx.AsyncClient", return_value=async_client),
+    ):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://abc123.prod-runtime.all-hands.dev",
+                "method": "POST",
+                "path": "/api/conversations/conv-1/events/respond_to_confirmation",
+                "headers": {"X-Session-API-Key": "session-key"},
+                "body": {"accept": True},
+            },
+        )
+
+    assert result.status_code == 200
+    assert result.json() == {"success": True}
+    async_client.request.assert_awaited_once_with(
+        "POST",
+        "https://abc123.prod-runtime.all-hands.dev"
+        "/api/conversations/conv-1/events/respond_to_confirmation",
+        headers={"X-Session-API-Key": "session-key"},
+        json={"accept": True},
+    )
+
+
+def test_cloud_proxy_forwards_compact_context_post():
+    client = make_client()
+    async_client = mock_upstream()
+
+    with (
+        patch("socket.getaddrinfo", return_value=public_dns_result()),
+        patch("httpx.AsyncClient", return_value=async_client),
+    ):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://abc123.prod-runtime.all-hands.dev",
+                "method": "POST",
+                "path": "/api/conversations/conv-1/condense",
+                "headers": {"X-Session-API-Key": "session-key"},
+            },
+        )
+
+    assert result.status_code == 200
+    async_client.request.assert_awaited_once_with(
+        "POST",
+        "https://abc123.prod-runtime.all-hands.dev/api/conversations/conv-1/condense",
+        headers={"X-Session-API-Key": "session-key"},
+        json=None,
+    )
+
+
+def test_cloud_proxy_drops_transport_headers_before_forwarding():
+    client = make_client()
+    async_client = mock_upstream()
+
+    with (
+        patch("socket.getaddrinfo", return_value=public_dns_result()),
+        patch("httpx.AsyncClient", return_value=async_client),
+    ):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://abc123.prod-runtime.all-hands.dev",
+                "method": "POST",
+                "path": "/api/conversations/conv-1/condense",
+                "headers": {
+                    "Host": "not-the-runtime.example",
+                    "Content-Length": "999",
+                    "X-Session-API-Key": "session-key",
+                },
+            },
+        )
+
+    assert result.status_code == 200
+    assert async_client.request.call_args.kwargs["headers"] == {
+        "X-Session-API-Key": "session-key"
+    }
+
+
+def test_cloud_proxy_rejects_non_absolute_host():
+    client = make_client()
+
+    result = client.post(
+        "/api/cloud-proxy",
+        json={
+            "host": "/relative",
+            "method": "GET",
+            "path": "/api/server_info",
+        },
+    )
+
+    assert result.status_code == 422
+
+
+def test_cloud_proxy_rejects_non_runtime_host():
+    client = make_client()
+
+    result = client.post(
+        "/api/cloud-proxy",
+        json={
+            "host": "https://example.com",
+            "method": "GET",
+            "path": "/api/server_info",
+        },
+    )
+
+    assert result.status_code == 422
+
+
+def test_cloud_proxy_rejects_runtime_host_with_path_or_port():
+    client = make_client()
+
+    for host in (
+        "https://abc123.prod-runtime.all-hands.dev:8443",
+        "https://abc123.prod-runtime.all-hands.dev/other",
+    ):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": host,
+                "method": "GET",
+                "path": "/api/server_info",
+            },
+        )
+        assert result.status_code == 422
+
+
+def test_cloud_proxy_rejects_protocol_relative_path():
+    client = make_client()
+
+    result = client.post(
+        "/api/cloud-proxy",
+        json={
+            "host": "https://abc123.prod-runtime.all-hands.dev",
+            "method": "GET",
+            "path": "//example.com/api/server_info",
+        },
+    )
+
+    assert result.status_code == 422
+
+
+def test_cloud_proxy_rejects_runtime_host_resolving_to_loopback():
+    client = make_client()
+
+    with patch("socket.getaddrinfo", return_value=public_dns_result("127.0.0.1")):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://abc123.prod-runtime.all-hands.dev",
+                "method": "GET",
+                "path": "/api/server_info",
+            },
+        )
+
+    assert result.status_code == 400
+    assert result.json()["detail"] == "host resolves to a non-public address"
+
+
+def test_cloud_proxy_rejects_runtime_host_resolving_to_link_local_metadata():
+    client = make_client()
+
+    with patch(
+        "socket.getaddrinfo",
+        return_value=public_dns_result("169.254.169.254"),
+    ):
+        result = client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://abc123.prod-runtime.all-hands.dev",
+                "method": "GET",
+                "path": "/latest/meta-data/",
+            },
+        )
+
+    assert result.status_code == 400
+    assert result.json()["detail"] == "host resolves to a non-public address"


### PR DESCRIPTION
HUMAN:

The compact-context request was returning 405 before reaching the runtime. I reproduced it locally and verified the proxy route and condense endpoint with focused tests.

AGENT:

## Why

In cloud mode, browser requests for conversation actions go through the agent-server because the browser cannot call each conversation runtime directly. The missing `/api/cloud-proxy` route caused compact context to stop with `405 Method Not Allowed` before reaching `POST /api/conversations/{conversation_id}/condense`.

## Summary

- Add the authenticated `POST /api/cloud-proxy` route.
- Forward runtime methods, paths, headers, and JSON bodies.
- Restrict forwarding to approved HTTPS OpenHands runtime hosts.
- Reject private, loopback, link-local, multicast, reserved, and unspecified DNS targets.
- Prevent redirects and remove hop-by-hop transport headers.
- Add regression coverage for confirmation requests and compact-context requests.

## How to Test

- `py -m pytest --noconftest tests/agent_server/test_cloud_proxy_router.py -q` — 9 passed
- Ruff checks passed.
- Formatting checks passed.

Fixes #4854
Fixes OpenHands/OpenHands#17131
