### PR TITLE
feat(agent-server): add per-conversation MCP reconnect endpoint

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -643,6 +643,31 @@ async def condense_conversation(
 
 
 @conversation_router.post(
+    "/{conversation_id}/reconnect_mcp",
+    responses={404: {"description": "Conversation not found"}},
+)
+async def reconnect_conversation_mcp(
+    conversation_id: UUID,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> dict[str, object]:
+    """Reconnect every MCP server attached to a conversation.
+
+    A chat whose MCP tools were lost because the underlying transport dropped
+    (e.g. a desktop bridge restarted or a network blip) can recover in place:
+    each MCP client is force-disconnected and reconnected, and the response
+    reports per-server status. The conversation must be idle.
+
+    Returns ``{"servers": [{"server", "tools", "connected", "reconnected",
+    "error"}]}``.
+    """
+    event_service = await conversation_service.get_event_service(conversation_id)
+    if event_service is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+    servers = await event_service.reconnect_mcp()
+    return {"servers": servers}
+
+
+@conversation_router.post(
     "/{conversation_id}/fork",
     responses={
         201: {"description": "Forked conversation created"},

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1833,6 +1833,65 @@ class EventService:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._conversation.condense)
 
+    async def reconnect_mcp(self) -> list[dict[str, object]]:
+        """Reconnect this conversation's MCP clients and report per-server status.
+
+        Collects the MCP executors attached to the conversation's agent, then
+        force-reconnects each distinct MCP client (requires
+        ``MCPClient.reconnect`` from OpenHands SDK). The conversation should be
+        idle before calling this.
+        """
+        if not self._conversation:
+            raise ValueError("inactive_service")
+
+        from openhands.sdk.mcp.tool import MCPToolExecutor
+
+        def collect() -> list[dict[str, object]]:
+            agent = self._conversation.agent
+            tools_map = getattr(agent, "tools_map", None) or {}
+            clients: dict[int, dict[str, object]] = {}
+            for name, tool in tools_map.items():
+                executor = getattr(tool, "executor", None)
+                if not isinstance(executor, MCPToolExecutor):
+                    continue
+                client = executor.client
+                key = id(client)
+                if key not in clients:
+                    clients[key] = {"client": client, "tools": []}
+                clients[key]["tools"].append(name)
+            return [
+                {"client": item["client"], "tools": item["tools"]}
+                for item in clients.values()
+            ]
+
+        loop = asyncio.get_running_loop()
+        entries = await loop.run_in_executor(None, collect)
+
+        results: list[dict[str, object]] = []
+        for entry in entries:
+            client = entry["client"]
+            tools = entry["tools"]
+            server = str(tools[0]).partition("_")[0] if tools else "mcp"
+            try:
+                await client.reconnect()
+                connected = bool(client.is_connected())
+                reconnected = True
+                error: str | None = None
+            except Exception as exc:  # noqa: BLE001
+                connected = False
+                reconnected = False
+                error = str(exc)
+            results.append(
+                {
+                    "server": server,
+                    "tools": tools,
+                    "connected": connected,
+                    "reconnected": reconnected,
+                    "error": error,
+                }
+            )
+        return results
+
     async def navigate_to(self, event_id: str | None) -> None:
         """Move the conversation HEAD to an existing event (in-place re-root).
 

--- a/openhands-sdk/openhands/sdk/mcp/client.py
+++ b/openhands-sdk/openhands/sdk/mcp/client.py
@@ -62,6 +62,27 @@ class MCPClient(AsyncMCPClient):
         except RuntimeError as exc:
             raise MCPError("MCP Connection Failure") from exc
 
+    async def reconnect(self) -> None:
+        """Force a fresh MCP connection, discarding any stale session.
+
+        fastmcp reference-counts the session via ``__aenter__``. When a remote
+        SSE transport drops mid-conversation (e.g. the desktop bridge app
+        restarts) the client can be left with a dead session while its nesting
+        counter is still > 0; in that state a plain ``connect()`` refuses to
+        start a new session ("nesting counter should be 0"), so the tools stay
+        broken for the rest of the conversation. Tear the session down first
+        (resets the nesting counter) and only then connect again.
+        """
+        try:
+            await self._disconnect(force=True)
+        except Exception:
+            # Best-effort teardown; the fresh connect below is authoritative.
+            pass
+        try:
+            await self.__aenter__()
+        except RuntimeError as exc:
+            raise MCPError("MCP Connection Failure") from exc
+
     def call_async_from_sync(
         self,
         awaitable_or_fn: Callable[..., Any] | Any,

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -70,57 +70,147 @@ class MCPToolExecutor(ToolExecutor):
         self.client = client
         self.timeout = timeout
 
+    @staticmethod
+    def _is_connection_error(exc: Exception) -> bool:
+        """Whether *exc* indicates the MCP transport/session dropped.
+
+        Only these errors are worth a reconnect-and-retry: a dropped SSE
+        transport or a closed session. Semantic tool errors (bad args, tool
+        raised, permission denied, ...) must NOT trigger a blind retry because
+        the tool may already have executed on the server. A generic timeout is
+        deliberately excluded for the same reason: a slow tool may still have
+        run, and re-running it after a reconnect could double-execute it.
+        """
+        text = str(exc).lower()
+        return (
+            "connection closed" in text
+            or "connection failure" in text
+            or "connection lost" in text
+            or "session not connected" in text
+            or "session closed" in text
+            or "broken pipe" in text
+            or "econnreset" in text
+            or "socket hang up" in text
+            or "server disconnected" in text
+            or "client has been closed" in text
+        )
+
+    @staticmethod
+    def _result_error_text(result: mcp.types.CallToolResult) -> str:
+        """Flatten a CallToolResult's text blocks into a single string."""
+        parts = []
+        for block in result.content or []:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(str(text))
+        return "\n".join(parts)
+
+    async def _reconnect_client(self) -> None:
+        if self.client._closed:
+            raise RuntimeError("MCP client has been closed and cannot be reconnected")
+        logger.info(
+            f"MCP client not connected for tool '{self.tool_name}'; "
+            "dropping the stale session and reconnecting."
+        )
+        await self.client.reconnect()
+
     @observe(name="MCPToolExecutor.call_tool", span_type="TOOL")
     async def call_tool(self, action: MCPToolAction) -> MCPToolObservation:
         """Execute the MCP tool call using the already-connected client.
 
-        If the client's session has been lost (e.g., due to a transient
-        server error such as HTTP 503), attempt to reconnect once before
-        failing. This prevents a single transient error from permanently
-        disabling all MCP tools for the remainder of the conversation.
+        Reconnection policy: if the session is already known to be gone we
+        reconnect before the call; if a call fails mid-flight with a
+        connection error (e.g. the desktop SSE bridge restarted underneath
+        us), we reconnect once and retry the call a single time. A transient
+        drop therefore can never permanently disable MCP tools for the rest
+        of the conversation.
         """
-        if not self.client.is_connected():
-            if self.client._closed:
-                return MCPToolObservation.from_text(
-                    text=(
-                        f"MCP client not connected for tool '{self.tool_name}'. "
-                        "The client has been closed and cannot be reconnected."
-                    ),
-                    is_error=True,
-                    tool_name=self.tool_name,
-                )
-            logger.info(
-                f"MCP client not connected for tool '{self.tool_name}'; "
-                "attempting reconnection before failing."
-            )
-            try:
-                await self.client.connect()
-            except Exception as exc:
-                return MCPToolObservation.from_text(
-                    text=(
-                        f"MCP client not connected for tool '{self.tool_name}'. "
-                        f"Reconnection attempt failed: {exc}"
-                    ),
-                    is_error=True,
-                    tool_name=self.tool_name,
-                )
         try:
-            logger.debug(
-                f"Calling MCP tool {self.tool_name} with args: {action.model_dump()}"
-            )
-            result: mcp.types.CallToolResult = await self.client.call_tool_mcp(
-                name=self.tool_name, arguments=action.to_mcp_arguments()
-            )
-            return MCPToolObservation.from_call_tool_result(
-                tool_name=self.tool_name, result=result
-            )
-        except Exception as e:
-            error_msg = f"Error calling MCP tool {self.tool_name}: {str(e)}"
-            logger.error(error_msg, exc_info=True)
+            if not self.client.is_connected():
+                await self._reconnect_client()
+        except Exception as exc:
             return MCPToolObservation.from_text(
-                text=error_msg,
+                text=(
+                    f"MCP client not connected for tool '{self.tool_name}'. "
+                    f"Reconnection attempt failed: {exc}"
+                ),
                 is_error=True,
                 tool_name=self.tool_name,
+            )
+        for attempt in (1, 2):
+            try:
+                logger.debug(
+                    f"Calling MCP tool {self.tool_name} with args: "
+                    f"{action.model_dump()}"
+                )
+                result: mcp.types.CallToolResult = await self.client.call_tool_mcp(
+                    name=self.tool_name, arguments=action.to_mcp_arguments()
+                )
+            except Exception as e:
+                if attempt == 1 and self._is_connection_error(e):
+                    logger.info(
+                        "MCP tool '%s' failed with a connection error (%s); "
+                        "reconnecting and retrying once.",
+                        self.tool_name,
+                        e,
+                    )
+                    try:
+                        await self._reconnect_client()
+                    except Exception as reconnect_exc:
+                        logger.error(
+                            "MCP tool '%s' reconnect failed: %s (original error: %s)",
+                            self.tool_name,
+                            reconnect_exc,
+                            e,
+                            exc_info=True,
+                        )
+                        return MCPToolObservation.from_text(
+                            text=(
+                                f"Error calling MCP tool {self.tool_name}: "
+                                f"reconnection failed ({reconnect_exc}); "
+                                f"original error: {e}"
+                            ),
+                            is_error=True,
+                            tool_name=self.tool_name,
+                        )
+                    continue
+                error_msg = f"Error calling MCP tool {self.tool_name}: {str(e)}"
+                logger.error(error_msg, exc_info=True)
+                return MCPToolObservation.from_text(
+                    text=error_msg,
+                    is_error=True,
+                    tool_name=self.tool_name,
+                )
+            # Some transports surface a dropped session as an *error result*
+            # rather than a raised exception (e.g. the in-process fastmcp
+            # gateway that fans out to the desktop bridge). Treat a
+            # connection-type error result exactly like a raised one:
+            # reconnect once and retry a single time.
+            is_err = getattr(result, "isError", getattr(result, "is_error", False))
+            if attempt == 1 and is_err and self._is_connection_error(
+                self._result_error_text(result)
+            ):
+                logger.info(
+                    "MCP tool '%s' returned a connection error result (%s); "
+                    "reconnecting and retrying once.",
+                    self.tool_name,
+                    self._result_error_text(result)[:200],
+                )
+                try:
+                    await self._reconnect_client()
+                except Exception as reconnect_exc:
+                    logger.error(
+                        "MCP tool '%s' reconnect failed: %s",
+                        self.tool_name,
+                        reconnect_exc,
+                        exc_info=True,
+                    )
+                    return MCPToolObservation.from_call_tool_result(
+                        tool_name=self.tool_name, result=result
+                    )
+                continue
+            return MCPToolObservation.from_call_tool_result(
+                tool_name=self.tool_name, result=result
             )
 
     def __call__(


### PR DESCRIPTION
HUMAN:
Tested in my deployment by restarting the MCP server mid-conversation and reconnecting via the new endpoint.

AGENT:
I did not run the project's full automated test suite in this environment. Verified with `py_compile` and `ruff check` (both pass) on the files changed in this PR and its dependency #4899. Manual verification steps are listed under "How to Test"; the `HUMAN:` note above confirms the reconnect flow was exercised against the new endpoint.

## Why
When a conversation's MCP transport drops (for example, the MCP server process is restarted or a network blip occurs), the conversation can lose its MCP tools for good: every later tool call fails with `Connection closed`. A client that wants to keep the same conversation history currently has no API to recover the MCP connection - the only workaround is creating a new conversation. This PR adds a server-side way to reconnect a conversation's MCP clients in place.

## Summary
- Adds `POST /api/conversations/{conversation_id}/reconnect_mcp`.
- Reconnects every MCP client attached to the conversation's agent and reports per-server status. Example response:
  ```json
  {
    "servers": [
      {
        "server": "example-server",
        "tools": ["example-server_tool_a"],
        "connected": true,
        "reconnected": true,
        "error": null
      }
    ]
  }
  ```
- Implementation: new `EventService.reconnect_mcp()` collects the conversation's MCP tool executors from the agent's tool map, deduplicates by underlying MCP client, calls `MCPClient.reconnect()` on each, and reports the result.
- The conversation should be idle when the endpoint is called.

## Issue Number
#4837

## How to Test
1. Start a conversation whose agent has an SSE/HTTP MCP server configured.
2. Call one of its tools successfully.
3. Stop and restart the MCP server process so the transport drops.
4. `POST /api/conversations/{id}/reconnect_mcp` and confirm the response shows `connected: true, reconnected: true`.
5. Call an MCP tool in the conversation again and confirm it succeeds.

## Video/Screenshots
None.

## Design Doc
None.

## Type
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes
This PR is stacked on #4899 (`fix(sdk/mcp): reconnect MCP sessions after the transport drops`), which adds the `MCPClient.reconnect()` method this endpoint relies on. The branch currently contains #4899's changes as well; once #4899 is merged into `main`, this branch will be rebased so only the endpoint changes remain.
