### PR TITLE
fix(tests): stop pinning LLM capability tests to upstream metadata

### DIFF
--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -54,10 +54,13 @@ def test_model_matches(name, pattern, expected):
         ("moonshot/kimi-k2.5", False),
         ("moonshot/kimi-k2-thinking", False),
         ("litellm_proxy/moonshot/kimi-k2-thinking", False),
-        # OpenRouter docs list these as reasoning models, but LiteLLM capability
-        # metadata does not currently mark them as reasoning-capable.
+        # Route-dependent, and both directions are correct: OpenRouter accepts
+        # `reasoning_effort` and translates it, while Moonshot's own API does
+        # not take the parameter at all (see the two rows above). These follow
+        # LiteLLM's per-route `supported_openai_params` rather than an SDK
+        # override, so a value here tracks upstream and may move again (#4877).
         ("openrouter/moonshotai/kimi-k2.5", False),
-        ("openrouter/moonshotai/kimi-k2-thinking", False),
+        ("openrouter/moonshotai/kimi-k2-thinking", True),
         # OpenRouter reasoning-capable models per LiteLLM metadata
         ("openrouter/deepseek/deepseek-r1", True),
         ("openrouter/anthropic/claude-opus-4.5", True),

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -1,3 +1,16 @@
+"""Capability-detection tests.
+
+LiteLLM fetches ``model_prices_and_context_window.json`` from its upstream
+``main`` branch at import time, so pinning litellm in ``uv.lock`` pins its code
+but not its model database — and the SDK sets no override, in tests or in
+production. These tests therefore run against data that changes without us.
+
+Assert what the SDK owns: its override lists, its model-name normalization, and
+that a routing wrapper does not change the answer. A bare capability value with
+no SDK rule behind it is upstream's to change, and pinning one here fails the
+day it does (#4877).
+"""
+
 import pytest
 from litellm.utils import supports_vision
 

--- a/tests/sdk/llm/test_runtime_metadata.py
+++ b/tests/sdk/llm/test_runtime_metadata.py
@@ -216,8 +216,13 @@ def test_openrouter_model_id_normalization():
 def test_effective_unchanged_before_resolution():
     llm = _openrouter_llm()
     assert llm.resolved_runtime_metadata is None
-    # Property performs no network I/O.
-    assert llm.effective_max_input_tokens is None
+    # The property performs no network I/O, so the route-aware limit this
+    # provider would report (262144, see PAYLOAD) cannot be in play yet — it
+    # falls through to LiteLLM's static metadata. That fallback is deliberately
+    # not asserted: it is upstream data, and pinning it here made this test
+    # fail the day LiteLLM learned the model (#4877).
+    assert llm.effective_max_input_tokens != 262144
+    assert llm.resolved_runtime_metadata is None
 
 
 def test_explicit_max_input_tokens_wins():


### PR DESCRIPTION
HUMAN:

`sdk-tests` is red on `main` and on every open PR branch, blocking unrelated work — please prioritise accordingly. I'd like a second opinion specifically on the `kimi-k2-thinking` row: I'm claiming the route-dependent answer is correct rather than a bug worth papering over, and that's the judgement call in this PR.

<!--
Note on authorship: this section was written by the agent at my explicit direction
in the session linked below, not typed by me. Flagging it so the attestation this
check exists to capture isn't taken at more than face value.
-->

---

AGENT:

## Why

`sdk-tests` has been red on `main` since run [34000698924](https://github.com/OpenHands/software-agent-sdk/actions/runs/34000698924) (`fe91d7df`, 2026-09-06 00:12 UTC) and is failing every open PR branch with it. Two LLM tests fail, both from LiteLLM model-metadata drift rather than any code change — identical code and `uv.lock` were green ~2.5 hours earlier (run [33993973807](https://github.com/OpenHands/software-agent-sdk/actions/runs/33993973807)).

Confirmed repo-wide, not branch-local: `fix/load-skills-agent-context-4863` fails both with byte-identical assertion values (`assert 1310720 is None`, `assert True == False`).

### Root cause: the version pin does not pin the model database

`uv.lock` pins litellm 1.93.0, but `litellm/__init__.py` runs
`model_cost = get_model_cost_map(url=...)` **at import time**, and that URL defaults to
`https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`.
The pin covers litellm's *code*; the model metadata is fetched live from upstream's `main`
branch on every run. Measured here:

| | map source | models | `openrouter/moonshotai/kimi-k2-thinking` | `openrouter/deepseek/deepseek-v4-flash-0731` |
|---|---|---|---|---|
| default (what CI does) | **remote, BerriAI `main`** | 3817 | `reasoning_effort` supported | `max_input_tokens=1310720` |
| `LITELLM_LOCAL_MODEL_COST_MAP=True` | bundled in the pinned wheel | 2953 | not supported | `None` |

So the two assertions had frozen a transient upstream state. The SDK sets no override, in
tests or in production, so CI is faithfully reproducing what users get at runtime.

**Why this PR does not simply force the local map.** That looks like the obvious hermetic
fix, but the snapshot bundled in the 1.93.0 wheel is *older than the SDK's own
expectations* — it has no `kimi-k3` at all, so forcing it turns these 2 failures into 11
(`test_kimi_k3_supports_vision`, `test_vision_is_active_supported_models`, …). Several
existing tests already rely on the live map. Freezing would also make CI stop reflecting
production, where the coupling remains either way.

The direction taken here is therefore: **assert what the SDK owns, never what the upstream
database owns.** Both failing rows were the latter.

## Summary

- **`test_effective_unchanged_before_resolution`** asserted `effective_max_input_tokens is None` for `openrouter/deepseek/deepseek-v4-flash-0731`. That only held while LiteLLM had no static metadata for the model; once it learned it, the property's own documented third fallback ("falling back to the value discovered from model metadata") correctly returned `1310720`. The property's real contract is that it performs **no network I/O**, so it cannot yet reflect the route-aware limit — it now asserts that (`!= 262144`, the value `PAYLOAD` would resolve to) plus `resolved_runtime_metadata is None`. The static fallback is upstream data and is deliberately left unpinned.

- **`test_reasoning_effort_support[openrouter/moonshotai/kimi-k2-thinking-False]`** expected the OpenRouter route to reject `reasoning_effort`. LiteLLM now lists it as supported there. I believe that is **correct rather than a regression**: OpenRouter accepts `reasoning_effort` and translates it, while Moonshot's own API does not take the parameter at all. Verified against the installed LiteLLM:

  | model | `reasoning_effort` in `supported_openai_params` | `get_features(...)` |
  |---|---|---|
  | `moonshot/kimi-k2-thinking` | False | False |
  | `litellm_proxy/moonshot/kimi-k2-thinking` | False | False |
  | `openrouter/moonshotai/kimi-k2-thinking` | **True** | **True** |
  | `openrouter/moonshotai/kimi-k2.5` | False | False |

  The two adjacent `moonshot/...` rows already assert `False` and still pass, so the SDK deliberately reports the same underlying model differently per route. The expectation is updated to `True` and the stale comment ("LiteLLM capability metadata does not currently mark them as reasoning-capable") replaced with one that says these rows follow LiteLLM's per-route `supported_openai_params` rather than an SDK override — so a future move reads as drift instead of a mystery.

No production code changes; both edits are test-only.

## Issue Number

Fixes #4877

## How to Test

The two tests from the issue, which fail on `main` and pass here:

```
uv run pytest tests/sdk/llm/test_runtime_metadata.py::test_effective_unchanged_before_resolution \
  "tests/sdk/llm/test_model_features.py::test_reasoning_effort_support[openrouter/moonshotai/kimi-k2-thinking-False]" -v
```

Both files in full — `219 passed`:

```
uv run pytest tests/sdk/llm/test_runtime_metadata.py tests/sdk/llm/test_model_features.py -q
```

Full suite under CI's invocation (`CI=true`, xdist at CI's worker count):

```
CI=true uv run python -m pytest -q -n 2 tests/sdk
# 6087 passed, 9 skipped, 11 xfailed, 1 xpassed
```

The single local failure that remains is `tests/sdk/utils/test_truncate.py::test_maybe_truncate_hash_based_filename`, a macOS-only artifact of the long `/private/var/folders/...` tmp path; it passes on Linux CI.

### Note for the reviewer

The `xpassed` above is a third, milder symptom of the same drift. It does not fail the run (xfail is not strict here), so I left it alone rather than widen this PR — worth a follow-up if you'd like the xfail markers re-audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xcUBSCfDEUysWgHYGkHY6


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d19fb97-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d19fb97-python \
  ghcr.io/openhands/agent-server:d19fb97-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d19fb97-golang-amd64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-golang-amd64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-golang-amd64
ghcr.io/openhands/agent-server:d19fb97-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d19fb97-golang-arm64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-golang-arm64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-golang-arm64
ghcr.io/openhands/agent-server:d19fb97-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d19fb97-java-amd64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-java-amd64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-java-amd64
ghcr.io/openhands/agent-server:d19fb97-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d19fb97-java-arm64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-java-arm64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-java-arm64
ghcr.io/openhands/agent-server:d19fb97-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d19fb97-python-amd64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python-amd64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python-amd64
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d19fb97-python-arm64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python-arm64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python-arm64
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d19fb97-python-slim-amd64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python-slim-amd64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python-slim-amd64
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:d19fb97-python-slim-arm64
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python-slim-arm64
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python-slim-arm64
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:d19fb97-golang
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-golang
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-golang
ghcr.io/openhands/agent-server:d19fb97-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d19fb97-java
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-java
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-java
ghcr.io/openhands/agent-server:d19fb97-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d19fb97-python-slim
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python-slim
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python-slim
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:d19fb97-python
ghcr.io/openhands/agent-server:d19fb97cf4dd3ab08815386ca03cc0811c64bc64-python
ghcr.io/openhands/agent-server:fix-litellm-metadata-drift-python
ghcr.io/openhands/agent-server:d19fb97-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d19fb97-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d19fb97-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->