### PR TITLE
chore(llm): record which model database the process loaded

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_cost_map.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_cost_map.py
@@ -1,0 +1,205 @@
+"""Provenance and sanity checks for LiteLLM's model database.
+
+LiteLLM resolves its model database at import time and, by default, fetches
+``model_prices_and_context_window.json`` from the tip of ``BerriAI/litellm@main``.
+Pinning ``litellm`` in ``uv.lock`` pins its *code*, not that data, so the same
+build reads different pricing, context windows and capability flags on
+different days — and on a fetch failure it silently falls back to the older
+copy bundled in the wheel, which answers those questions differently again.
+
+Pinning the data is not available as a fix: the map describes provider APIs
+that change weekly, so freezing it makes new models invisible to the SDK (no
+context window, no capability flags). See #4880.
+
+What is available is knowing what we loaded and noticing when it is absurd:
+
+- :func:`model_cost_map_provenance` fingerprints the map actually in use, so a
+  silent fallback or an unexpected change is diagnosable rather than invisible.
+- :func:`describe_metadata_anomalies` bounds-checks the handful of fields the
+  SDK consumes, which catches gross tampering and upstream mistakes alike —
+  #4877 was the latter, and would have been reported by it.
+
+Detection only, deliberately: these paths decide truncation and what the SDK
+puts on the wire, so a false positive that refused a legitimate new model
+would be worse than the drift it guards against. Enforcement can follow once
+the signal has been observed in the wild.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+from litellm import model_cost
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+# Numeric limits the SDK reads off model metadata. A value outside these bounds
+# is not a model we do not know about yet — it is a value that would break
+# truncation arithmetic.
+_TOKEN_LIMIT_KEYS = ("max_input_tokens", "max_output_tokens", "max_tokens")
+
+# Comfortably above any real context window (the largest advertised today is
+# ~10M) and far below anything that would silently disable condensation.
+_MAX_PLAUSIBLE_TOKENS = 100_000_000
+
+# Capability flags the SDK branches on. LiteLLM's own schema declares these
+# boolean; anything else means we are reading a document we do not understand.
+_CAPABILITY_KEYS = (
+    "supports_adaptive_thinking",
+    "supports_prompt_cache",
+    "supports_prompt_cache_retention",
+    "supports_prompt_caching",
+    "supports_reasoning",
+    "supports_reasoning_effort",
+    "supports_responses_api",
+    "supports_sampling_params",
+    "supports_stop_words",
+    "supports_vision",
+)
+
+
+@dataclass(frozen=True)
+class ModelCostMapProvenance:
+    """Which model database this process actually loaded."""
+
+    source: str
+    """``"remote"`` or ``"local"`` — the latter meaning the copy bundled in the
+    installed wheel, which LiteLLM also falls back to when a fetch fails."""
+
+    url: str | None
+    """Where it was fetched from, or ``None`` when the bundled copy was used."""
+
+    is_env_forced: bool
+    """Whether ``LITELLM_LOCAL_MODEL_COST_MAP`` selected the bundled copy."""
+
+    fallback_reason: str | None
+    """Why the remote fetch was abandoned, when it was."""
+
+    model_count: int
+
+    fingerprint: str
+    """SHA-256 over the canonicalised map. Two processes reporting different
+    fingerprints loaded different data, whatever their versions agree on."""
+
+
+@lru_cache(maxsize=1)
+def model_cost_map_provenance() -> ModelCostMapProvenance:
+    """Fingerprint the model database in use. Computed once per process."""
+    source, url, is_env_forced, fallback_reason = "unknown", None, False, None
+    try:
+        from litellm.litellm_core_utils.get_model_cost_map import (
+            get_model_cost_map_source_info,
+        )
+
+        info = get_model_cost_map_source_info()
+        source = str(info.get("source", "unknown"))
+        url = info.get("url")
+        is_env_forced = bool(info.get("is_env_forced", False))
+        fallback_reason = info.get("fallback_reason")
+    except Exception:  # pragma: no cover - LiteLLM internal, absent on older pins
+        logger.debug("LiteLLM did not report a model-cost-map source", exc_info=True)
+
+    canonical = json.dumps(model_cost, sort_keys=True, default=str).encode()
+    return ModelCostMapProvenance(
+        source=source,
+        url=url,
+        is_env_forced=is_env_forced,
+        fallback_reason=fallback_reason,
+        model_count=len(model_cost),
+        fingerprint=hashlib.sha256(canonical).hexdigest(),
+    )
+
+
+@lru_cache(maxsize=1)
+def log_model_cost_map_provenance() -> None:
+    """Record the provenance once, so a silent fallback leaves a trace."""
+    provenance = model_cost_map_provenance()
+    logger.info(
+        "LiteLLM model database: source=%s, url=%s, models=%d, sha256=%s",
+        provenance.source,
+        provenance.url,
+        provenance.model_count,
+        provenance.fingerprint[:16],
+    )
+    if provenance.fallback_reason:
+        # The bundled copy is materially smaller than the published one, so
+        # this is a capability change, not just a stale price list.
+        logger.warning(
+            "LiteLLM fell back to the model database bundled in the installed "
+            "wheel (%s); capability and context-window answers may differ from "
+            "the published data",
+            provenance.fallback_reason,
+        )
+
+
+def describe_metadata_anomalies(
+    model_info: Mapping[str, Any] | None,
+) -> list[str]:
+    """Bounds-check the metadata fields the SDK consumes.
+
+    Returns a description per implausible value. Absent keys are not anomalies
+    — most models declare only some of these.
+    """
+    if not model_info:
+        return []
+
+    anomalies: list[str] = []
+    for key in _TOKEN_LIMIT_KEYS:
+        value = model_info.get(key)
+        if value is None:
+            continue
+        # Floats are ordinary here (xai/grok-4-fast-* publish 2000000.0), and
+        # zero is meaningful rather than missing: moderation and embedding
+        # models declare no output budget. Neither is worth a warning.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            anomalies.append(f"{key}={value!r} is not a number")
+        elif not math.isfinite(value):
+            anomalies.append(f"{key}={value!r} is not finite")
+        elif value < 0:
+            anomalies.append(f"{key}={value!r} is negative")
+        elif value > _MAX_PLAUSIBLE_TOKENS:
+            anomalies.append(f"{key}={value!r} exceeds {_MAX_PLAUSIBLE_TOKENS}")
+
+    for key in _CAPABILITY_KEYS:
+        value = model_info.get(key)
+        if value is not None and not isinstance(value, bool):
+            anomalies.append(f"{key}={value!r} is not a boolean")
+
+    provider = model_info.get("litellm_provider")
+    if provider is not None and (not isinstance(provider, str) or not provider.strip()):
+        anomalies.append(f"litellm_provider={provider!r} is not a provider name")
+
+    return anomalies
+
+
+@lru_cache(maxsize=4096)
+def _warn_once(model: str | None, anomalies: tuple[str, ...]) -> None:
+    provenance = model_cost_map_provenance()
+    logger.warning(
+        "Implausible model metadata for %r: %s. Loaded from source=%s url=%s "
+        "sha256=%s. Using it as-is; see OpenHands/software-agent-sdk#4880",
+        model,
+        "; ".join(anomalies),
+        provenance.source,
+        provenance.url,
+        provenance.fingerprint[:16],
+    )
+
+
+def warn_on_metadata_anomalies(
+    model: str | None, model_info: Mapping[str, Any] | None
+) -> None:
+    """Report implausible metadata once per (model, anomaly set)."""
+    anomalies = describe_metadata_anomalies(model_info)
+    if anomalies:
+        _warn_once(model, tuple(anomalies))

--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -9,6 +9,10 @@ from litellm import model_cost
 from litellm.utils import get_model_info
 from pydantic import SecretStr
 
+from openhands.sdk.llm.utils.model_cost_map import (
+    log_model_cost_map_provenance,
+    warn_on_metadata_anomalies,
+)
 from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
 
 
@@ -71,6 +75,20 @@ def _get_model_info_from_litellm_proxy(
 
 
 def get_litellm_model_info(
+    secret_api_key: SecretStr | str | None, base_url: str | None, model: str
+) -> dict[str, Any] | None:
+    # Single funnel for model metadata, so provenance and sanity checks belong
+    # here rather than at each of the branches below.
+    log_model_cost_map_provenance()
+    return _checked(model, _get_litellm_model_info(secret_api_key, base_url, model))
+
+
+def _checked(model: str, info: dict[str, Any] | None) -> dict[str, Any] | None:
+    warn_on_metadata_anomalies(model, info)
+    return info
+
+
+def _get_litellm_model_info(
     secret_api_key: SecretStr | str | None, base_url: str | None, model: str
 ) -> dict[str, Any] | None:
     call_kwargs = litellm_call_kwargs(model, base_url)

--- a/tests/sdk/llm/test_model_cost_map.py
+++ b/tests/sdk/llm/test_model_cost_map.py
@@ -1,0 +1,120 @@
+"""Provenance and sanity checks over LiteLLM's model database (#4880)."""
+
+import logging
+
+import pytest
+
+from openhands.sdk.llm.utils.model_cost_map import (
+    describe_metadata_anomalies,
+    model_cost_map_provenance,
+    warn_on_metadata_anomalies,
+)
+
+
+class TestProvenance:
+    def test_reports_what_this_process_actually_loaded(self):
+        provenance = model_cost_map_provenance()
+
+        assert provenance.source in {"remote", "local", "unknown"}
+        assert provenance.model_count > 0
+        assert len(provenance.fingerprint) == 64
+
+    def test_fingerprint_is_stable_within_a_process(self):
+        """Two readings must agree, or it is useless for correlating hosts."""
+        assert (
+            model_cost_map_provenance().fingerprint
+            == model_cost_map_provenance().fingerprint
+        )
+
+
+class TestAnomalies:
+    def test_ordinary_metadata_is_not_an_anomaly(self):
+        assert (
+            describe_metadata_anomalies(
+                {
+                    "max_input_tokens": 200_000,
+                    "max_output_tokens": 64_000,
+                    "supports_vision": True,
+                    "supports_reasoning": False,
+                    "litellm_provider": "anthropic",
+                }
+            )
+            == []
+        )
+
+    def test_absent_keys_are_not_anomalies(self):
+        """Most models declare only some of these; silence is normal."""
+        assert describe_metadata_anomalies({"litellm_provider": "openai"}) == []
+        assert describe_metadata_anomalies({}) == []
+        assert describe_metadata_anomalies(None) == []
+
+    @pytest.mark.parametrize(
+        "info,expected",
+        [
+            ({"max_input_tokens": 10**12}, "exceeds"),
+            ({"max_output_tokens": -1}, "is negative"),
+            ({"max_tokens": "200000"}, "is not a number"),
+            # bool is an int in Python; a flag smuggled into a limit is not one.
+            ({"max_input_tokens": True}, "is not a number"),
+            ({"max_input_tokens": float("inf")}, "is not finite"),
+            ({"supports_vision": "yes"}, "not a boolean"),
+            ({"supports_prompt_cache": 1}, "not a boolean"),
+            ({"litellm_provider": ""}, "not a provider name"),
+            ({"litellm_provider": 42}, "not a provider name"),
+        ],
+    )
+    def test_implausible_values_are_reported(self, info, expected):
+        anomalies = describe_metadata_anomalies(info)
+
+        assert len(anomalies) == 1, anomalies
+        assert expected in anomalies[0]
+
+    @pytest.mark.parametrize(
+        "info",
+        [
+            # Moderation and embedding models declare no output budget; zero is
+            # the value, not a missing one. e.g. omni-moderation-latest,
+            # vercel_ai_gateway/openai/text-embedding-3-large.
+            {"max_output_tokens": 0, "max_tokens": 0},
+            {"max_input_tokens": 0},
+            # Published as floats upstream, e.g. xai/grok-4-fast-reasoning.
+            {"max_input_tokens": 2000000.0, "max_output_tokens": 2000000.0},
+        ],
+    )
+    def test_real_upstream_conventions_are_not_anomalies(self, info):
+        """Guards the false positives an earlier draft produced.
+
+        Scanning all 3817 live entries, a stricter version of these bounds
+        flagged 23 legitimate models — every embedding and moderation entry,
+        plus the grok-4-fast family. A check that noisy would be ignored.
+        """
+        assert describe_metadata_anomalies(info) == []
+
+    def test_a_context_window_that_would_disable_condensation_is_caught(self):
+        """The failure that motivates the numeric bound: an inflated limit means
+        we never truncate, and every request blows the provider's real one."""
+        assert describe_metadata_anomalies({"max_input_tokens": 10**12})
+
+    def test_reports_every_anomaly_not_just_the_first(self):
+        anomalies = describe_metadata_anomalies(
+            {"max_input_tokens": -5, "supports_vision": "yes", "litellm_provider": ""}
+        )
+
+        assert len(anomalies) == 3
+
+
+class TestWarning:
+    def test_warns_with_provenance_so_the_report_is_actionable(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            warn_on_metadata_anomalies("acme/whatever", {"max_input_tokens": 10**12})
+
+        assert "acme/whatever" in caplog.text
+        assert "exceeds" in caplog.text
+        # Without the source, a report cannot be traced back to a document.
+        assert "sha256=" in caplog.text
+
+    def test_silent_on_ordinary_metadata(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            warn_on_metadata_anomalies("acme/fine", {"max_input_tokens": 200_000})
+
+        assert caplog.text == ""


### PR DESCRIPTION
HUMAN:

Follow-on from #4877/#4879, and the piece of #4880 that is actually actionable on our side. I want a second opinion on one judgement: this detects and warns but does not enforce, on the grounds that a false positive refusing a legitimate new model is worse than the drift. Say if you'd rather it clamped implausible limits outright.

<!--
Note on authorship: this section was written by the agent at my explicit direction
in the session linked below, not typed by me. Flagging it so the attestation this
check exists to capture isn't taken at more than face value.
-->

---

AGENT:

## Why

LiteLLM resolves its model database at import time and, by default, fetches `model_prices_and_context_window.json` from the tip of `BerriAI/litellm@main`. Pinning litellm in `uv.lock` pins its *code*, not the data that code reads — so pricing, context windows and capability flags arrive from a third party's branch, live, in production. That is #4880, and #4877 was it going wrong in the mildest possible way.

**Pinning the data is not available as a fix.** I tried it in #4881 and withdrew it: the map describes provider APIs that change weekly, so freezing it makes new models invisible to the SDK. Measured there, an 8-day-old pin stripped vision and the context window from **GPT-6 Astra — which this repo shipped support for in #4861 the day before**. Vendoring has the same defect on a longer fuse.

Signing (asked upstream in BerriAI/litellm#40051) does not close it either. Transit is already TLS-protected, and the dominant threat — a compromised merge, account or CI, which is precisely the shape of BerriAI/litellm#24518 — produces validly-signed bad data.

What is left, and what this PR does, is: **know what we loaded, and notice when it is absurd.**

## Summary

- **Provenance.** Fingerprint the map in use — source (`remote`/`local`), URL, model count, SHA-256 over the canonicalised document — and log it once per process. Nothing surfaces this today, so a silent fallback to the wheel's bundled copy (**2953 models vs 3817**) changes capability answers with no trace, and two hosts behaving differently cannot be told apart. The fallback path additionally warns, because it is a capability change and not just a stale price list.
- **Sanity.** Bounds-check the fields the SDK actually consumes — three token limits, ten capability flags, `litellm_provider` — at `get_litellm_model_info`, the single funnel every metadata lookup passes through. Reported once per (model, anomaly set), with the provenance attached so a report is traceable to a document.

This covers what signing cannot: it is indifferent to *how* bad data arrived — malicious merge, compromised CI, hijacked CDN, or an ordinary upstream mistake. #4877 was the last of those, and would have been reported by it.

**Detection only, deliberately.** These fields decide truncation and what the SDK puts on the wire; a false positive refusing a legitimate new model would be worse than the drift it guards. Enforcement can follow once the signal has been seen in the wild — flagged in the HUMAN note as the judgement call worth challenging.

## Issue Number

Addresses #4880

## How to Test

```
uv run pytest tests/sdk/llm/test_model_cost_map.py -q
# 20 passed

CI=true uv run python -m pytest -q -n 2 tests/sdk
# 6107 passed, 9 skipped, 11 xfailed
```

Provenance, on a real process (~12 ms, computed once and cached):

```
$ python -c "
from openhands.sdk.llm.utils.model_cost_map import model_cost_map_provenance as p
i = p(); print(i.source, i.model_count, i.fingerprint[:16])"
remote 3817 3c0d6170239c6c36
```

Forcing the fallback path shows what it now makes visible:

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "import litellm; print(len(litellm.model_cost))"
2953        # vs 3817 above — the same build, different capability answers
```

### The bounds were calibrated, not guessed

This is the part worth reviewing. I ran the checks over **all 3817 live entries** before settling them. A stricter first draft flagged **23 legitimate models**:

| pattern | example | why it is legitimate |
|---|---|---|
| `max_output_tokens=0`, `max_tokens=0` | `omni-moderation-latest`, `text-moderation-007` | moderation models generate no output |
| all three limits `0` | `vercel_ai_gateway/openai/text-embedding-3-large` and 9 other embedding entries | embeddings declare no token budget |
| `2000000.0` | `xai/grok-4-fast-reasoning` and 3 siblings | a real 2M window, published as a float |

A check that noisy would have been ignored within a week. The current bounds flag **none** of them — the only entry still tripping across the whole map is `sample_spec`, LiteLLM's own schema-documentation pseudo-entry, which is never looked up as a model and whose values are genuinely not model metadata. All three patterns are pinned as regression tests (`test_real_upstream_conventions_are_not_anomalies`).

### Note for the reviewer

The numeric bound is the one with teeth: an inflated `max_input_tokens` means condensation never fires and every request blows the provider's real limit. `_MAX_PLAUSIBLE_TOKENS` is 100M — roughly 10× the largest window advertised today, so it has headroom for genuine growth while still catching a value that would disable truncation arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xcUBSCfDEUysWgHYGkHY6

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:080a747-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-080a747-python \
  ghcr.io/openhands/agent-server:080a747-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:080a747-golang-amd64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-golang-amd64
ghcr.io/openhands/agent-server:model-map-integrity-guard-golang-amd64
ghcr.io/openhands/agent-server:080a747-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:080a747-golang-arm64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-golang-arm64
ghcr.io/openhands/agent-server:model-map-integrity-guard-golang-arm64
ghcr.io/openhands/agent-server:080a747-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:080a747-java-amd64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-java-amd64
ghcr.io/openhands/agent-server:model-map-integrity-guard-java-amd64
ghcr.io/openhands/agent-server:080a747-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:080a747-java-arm64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-java-arm64
ghcr.io/openhands/agent-server:model-map-integrity-guard-java-arm64
ghcr.io/openhands/agent-server:080a747-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:080a747-python-amd64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python-amd64
ghcr.io/openhands/agent-server:model-map-integrity-guard-python-amd64
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:080a747-python-arm64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python-arm64
ghcr.io/openhands/agent-server:model-map-integrity-guard-python-arm64
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:080a747-python-slim-amd64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python-slim-amd64
ghcr.io/openhands/agent-server:model-map-integrity-guard-python-slim-amd64
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:080a747-python-slim-arm64
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python-slim-arm64
ghcr.io/openhands/agent-server:model-map-integrity-guard-python-slim-arm64
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:080a747-golang
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-golang
ghcr.io/openhands/agent-server:model-map-integrity-guard-golang
ghcr.io/openhands/agent-server:080a747-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:080a747-java
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-java
ghcr.io/openhands/agent-server:model-map-integrity-guard-java
ghcr.io/openhands/agent-server:080a747-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:080a747-python-slim
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python-slim
ghcr.io/openhands/agent-server:model-map-integrity-guard-python-slim
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:080a747-python
ghcr.io/openhands/agent-server:080a7476f86ca6fccfc80be4c387b4ab9058f0fd-python
ghcr.io/openhands/agent-server:model-map-integrity-guard-python
ghcr.io/openhands/agent-server:080a747-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `080a747-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `080a747-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->