### PR TITLE
fix(agent-server): recover conversations after PID reuse

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_lease.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_lease.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NotRequired, TypedDict
+from uuid import uuid4
 
 from filelock import FileLock
 
@@ -18,6 +19,10 @@ logger = get_logger(__name__)
 LEASE_FILE_NAME = "owner_lease.json"
 LEASE_LOCK_FILE_NAME = ".owner_lease.lock"
 DEFAULT_LEASE_TTL_SECONDS = 45.0
+# A PID can be reused after a fast process restart, especially when the
+# server runs as PID 1 in a container. This token distinguishes that new
+# process from the one that wrote an otherwise still-live lease.
+_PROCESS_TOKEN = uuid4().hex
 
 
 @dataclass(frozen=True)
@@ -35,6 +40,7 @@ class LeasePayload(TypedDict):
     # must treat them as optional.
     owner_host: NotRequired[str]
     owner_pid: NotRequired[int]
+    owner_process_token: NotRequired[str]
 
 
 def _current_host() -> str:
@@ -178,10 +184,14 @@ class ConversationLease:
             return False
         if owner_host != _current_host():
             return False
-        # Don't mistakenly consider ourselves dead if the lease points at
-        # this very process (e.g. a same-process re-claim).
+        # A PID may have been reused by a restarted server. The process token
+        # distinguishes that case while preserving same-process re-claims.
         if owner_pid == os.getpid():
-            return False
+            owner_process_token = payload.get("owner_process_token")
+            return (
+                isinstance(owner_process_token, str)
+                and owner_process_token != _PROCESS_TOKEN
+            )
         return not _is_pid_alive(owner_pid)
 
     def renew(self, generation: int) -> None:
@@ -260,6 +270,9 @@ class ConversationLease:
             owner_pid = raw_payload.get("owner_pid")
             if isinstance(owner_pid, int):
                 payload["owner_pid"] = owner_pid
+            owner_process_token = raw_payload.get("owner_process_token")
+            if isinstance(owner_process_token, str) and owner_process_token:
+                payload["owner_process_token"] = owner_process_token
             return payload
         except Exception:
             logger.warning(
@@ -275,6 +288,7 @@ class ConversationLease:
             "expires_at": expires_at,
             "owner_host": _current_host(),
             "owner_pid": os.getpid(),
+            "owner_process_token": _PROCESS_TOKEN,
         }
         tmp_path = self._lease_path.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(payload))

--- a/tests/agent_server/test_conversation_lease.py
+++ b/tests/agent_server/test_conversation_lease.py
@@ -149,6 +149,9 @@ def test_claim_writes_owner_host_and_pid(tmp_path: Path) -> None:
 
     assert payload.get("owner_host") == socket.gethostname()
     assert payload.get("owner_pid") == os.getpid()
+    assert (
+        payload.get("owner_process_token") == conversation_lease_module._PROCESS_TOKEN
+    )
 
 
 def test_claim_takes_over_when_previous_owner_pid_is_dead(
@@ -304,3 +307,33 @@ def test_claim_self_pid_match_is_not_treated_as_dead(tmp_path: Path) -> None:
     )
     with pytest.raises(ConversationLeaseHeldError):
         secondary.claim()
+
+
+def test_claim_takes_over_when_pid_was_reused_by_a_new_process(
+    tmp_path: Path,
+) -> None:
+    """A restarted process can reuse the PID from a stale lease."""
+    conversation_dir = tmp_path / "conversation"
+    primary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="primary",
+        ttl_seconds=3600.0,
+    )
+    primary_claim = primary.claim()
+
+    payload = _read_lease_payload(conversation_dir)
+    forged = dict(payload)
+    forged["owner_process_token"] = "previous-process"
+    forged["owner_pid"] = os.getpid()
+    (conversation_dir / LEASE_FILE_NAME).write_text(json.dumps(forged))
+
+    secondary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="secondary",
+    )
+    secondary_claim = secondary.claim()
+
+    new_payload = _read_lease_payload(conversation_dir)
+    assert secondary_claim.takeover is True
+    assert secondary_claim.generation == primary_claim.generation + 1
+    assert new_payload["owner_instance_id"] == "secondary"

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import socket
 import tempfile
 import threading
@@ -852,6 +853,48 @@ async def test_restart_resumes_conversations_after_non_graceful_shutdown(tmp_pat
             "Lazy hydration failed to pick up an existing conversation whose "
             "lease was left orphaned by a non-graceful shutdown."
         )
+
+
+@pytest.mark.asyncio
+async def test_restart_resumes_when_pid_is_reused(tmp_path):
+    """A fast restart must not mistake a reused PID for the old server."""
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(request)
+        conversation_id = conversation_info.id
+        assert primary._event_services is not None
+        primary_state = await primary._event_services[conversation_id].get_state()
+        primary_state.execution_status = ConversationExecutionStatus.RUNNING
+
+    lease_path = conversations_dir / conversation_id.hex / LEASE_FILE_NAME
+    forged_payload = {
+        "owner_instance_id": "previous-server-instance",
+        "generation": 1,
+        "expires_at": time.time() + 3600.0,
+        "owner_host": socket.gethostname(),
+        "owner_pid": os.getpid(),
+        "owner_process_token": "previous-process",
+    }
+    lease_path.write_text(json.dumps(forged_payload))
+
+    async with ConversationService(conversations_dir=conversations_dir) as restarted:
+        assert restarted._event_services is not None
+        assert conversation_id in restarted._event_services
+        restarted_event_service = await restarted.get_event_service(conversation_id)
+        assert restarted_event_service is not None, (
+            "Lazy hydration failed after the server PID was reused."
+        )
+        restarted_state = await restarted_event_service.get_state()
+        assert restarted_state.execution_status == ConversationExecutionStatus.ERROR
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN:

I tested the lease unit suite, the conversation-service restart cases including a persisted RUNNING state with a reused PID, and the event-service suite.

AGENT:

This pull request was prepared by an AI agent (OpenHands) on behalf of jstar0.

## Why

When an agent-server restarts quickly, especially as PID 1 in a container, the replacement process can reuse the PID recorded in a conversation lease. The existing liveness check treats that PID as the original owner and skips the conversation until the lease TTL expires. A conversation left in RUNNING state is then unavailable through the normal resume API.

## Summary

- Record a process-local token in new conversation leases.
- Treat a same-host, same-PID lease with a different process token as owned by a replaced process, allowing safe takeover and fencing by the existing generation mechanism.
- Preserve same-process re-claim behavior, cross-host TTL protection, and legacy lease compatibility.
- Add lease and conversation-service regressions for PID reuse and persisted RUNNING recovery.

## Issue Number

Fixes #4893

## How to Test

From the repository root:

```bash
uv run pytest -q tests/agent_server/test_conversation_lease.py tests/agent_server/test_conversation_service.py tests/agent_server/test_event_service.py
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/conversation_lease.py tests/agent_server/test_conversation_lease.py tests/agent_server/test_conversation_service.py
```

Results:

- Agent-server lease, conversation-service, and event-service tests: 237 passed
- Ruff format, Ruff lint, pycodestyle, Pyright, import dependency rules, and tool subclass registration: passed

The new conversation-service regression persists a RUNNING conversation, simulates a still-valid lease from a previous process that reused the current PID, and verifies that startup takes over the lease and loads the conversation through the existing stale-run recovery path.

## Video/Screenshots

Not applicable: this is an agent-server lease and conversation lifecycle fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Lease files written by older versions without a process token retain the existing conservative behavior. Cross-host ownership still relies on lease expiration because local PID information cannot establish liveness on another host.

- [ ] A human has tested these changes.