### PR TITLE
refactor(agent-server): derive ConversationInfo from source schemas

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -458,10 +458,6 @@ def _compose_conversation_info(
     state: ConversationState,
     sub_conversation_ids: list[UUID] | None = None,
 ) -> ConversationInfo:
-    # Use mode='json' so SecretStr in nested structures (e.g. LookupSecret.headers,
-    # agent.agent_context.secrets) serialize to strings. Without it, validation
-    # fails because ConversationInfo expects dict[str, str] but receives SecretStr.
-    #
     # ACP model state is lifted onto top-level ConversationInfo fields because
     # the agent holds it in PrivateAttrs (ACPAgent is frozen) which don't survive
     # ``model_dump``. ``getattr`` keeps non-ACP agents a no-op. We read the live
@@ -514,21 +510,13 @@ def _compose_conversation_info(
     supports_runtime_model_switch = bool(
         agent_state.get("acp_supports_runtime_model_switch", False)
     )
-    return ConversationInfo(
-        **state.model_dump(mode="json"),
-        title=stored.title,
-        metrics=stored.metrics,
-        created_at=stored.created_at,
-        updated_at=stored.updated_at,
-        forked_from_conversation_id=stored.forked_from_conversation_id,
-        forked_from_event_id=stored.forked_from_event_id,
-        parent_conversation_id=stored.parent_conversation_id,
-        sub_conversation_ids=sub_conversation_ids or [],
+    return ConversationInfo.from_sources(
+        state,
+        stored,
         current_model_id=current_model_id,
         available_models=available_models,
         supports_runtime_model_switch=supports_runtime_model_switch,
-        client_tools=stored.client_tools,
-        launched_agent_profile=stored.launched_agent_profile,
+        sub_conversation_ids=sub_conversation_ids or [],
     )
 
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -601,23 +601,12 @@ def _stored_metadata_signature(stored: StoredConversation) -> int:
 
     ``cached_info`` is keyed by ``base_state.json``, but also embeds
     ``StoredConversation`` metadata that can change independently via
-    ``meta.json`` (notably auto-title). Fingerprint exactly the fields
-    ``_compose_conversation_info`` lifts from ``stored`` so a metadata-only
-    update invalidates the cache. Keep the set in sync with that function.
+    ``meta.json`` (notably auto-title). Fingerprint exactly the public metadata
+    fields so a metadata-only update invalidates the cache.
     """
     metadata = stored.model_dump(
         mode="json",
-        include={
-            "title",
-            "metrics",
-            "created_at",
-            "updated_at",
-            "forked_from_conversation_id",
-            "forked_from_event_id",
-            "parent_conversation_id",
-            "client_tools",
-            "launched_agent_profile",
-        },
+        include=set(ConversationInfo.STORED_METADATA_FIELDS),
     )
     return hash(json.dumps(metadata, sort_keys=True, default=str))
 

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any
+from typing import Any, Self
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
@@ -18,7 +18,10 @@ from openhands.sdk.conversation.request import (  # re-export for backward compa
     StartConversationRequest as StartConversationRequest,
 )
 from openhands.sdk.conversation.secret_registry import SecretRegistry
-from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
 from openhands.sdk.conversation.types import ConversationTags
 from openhands.sdk.event.base import Event
 from openhands.sdk.hooks import HookConfig
@@ -335,6 +338,70 @@ class ConversationInfo(_ConversationInfoBase):
             "persisted events, avoiding 'Unknown kind' deserialization errors."
         ),
     )
+
+    @classmethod
+    def from_sources(
+        cls,
+        state: ConversationState,
+        stored: StoredConversation,
+        *,
+        current_model_id: str | None,
+        available_models: list[ACPModelInfo],
+        supports_runtime_model_switch: bool,
+        sub_conversation_ids: list[UUID],
+    ) -> Self:
+        """Build public conversation info from its explicit source models."""
+        # Preserve JSON-mode redaction for secret-bearing nested state.
+        serialized = state.model_dump(
+            mode="json",
+            include={
+                "agent",
+                "agent_state",
+                "secret_registry",
+                "security_analyzer",
+            },
+        )
+        return cls(
+            id=state.id,
+            agent=AgentBase.model_validate(serialized["agent"]),
+            workspace=state.workspace,
+            persistence_dir=state.persistence_dir,
+            max_iterations=state.max_iterations,
+            stuck_detection=state.stuck_detection,
+            execution_status=state.execution_status,
+            confirmation_policy=state.confirmation_policy,
+            security_analyzer=(
+                SecurityAnalyzerBase.model_validate(serialized["security_analyzer"])
+                if serialized["security_analyzer"] is not None
+                else None
+            ),
+            activated_knowledge_skills=state.activated_knowledge_skills,
+            invoked_skills=state.invoked_skills,
+            blocked_actions=state.blocked_actions,
+            blocked_messages=state.blocked_messages,
+            last_user_message_id=state.last_user_message_id,
+            leaf_event_id=state.leaf_event_id,
+            stats=state.stats,
+            secret_registry=SecretRegistry.model_validate(
+                serialized["secret_registry"]
+            ),
+            agent_state=serialized["agent_state"],
+            hook_config=state.hook_config,
+            tags=state.tags,
+            title=stored.title,
+            metrics=stored.metrics,
+            created_at=stored.created_at,
+            updated_at=stored.updated_at,
+            forked_from_conversation_id=stored.forked_from_conversation_id,
+            forked_from_event_id=stored.forked_from_event_id,
+            parent_conversation_id=stored.parent_conversation_id,
+            client_tools=stored.client_tools,
+            launched_agent_profile=stored.launched_agent_profile,
+            current_model_id=current_model_id,
+            available_models=available_models,
+            supports_runtime_model_switch=supports_runtime_model_switch,
+            sub_conversation_ids=sub_conversation_ids,
+        )
 
 
 class ConversationPage(BaseModel):

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -3,28 +3,24 @@ from __future__ import annotations
 from abc import ABC
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, Self
+from typing import Any, ClassVar, Self
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.agent.acp_models import ACPModelInfo
-from openhands.sdk.agent.base import AgentBase
-from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.request import (  # re-export for backward compat
     ACPEnabledAgent as ACPEnabledAgent,
     ConversationConfig as ConversationConfig,
     SendMessageRequest as SendMessageRequest,
     StartConversationRequest as StartConversationRequest,
 )
-from openhands.sdk.conversation.secret_registry import SecretRegistry
 from openhands.sdk.conversation.state import (
-    ConversationExecutionStatus,
+    ConversationPublicState,
     ConversationState,
 )
 from openhands.sdk.conversation.types import ConversationTags
 from openhands.sdk.event.base import Event
-from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm.message import (  # re-export
     ImageContent as ImageContent,
     TextContent as TextContent,
@@ -37,7 +33,6 @@ from openhands.sdk.secret import SecretSource
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
-    NeverConfirm,
 )
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.utils import OpenHandsUUID, utc_now
@@ -45,7 +40,6 @@ from openhands.sdk.utils.models import (
     DiscriminatedUnionMixin,
     OpenHandsModel,
 )
-from openhands.sdk.workspace.base import BaseWorkspace
 
 
 class ServerErrorEvent(Event):
@@ -123,99 +117,8 @@ class StoredConversation(ConversationConfig):
     )
 
 
-class _ConversationInfoBase(BaseModel):
+class _ConversationInfoBase(ConversationPublicState):
     """Common conversation info fields shared by conversation contracts."""
-
-    id: UUID = Field(description="Unique conversation ID")
-    workspace: BaseWorkspace = Field(
-        ...,
-        description=(
-            "Workspace used by the agent to execute commands and read/write files. "
-            "Not the process working directory."
-        ),
-    )
-    persistence_dir: str | None = Field(
-        default="workspace/conversations",
-        description="Directory for persisting conversation state and events. "
-        "If None, conversation will not be persisted.",
-    )
-    max_iterations: int = Field(
-        default=500,
-        gt=0,
-        description=(
-            "Maximum number of iterations the agent can perform in a single run."
-        ),
-    )
-    stuck_detection: bool = Field(
-        default=True,
-        description="Whether to enable stuck detection for the agent.",
-    )
-    execution_status: ConversationExecutionStatus = Field(
-        default=ConversationExecutionStatus.IDLE
-    )
-    confirmation_policy: ConfirmationPolicyBase = Field(default=NeverConfirm())
-    security_analyzer: SecurityAnalyzerBase | None = Field(
-        default=None,
-        description="Optional security analyzer to evaluate action risks.",
-    )
-    activated_knowledge_skills: list[str] = Field(
-        default_factory=list,
-        description="List of activated knowledge skills name",
-    )
-    invoked_skills: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Names of progressive-disclosure skills explicitly invoked via the "
-            "`invoke_skill` tool."
-        ),
-    )
-    blocked_actions: dict[str, str] = Field(
-        default_factory=dict,
-        description="Actions blocked by PreToolUse hooks, keyed by action ID",
-    )
-    blocked_messages: dict[str, str] = Field(
-        default_factory=dict,
-        description="Messages blocked by UserPromptSubmit hooks, keyed by message ID",
-    )
-    last_user_message_id: str | None = Field(
-        default=None,
-        description=(
-            "Most recent user MessageEvent id for hook block checks. "
-            "Updated when user messages are emitted so Agent.step can pop "
-            "blocked_messages without scanning the event log. If None, "
-            "hook-blocked checks are skipped (legacy conversations)."
-        ),
-    )
-    leaf_event_id: str | None = Field(
-        default=None,
-        description=(
-            "HEAD of the conversation tree: the parent of the next appended "
-            "event. ``None`` means an empty tree (or, for pre-feature "
-            "conversations, the linear tail). Moving it via ``navigate`` "
-            "re-roots the active branch the agent runs on."
-        ),
-    )
-    stats: ConversationStats = Field(
-        default_factory=ConversationStats,
-        description="Conversation statistics for tracking LLM metrics",
-    )
-    secret_registry: SecretRegistry = Field(
-        default_factory=SecretRegistry,
-        description="Registry for handling secrets and sensitive data",
-    )
-    agent_state: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Dictionary for agent-specific runtime state that persists across "
-        "iterations.",
-    )
-    hook_config: HookConfig | None = Field(
-        default=None,
-        description=(
-            "Hook configuration for this conversation. Includes definitions for "
-            "PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, SessionEnd, "
-            "and Stop hooks."
-        ),
-    )
 
     title: str | None = Field(
         default=None, description="User-defined title for the conversation"
@@ -255,13 +158,6 @@ class _ConversationInfoBase(BaseModel):
         ),
     )
 
-    tags: ConversationTags = Field(
-        default_factory=dict,
-        description=(
-            "Key-value tags for the conversation. Keys must be lowercase "
-            "alphanumeric. Values are arbitrary strings up to 256 characters."
-        ),
-    )
     current_model_id: str | None = Field(
         default=None,
         description=(
@@ -325,10 +221,20 @@ class _ConversationInfoBase(BaseModel):
 class ConversationInfo(_ConversationInfoBase):
     """Information about a conversation running locally without a Runtime sandbox."""
 
-    agent: AgentBase = Field(
-        ...,
-        description="The agent running in the conversation.",
+    STORED_METADATA_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "title",
+            "metrics",
+            "created_at",
+            "updated_at",
+            "forked_from_conversation_id",
+            "forked_from_event_id",
+            "parent_conversation_id",
+            "client_tools",
+            "launched_agent_profile",
+        }
     )
+
     client_tools: list[ClientToolSpec] = Field(
         default_factory=list,
         description=(
@@ -351,52 +257,17 @@ class ConversationInfo(_ConversationInfoBase):
         sub_conversation_ids: list[UUID],
     ) -> Self:
         """Build public conversation info from its explicit source models."""
-        # Preserve JSON-mode redaction for secret-bearing nested state.
-        serialized = state.model_dump(
+        public_state = state.model_dump(
             mode="json",
-            include={
-                "agent",
-                "agent_state",
-                "secret_registry",
-                "security_analyzer",
-            },
+            include=set(ConversationPublicState.model_fields),
+        )
+        stored_metadata = stored.model_dump(
+            mode="json",
+            include=set(cls.STORED_METADATA_FIELDS),
         )
         return cls(
-            id=state.id,
-            agent=AgentBase.model_validate(serialized["agent"]),
-            workspace=state.workspace,
-            persistence_dir=state.persistence_dir,
-            max_iterations=state.max_iterations,
-            stuck_detection=state.stuck_detection,
-            execution_status=state.execution_status,
-            confirmation_policy=state.confirmation_policy,
-            security_analyzer=(
-                SecurityAnalyzerBase.model_validate(serialized["security_analyzer"])
-                if serialized["security_analyzer"] is not None
-                else None
-            ),
-            activated_knowledge_skills=state.activated_knowledge_skills,
-            invoked_skills=state.invoked_skills,
-            blocked_actions=state.blocked_actions,
-            blocked_messages=state.blocked_messages,
-            last_user_message_id=state.last_user_message_id,
-            leaf_event_id=state.leaf_event_id,
-            stats=state.stats,
-            secret_registry=SecretRegistry.model_validate(
-                serialized["secret_registry"]
-            ),
-            agent_state=serialized["agent_state"],
-            hook_config=state.hook_config,
-            tags=state.tags,
-            title=stored.title,
-            metrics=stored.metrics,
-            created_at=stored.created_at,
-            updated_at=stored.updated_at,
-            forked_from_conversation_id=stored.forked_from_conversation_id,
-            forked_from_event_id=stored.forked_from_event_id,
-            parent_conversation_id=stored.parent_conversation_id,
-            client_tools=stored.client_tools,
-            launched_agent_profile=stored.launched_agent_profile,
+            **public_state,
+            **stored_metadata,
             current_model_id=current_model_id,
             available_models=available_models,
             supports_runtime_model_switch=supports_runtime_model_switch,

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Self
 
-from pydantic import Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr
 
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context.view import View
@@ -38,7 +38,6 @@ from openhands.sdk.security.confirmation_policy import (
     NeverConfirm,
 )
 from openhands.sdk.utils.cipher import Cipher
-from openhands.sdk.utils.models import OpenHandsModel
 from openhands.sdk.workspace.base import BaseWorkspace
 
 
@@ -79,8 +78,9 @@ class ConversationExecutionStatus(str, Enum):
         )
 
 
-class ConversationState(OpenHandsModel):
-    # ===== Public, validated fields =====
+class ConversationPublicState(BaseModel):
+    """Conversation state fields safe to expose outside the runtime."""
+
     id: ConversationID = Field(description="Unique conversation ID")
 
     agent: AgentBase = Field(
@@ -131,15 +131,6 @@ class ConversationState(OpenHandsModel):
         description="List of activated knowledge skills name",
     )
 
-    activated_path_rules: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Names of path-scoped rules already injected on file-touch. "
-            "Mirrors activated_knowledge_skills to dedup rule injection "
-            "once per conversation."
-        ),
-    )
-
     invoked_skills: list[str] = Field(
         default_factory=list,
         description=(
@@ -182,12 +173,6 @@ class ConversationState(OpenHandsModel):
         ),
     )
 
-    # Distinguishes a deliberate empty HEAD (navigate_to(None)) from an unset
-    # ``leaf_event_id``, which triggers legacy back-compat. Without it, emptying a
-    # single-root tree is indistinguishable from a pre-tree conversation. Persisted
-    # so the empty HEAD survives a save/reload. See _resolve_active_leaf.
-    head_is_empty: bool = Field(default=False)
-
     # Conversation statistics for LLM usage tracking
     stats: ConversationStats = Field(
         default_factory=ConversationStats,
@@ -228,6 +213,23 @@ class ConversationState(OpenHandsModel):
             "points during conversation execution."
         ),
     )
+
+
+class ConversationState(ConversationPublicState):
+    activated_path_rules: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of path-scoped rules already injected on file-touch. "
+            "Mirrors activated_knowledge_skills to dedup rule injection "
+            "once per conversation."
+        ),
+    )
+
+    # Distinguishes a deliberate empty HEAD (navigate_to(None)) from an unset
+    # ``leaf_event_id``, which triggers legacy back-compat. Without it, emptying a
+    # single-root tree is indistinguishable from a pre-tree conversation. Persisted
+    # so the empty HEAD survives a save/reload. See _resolve_active_leaf.
+    head_is_empty: bool = Field(default=False)
 
     # ===== Private attrs (NOT Fields) =====
     _fs: FileStore = PrivateAttr()  # filestore for persistence

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -438,6 +438,62 @@ def test_conversation_info_from_sources_maps_runtime_fields():
     assert info.sub_conversation_ids == child_ids
 
 
+def test_conversation_info_json_wire_contract():
+    agent = Agent(
+        llm=LLM(
+            model="gpt-4o",
+            api_key=SecretStr("test-key"),
+            usage_id="test-llm",
+        ),
+        tools=[Tool(name="TerminalTool")],
+    )
+    state = _make_state(agent)
+    info = _compose_conversation_info(_make_stored(state), state)
+
+    payload = info.model_dump(mode="json")
+
+    assert set(payload) == {
+        "id",
+        "agent",
+        "workspace",
+        "persistence_dir",
+        "max_iterations",
+        "stuck_detection",
+        "execution_status",
+        "confirmation_policy",
+        "security_analyzer",
+        "activated_knowledge_skills",
+        "invoked_skills",
+        "blocked_actions",
+        "blocked_messages",
+        "last_user_message_id",
+        "leaf_event_id",
+        "stats",
+        "secret_registry",
+        "tags",
+        "agent_state",
+        "hook_config",
+        "title",
+        "metrics",
+        "created_at",
+        "updated_at",
+        "forked_from_conversation_id",
+        "forked_from_event_id",
+        "parent_conversation_id",
+        "sub_conversation_ids",
+        "current_model_id",
+        "available_models",
+        "supports_runtime_model_switch",
+        "launched_agent_profile",
+        "client_tools",
+    }
+    assert "activated_path_rules" not in payload
+    assert "head_is_empty" not in payload
+    assert payload["id"] == str(state.id)
+    assert payload["agent"]["kind"] == "Agent"
+    assert payload["agent"]["llm"]["api_key"] is None
+
+
 def test_conversation_info_reuses_public_state_schema():
     internal_state_fields = {"activated_path_rules", "head_is_empty"}
 

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -33,7 +33,10 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.llm.utils.metrics import MetricsSnapshot
+from openhands.sdk.profiles.agent_profile import LaunchedAgentProfile
 from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -338,3 +341,152 @@ def test_supports_runtime_model_switch_defaults_false():
     info = _compose_conversation_info(stored, state)
 
     assert info.supports_runtime_model_switch is False
+
+
+def test_conversation_info_from_sources_maps_state_fields():
+    state = _make_state(ACPAgent(acp_command=["echo", "test"]))
+    state.persistence_dir = "/tmp/conversations"
+    state.max_iterations = 17
+    state.stuck_detection = False
+    state.execution_status = ConversationExecutionStatus.PAUSED
+    state.activated_knowledge_skills = ["knowledge"]
+    state.invoked_skills = ["review"]
+    state.blocked_actions = {"action-id": "blocked"}
+    state.blocked_messages = {"message-id": "blocked"}
+    state.last_user_message_id = "message-id"
+    state.leaf_event_id = "leaf-id"
+    state.tags = {"source": "state"}
+    state.agent_state = {"key": "value"}
+    stored = _make_stored(state).model_copy(
+        update={
+            "id": uuid4(),
+            "max_iterations": 99,
+            "stuck_detection": True,
+            "tags": {"source": "stored"},
+        }
+    )
+
+    info = ConversationInfo.from_sources(
+        state,
+        stored,
+        current_model_id=None,
+        available_models=[],
+        supports_runtime_model_switch=False,
+        sub_conversation_ids=[],
+    )
+
+    exposed_state_fields = set(ConversationState.model_fields) - {
+        "activated_path_rules",
+        "head_is_empty",
+    }
+    assert info.model_dump(mode="json", include=exposed_state_fields) == (
+        state.model_dump(mode="json", include=exposed_state_fields)
+    )
+
+
+def test_conversation_info_from_sources_maps_stored_metadata():
+    state = _make_state(ACPAgent(acp_command=["echo", "test"]))
+    parent_id = uuid4()
+    fork_id = uuid4()
+    profile = LaunchedAgentProfile(agent_profile_id=uuid4(), revision=3)
+    client_tool = ClientToolSpec(
+        name="lookup", description="Look up a value", parameters={"type": "object"}
+    )
+    stored = _make_stored(state).model_copy(
+        update={
+            "title": "Stored title",
+            "metrics": MetricsSnapshot(model_name="test", accumulated_cost=1.25),
+            "parent_conversation_id": parent_id,
+            "forked_from_conversation_id": fork_id,
+            "forked_from_event_id": "fork-event",
+            "client_tools": [client_tool],
+            "launched_agent_profile": profile,
+        }
+    )
+
+    info = ConversationInfo.from_sources(
+        state,
+        stored,
+        current_model_id=None,
+        available_models=[],
+        supports_runtime_model_switch=False,
+        sub_conversation_ids=[],
+    )
+
+    assert (
+        info.title,
+        info.metrics,
+        info.created_at,
+        info.updated_at,
+        info.parent_conversation_id,
+        info.forked_from_conversation_id,
+        info.forked_from_event_id,
+        info.client_tools,
+        info.launched_agent_profile,
+    ) == (
+        stored.title,
+        stored.metrics,
+        stored.created_at,
+        stored.updated_at,
+        stored.parent_conversation_id,
+        stored.forked_from_conversation_id,
+        stored.forked_from_event_id,
+        stored.client_tools,
+        stored.launched_agent_profile,
+    )
+
+
+def test_conversation_info_from_sources_maps_runtime_fields():
+    state = _make_state(ACPAgent(acp_command=["echo", "test"]))
+    stored = _make_stored(state)
+    child_ids = [uuid4(), uuid4()]
+    models = [ACPModelInfo(model_id="model-id", name="Model")]
+
+    info = ConversationInfo.from_sources(
+        state,
+        stored,
+        current_model_id="model-id",
+        available_models=models,
+        supports_runtime_model_switch=True,
+        sub_conversation_ids=child_ids,
+    )
+
+    assert info.current_model_id == "model-id"
+    assert info.available_models == models
+    assert info.supports_runtime_model_switch is True
+    assert info.sub_conversation_ids == child_ids
+
+
+def test_conversation_info_source_fields_are_exposed_or_excluded():
+    exposed_state_fields = set(
+        "id agent workspace persistence_dir max_iterations stuck_detection "
+        "execution_status confirmation_policy security_analyzer "
+        "activated_knowledge_skills invoked_skills blocked_actions blocked_messages "
+        "last_user_message_id leaf_event_id stats secret_registry tags agent_state "
+        "hook_config".split()
+    )
+    excluded_state_fields = {"activated_path_rules", "head_is_empty"}
+    exposed_stored_fields = set(
+        "title metrics created_at updated_at forked_from_conversation_id "
+        "forked_from_event_id parent_conversation_id client_tools "
+        "launched_agent_profile".split()
+    )
+    excluded_stored_fields = set(
+        "workspace worktree conversation_id confirmation_policy security_analyzer "
+        "initial_message max_iterations stuck_detection secrets secrets_encrypted "
+        "tool_module_qualnames agent_launch_additions agent_definitions plugins "
+        "hook_config tags user_id observability_metadata observability_tags "
+        "observability_span_name autotitle title_llm_profile "
+        "required_runtime_credential_bindings id".split()
+    )
+    runtime_fields = set(
+        "current_model_id available_models supports_runtime_model_switch "
+        "sub_conversation_ids".split()
+    )
+    info_fields = set(ConversationInfo.model_fields)
+    state_fields = set(ConversationState.model_fields)
+    stored_fields = set(StoredConversation.model_fields)
+
+    assert state_fields == exposed_state_fields | excluded_state_fields
+    assert stored_fields == exposed_stored_fields | excluded_stored_fields
+    assert info_fields == exposed_state_fields | exposed_stored_fields | runtime_fields

--- a/tests/agent_server/test_conversation_info_model.py
+++ b/tests/agent_server/test_conversation_info_model.py
@@ -31,6 +31,7 @@ from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
+    ConversationPublicState,
     ConversationState,
 )
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
@@ -375,12 +376,9 @@ def test_conversation_info_from_sources_maps_state_fields():
         sub_conversation_ids=[],
     )
 
-    exposed_state_fields = set(ConversationState.model_fields) - {
-        "activated_path_rules",
-        "head_is_empty",
-    }
-    assert info.model_dump(mode="json", include=exposed_state_fields) == (
-        state.model_dump(mode="json", include=exposed_state_fields)
+    public_state_fields = set(ConversationPublicState.model_fields)
+    assert info.model_dump(mode="json", include=public_state_fields) == (
+        state.model_dump(mode="json", include=public_state_fields)
     )
 
 
@@ -413,26 +411,9 @@ def test_conversation_info_from_sources_maps_stored_metadata():
         sub_conversation_ids=[],
     )
 
-    assert (
-        info.title,
-        info.metrics,
-        info.created_at,
-        info.updated_at,
-        info.parent_conversation_id,
-        info.forked_from_conversation_id,
-        info.forked_from_event_id,
-        info.client_tools,
-        info.launched_agent_profile,
-    ) == (
-        stored.title,
-        stored.metrics,
-        stored.created_at,
-        stored.updated_at,
-        stored.parent_conversation_id,
-        stored.forked_from_conversation_id,
-        stored.forked_from_event_id,
-        stored.client_tools,
-        stored.launched_agent_profile,
+    stored_metadata_fields = set(ConversationInfo.STORED_METADATA_FIELDS)
+    assert info.model_dump(include=stored_metadata_fields) == stored.model_dump(
+        include=stored_metadata_fields
     )
 
 
@@ -457,36 +438,34 @@ def test_conversation_info_from_sources_maps_runtime_fields():
     assert info.sub_conversation_ids == child_ids
 
 
-def test_conversation_info_source_fields_are_exposed_or_excluded():
-    exposed_state_fields = set(
-        "id agent workspace persistence_dir max_iterations stuck_detection "
-        "execution_status confirmation_policy security_analyzer "
-        "activated_knowledge_skills invoked_skills blocked_actions blocked_messages "
-        "last_user_message_id leaf_event_id stats secret_registry tags agent_state "
-        "hook_config".split()
-    )
-    excluded_state_fields = {"activated_path_rules", "head_is_empty"}
-    exposed_stored_fields = set(
-        "title metrics created_at updated_at forked_from_conversation_id "
-        "forked_from_event_id parent_conversation_id client_tools "
-        "launched_agent_profile".split()
-    )
-    excluded_stored_fields = set(
-        "workspace worktree conversation_id confirmation_policy security_analyzer "
-        "initial_message max_iterations stuck_detection secrets secrets_encrypted "
-        "tool_module_qualnames agent_launch_additions agent_definitions plugins "
-        "hook_config tags user_id observability_metadata observability_tags "
-        "observability_span_name autotitle title_llm_profile "
-        "required_runtime_credential_bindings id".split()
-    )
-    runtime_fields = set(
-        "current_model_id available_models supports_runtime_model_switch "
-        "sub_conversation_ids".split()
-    )
-    info_fields = set(ConversationInfo.model_fields)
-    state_fields = set(ConversationState.model_fields)
-    stored_fields = set(StoredConversation.model_fields)
+def test_conversation_info_reuses_public_state_schema():
+    internal_state_fields = {"activated_path_rules", "head_is_empty"}
 
-    assert state_fields == exposed_state_fields | excluded_state_fields
-    assert stored_fields == exposed_stored_fields | excluded_stored_fields
-    assert info_fields == exposed_state_fields | exposed_stored_fields | runtime_fields
+    assert issubclass(ConversationState, ConversationPublicState)
+    assert issubclass(ConversationInfo, ConversationPublicState)
+    assert set(ConversationPublicState.model_fields) <= set(
+        ConversationInfo.model_fields
+    )
+    assert (
+        set(ConversationState.model_fields) - set(ConversationPublicState.model_fields)
+        == internal_state_fields
+    )
+    assert internal_state_fields.isdisjoint(ConversationInfo.model_fields)
+
+
+def test_stored_metadata_projection_has_one_field_definition():
+    runtime_fields = {
+        "current_model_id",
+        "available_models",
+        "supports_runtime_model_switch",
+        "sub_conversation_ids",
+    }
+
+    assert ConversationInfo.STORED_METADATA_FIELDS <= set(
+        StoredConversation.model_fields
+    )
+    assert set(ConversationInfo.model_fields) == (
+        set(ConversationPublicState.model_fields)
+        | ConversationInfo.STORED_METADATA_FIELDS
+        | runtime_fields
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

ConversationInfo has some duplicated fields today. This makes it easy for the API response to get out of sync with ConversationState. This change gives those shared fields one source of truth and makes the mapping clearer.

---

AGENT:

## Why

`ConversationInfo` repeated state fields and was assembled from serialized models whose unknown fields were silently ignored. That made a public state field easy to omit from every conversation response and left stored metadata cache invalidation coupled to a separate hand-maintained list.

## Summary

- Add `ConversationPublicState` as the single declaration for state fields exposed outside the conversation runtime.
- Derive both `ConversationState` and `ConversationInfo` from that schema, while keeping `activated_path_rules` and `head_is_empty` internal.
- Keep `ConversationInfo.from_sources()` as the typed assembly boundary and preserve JSON-mode serialization for nested secret-bearing values.
- Reuse `ConversationInfo.STORED_METADATA_FIELDS` for both stored metadata projection and cache signatures.
- Add structural ownership checks and a JSON wire-contract regression covering public keys, UUID output, nested agent serialization, and secret redaction.

## Issue Number

Fixes #4849

## How to Test

- `uv run pytest tests/agent_server/test_conversation_info_model.py -q` (22 passed)
- `uv run pytest tests/agent_server/test_conversation_info_model.py tests/agent_server/test_conversation_service.py tests/agent_server/test_openapi_contract.py tests/agent_server/test_openapi_discriminator.py tests/sdk/conversation/local/test_state_serialization.py -q` (178 passed)
- `uv run pytest tests/sdk/conversation -qq --disable-warnings` (803 passed)
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/state.py openhands-agent-server/openhands/agent_server/models.py openhands-agent-server/openhands/agent_server/conversation_service.py tests/agent_server/test_conversation_info_model.py` (all hooks passed)

## Video/Screenshots

Not applicable; this changes response assembly without changing the response fields.

## Design Doc

Not included; the shared schema is a focused refactor and the REST wire shape remains unchanged.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No competing open pull request for #4849 was found.
