### PR TITLE
fix(llm): pin LiteLLM's model database to an immutable commit

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
+# Must precede every other openhands import: pins LiteLLM's model database on
+# import, and LiteLLM reads that URL once, when it is itself imported.
+import openhands.sdk.model_cost_map_pin  # noqa: F401
 from openhands.sdk.agent import (
     Agent,
     AgentBase,

--- a/openhands-sdk/openhands/sdk/model_cost_map_pin.py
+++ b/openhands-sdk/openhands/sdk/model_cost_map_pin.py
@@ -1,0 +1,55 @@
+"""Pin the LiteLLM model database to an immutable commit.
+
+LiteLLM resolves ``model_cost_map_url`` at import time and, left at its
+default, fetches ``model_prices_and_context_window.json`` from the tip of
+``BerriAI/litellm@main``. Pinning ``litellm`` in ``uv.lock`` therefore pins its
+*code* and not the data that code reads: the same build answers capability and
+pricing questions differently on different days, and an unreviewed upstream
+merge reaches every process on its next import.
+
+A branch name is not a pin — only a commit SHA is immutable (the tj-actions
+tag-rewrite attack is the standing example). :data:`MODEL_COST_MAP_URL` is
+therefore SHA-addressed, and moving it is an ordinary reviewable diff.
+
+Deliberately ``setdefault``: an operator who wants the live map, or an internal
+mirror, sets ``LITELLM_MODEL_COST_MAP_URL`` and this stays out of the way.
+
+See OpenHands/software-agent-sdk#4880 and #4308.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+MODEL_COST_MAP_COMMIT = "42d8360f297db9057c205ea0281f15a7c2e4f67e"
+"""Pinned ``BerriAI/litellm`` commit supplying the model database.
+
+Bumping this is a data update: it can change context windows, pricing and
+capability flags, so the capability suites in ``tests/sdk/llm`` are the
+regression net for it. Pick a commit old enough to clear the repository's
+supply-chain freshness window rather than the newest one available.
+"""
+
+MODEL_COST_MAP_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/"
+    f"{MODEL_COST_MAP_COMMIT}/model_prices_and_context_window.json"
+)
+
+_ENV_VAR = "LITELLM_MODEL_COST_MAP_URL"
+
+
+def apply_model_cost_map_pin() -> None:
+    """Point LiteLLM at the pinned map, unless the environment already says.
+
+    Must run before anything imports ``litellm``: the URL is read once, at
+    LiteLLM's own import, so a later assignment silently does nothing.
+    """
+    os.environ.setdefault(_ENV_VAR, MODEL_COST_MAP_URL)
+
+
+# Applied on import rather than by a call in ``openhands.sdk.__init__``: twenty
+# modules across the package import litellm, so the package __init__ is the
+# only reliable point, and a statement between its imports would push every
+# one of them past E402.
+apply_model_cost_map_pin()

--- a/tests/sdk/test_model_cost_map_pin.py
+++ b/tests/sdk/test_model_cost_map_pin.py
@@ -1,0 +1,70 @@
+"""The LiteLLM model database is pinned to an immutable commit."""
+
+import os
+import re
+import subprocess
+import sys
+
+from openhands.sdk.model_cost_map_pin import (
+    MODEL_COST_MAP_COMMIT,
+    MODEL_COST_MAP_URL,
+    apply_model_cost_map_pin,
+)
+
+
+_ENV_VAR = "LITELLM_MODEL_COST_MAP_URL"
+
+
+def test_pin_is_a_commit_sha_not_a_branch():
+    """A branch name is not a pin — it moves under us, which is the whole
+    failure this module exists to prevent (#4877, #4880)."""
+    assert re.fullmatch(r"[0-9a-f]{40}", MODEL_COST_MAP_COMMIT), (
+        f"{MODEL_COST_MAP_COMMIT!r} is not a full commit SHA; a branch or tag "
+        "is mutable and does not pin anything"
+    )
+    assert MODEL_COST_MAP_COMMIT in MODEL_COST_MAP_URL
+    assert "/main/" not in MODEL_COST_MAP_URL
+
+
+def test_applies_the_pin_when_the_environment_is_silent(monkeypatch):
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+
+    apply_model_cost_map_pin()
+
+    assert os.environ[_ENV_VAR] == MODEL_COST_MAP_URL
+
+
+def test_an_explicit_url_wins(monkeypatch):
+    """Operators who want the live map, or an internal mirror, keep it."""
+    monkeypatch.setenv(_ENV_VAR, "https://mirror.internal/model_prices.json")
+
+    apply_model_cost_map_pin()
+
+    assert os.environ[_ENV_VAR] == "https://mirror.internal/model_prices.json"
+
+
+def test_importing_the_sdk_pins_the_map_litellm_actually_loads():
+    """The end-to-end property, in a fresh interpreter.
+
+    LiteLLM resolves the URL once at its own import, so the pin only works if
+    it lands first. Asserting on the module in isolation would pass even if
+    `openhands.sdk.__init__` imported it too late to matter.
+    """
+    source = (
+        "import openhands.sdk\n"
+        "from litellm.litellm_core_utils.get_model_cost_map import "
+        "get_model_cost_map_source_info as s\n"
+        "print(s()['url'])\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={"PATH": "/usr/bin:/bin", "OPENHANDS_SUPPRESS_BANNER": "1"},
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert MODEL_COST_MAP_COMMIT in result.stdout, (
+        f"litellm loaded {result.stdout.strip()!r}, not the pinned commit — "
+        "something imports litellm before openhands.sdk applies the pin"
+    )


### PR DESCRIPTION
HUMAN:

This supersedes #4879 — same bug, root cause instead of the symptom, and it needs no assertion edits at all. Please review the production-behaviour question first: this pins the model database for SDK *users*, not just CI, which is the deliberate part and the bit I most want a second opinion on. Applying the doctrine from my own #4308 here: a branch name is not a pin.

<!--
Note on authorship: this section was written by the agent at my explicit direction
in the session linked below, not typed by me. Flagging it so the attestation this
check exists to capture isn't taken at more than face value.
-->

---

AGENT:

## Why

`sdk-tests` went red on `main` and every open branch with two LLM failures, and identical code with an identical `uv.lock` had been green ~2.5 hours earlier. The cause is that **the version pin does not pin the data**.

`litellm/__init__.py` runs, at import time:

```python
model_cost_map_url: str = os.getenv(
    "LITELLM_MODEL_COST_MAP_URL",
    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
)
model_cost = get_model_cost_map(url=model_cost_map_url)
```

So `uv.lock` pins litellm 1.93.0's *code*, while the model database it reads comes from the tip of a third party's `main` branch, fetched fresh on every import. The SDK overrides this nowhere — not in tests, not in production:

```
$ grep -rn "LITELLM_LOCAL_MODEL_COST_MAP\|LITELLM_MODEL_COST_MAP_URL" openhands-sdk/ openhands-agent-server/
(no matches)
```

Measured on `main`:

| | map source | models | `openrouter/moonshotai/kimi-k2-thinking` | `openrouter/deepseek/deepseek-v4-flash-0731` |
|---|---|---|---|---|
| default | **remote, BerriAI `main`** | 3817 | `reasoning_effort` supported | `max_input_tokens=1310720` |
| `LITELLM_LOCAL_MODEL_COST_MAP=True` | bundled in the pinned wheel | 2953 | not supported | `None` |

This is the class of finding #4308 catalogues, in a category its inventory did not cover: a **runtime data dependency**, rather than a build-time install. #4308's own conclusion from the tj-actions tag-rewrite attack applies directly — *tag-pinning isn't real pinning; only a SHA is immutable*. We are not even tag-pinned here.

## Summary

- Pin `LITELLM_MODEL_COST_MAP_URL` to a **SHA-addressed** raw URL. Moving it becomes an ordinary reviewable diff, like any Action pin.
- Applied as an import side effect of `openhands.sdk`. Twenty modules across the package import litellm, so the package `__init__` is the only point that reliably precedes all of them — and a *statement* between its imports would push every one past `E402`, so the side effect stays in the pinned module.
- `os.environ.setdefault`, so an operator who wants the live map, or an internal mirror, sets the variable and this stays out of the way.
- The pinned commit is **8 days old**, deliberately clearing the repository's supply-chain freshness window rather than taking the newest available.

### Why not the two obvious alternatives

- **`LITELLM_LOCAL_MODEL_COST_MAP=True`** (use the wheel's bundled copy) looks like the clean hermetic fix. It isn't: that snapshot is *older than the SDK's own tests expect* — it has no `kimi-k3` at all, so forcing it turns these 2 failures into **11** (`test_kimi_k3_supports_vision`, `test_vision_is_active_supported_models`). Verified.
- **Vendoring the JSON in-repo** means a 2.3 MB blob, a bespoke `litellm.model_cost` override in conftest (litellm's fetch is httpx, so a `file://` URL will not work), and a refresh process someone owns. The SHA pin gets the same determinism with one env var.

### Relationship to #4879

#4879 fixed the same two failures by adjusting the assertions to match whatever upstream currently says. This fixes the cause instead, and **needs no assertion changes at all** — both tests pass exactly as written on `main`. I'd suggest closing #4879 in favour of this; its module-docstring rule ("never assert a value the upstream DB owns") also stops applying once the values are ours rather than upstream's.

If you'd rather land #4879 first to unblock the repo sooner, this PR will need a trivial rebase to drop its two edits.

## Issue Number

Fixes #4877

## How to Test

The two failing tests, **unmodified**, now pass:

```
uv run pytest tests/sdk/llm/test_runtime_metadata.py::test_effective_unchanged_before_resolution \
  "tests/sdk/llm/test_model_features.py::test_reasoning_effort_support[openrouter/moonshotai/kimi-k2-thinking-False]" -q
# 2 passed
```

The whole LLM suite, including the `kimi-k3` tests the wheel's bundled map would have broken:

```
uv run pytest tests/sdk/llm -q
# 983 passed
```

Full suite under CI's invocation:

```
CI=true uv run python -m pytest -q -n 2 tests/sdk
# 6091 passed, 9 skipped, 12 xfailed
```

Note `12 xfailed, 0 xpassed` — the stray `xpassed` that was a third symptom of the same drift is also resolved, without touching a marker.

The pin is verifiably live rather than merely declared:

```
$ python -c "import openhands.sdk, litellm
from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map_source_info as s
print(s()['url'], len(litellm.model_cost))"
https://raw.githubusercontent.com/BerriAI/litellm/42d8360f.../model_prices_and_context_window.json 3407
```

### Note for the reviewer

`test_importing_the_sdk_pins_the_map_litellm_actually_loads` runs in a fresh interpreter on purpose. LiteLLM resolves the URL once, at its own import, so a test asserting on the pinned module alone would pass even if `openhands.sdk.__init__` applied it too late to matter. Confirmed sensitive: removing the import from `__init__.py` makes it fail with the live `…/main/…` URL rather than passing quietly.

`test_pin_is_a_commit_sha_not_a_branch` guards the actual regression — someone restoring a branch ref would otherwise reintroduce exactly this bug silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xcUBSCfDEUysWgHYGkHY6

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f4b6dc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f4b6dc6-python \
  ghcr.io/openhands/agent-server:f4b6dc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f4b6dc6-golang-amd64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-golang-amd64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-golang-amd64
ghcr.io/openhands/agent-server:f4b6dc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f4b6dc6-golang-arm64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-golang-arm64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-golang-arm64
ghcr.io/openhands/agent-server:f4b6dc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f4b6dc6-java-amd64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-java-amd64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-java-amd64
ghcr.io/openhands/agent-server:f4b6dc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f4b6dc6-java-arm64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-java-arm64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-java-arm64
ghcr.io/openhands/agent-server:f4b6dc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f4b6dc6-python-amd64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python-amd64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python-amd64
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f4b6dc6-python-arm64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python-arm64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python-arm64
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f4b6dc6-python-slim-amd64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python-slim-amd64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python-slim-amd64
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:f4b6dc6-python-slim-arm64
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python-slim-arm64
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python-slim-arm64
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:f4b6dc6-golang
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-golang
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-golang
ghcr.io/openhands/agent-server:f4b6dc6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f4b6dc6-java
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-java
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-java
ghcr.io/openhands/agent-server:f4b6dc6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f4b6dc6-python-slim
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python-slim
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python-slim
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:f4b6dc6-python
ghcr.io/openhands/agent-server:f4b6dc688abebb71a88a57b0a82f21ac242f3934-python
ghcr.io/openhands/agent-server:pin-litellm-model-cost-map-python
ghcr.io/openhands/agent-server:f4b6dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f4b6dc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f4b6dc6-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->