### PR TITLE
fix(ci): centralize release publication dispatches

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -4,12 +4,13 @@ This document describes the automated release workflows for the OpenHands Softwa
 
 ## Overview
 
-The release process has been automated with three GitHub Actions workflows:
+The release process uses `create-release.yml` as its sole orchestrator:
 
-1. **prepare-release.yml** - Prepares a release PR with version updates
-2. **pypi-release.yml** - Automatically publishes packages to PyPI when a release is created
-3. **release-binaries.yml** - Builds and smoke-tests multi-arch agent-server binaries
-   on releases and main pushes; release runs also attach binaries to the release
+1. **prepare-release.yml** prepares a release PR with synchronized package versions.
+2. Merging the release PR runs **create-release.yml**, which creates the GitHub release and explicitly dispatches every publisher against its immutable tag.
+3. The dispatched workflows publish Python packages, the TypeScript client, agent-server images, and release binaries.
+
+Publisher workflows do not listen for GitHub release events. This avoids relying on events created with `GITHUB_TOKEN`, which GitHub does not use to trigger downstream workflows.
 
 ## How to Create a New Release
 
@@ -38,30 +39,21 @@ The created PR will include a checklist. Complete the following:
 - [ ] Confirm any merged `release-note-required` PRs are accurately called out in the final release notes
 - [ ] Review and approve the PR
 
-### Step 3: Create the GitHub Release
+### Step 3: Merge the Release PR
 
-1. Go to [Releases](https://github.com/OpenHands/software-agent-sdk/releases/new)
-2. Click **"Draft a new release"**
-3. Configure the release:
-   - **Tag**: `vX.Y.Z` (must match the version)
-   - **Branch**: `rel-X.Y.Z` (the branch created by the workflow)
-   - **Previous tag**: Select the previous release version
-4. Click **"Generate release notes"** to auto-generate the changelog
-5. Review and edit the release notes as needed
-6. Click **"Publish release"**
+Merging the release PR runs **create-release.yml**, which:
 
-### Step 4: PyPI Publication (Automated)
+- creates tag and GitHub release `vX.Y.Z` at the merge commit;
+- explicitly dispatches PyPI publication with version `X.Y.Z`;
+- explicitly dispatches TypeScript publication to npm and GitHub Packages with version `X.Y.Z`;
+- explicitly dispatches versioned agent-server image builds against tag `vX.Y.Z`;
+- explicitly dispatches release binaries against tag `vX.Y.Z`.
 
-Once the release is published, the **pypi-release.yml** workflow will automatically:
-- ✅ Build all packages (openhands-sdk, openhands-tools, openhands-workspace, openhands-agent-server)
-- ✅ Publish them to PyPI
+Each publisher validates that its checked-out package version matches the requested version before publishing. Monitor the dispatched workflows in the [Actions tab](https://github.com/OpenHands/software-agent-sdk/actions).
 
-You can monitor the progress in the [Actions tab](https://github.com/OpenHands/software-agent-sdk/actions/workflows/pypi-release.yml).
+### Step 4: Release Binaries + Docker Smoke Test (Automated)
 
-### Step 4b: Release Binaries + Docker Smoke Test (Automated)
-
-In parallel with the PyPI workflow, **release-binaries.yml** also fires on `release: published`.
-It also runs on every push to `main` as ongoing smoke coverage. It:
+**release-binaries.yml** is explicitly dispatched for releases. It also runs on every push to `main` as ongoing smoke coverage. It:
 
 - ✅ Builds the agent-server PyInstaller binary on a 5-runner matrix
   (linux x86_64/arm64, macOS x86_64/arm64, windows x86_64) and smoke-tests each
@@ -124,22 +116,27 @@ These PRs will:
 - [ ] Review and merge the auto-created version bump PRs in OpenHands-CLI, automation, and the TypeScript client (merging the automation PR triggers its release-please release PR; merge that too to publish the pinned `openhands-automation`)
 - [ ] Announce the release
 
-## Manual PyPI Release (If Needed)
+## Manual Publication Recovery
 
-If you need to manually trigger the PyPI release workflow:
+To retry a registry publisher, run the latest workflow from `main` and pass the release version without the leading `v`. The workflow checks out the corresponding immutable `vX.Y.Z` tag and validates its package version before publishing. For example, recover `v1.45.0` with version input `1.45.0`; never publish package contents from a moving branch.
 
-1. Go to the [Actions tab](https://github.com/OpenHands/software-agent-sdk/actions)
-2. Select **"Publish all OpenHands packages (uv)"** workflow
-3. Click **"Run workflow"**
-4. Select the branch/tag you want to publish from
-5. Click **"Run workflow"**
+The independently retryable publisher workflows are:
+
+- **Publish all OpenHands packages (uv)** for PyPI;
+- **Publish TypeScript client to npm**;
+- **Publish TypeScript client to GitHub Packages**;
+- **Agent Server** for versioned container images;
+- **Publish agent-server release artifacts** for binaries and `openapi.json`.
 
 ## Workflow Files
 
 - `.github/workflows/prepare-release.yml` - Automated release preparation
-- `.github/workflows/pypi-release.yml` - PyPI package publication
-- `.github/workflows/release-binaries.yml` - Multi-arch binary publishing and
-  docker manifest smoke test on releases and main pushes
+- `.github/workflows/create-release.yml` - GitHub release creation and sole publisher orchestrator
+- `.github/workflows/pypi-release.yml` - Dispatch-only PyPI package publication
+- `.github/workflows/typescript-client-npm-publish.yml` - Dispatch-only npm publication
+- `.github/workflows/typescript-client-github-packages-publish.yml` - Dispatch-only GitHub Packages publication
+- `.github/workflows/server.yml` - Agent-server builds for PRs, main, and explicit release dispatches
+- `.github/workflows/release-binaries.yml` - Multi-arch binary publishing and Docker manifest smoke tests on main and explicit release dispatches
 
 ## Troubleshooting
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,9 +1,8 @@
 ---
 name: Create GitHub Release
 
-# Automatically create a GitHub release when a release PR is merged into main.
-# This bridges the gap between merging the release PR and the pypi-release
-# workflow (which triggers on release published).
+# Create a GitHub release when a release PR merges, then explicitly dispatch
+# every publisher against the immutable release tag.
 
 on:
     pull_request:
@@ -176,9 +175,37 @@ jobs:
               run: |
                   gh workflow run pypi-release.yml \
                     --repo "${{ github.repository }}" \
-                    --ref "v${VERSION}"
+                    --ref main \
+                    -f "version=${VERSION}"
 
                   echo "🚀 Dispatched pypi-release.yml for v${VERSION}"
+
+            - name: Dispatch TypeScript npm release workflow
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run typescript-client-npm-publish.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref main \
+                    -f "version=${VERSION}"
+
+                  echo "🚀 Dispatched TypeScript npm publish for v${VERSION}"
+            - name: Dispatch TypeScript GitHub Packages release workflow
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run typescript-client-github-packages-publish.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref main \
+                    -f "version=${VERSION}"
+
+                  echo "🚀 Dispatched TypeScript GitHub Packages publish for v${VERSION}"
+
+
 
             - name: Dispatch Agent Server image build
               # server.yml builds versioned Docker images (e.g. 1.21.0-python) when
@@ -196,8 +223,6 @@ jobs:
                   echo "🐳 Dispatched server.yml image build for v${VERSION}"
 
             - name: Dispatch release binaries workflow
-              # Same GITHUB_TOKEN limitation applies to release-binaries.yml
-              # which triggers on release:published events.
               if: steps.check.outputs.exists == 'false'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -220,5 +245,6 @@ jobs:
                   echo "- **Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "" >> "$GITHUB_STEP_SUMMARY"
                   echo "The \`pypi-release.yml\` workflow was dispatched to publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"
+                  echo "The TypeScript publishers were dispatched for npm and GitHub Packages." >> "$GITHUB_STEP_SUMMARY"
                   echo "The \`server.yml\` workflow was dispatched to build versioned Docker images." >> "$GITHUB_STEP_SUMMARY"
                   echo "The \`release-binaries.yml\` workflow was dispatched to build and attach release binaries." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -111,8 +111,8 @@ jobs:
                   ### What happens on merge
                   When this PR is merged, the `create-release.yml` workflow will automatically:
                   1. Create a GitHub release with tag `v{version}` and auto-generated notes, plus an explicit preamble for merged `release-note-required` PRs
-                  2. Trigger `pypi-release.yml` to publish all packages to PyPI
-                  3. Trigger `version-bump-prs.yml` to create downstream version bump PRs
+                  2. Explicitly dispatch PyPI, npm, GitHub Packages, agent-server image, and binary publishers against tag `v{version}`
+                  3. Trigger `version-bump-prs.yml` after successful PyPI publication
                   """
                   )
                   PY

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,21 +2,20 @@
 name: Publish all OpenHands packages (uv)
 
 on:
-  # Run manually
     workflow_dispatch:
-  # Run automatically when a release is published
-    release:
-        types: [published]
+        inputs:
+            version:
+                description: Version to publish without a leading v
+                required: true
+                type: string
+
+concurrency:
+    group: pypi-release-${{ inputs.version }}
+    cancel-in-progress: false
+
 
 jobs:
     publish:
-        # Skip PyPI publishing for pre-releases (e.g., release candidates).
-        # Pre-releases can still be created on GitHub for testing without
-        # pushing packages to PyPI.  Manual workflow_dispatch always runs.
-        if: >
-            github.event_name == 'workflow_dispatch' ||
-            (!github.event.release.prerelease &&
-             startsWith(github.event.release.tag_name, 'v'))
         runs-on: ubuntu-24.04
         permissions:
             actions: write
@@ -24,23 +23,23 @@ jobs:
         outputs:
             version: ${{ steps.extract_version.outputs.version }}
         steps:
-            - name: Checkout
+            - name: Check out release tag
               uses: actions/checkout@v7
+              with:
+                  ref: v${{ inputs.version }}
 
-            - name: Extract version from release tag
+            - name: Validate release version
               id: extract_version
               env:
-                  GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+                  VERSION: ${{ inputs.version }}
               run: |
-                  # Get version from release tag (e.g., v1.2.3 -> 1.2.3)
-                  if [[ "${{ github.event_name }}" == "release" ]]; then
-                    VERSION="$GITHUB_EVENT_RELEASE_TAG_NAME"
-                    VERSION="${VERSION#v}"  # Remove 'v' prefix if present
-                  else
-                    # For manual dispatch, extract from pyproject.toml
-                    VERSION=$(grep -m1 '^version = ' openhands-sdk/pyproject.toml | cut -d'"' -f2)
+                  set -euo pipefail
+                  actual_version=$(grep -m1 '^version = ' openhands-sdk/pyproject.toml | cut -d'"' -f2)
+                  if [ "$actual_version" != "$VERSION" ]; then
+                    echo "❌ SDK version $actual_version does not match requested version $VERSION"
+                    exit 1
                   fi
-                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                   echo "📦 Version: $VERSION"
 
             - name: Install uv
@@ -52,6 +51,7 @@ jobs:
             - name: Build and publish all packages
               env:
                   UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN_OPENHANDS }}
+                  VERSION: ${{ steps.extract_version.outputs.version }}
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,10 +1,10 @@
 ---
 name: Publish agent-server release artifacts
 
-# On release published or push to main:
+# On push to main or explicit release dispatch:
 #   1. Build the agent-server PyInstaller binary on Linux + macOS for both
 #      x86_64 and arm64, smoke-test it, and upload workflow artifacts.
-#   2. On release events/manual runs, attach those binaries plus a combined
+#   2. On explicit release dispatches, attach those binaries plus a combined
 #      SHA256SUMS file to the GitHub release.
 #   3. Smoke-test the multi-arch Docker images pushed by `server.yml`,
 #      verifying that every published variant has a manifest covering both
@@ -14,8 +14,6 @@ name: Publish agent-server release artifacts
 on:
     push:
         branches: [main]
-    release:
-        types: [published]
     workflow_dispatch:
         inputs:
             release_tag:
@@ -29,9 +27,6 @@ permissions:
 
 jobs:
     resolve-tag:
-        if: >-
-            github.event_name != 'release' ||
-            startsWith(github.event.release.tag_name, 'v')
         name: Resolve artifact and image tag
         runs-on: ubuntu-24.04
         outputs:
@@ -42,14 +37,10 @@ jobs:
             - id: resolve
               shell: bash
               env:
-                  GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
                   INPUTS_RELEASE_TAG: ${{ inputs.release_tag }}
               run: |
                   set -euo pipefail
-                  if [[ "${{ github.event_name }}" == "release" ]]; then
-                      TAG="$GITHUB_EVENT_RELEASE_TAG_NAME"
-                      VERSION="${TAG#v}"
-                  elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                       TAG="$INPUTS_RELEASE_TAG"
                       VERSION="${TAG#v}"
                   elif [[ "${{ github.event_name }}" == "push" ]]; then

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -4,8 +4,6 @@ name: Agent Server
 on:
     push:
         branches: [main]
-        tags:
-            - '*'  # Trigger on any tag (e.g., 1.0.0, 1.0.0a5, build-docker)
     pull_request:
         branches: [main]
     workflow_dispatch:

--- a/.github/workflows/typescript-client-github-packages-publish.yml
+++ b/.github/workflows/typescript-client-github-packages-publish.yml
@@ -2,14 +2,17 @@
 name: Publish TypeScript client to GitHub Packages
 
 on:
-    release:
-        types: [published]
     workflow_dispatch:
         inputs:
             version:
                 description: Version to publish without a leading v
                 required: true
                 type: string
+
+concurrency:
+    group: typescript-client-github-packages-publish-${{ inputs.version }}
+    cancel-in-progress: false
+
 
 permissions:
     contents: read
@@ -21,14 +24,12 @@ defaults:
 
 jobs:
     publish:
-        if: >-
-            github.event_name == 'workflow_dispatch' ||
-            (!github.event.release.prerelease &&
-             startsWith(github.event.release.tag_name, 'v'))
         runs-on: ubuntu-latest
         steps:
-            - name: Check out repository
+            - name: Check out release tag
               uses: actions/checkout@v4
+              with:
+                  ref: v${{ inputs.version }}
 
             - name: Set up Node.js for GitHub Packages
               uses: actions/setup-node@v6
@@ -45,17 +46,15 @@ jobs:
             - name: Run tests
               run: npm test
 
-            - name: Set package version
+            - name: Validate package version
               env:
-                  DISPATCH_VERSION: ${{ inputs.version }}
-                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  VERSION: ${{ inputs.version }}
               run: |
-                  if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-                    target_version="$DISPATCH_VERSION"
-                  else
-                    target_version="${RELEASE_TAG#v}"
+                  current_version=$(node -p "require('./package.json').version")
+                  if [ "$current_version" != "$VERSION" ]; then
+                    echo "Package version $current_version does not match requested version $VERSION"
+                    exit 1
                   fi
-                  npm version "$target_version" --no-git-tag-version --allow-same-version
 
             - name: Build package
               run: npm run build

--- a/.github/workflows/typescript-client-npm-publish.yml
+++ b/.github/workflows/typescript-client-npm-publish.yml
@@ -2,8 +2,6 @@
 name: Publish TypeScript client to npm
 
 on:
-    release:
-        types: [published]
     workflow_dispatch:
         inputs:
             version:
@@ -12,7 +10,7 @@ on:
                 type: string
 
 concurrency:
-    group: typescript-client-npm-publish-${{ github.ref }}
+    group: typescript-client-npm-publish-${{ inputs.version }}
     cancel-in-progress: false
 
 permissions:
@@ -25,15 +23,13 @@ defaults:
 
 jobs:
     publish:
-        if: >-
-            github.event_name == 'workflow_dispatch' ||
-            (!github.event.release.prerelease &&
-             startsWith(github.event.release.tag_name, 'v'))
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Check out repository
+            - name: Check out release tag
               uses: actions/checkout@v4
+              with:
+                  ref: v${{ inputs.version }}
 
             - name: Set up Node.js for npm trusted publishing
               uses: actions/setup-node@v6
@@ -52,17 +48,15 @@ jobs:
             - name: Run tests
               run: npm test
 
-            - name: Set package version
+            - name: Validate package version
               env:
-                  DISPATCH_VERSION: ${{ inputs.version }}
-                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  VERSION: ${{ inputs.version }}
               run: |
-                  if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-                    target_version="$DISPATCH_VERSION"
-                  else
-                    target_version="${RELEASE_TAG#v}"
+                  current_version=$(node -p "require('./package.json').version")
+                  if [ "$current_version" != "$VERSION" ]; then
+                    echo "Package version $current_version does not match requested version $VERSION"
+                    exit 1
                   fi
-                  npm version "$target_version" --no-git-tag-version --allow-same-version
 
             - name: Build package
               run: npm run build


### PR DESCRIPTION
HUMAN:

I checked and LGTM, will test on main.

AGENT:

## Why

The release process mixed explicit workflow dispatches with `release: published` listeners. Releases created with `GITHUB_TOKEN` suppress those downstream events, which skipped both TypeScript publishers for v1.45.0. The PyPI workflow also referenced a version that was not passed between steps.

## What changed

- Make `create-release.yml` the sole release-publication orchestrator.
- Explicitly dispatch PyPI, npm, GitHub Packages, server-image, and binary workflows.
- Make registry publishers dispatch-only with required version inputs and per-version concurrency.
- Run current publisher definitions from `main`, while explicitly checking out and validating immutable `vX.Y.Z` package sources.
- Remove redundant release/tag publication triggers from server and binary workflows while retaining PR/main validation builds.
- Update release and recovery documentation to describe the single orchestration path.

## How to Test

- Workflow YAML formatting passed via pre-commit.
- No release publisher retains a `release: published` trigger.
- All five publication/build workflows are explicitly dispatched by `create-release.yml`.
- Registry publishers check out `v${inputs.version}` and validate package versions before publishing.
- Python failure reproduced in runs 34078563501 and 34078890818.
- TypeScript npm recovery run 34078808973 succeeded; npm reports 1.45.0 as latest.
- After merge, dispatch PyPI and GitHub Packages from `main` with version `1.45.0` and verify both registries.

## Issue Number

Fixes #4887

_This PR description was generated by an AI agent (OpenHands) on behalf of Graham Neubig._

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5c6d644-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5c6d644-python \
  ghcr.io/openhands/agent-server:5c6d644-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5c6d644-golang-amd64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-golang-amd64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-golang-amd64
ghcr.io/openhands/agent-server:5c6d644-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5c6d644-golang-arm64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-golang-arm64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-golang-arm64
ghcr.io/openhands/agent-server:5c6d644-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5c6d644-java-amd64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-java-amd64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-java-amd64
ghcr.io/openhands/agent-server:5c6d644-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5c6d644-java-arm64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-java-arm64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-java-arm64
ghcr.io/openhands/agent-server:5c6d644-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5c6d644-python-amd64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python-amd64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python-amd64
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5c6d644-python-arm64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python-arm64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python-arm64
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5c6d644-python-slim-amd64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python-slim-amd64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python-slim-amd64
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:5c6d644-python-slim-arm64
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python-slim-arm64
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python-slim-arm64
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:5c6d644-golang
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-golang
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-golang
ghcr.io/openhands/agent-server:5c6d644-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5c6d644-java
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-java
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-java
ghcr.io/openhands/agent-server:5c6d644-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5c6d644-python-slim
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python-slim
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python-slim
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:5c6d644-python
ghcr.io/openhands/agent-server:5c6d644a031b52131a80c33307738e79c1b311a0-python
ghcr.io/openhands/agent-server:fix-release-publish-dispatch-python
ghcr.io/openhands/agent-server:5c6d644-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5c6d644-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5c6d644-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->