### PR TITLE
chore: forbid getattr and setattr in SDK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,13 @@ repos:
             types: [python]
             pass_filenames: true
             always_run: false
+          - id: check-forbidden-dynamic-attributes
+            name: Forbid getattr and setattr in SDK
+            entry: uv run python scripts/check_forbidden_dynamic_attributes.py
+            language: system
+            files: ^openhands-sdk/.*\.py$
+            pass_filenames: true
+            always_run: false
           - id: check-import-rules
             name: Check import dependency rules
             entry: uv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,8 @@ repos:
             entry: uv run python scripts/check_forbidden_dynamic_attributes.py
             language: system
             files: ^openhands-sdk/.*\.py$
-            pass_filenames: true
-            always_run: false
+            pass_filenames: false
+            always_run: true
           - id: check-import-rules
             name: Check import dependency rules
             entry: uv

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -124,8 +124,11 @@ def main(argv: list[str]) -> int:
     if stale:
         count = len(stale)
         unit = "entry is" if count == 1 else "entries are"
-        print(f"note: {count} baseline {unit} stale; run --update-baseline to refresh.")
-    if new_violations:
+        print(
+            f"error: {count} baseline {unit} stale; "
+            "run --update-baseline to refresh."
+        )
+    if new_violations or stale:
         return 1
     return 0
 

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -69,6 +69,18 @@ def _write_baseline(entries: list[tuple[str, str, str]]) -> None:
     BASELINE_FILE.write_text(json.dumps(payload, indent=4) + "\n")
 
 
+SDK_ROOT = "openhands-sdk"
+
+
+def _discover_sdk_files() -> list[str]:
+    """Return all Python files under the SDK root, relative to the repo root."""
+    root = Path(__file__).resolve().parent.parent
+    return [
+        str(p.relative_to(root))
+        for p in sorted(root.glob(f"{SDK_ROOT}/**/*.py"))
+    ]
+
+
 def _current_entries(
     paths: list[str],
 ) -> list[tuple[str, str, str, int]]:
@@ -90,7 +102,11 @@ def main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
-    current = _current_entries(args.paths)
+    # When no paths are given (e.g. via pre-commit with pass_filenames: false),
+    # auto-discover all SDK Python files so deletions are caught.
+    paths = args.paths if args.paths else _discover_sdk_files()
+
+    current = _current_entries(paths)
 
     if args.update_baseline:
         _write_baseline([(file, name, digest) for file, name, digest, _ in current])
@@ -101,7 +117,7 @@ def main(argv: list[str]) -> int:
     current_counter = Counter(
         (file, name, digest) for file, name, digest, _ in current
     )
-    passed_files = set(args.paths)
+    checked_files = set(paths)
 
     # New violations: occurrences that exceed the baseline count for each key.
     new_violations: list[tuple[str, int, str]] = []
@@ -111,12 +127,13 @@ def main(argv: list[str]) -> int:
             new_violations.append((file, line, name))
             current_counter[key] -= 1  # count only the excess as new
 
-    # Stale: baseline entries no longer present in the current code (for files
-    # actually being checked, so subset runs don't report unrelated drift).
+    # Stale: baseline entries no longer present in the current code.  When the
+    # checker runs on all SDK files (auto-discovery), entries for deleted files
+    # are also flagged; subset runs only report drift for files they checked.
     stale = {
         key
         for key, count in (baseline - current_counter).items()
-        if key[0] in passed_files
+        if key[0] in checked_files or not Path(key[0]).exists()
     }
 
     for file, line, name in sorted(new_violations):

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -5,9 +5,10 @@ the hook can be introduced before the cleanup work (tracked in #4903, #4904,
 #4905) is finished.  Only calls *not* present in the baseline are reported.
 
 A violation is identified by its file path (relative to the repo root), the
-call name, and a hash of the stripped source line.  Keying on the source line
-instead of the line number keeps the baseline stable when unrelated edits shift
-line numbers, while still flagging genuine edits to an existing call.
+call name, and a hash of the full call source segment (not just the first
+physical line).  Keying on the complete expression keeps the baseline stable
+when unrelated edits shift line numbers, while still flagging genuine edits
+to an existing call — including argument changes on subsequent lines.
 
 The baseline is a *multiset* (occurrence counts are preserved), so adding
 another copy of an already-baselined call is still flagged.
@@ -33,15 +34,23 @@ FORBIDDEN = {"getattr", "setattr"}
 BASELINE_FILE = Path(__file__).with_name("forbidden_dynamic_attributes_baseline.json")
 
 
-def _line_hash(source: str) -> str:
-    return hashlib.sha256(source.strip().encode("utf-8")).hexdigest()
+def _segment_hash(source: str, node: ast.Call) -> str:
+    """Hash the full source segment of *node*, not just its first line."""
+    segment = ast.get_source_segment(source, node)
+    if segment is not None:
+        text = segment
+    else:
+        # Fallback: join all physical lines the node spans.
+        lines = source.splitlines()
+        end = getattr(node, "end_lineno", node.lineno) or node.lineno
+        text = "\n".join(lines[node.lineno - 1 : end])
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
 
 def violations(path: Path) -> list[tuple[int, str, str]]:
-    """Return ``(lineno, name, line_hash)`` for each forbidden call in *path*."""
+    """Return ``(lineno, name, segment_hash)`` for each forbidden call in *path*."""
     source = path.read_text()
     tree = ast.parse(source, filename=str(path))
-    lines = source.splitlines()
     result: list[tuple[int, str, str]] = []
     for node in ast.walk(tree):
         if (
@@ -49,8 +58,7 @@ def violations(path: Path) -> list[tuple[int, str, str]]:
             and isinstance(node.func, ast.Name)
             and node.func.id in FORBIDDEN
         ):
-            line_text = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
-            result.append((node.lineno, node.func.id, _line_hash(line_text)))
+            result.append((node.lineno, node.func.id, _segment_hash(source, node)))
     return result
 
 

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -75,10 +75,7 @@ SDK_ROOT = "openhands-sdk"
 def _discover_sdk_files() -> list[str]:
     """Return all Python files under the SDK root, relative to the repo root."""
     root = Path(__file__).resolve().parent.parent
-    return [
-        str(p.relative_to(root))
-        for p in sorted(root.glob(f"{SDK_ROOT}/**/*.py"))
-    ]
+    return [str(p.relative_to(root)) for p in sorted(root.glob(f"{SDK_ROOT}/**/*.py"))]
 
 
 def _current_entries(
@@ -114,9 +111,7 @@ def main(argv: list[str]) -> int:
         return 0
 
     baseline = _load_baseline()
-    current_counter = Counter(
-        (file, name, digest) for file, name, digest, _ in current
-    )
+    current_counter = Counter((file, name, digest) for file, name, digest, _ in current)
     checked_files = set(paths)
 
     # New violations: occurrences that exceed the baseline count for each key.
@@ -141,10 +136,7 @@ def main(argv: list[str]) -> int:
     if stale:
         count = len(stale)
         unit = "entry is" if count == 1 else "entries are"
-        print(
-            f"error: {count} baseline {unit} stale; "
-            "run --update-baseline to refresh."
-        )
+        print(f"error: {count} baseline {unit} stale; run --update-baseline to refresh")
     if new_violations or stale:
         return 1
     return 0

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -1,0 +1,35 @@
+"""Reject dynamic attribute access in SDK source files."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+FORBIDDEN = {"getattr", "setattr"}
+
+
+def violations(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    return [
+        (node.lineno, node.func.id)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in FORBIDDEN
+    ]
+
+
+def main(paths: list[str]) -> int:
+    found = False
+    for raw_path in paths:
+        path = Path(raw_path)
+        for line, name in violations(path):
+            print(f"{path}:{line}: forbidden dynamic attribute call: {name}")
+            found = True
+    return int(found)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -1,34 +1,119 @@
-"""Reject dynamic attribute access in SDK source files."""
+"""Reject new dynamic attribute access in SDK source files.
+
+Existing ``getattr``/``setattr`` calls are recorded in a committed baseline so
+the hook can be introduced before the cleanup work (tracked in #4903, #4904,
+#4905) is finished.  Only calls *not* present in the baseline are reported.
+
+A violation is identified by its file path (relative to the repo root), the
+call name, and a hash of the stripped source line.  Keying on the source line
+instead of the line number keeps the baseline stable when unrelated edits shift
+line numbers, while still flagging genuine edits to an existing call.
+
+Regenerate the baseline after removing existing calls with::
+
+    uv run python scripts/check_forbidden_dynamic_attributes.py \\
+        --update-baseline $(find openhands-sdk -name '*.py')
+"""
 
 from __future__ import annotations
 
+import argparse
 import ast
+import hashlib
+import json
 import sys
 from pathlib import Path
 
 
 FORBIDDEN = {"getattr", "setattr"}
+BASELINE_FILE = Path(__file__).with_name("forbidden_dynamic_attributes_baseline.json")
 
 
-def violations(path: Path) -> list[tuple[int, str]]:
-    tree = ast.parse(path.read_text(), filename=str(path))
-    return [
-        (node.lineno, node.func.id)
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id in FORBIDDEN
+def _line_hash(source: str) -> str:
+    return hashlib.sha256(source.strip().encode("utf-8")).hexdigest()
+
+
+def violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, name, line_hash)`` for each forbidden call in *path*."""
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+    lines = source.splitlines()
+    result: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in FORBIDDEN
+        ):
+            line_text = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+            result.append((node.lineno, node.func.id, _line_hash(line_text)))
+    return result
+
+
+def _load_baseline() -> set[tuple[str, str, str]]:
+    if not BASELINE_FILE.exists():
+        return set()
+    data = json.loads(BASELINE_FILE.read_text())
+    return {(entry["file"], entry["name"], entry["hash"]) for entry in data}
+
+
+def _write_baseline(entries: list[tuple[str, str, str]]) -> None:
+    payload = [
+        {"file": file, "name": name, "hash": digest}
+        for file, name, digest in sorted(entries)
     ]
+    BASELINE_FILE.write_text(json.dumps(payload, indent=4) + "\n")
 
 
-def main(paths: list[str]) -> int:
-    found = False
+def _current_entries(
+    paths: list[str],
+) -> list[tuple[str, str, str, int]]:
+    """Return all current violations across *paths* as ``(file, name, hash, line)``."""
+    entries: list[tuple[str, str, str, int]] = []
     for raw_path in paths:
-        path = Path(raw_path)
-        for line, name in violations(path):
-            print(f"{path}:{line}: forbidden dynamic attribute call: {name}")
-            found = True
-    return int(found)
+        for line, name, digest in violations(Path(raw_path)):
+            entries.append((raw_path, name, digest, line))
+    return entries
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Python files to check")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Rewrite the baseline from the current violations and exit 0.",
+    )
+    args = parser.parse_args(argv)
+
+    current = _current_entries(args.paths)
+
+    if args.update_baseline:
+        _write_baseline([(file, name, digest) for file, name, digest, _ in current])
+        print(f"Baseline updated: {len(current)} existing violations recorded.")
+        return 0
+
+    baseline = _load_baseline()
+    current_keys = {(file, name, digest) for file, name, digest, _ in current}
+    passed_files = set(args.paths)
+    new_violations = [
+        (file, line, name)
+        for file, name, digest, line in current
+        if (file, name, digest) not in baseline
+    ]
+    # Only flag staleness for files actually being checked, so subset runs
+    # (e.g. pre-commit on changed files) don't report unrelated drift.
+    stale = {entry for entry in baseline - current_keys if entry[0] in passed_files}
+
+    for file, line, name in sorted(new_violations):
+        print(f"{file}:{line}: forbidden dynamic attribute call: {name}")
+    if stale:
+        count = len(stale)
+        unit = "entry is" if count == 1 else "entries are"
+        print(f"note: {count} baseline {unit} stale; run --update-baseline to refresh.")
+    if new_violations:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -9,6 +9,9 @@ call name, and a hash of the stripped source line.  Keying on the source line
 instead of the line number keeps the baseline stable when unrelated edits shift
 line numbers, while still flagging genuine edits to an existing call.
 
+The baseline is a *multiset* (occurrence counts are preserved), so adding
+another copy of an already-baselined call is still flagged.
+
 Regenerate the baseline after removing existing calls with::
 
     uv run python scripts/check_forbidden_dynamic_attributes.py \\
@@ -22,6 +25,7 @@ import ast
 import hashlib
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 
@@ -50,11 +54,11 @@ def violations(path: Path) -> list[tuple[int, str, str]]:
     return result
 
 
-def _load_baseline() -> set[tuple[str, str, str]]:
+def _load_baseline() -> Counter[tuple[str, str, str]]:
     if not BASELINE_FILE.exists():
-        return set()
+        return Counter()
     data = json.loads(BASELINE_FILE.read_text())
-    return {(entry["file"], entry["name"], entry["hash"]) for entry in data}
+    return Counter((entry["file"], entry["name"], entry["hash"]) for entry in data)
 
 
 def _write_baseline(entries: list[tuple[str, str, str]]) -> None:
@@ -94,16 +98,26 @@ def main(argv: list[str]) -> int:
         return 0
 
     baseline = _load_baseline()
-    current_keys = {(file, name, digest) for file, name, digest, _ in current}
+    current_counter = Counter(
+        (file, name, digest) for file, name, digest, _ in current
+    )
     passed_files = set(args.paths)
-    new_violations = [
-        (file, line, name)
-        for file, name, digest, line in current
-        if (file, name, digest) not in baseline
-    ]
-    # Only flag staleness for files actually being checked, so subset runs
-    # (e.g. pre-commit on changed files) don't report unrelated drift.
-    stale = {entry for entry in baseline - current_keys if entry[0] in passed_files}
+
+    # New violations: occurrences that exceed the baseline count for each key.
+    new_violations: list[tuple[str, int, str]] = []
+    for file, name, digest, line in current:
+        key = (file, name, digest)
+        if current_counter[key] > baseline.get(key, 0):
+            new_violations.append((file, line, name))
+            current_counter[key] -= 1  # count only the excess as new
+
+    # Stale: baseline entries no longer present in the current code (for files
+    # actually being checked, so subset runs don't report unrelated drift).
+    stale = {
+        key
+        for key, count in (baseline - current_counter).items()
+        if key[0] in passed_files
+    }
 
     for file, line, name in sorted(new_violations):
         print(f"{file}:{line}: forbidden dynamic attribute call: {name}")

--- a/scripts/forbidden_dynamic_attributes_baseline.json
+++ b/scripts/forbidden_dynamic_attributes_baseline.json
@@ -1,0 +1,637 @@
+[
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "0074d962cc3758d4b2db122d0ccf29d8a10f4d121fd44bf30481bb82898dacc0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "0905f17c6bc23f16a729d95ef2b28c5248413c5d653d6919e54bef8e19757cae"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "3d4f89d0a35bf42629e8d54da4fc75eebad9cff56089f54621aa4d659027fe12"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "46f5e108bb9530a09d81afe867dd66265cd38b06c18dc5dc4d62e1686acfaf55"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "46f5e108bb9530a09d81afe867dd66265cd38b06c18dc5dc4d62e1686acfaf55"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "56343cf5eeb8936e0c92dc62a5d677fa23838d590a5d21f726664365645e8153"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "695f8163cf8f6f89be06de059cbb39312ac87ba96b1356b4038977492300216b"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "6e03a359379e21d645bae981106d11ce9c385ac716a837c385649ca604d83722"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "6e4e773ff4f8abdab89fd63df249be58a778accec44a2e76ea2d714c5a4c1b70"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "80c2977c5c737c514bef40be399420eb59d4af0a5bd3957cd7302b2b64f9e7b3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "8c8150c8e0d2db126285d1a680b62f2d245f9dce7ae5f491209ce74c5f212fbb"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "9d91e1c7c1d5a893f236443c3de7069f2adf619a70b06d624ab79813c43794b2"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "bb09e04ed0984f2a2ba0d2723159b0e399d8c9b2497bcdbe6e863d6136bb57fc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "cb8b8f448e06c17aebe5047e75ff9df0c9fd200a723abf60ed1285a9d276fb75"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "cbaa5a14745466d14d1c1bf0649fbff70a7da2b29f4483f358953051ffa8da15"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "cc3ad874fdcb8c35e57894d3c8df477c73926b2194ba48778f43ddffd72f1dd8"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "getattr",
+        "hash": "d634f089d5731a684e044e001a2151a6393a866b6de090b06abbcf7f8a8d84b5"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
+        "name": "setattr",
+        "hash": "6e4858b4df5eac72a61b1c6e3637f4d421808303f4d197a134e5dde26365b952"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_file_credentials.py",
+        "name": "getattr",
+        "hash": "a9b8acd2b2c3e50afdc30bb28e4fdaa4fc716a3dbc72256d09d5dae47b1b596f"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
+        "name": "getattr",
+        "hash": "1b9fdc8d2363d13b0728c5fa2c8b788dfacdb18ada50bc683c8b58c44c9f4ff0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
+        "name": "getattr",
+        "hash": "51a9cdd92a6cc9013b36c051dbbcc713ca4bdb013f45e1c9c378e37b00623a30"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
+        "name": "getattr",
+        "hash": "b3ed1b61c0bb9606dbc1d0fae3af577f0bb462b0eea1d31d5d341dea8f2dd93d"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/acp_tracing.py",
+        "name": "getattr",
+        "hash": "d8b34609432df00fa15ae03fdcafc969dba2855aedecc515d7e9d426c1b90d0a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/agent.py",
+        "name": "getattr",
+        "hash": "03906f076770c941514f71cbf60728486dec402e86ff0ebfa06fcce691f5e534"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/agent.py",
+        "name": "setattr",
+        "hash": "e3aa9f25624446ebdd5ddcf3437c95cd189e77ab30870ace82aacd7ff1f33168"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/agent.py",
+        "name": "setattr",
+        "hash": "e3aa9f25624446ebdd5ddcf3437c95cd189e77ab30870ace82aacd7ff1f33168"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/base.py",
+        "name": "getattr",
+        "hash": "0775b72763a038ce44fd1d6978633337ab1978c21e9bf6951b6c943cb592c0a2"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/base.py",
+        "name": "getattr",
+        "hash": "0775b72763a038ce44fd1d6978633337ab1978c21e9bf6951b6c943cb592c0a2"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/base.py",
+        "name": "getattr",
+        "hash": "17b4e10fb59bceb3ff8ae7986a814e40809ba87b98c487aa6e4967bcd03ea484"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "271f894a42aa026f8b79c809d411b021293e857c3db6c824898aff8f9388a87f"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "2c347967a81b357e59e6617709e54cbca76d4b3baa0fe6413c30cbddade789f5"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "773cbbf8eba9fac7d103d1a93a306129e581213d38b1ba08f153c3cba69d0ff2"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "9130bf0611d113c6fca02959ef2f32f8a8b9fb72acc26d5e0da72b722f076ed7"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "dda6d84a3166f57f52eaf709c095f9e11ee7f65607b2a2ed0e17525f36375f74"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
+        "name": "getattr",
+        "hash": "f8aa16774d66293229c94ed69159b958881cee11d5d699ddb9ac9b357347d77d"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/secret_registry.py",
+        "name": "getattr",
+        "hash": "00860a07898dc227acdd881869173ee45a47b4beab2c8af1408cf0b3a3f4fe04"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "24e9ed8e164b71c5f44e01eb927cf32daa250d5ed06389a8d5bb6f326b31b508"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "4682345500bbfdf799f08657a90a62bb72b24429642a3ab36037c8fde2a6a53a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "4682345500bbfdf799f08657a90a62bb72b24429642a3ab36037c8fde2a6a53a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "b698bc9c86d7dae1983d493480e705745e29e8f2d15b2f2fa3e76502d159d8a3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "da77e75d25fdb307beaa9f6ec5877688a10941024799c2b571918a1d03085ff3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "f19ee92632d967f0d377ef739af2bd082b787a060cc45bdbf951e9327472b326"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/state.py",
+        "name": "getattr",
+        "hash": "f19ee92632d967f0d377ef739af2bd082b787a060cc45bdbf951e9327472b326"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/conversation/visualizer/default.py",
+        "name": "getattr",
+        "hash": "931953237d89d542da07dc52dd1a1897c555268c9305084cf06267e1f1386bc0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/event/acp_tool_call.py",
+        "name": "getattr",
+        "hash": "07f43c8059bbed3a1274722109b05d512acd0387b493a6b65dd4f4f11849fbfc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/event/resume_transcript.py",
+        "name": "getattr",
+        "hash": "d09b50f751e11defbe93f84fc0383fc78524f1780ee7e4ba7c9d5ddb92cce7c1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/hooks/config.py",
+        "name": "getattr",
+        "hash": "a5a12c86aa54fd17b2c60fc50ad4fb5e82e8754ec81121488adad55a095990e7"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/hooks/config.py",
+        "name": "getattr",
+        "hash": "ad9c759ec52a1bbc0d6377fe13454bb9d05e3b3cda5731f4870d72cfa370a47c"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/hooks/executor.py",
+        "name": "getattr",
+        "hash": "cd2367cf983de7e26342d3d509800a682652370c859941a4b2ab224d3cdb8cc6"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/auth/openai.py",
+        "name": "getattr",
+        "hash": "207be28f3235891733791c4ee2a01fa5caa1fc59a87ac86be1ffcf681b14e624"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "03dd6017d2e87750086a90dbf5f30eae396449150963e71dbf0920f4c574edc3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "10c2cf80875db2f3269702c8a35c9a60e9626d1db52f3b8f4ec05fc6f5cedcce"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "5f996889dbb31b08a73936c080ff9feb7a9857be572ae7b2270648434d6803ae"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "66947cfc047b9fc4355f959bc7646f1c436597ab7b25e3a9572c1fdd884f4c9d"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "777c6351ad8b47f49c77fc83b3e4baa78333853a71abee62456e512f9a9115ae"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "777c6351ad8b47f49c77fc83b3e4baa78333853a71abee62456e512f9a9115ae"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "8265ec9366e4066ae9dd46a139ea9ba503c48eee8d27c5f3f2803e8fdb532bce"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "c73058cb389df4d0b5ccef727530f44324d4dd64d3b5dc433ecbec433584fb25"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "c73058cb389df4d0b5ccef727530f44324d4dd64d3b5dc433ecbec433584fb25"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/llm.py",
+        "name": "getattr",
+        "hash": "cb2e995234564fd5d452544d4a2cd760102d87a9764aa4c33a3839556ffe5bc1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/message.py",
+        "name": "getattr",
+        "hash": "1cc23aa37c2e9fe3fcf779fdc18c586ca4cadacf2dfcb8b88c6fc1a26afd434b"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/message.py",
+        "name": "getattr",
+        "hash": "96417dd344d5010a60b6bc0f99d30ac97630437cfcf5b53aeeb304bfa6f49758"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/message.py",
+        "name": "getattr",
+        "hash": "ca4b51965146b49c0e83ded407a39de2dfe0aeb2289924e38890c9430a8e85d1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/mixins/non_native_fc.py",
+        "name": "getattr",
+        "hash": "8dfbcf26a47a605931d46309e02f2410a6c550a29e3d0c7e18e17b8f1c26fb56"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/router/base.py",
+        "name": "getattr",
+        "hash": "93a0a813d217c38dd68bc572c71d471b70ffeaef8d621d9a5ca968c841859243"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "getattr",
+        "hash": "496e2b64f170d9f3cecfbfd5a8eb1ec0ea85ff0dabd02cf6efb2912e80708432"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "getattr",
+        "hash": "5b2eeb62aceb269fb7b64a3ad5577a7a752a20c7c996270842224cbeb984f6ba"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "getattr",
+        "hash": "8d96d68aad1ff2bdb5258304fea9c7fed79da065e1df3228f4464502209ea98e"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "getattr",
+        "hash": "ac7d83c0c87ab9ee53b952385d00b28e9eff1635a5a102121d1b3a14d79f4387"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "getattr",
+        "hash": "def33bfb510130af21e2f42ff8fb0c814199f5e91f85d7c6bd05733b68565bb1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "setattr",
+        "hash": "54d825e87ca15618b0c0bd3a08b59e8120610cc4ef5dada540338d06bec10bbc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
+        "name": "setattr",
+        "hash": "d4ecbffdea4079a4ee8eddd421135d7f9d89b32e3d84e567fc6277758c1aef37"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "13a0f918f79f3f28ee75f8fb3868adf973131b78a2c36569793fe8f6e1ddab5a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "307b4fdddc4476e66690c2c9ecbb0e3534f794d51959c76a67f747235346be9e"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "3575764d9e3b877f7ff6644d73395a6a49e3c315beeeb35459260d942661e131"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "591c2d2de8ede7442a6070fcd76b74f37c7ce6ef6e2f66263a4ac512bdbf0131"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "5c407f577a15efd96113d12ab1d5bc59d46ccfdaf24e0f387b728daa10f671b3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "5c407f577a15efd96113d12ab1d5bc59d46ccfdaf24e0f387b728daa10f671b3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "5d888dc65ac199ee358845a330609b7717a7a7f40dca76d8bad36828da783693"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "5d888dc65ac199ee358845a330609b7717a7a7f40dca76d8bad36828da783693"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "6239ffda957974e18d62716c0e7b3eac3033ee4678bbeaf6d385a25bbd8c9b35"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "644482bf262e55268eec448e27aecdc61d518403c7c18d657cff3ca28a4f13ab"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "687c4f0948a07245a238ac1e44d1ae0a3b414315f39168c78fca18b1d3e002a3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "687c4f0948a07245a238ac1e44d1ae0a3b414315f39168c78fca18b1d3e002a3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "70181179d4e6ceee97c9c97f25163c0c8b2ecda8d6fc0387e1c0b2c3eced12fc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "70181179d4e6ceee97c9c97f25163c0c8b2ecda8d6fc0387e1c0b2c3eced12fc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "7899c57f735b4764f9b5cf5970667d1ab26d5ce92fa80e6c3a87fa0f5486c5aa"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "8df9dc2392716c27b63c233df299dd76980a948ae5bae086eddc4855b9ef93b7"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "91c31b6d60a1d8a89144ae1b60ad38233b0efe8a01661b12f2d7781b375c425a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "991bec388d4e818c9d7178ab396a19beb606d74c556cf3be760c70ade55bb29a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "a429e1b59adc4dbfdfa5d66dbaf733067807895736e4f7de4da8c4cf045f51f0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "c3260b5ba685b65051f4e07e906a0dfa5aff508542f95e2654acc8ea80ff392c"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "c3260b5ba685b65051f4e07e906a0dfa5aff508542f95e2654acc8ea80ff392c"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "ca433b589834a4cce3dc1a4d9189de5564c87a021b610673875638e3be1ff2b7"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "d41451c51ebe1c9d6da7767dba69ec14627f2547a01edef295f0b91be796c139"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "dc8a9fd099a24724217efa41a514849b66e9542b386b4d151f422beb01034597"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "dc8a9fd099a24724217efa41a514849b66e9542b386b4d151f422beb01034597"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "ef27a354e32930becc8ad948f52508a658540c5076ab6a478f73e268719bb7fc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "ef27a354e32930becc8ad948f52508a658540c5076ab6a478f73e268719bb7fc"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "f4e8fa890947f7462f86835141f7cc99181b8b7e86256f2eb8a3097e6bc401ee"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "fe328495a33c0bd524d389e7b46d1d362269d67a3b917d9e74291678851903e6"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/marketplace/__init__.py",
+        "name": "getattr",
+        "hash": "98367f9cd75e70be9d6ca295572b3a225252f87449ff1c0084bc9d41facc9af1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/marketplace/__init__.py",
+        "name": "getattr",
+        "hash": "f6a0087d1b9e8c6c2a67be7e13cbc87289015967352d623df86778c51f82a0e0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
+        "name": "getattr",
+        "hash": "0b4c341b7f42ae7692a409eecf87704bd3ec33ae3925fd4f305729dc31228b0d"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
+        "name": "getattr",
+        "hash": "2850b07c464d0ff4548f82675de6c19474070920c5ead19fa21f6651a32d28bd"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
+        "name": "getattr",
+        "hash": "84488f6c77ac652b4237ee482c6251b5dea9bfa21b92028ddcecf876ce8fae45"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/observability/laminar.py",
+        "name": "getattr",
+        "hash": "26623841b0ee6dc5eb792261399e31a70af34b5e30bc912539f706bdda80bada"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/profiles/agent_profile.py",
+        "name": "getattr",
+        "hash": "fa88da35b819b713a36feb9bfab3429b52aec305cc383b858133d93270d1e027"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/__init__.py",
+        "name": "getattr",
+        "hash": "e2759ed32215ef8ae36973bd30b46c5db9c8942dfbbae7709963c0a029dccfd1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "4a4768d43ad765fbbdc6509fccf75f4e93d5e6f1c1f706ac18199b40277a6dc6"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "8bd0e6cbaf5390100f47518efa526dd7084e957d9534f883eb3faf81f1002a8f"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "8cba41cb787e52f65daa709a3f29d8ed3a590c6152ad026f84681373a6539a76"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "a08515ff141360357da9787e59dda5df62052ec6fef0bb38350c723c08c1a0a0"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "ce55ab06fdd7048bf1e873d0c57b57cc03958b990f0300992dd2623a31f7d80f"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/settings/model.py",
+        "name": "getattr",
+        "hash": "fa88da35b819b713a36feb9bfab3429b52aec305cc383b858133d93270d1e027"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/skills/utils.py",
+        "name": "setattr",
+        "hash": "4735168bb9a033624fdf23570f93049f4b9d3bb5512c65644ea494e742e98efa"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/builtins/invoke_skill.py",
+        "name": "getattr",
+        "hash": "e741f074de4dc8a5e28c2440296b3a049ab107a7c8c3746bb1845c1ac8056f02"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/registry.py",
+        "name": "getattr",
+        "hash": "362c29cc1a33c35bb0aa6f87dee515541781abeba354cff00837fba52510775a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/registry.py",
+        "name": "getattr",
+        "hash": "6959050501c6c9cd562856114461f86272054dd05c08deabb1e7674727432342"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/schema.py",
+        "name": "getattr",
+        "hash": "8a2d019e79964d21ceeb0b095d1b1b022d6cf663bb39e4b47b72abc1952d74b5"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/schema.py",
+        "name": "getattr",
+        "hash": "d3450d98e235d3353a3bd97acea6e3967e851b7d69a9090133948ffc847d424c"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/schema.py",
+        "name": "setattr",
+        "hash": "02fa63a9774d5ac6a846ea8184c715e6b7e78ea4dd606220ff3560ad57088a3a"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/tool/schema.py",
+        "name": "setattr",
+        "hash": "4f0ba85834954feb97a0648d020db3147d4a61c1e6d6c897df1347c31e789162"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/utils/files.py",
+        "name": "getattr",
+        "hash": "d762e82ce86816818035f2becd3e86ce24fa3e650f941a2a86a8cd6db2a4cc8e"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/utils/models.py",
+        "name": "getattr",
+        "hash": "7dbf2bc94d32c54160f2040a628d2786dc6a81d82ae5684f6c21bd5f30702e2f"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py",
+        "name": "getattr",
+        "hash": "7afbea12f235f22be6dbed3e2fa3a6f4c650b331dbbc1b139b3568f04abe3b6e"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/workspace/remote/base.py",
+        "name": "getattr",
+        "hash": "7afbea12f235f22be6dbed3e2fa3a6f4c650b331dbbc1b139b3568f04abe3b6e"
+    }
+]

--- a/scripts/forbidden_dynamic_attributes_baseline.json
+++ b/scripts/forbidden_dynamic_attributes_baseline.json
@@ -2,87 +2,87 @@
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "0074d962cc3758d4b2db122d0ccf29d8a10f4d121fd44bf30481bb82898dacc0"
+        "hash": "046132ee1e8f764c967fab63318920cd1ecbd513e69500443644de573c59a491"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "0905f17c6bc23f16a729d95ef2b28c5248413c5d653d6919e54bef8e19757cae"
+        "hash": "09572935c2b01d31a43c1cc1f36a0ffeed72ca98b07917dce2bb6203d7e36f6a"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "3d4f89d0a35bf42629e8d54da4fc75eebad9cff56089f54621aa4d659027fe12"
+        "hash": "2ed29d6bb6db3fcd770c70bc897ec394d639a46ccece58542ffebc293d0cbabb"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "46f5e108bb9530a09d81afe867dd66265cd38b06c18dc5dc4d62e1686acfaf55"
+        "hash": "355e8f4d2c05b18e6c8bf72bdcbdc5af445e9b05223b0b69230339f1f29e55d5"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "46f5e108bb9530a09d81afe867dd66265cd38b06c18dc5dc4d62e1686acfaf55"
+        "hash": "35948af158a5b6ddfee2b70fd59584b865b415374555188187125e2bff018b6a"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "56343cf5eeb8936e0c92dc62a5d677fa23838d590a5d21f726664365645e8153"
+        "hash": "542d26967e84afdc6dd93da5d90e03f135155548024fd2de49d8e906243f50bd"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "695f8163cf8f6f89be06de059cbb39312ac87ba96b1356b4038977492300216b"
+        "hash": "5a6f2bae13f2b0cc3989b52de1c194886c173c6a32ede3f69705fed853488a66"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "6e03a359379e21d645bae981106d11ce9c385ac716a837c385649ca604d83722"
+        "hash": "75d505a43084608fc95fc2ee7a88c1eb44ecde124d96e5dc458d7ef42b200007"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "6e4e773ff4f8abdab89fd63df249be58a778accec44a2e76ea2d714c5a4c1b70"
+        "hash": "81fb5224ae22630e0ef79429d964d699e3a5d424cc7a9c60e6870c7a82e95fb1"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "80c2977c5c737c514bef40be399420eb59d4af0a5bd3957cd7302b2b64f9e7b3"
+        "hash": "865dec7abb198efeacf93dd891af388f7a7f266f4fcc2426f3dc90053ad089e7"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "8c8150c8e0d2db126285d1a680b62f2d245f9dce7ae5f491209ce74c5f212fbb"
+        "hash": "98502a7019186ceecc55e266718250ee99484b5906835a43f49039c57bb9f0f6"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "9d91e1c7c1d5a893f236443c3de7069f2adf619a70b06d624ab79813c43794b2"
+        "hash": "98502a7019186ceecc55e266718250ee99484b5906835a43f49039c57bb9f0f6"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "bb09e04ed0984f2a2ba0d2723159b0e399d8c9b2497bcdbe6e863d6136bb57fc"
+        "hash": "b6862d659e6c2778244b671b5c0bd22bf564a1e5931e75d974186bf0a2464847"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "cb8b8f448e06c17aebe5047e75ff9df0c9fd200a723abf60ed1285a9d276fb75"
+        "hash": "b6c18582db754b345d4044f6d4f2d759c11989805962d3f8e258b06f42a85077"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "cbaa5a14745466d14d1c1bf0649fbff70a7da2b29f4483f358953051ffa8da15"
+        "hash": "c2b936158119ddc858319dfee541542de5a1d2e1c024829585f4a6807a1c6b50"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "cc3ad874fdcb8c35e57894d3c8df477c73926b2194ba48778f43ddffd72f1dd8"
+        "hash": "c2b936158119ddc858319dfee541542de5a1d2e1c024829585f4a6807a1c6b50"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
         "name": "getattr",
-        "hash": "d634f089d5731a684e044e001a2151a6393a866b6de090b06abbcf7f8a8d84b5"
+        "hash": "c50696cae2c8b6e499477c7f42c93e2902a4833f73d55415151924e205692a3c"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_agent.py",
@@ -92,262 +92,262 @@
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_file_credentials.py",
         "name": "getattr",
-        "hash": "a9b8acd2b2c3e50afdc30bb28e4fdaa4fc716a3dbc72256d09d5dae47b1b596f"
+        "hash": "598146b3a102978154f4a563933f96d8183bb9f7413075f678452d3651fd3862"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
         "name": "getattr",
-        "hash": "1b9fdc8d2363d13b0728c5fa2c8b788dfacdb18ada50bc683c8b58c44c9f4ff0"
+        "hash": "b1fa8d6db640301ba8001801aadf3fd5fb162e03cb26e40bc90e45836102afe5"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
         "name": "getattr",
-        "hash": "51a9cdd92a6cc9013b36c051dbbcc713ca4bdb013f45e1c9c378e37b00623a30"
+        "hash": "d07e69e154b6c0f5439c230b7e597b2d16887bd1bd8c6a73de5a3f021afede39"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_models.py",
         "name": "getattr",
-        "hash": "b3ed1b61c0bb9606dbc1d0fae3af577f0bb462b0eea1d31d5d341dea8f2dd93d"
+        "hash": "e363ed7edc7fe7187b48f931411b0c52e2fa3e2a7c5a4debcba98872b6ed318a"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/acp_tracing.py",
         "name": "getattr",
-        "hash": "d8b34609432df00fa15ae03fdcafc969dba2855aedecc515d7e9d426c1b90d0a"
+        "hash": "f7d039217f7373cc7d095506305e6edde8274fe45be2388a2dd04a7ee4c75224"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/agent.py",
         "name": "getattr",
-        "hash": "03906f076770c941514f71cbf60728486dec402e86ff0ebfa06fcce691f5e534"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/agent/agent.py",
-        "name": "setattr",
-        "hash": "e3aa9f25624446ebdd5ddcf3437c95cd189e77ab30870ace82aacd7ff1f33168"
+        "hash": "5c6721b14ab482ccc26fd3a02a5d1f6bb6610470fcb94a3f870c4769b0310a60"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/agent.py",
         "name": "setattr",
-        "hash": "e3aa9f25624446ebdd5ddcf3437c95cd189e77ab30870ace82aacd7ff1f33168"
+        "hash": "e0dc931e286ba80232591dad7af09e31295b1f24666000898c5fb8794893ecf1"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/agent/agent.py",
+        "name": "setattr",
+        "hash": "e0dc931e286ba80232591dad7af09e31295b1f24666000898c5fb8794893ecf1"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/base.py",
         "name": "getattr",
-        "hash": "0775b72763a038ce44fd1d6978633337ab1978c21e9bf6951b6c943cb592c0a2"
+        "hash": "3774d7ed247b4d8931865461a9bf214876652b2d71b32b201078a01ada7c1a55"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/base.py",
         "name": "getattr",
-        "hash": "0775b72763a038ce44fd1d6978633337ab1978c21e9bf6951b6c943cb592c0a2"
+        "hash": "3774d7ed247b4d8931865461a9bf214876652b2d71b32b201078a01ada7c1a55"
     },
     {
         "file": "openhands-sdk/openhands/sdk/agent/base.py",
         "name": "getattr",
-        "hash": "17b4e10fb59bceb3ff8ae7986a814e40809ba87b98c487aa6e4967bcd03ea484"
+        "hash": "55198caa91bfc3d6c63e77b0b2ce1a357d4a41a68b3673bfe9b59bc698ee22e1"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "271f894a42aa026f8b79c809d411b021293e857c3db6c824898aff8f9388a87f"
+        "hash": "29cef9dd20811ee57d215d6edfe0e0448fb82133020422ec0a680a0adb8e26ad"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "2c347967a81b357e59e6617709e54cbca76d4b3baa0fe6413c30cbddade789f5"
+        "hash": "888bc227eb4bd2be63c83b619c57e698f5b33126cac011346a984826f34e9dc5"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "773cbbf8eba9fac7d103d1a93a306129e581213d38b1ba08f153c3cba69d0ff2"
+        "hash": "914ec96e029998cb095ab76f99c391d9b5e9b18132747fce13abe1ad61a6bbdd"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "9130bf0611d113c6fca02959ef2f32f8a8b9fb72acc26d5e0da72b722f076ed7"
+        "hash": "922770bc3d20b2b2573a4d2dbfbf00ac88a2d543a2555d7de43f251b3e4c6050"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "dda6d84a3166f57f52eaf709c095f9e11ee7f65607b2a2ed0e17525f36375f74"
+        "hash": "ce66158438a58ffad4dd20694b68f470b87dd2e98fd517ccb5fbed84a82d3247"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py",
         "name": "getattr",
-        "hash": "f8aa16774d66293229c94ed69159b958881cee11d5d699ddb9ac9b357347d77d"
+        "hash": "d8350fd78aafacbb8785b160132d901128ee2090a029067a44610b38b6dc4660"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/secret_registry.py",
         "name": "getattr",
-        "hash": "00860a07898dc227acdd881869173ee45a47b4beab2c8af1408cf0b3a3f4fe04"
+        "hash": "c813b420150ebdc58a521958ab0ebce7a2bebfd34e0f2e9da1fa6b4bdfa8e90c"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "24e9ed8e164b71c5f44e01eb927cf32daa250d5ed06389a8d5bb6f326b31b508"
+        "hash": "0e167d27747b334dff8af1ae1df38cb9eb71a1de9e134b7805f54c3dbf837644"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "4682345500bbfdf799f08657a90a62bb72b24429642a3ab36037c8fde2a6a53a"
+        "hash": "32520caf80a6aa64abd3eefe756b2ad706e05b111dd82373859dd0b656047ffd"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "4682345500bbfdf799f08657a90a62bb72b24429642a3ab36037c8fde2a6a53a"
+        "hash": "32520caf80a6aa64abd3eefe756b2ad706e05b111dd82373859dd0b656047ffd"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "b698bc9c86d7dae1983d493480e705745e29e8f2d15b2f2fa3e76502d159d8a3"
+        "hash": "5faddde1cded1902f6ecc70171a0b71b9c4fa23ba4aaf0d8f9fbf72ce6b819e5"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "da77e75d25fdb307beaa9f6ec5877688a10941024799c2b571918a1d03085ff3"
+        "hash": "b1a126cc0c429f2c12e5b13490fc6815e70a940ef656f91f8afee30f752c748e"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "f19ee92632d967f0d377ef739af2bd082b787a060cc45bdbf951e9327472b326"
+        "hash": "b1a126cc0c429f2c12e5b13490fc6815e70a940ef656f91f8afee30f752c748e"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/state.py",
         "name": "getattr",
-        "hash": "f19ee92632d967f0d377ef739af2bd082b787a060cc45bdbf951e9327472b326"
+        "hash": "e2838e974d83aa4088868265fcf74b6f66eb886fe661516cc0526a6fe0efbd1d"
     },
     {
         "file": "openhands-sdk/openhands/sdk/conversation/visualizer/default.py",
         "name": "getattr",
-        "hash": "931953237d89d542da07dc52dd1a1897c555268c9305084cf06267e1f1386bc0"
+        "hash": "641c3ba47946a4d48509156e4e8716c6ee80fa5f367e368c064d3266daee7994"
     },
     {
         "file": "openhands-sdk/openhands/sdk/event/acp_tool_call.py",
         "name": "getattr",
-        "hash": "07f43c8059bbed3a1274722109b05d512acd0387b493a6b65dd4f4f11849fbfc"
+        "hash": "d8b3a40c86ccd813700d7f9d98b629a49f7f0e8b2be088d48063b0e0d9848d4e"
     },
     {
         "file": "openhands-sdk/openhands/sdk/event/resume_transcript.py",
         "name": "getattr",
-        "hash": "d09b50f751e11defbe93f84fc0383fc78524f1780ee7e4ba7c9d5ddb92cce7c1"
+        "hash": "295c04e16fcc61460fda315b541dcb1584c8c3b784c5247d5b2529fa7909d256"
     },
     {
         "file": "openhands-sdk/openhands/sdk/hooks/config.py",
         "name": "getattr",
-        "hash": "a5a12c86aa54fd17b2c60fc50ad4fb5e82e8754ec81121488adad55a095990e7"
+        "hash": "c4a063ff99556c1ea54a7b42cf10fb5cc7ec576c9b8b527458be5bcc70de1ec0"
     },
     {
         "file": "openhands-sdk/openhands/sdk/hooks/config.py",
         "name": "getattr",
-        "hash": "ad9c759ec52a1bbc0d6377fe13454bb9d05e3b3cda5731f4870d72cfa370a47c"
+        "hash": "cb028d0a55d58c26413712ea213f75506dcdd18ce8009ad4b46e459a7ad4e51d"
     },
     {
         "file": "openhands-sdk/openhands/sdk/hooks/executor.py",
         "name": "getattr",
-        "hash": "cd2367cf983de7e26342d3d509800a682652370c859941a4b2ab224d3cdb8cc6"
+        "hash": "78f8ec7ea04cc59e459c05dcd493ea2130576872db521152af8522537ba36759"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/auth/openai.py",
         "name": "getattr",
-        "hash": "207be28f3235891733791c4ee2a01fa5caa1fc59a87ac86be1ffcf681b14e624"
+        "hash": "e8aaa9f7c905a0577ca827eb2b980493e75fa15576fb36ea3caedec465952a44"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "03dd6017d2e87750086a90dbf5f30eae396449150963e71dbf0920f4c574edc3"
+        "hash": "1d0d7334f8d3cbf5ce405a9ebeeee696ee3cd6ab1f3f3a3ec090281e87c26a0e"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "10c2cf80875db2f3269702c8a35c9a60e9626d1db52f3b8f4ec05fc6f5cedcce"
+        "hash": "33f6fe273fcfcda244277c7d4aa17986ba7d99a42405ccc17e9345ec68222537"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "5f996889dbb31b08a73936c080ff9feb7a9857be572ae7b2270648434d6803ae"
+        "hash": "33f6fe273fcfcda244277c7d4aa17986ba7d99a42405ccc17e9345ec68222537"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "66947cfc047b9fc4355f959bc7646f1c436597ab7b25e3a9572c1fdd884f4c9d"
+        "hash": "5a80cf21fe817b05c844205796ac76fed3a6a1d042f5c4367d5c39b388457dc6"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "777c6351ad8b47f49c77fc83b3e4baa78333853a71abee62456e512f9a9115ae"
+        "hash": "5f6d2f400daee58255781c296e9c4026364e2874d45332ceadc3b346ff7b9d32"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "777c6351ad8b47f49c77fc83b3e4baa78333853a71abee62456e512f9a9115ae"
+        "hash": "5f6d2f400daee58255781c296e9c4026364e2874d45332ceadc3b346ff7b9d32"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "8265ec9366e4066ae9dd46a139ea9ba503c48eee8d27c5f3f2803e8fdb532bce"
+        "hash": "9672c13062337d7dfb0a64e85dae4a6047b9b472f81aa8c63731b2dd3ccc1897"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "c73058cb389df4d0b5ccef727530f44324d4dd64d3b5dc433ecbec433584fb25"
+        "hash": "c4e5024ff23b196f9a60499e789bae6bd0186db335aa1880609061175f829c12"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "c73058cb389df4d0b5ccef727530f44324d4dd64d3b5dc433ecbec433584fb25"
+        "hash": "d4dc7589836524abc1e8a26c10bdbdf84be115c935a0931e4f5a4a79bd4fd7db"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/llm.py",
         "name": "getattr",
-        "hash": "cb2e995234564fd5d452544d4a2cd760102d87a9764aa4c33a3839556ffe5bc1"
+        "hash": "d4ddba252ea12924b2dd05cb4fb5ebcbf7b22685fc0a9b6ce305015b9cdd81d0"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/message.py",
         "name": "getattr",
-        "hash": "1cc23aa37c2e9fe3fcf779fdc18c586ca4cadacf2dfcb8b88c6fc1a26afd434b"
+        "hash": "1a2ef4748a97e7d2722b1355156c007372e94b28f026ba05d030164012fc2493"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/message.py",
         "name": "getattr",
-        "hash": "96417dd344d5010a60b6bc0f99d30ac97630437cfcf5b53aeeb304bfa6f49758"
+        "hash": "48bf373a29427605f13467bb9a458397957110a13bc0368fbf2fbfc95a9e126b"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/message.py",
         "name": "getattr",
-        "hash": "ca4b51965146b49c0e83ded407a39de2dfe0aeb2289924e38890c9430a8e85d1"
+        "hash": "a04f50426bd6b5af685f0bd5ea2450de70cdc290c0ee90f1eec530b43a444cf6"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/mixins/non_native_fc.py",
         "name": "getattr",
-        "hash": "8dfbcf26a47a605931d46309e02f2410a6c550a29e3d0c7e18e17b8f1c26fb56"
+        "hash": "2a87adf20dc79edbdd0c81c0c4ec8891939073de00d9ff355acf3b81013870f8"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/router/base.py",
         "name": "getattr",
-        "hash": "93a0a813d217c38dd68bc572c71d471b70ffeaef8d621d9a5ca968c841859243"
+        "hash": "09cb8fcdbf2f2742d279d873b054ece03eb4d8362f0dffe5c58f34e22c45fb66"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
         "name": "getattr",
-        "hash": "496e2b64f170d9f3cecfbfd5a8eb1ec0ea85ff0dabd02cf6efb2912e80708432"
+        "hash": "13e85f83c28c8128bf7d3351721af90cf477f8a6cb068c34d49044f163e40429"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
         "name": "getattr",
-        "hash": "5b2eeb62aceb269fb7b64a3ad5577a7a752a20c7c996270842224cbeb984f6ba"
+        "hash": "449c0a2bf53536ae90534440fbb4517fcfafd4f49c4f860762df8f5cf8ac4880"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
         "name": "getattr",
-        "hash": "8d96d68aad1ff2bdb5258304fea9c7fed79da065e1df3228f4464502209ea98e"
+        "hash": "56d43cbac8d37c56e6e20f7952d4c9bd04e28f717eae5e6cd47198a5f41e7d63"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
         "name": "getattr",
-        "hash": "ac7d83c0c87ab9ee53b952385d00b28e9eff1635a5a102121d1b3a14d79f4387"
+        "hash": "643df67697c54065898bae822ed007b40fa69517a588295e77b4d251cf77bfb0"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
         "name": "getattr",
-        "hash": "def33bfb510130af21e2f42ff8fb0c814199f5e91f85d7c6bd05733b68565bb1"
+        "hash": "cffbf49aac4e818f959b7953c7556e0f0d54d5ad671c9b08ffb8386ddc80e52d"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py",
@@ -362,117 +362,107 @@
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "13a0f918f79f3f28ee75f8fb3868adf973131b78a2c36569793fe8f6e1ddab5a"
+        "hash": "04a4aaf6db8703e7d99fb32cb5554fe1a549c58fe55cb38146ae0ca26be045ff"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "307b4fdddc4476e66690c2c9ecbb0e3534f794d51959c76a67f747235346be9e"
+        "hash": "34532ce6ba0ef0f64cbb540bd6e282a137c0a759b39d23eb8ec93761d593f789"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "3575764d9e3b877f7ff6644d73395a6a49e3c315beeeb35459260d942661e131"
+        "hash": "4195e43bdf920781d93f8b42a955b0be81191b07b749a8397be797185c9bd3d4"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "591c2d2de8ede7442a6070fcd76b74f37c7ce6ef6e2f66263a4ac512bdbf0131"
+        "hash": "4195e43bdf920781d93f8b42a955b0be81191b07b749a8397be797185c9bd3d4"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "5c407f577a15efd96113d12ab1d5bc59d46ccfdaf24e0f387b728daa10f671b3"
+        "hash": "4195e43bdf920781d93f8b42a955b0be81191b07b749a8397be797185c9bd3d4"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "5c407f577a15efd96113d12ab1d5bc59d46ccfdaf24e0f387b728daa10f671b3"
+        "hash": "47404691ad754f6d634e7663cdf0779890f4564efb5d7f832347c4761b5e5a11"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "5d888dc65ac199ee358845a330609b7717a7a7f40dca76d8bad36828da783693"
+        "hash": "5dc7e91a286b33029955a6749cd7bf00ce5065ef485585fe184f9c2a2e3d4717"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "5d888dc65ac199ee358845a330609b7717a7a7f40dca76d8bad36828da783693"
+        "hash": "69e5e28543d27d551b8fa6322d51917f54fed9aa61f6f2ee608476736ad6c027"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "6239ffda957974e18d62716c0e7b3eac3033ee4678bbeaf6d385a25bbd8c9b35"
+        "hash": "69e5e28543d27d551b8fa6322d51917f54fed9aa61f6f2ee608476736ad6c027"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "644482bf262e55268eec448e27aecdc61d518403c7c18d657cff3ca28a4f13ab"
+        "hash": "6d766e456aa47c88cd8f444528cc79044e9ab673cb87d7ab796f42fe201816b7"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "687c4f0948a07245a238ac1e44d1ae0a3b414315f39168c78fca18b1d3e002a3"
+        "hash": "6e99d59128a818c066f49c6e463caa28a887446db33c9d614c2fd3b602e51310"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "687c4f0948a07245a238ac1e44d1ae0a3b414315f39168c78fca18b1d3e002a3"
+        "hash": "6e99d59128a818c066f49c6e463caa28a887446db33c9d614c2fd3b602e51310"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "70181179d4e6ceee97c9c97f25163c0c8b2ecda8d6fc0387e1c0b2c3eced12fc"
+        "hash": "7e0a34e78ce4877def53523401778467dba57bac511e33b2618e7da6d422ea57"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "70181179d4e6ceee97c9c97f25163c0c8b2ecda8d6fc0387e1c0b2c3eced12fc"
+        "hash": "7e0a34e78ce4877def53523401778467dba57bac511e33b2618e7da6d422ea57"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "7899c57f735b4764f9b5cf5970667d1ab26d5ce92fa80e6c3a87fa0f5486c5aa"
+        "hash": "7e0a34e78ce4877def53523401778467dba57bac511e33b2618e7da6d422ea57"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "8df9dc2392716c27b63c233df299dd76980a948ae5bae086eddc4855b9ef93b7"
+        "hash": "87bd2727ce5eef3fdf2a169d38b23a4615bed1edfacccf917f4e60d92e7dc6f0"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "91c31b6d60a1d8a89144ae1b60ad38233b0efe8a01661b12f2d7781b375c425a"
+        "hash": "a2f271f61f01e70e183a017e7b67de2171beff8bfefb09e604baaf48bb1f480f"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "991bec388d4e818c9d7178ab396a19beb606d74c556cf3be760c70ade55bb29a"
+        "hash": "b6ac688d986e964a9a8cee6d47617e207a02740d7ae0648fb966eab33a048dc8"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "a429e1b59adc4dbfdfa5d66dbaf733067807895736e4f7de4da8c4cf045f51f0"
+        "hash": "cb8eb6e82d059fb861a0bcc3820067d85b5dabb9ab199cf81186ec57d4d14f19"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "c3260b5ba685b65051f4e07e906a0dfa5aff508542f95e2654acc8ea80ff392c"
+        "hash": "cce9dbfcf2e3c10a5b17bbe043532e50bf7cbb4e0f6372fe808869daed684e77"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "c3260b5ba685b65051f4e07e906a0dfa5aff508542f95e2654acc8ea80ff392c"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
-        "hash": "ca433b589834a4cce3dc1a4d9189de5564c87a021b610673875638e3be1ff2b7"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
-        "hash": "d41451c51ebe1c9d6da7767dba69ec14627f2547a01edef295f0b91be796c139"
+        "hash": "dc8a9fd099a24724217efa41a514849b66e9542b386b4d151f422beb01034597"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
@@ -497,82 +487,92 @@
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "f4e8fa890947f7462f86835141f7cc99181b8b7e86256f2eb8a3097e6bc401ee"
+        "hash": "ef27a354e32930becc8ad948f52508a658540c5076ab6a478f73e268719bb7fc"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "fe328495a33c0bd524d389e7b46d1d362269d67a3b917d9e74291678851903e6"
+        "hash": "efc819a5f5da0799c8335a7ba571e8e7d7cc5b91a238681ddee08e56c0dbbc1b"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "efd176e5ba2070d938707205cd15bfbf86d8379450bf993cdd0e0a6070af12a3"
+    },
+    {
+        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
+        "name": "getattr",
+        "hash": "fc0ade2f76973b01c91234391ee5b86111af1726cbba22671b3fa565f40e62b4"
     },
     {
         "file": "openhands-sdk/openhands/sdk/marketplace/__init__.py",
         "name": "getattr",
-        "hash": "98367f9cd75e70be9d6ca295572b3a225252f87449ff1c0084bc9d41facc9af1"
+        "hash": "9aa4828d48dae647719893510d2619568cbda8ac9f10643d4f3471a3a9fa07b1"
     },
     {
         "file": "openhands-sdk/openhands/sdk/marketplace/__init__.py",
         "name": "getattr",
-        "hash": "f6a0087d1b9e8c6c2a67be7e13cbc87289015967352d623df86778c51f82a0e0"
+        "hash": "a7b68b2aee3e1c77287fc8b9608f1fae0cc79e54d0bfa5c35d6475f78113fcfc"
     },
     {
         "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
         "name": "getattr",
-        "hash": "0b4c341b7f42ae7692a409eecf87704bd3ec33ae3925fd4f305729dc31228b0d"
+        "hash": "552cdba2a411e0403dd9e5c09f2e9c4e50513ce077a816c024fe3937eba93958"
     },
     {
         "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
         "name": "getattr",
-        "hash": "2850b07c464d0ff4548f82675de6c19474070920c5ead19fa21f6651a32d28bd"
+        "hash": "d43e3cfac08625006b821cd2668ea3f4e852319f06487ba5d6922b08d0102215"
     },
     {
         "file": "openhands-sdk/openhands/sdk/mcp/__init__.py",
         "name": "getattr",
-        "hash": "84488f6c77ac652b4237ee482c6251b5dea9bfa21b92028ddcecf876ce8fae45"
+        "hash": "edd18d2ff8519b8296dfb7aa7895bf5e1e2c668a626da725e41390c26747eae8"
     },
     {
         "file": "openhands-sdk/openhands/sdk/observability/laminar.py",
         "name": "getattr",
-        "hash": "26623841b0ee6dc5eb792261399e31a70af34b5e30bc912539f706bdda80bada"
+        "hash": "b5bcd8aea3ba63bce5220bc19ff504017e36402523dd1add6de1ece66d59be1c"
     },
     {
         "file": "openhands-sdk/openhands/sdk/profiles/agent_profile.py",
         "name": "getattr",
-        "hash": "fa88da35b819b713a36feb9bfab3429b52aec305cc383b858133d93270d1e027"
+        "hash": "1d0607d791dcbf80ab835e909b2da5b4886b8b3d1e092f16f653f33053cbde08"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/__init__.py",
         "name": "getattr",
-        "hash": "e2759ed32215ef8ae36973bd30b46c5db9c8942dfbbae7709963c0a029dccfd1"
+        "hash": "c813b420150ebdc58a521958ab0ebce7a2bebfd34e0f2e9da1fa6b4bdfa8e90c"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "4a4768d43ad765fbbdc6509fccf75f4e93d5e6f1c1f706ac18199b40277a6dc6"
+        "hash": "15424dd2686bddcaad7ac064779c430cb8e270ebb767d7ba117f0b062ea29293"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "8bd0e6cbaf5390100f47518efa526dd7084e957d9534f883eb3faf81f1002a8f"
+        "hash": "1d0607d791dcbf80ab835e909b2da5b4886b8b3d1e092f16f653f33053cbde08"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "8cba41cb787e52f65daa709a3f29d8ed3a590c6152ad026f84681373a6539a76"
+        "hash": "31f3620b0ab75ba4042ce23f6427eec4dd0fcd8f08a135d4435e51760023d471"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "a08515ff141360357da9787e59dda5df62052ec6fef0bb38350c723c08c1a0a0"
+        "hash": "506e5962f93218314187c4419c81e3fa94fa994b7a4366058caa2e77534aa2b8"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "ce55ab06fdd7048bf1e873d0c57b57cc03958b990f0300992dd2623a31f7d80f"
+        "hash": "914ec96e029998cb095ab76f99c391d9b5e9b18132747fce13abe1ad61a6bbdd"
     },
     {
         "file": "openhands-sdk/openhands/sdk/settings/model.py",
         "name": "getattr",
-        "hash": "fa88da35b819b713a36feb9bfab3429b52aec305cc383b858133d93270d1e027"
+        "hash": "f6199e19d020e36caa6ebb5a7a180f9fc2fb767c79f06b03665869c2b8e28c86"
     },
     {
         "file": "openhands-sdk/openhands/sdk/skills/utils.py",
@@ -582,27 +582,27 @@
     {
         "file": "openhands-sdk/openhands/sdk/tool/builtins/invoke_skill.py",
         "name": "getattr",
-        "hash": "e741f074de4dc8a5e28c2440296b3a049ab107a7c8c3746bb1845c1ac8056f02"
+        "hash": "88e73b594847ba47980fbc67d834cfc5adfc07b7a1beeb1075187230fc540c16"
     },
     {
         "file": "openhands-sdk/openhands/sdk/tool/registry.py",
         "name": "getattr",
-        "hash": "362c29cc1a33c35bb0aa6f87dee515541781abeba354cff00837fba52510775a"
+        "hash": "a23e41dcbc46514255db7692e4903034dc678afe04435a4cb2b9a98436f8dd78"
     },
     {
         "file": "openhands-sdk/openhands/sdk/tool/registry.py",
         "name": "getattr",
-        "hash": "6959050501c6c9cd562856114461f86272054dd05c08deabb1e7674727432342"
+        "hash": "caf4032041494d5275a4042f22792c880f866c7132eb5f68821985853a11bf5f"
     },
     {
         "file": "openhands-sdk/openhands/sdk/tool/schema.py",
         "name": "getattr",
-        "hash": "8a2d019e79964d21ceeb0b095d1b1b022d6cf663bb39e4b47b72abc1952d74b5"
+        "hash": "e1da333e797a071f947a9364497d2e22be3d22d22295824cdd815046ba1497f5"
     },
     {
         "file": "openhands-sdk/openhands/sdk/tool/schema.py",
         "name": "getattr",
-        "hash": "d3450d98e235d3353a3bd97acea6e3967e851b7d69a9090133948ffc847d424c"
+        "hash": "f017a075a9b7c343d52f5c8c24fdbb28de15f9804bd548d50c36876728be49da"
     },
     {
         "file": "openhands-sdk/openhands/sdk/tool/schema.py",
@@ -617,21 +617,21 @@
     {
         "file": "openhands-sdk/openhands/sdk/utils/files.py",
         "name": "getattr",
-        "hash": "d762e82ce86816818035f2becd3e86ce24fa3e650f941a2a86a8cd6db2a4cc8e"
+        "hash": "9a5d0f3abecca6d2b3809c4432327f6c70645b38dc12aa443f9be47cd7be0882"
     },
     {
         "file": "openhands-sdk/openhands/sdk/utils/models.py",
         "name": "getattr",
-        "hash": "7dbf2bc94d32c54160f2040a628d2786dc6a81d82ae5684f6c21bd5f30702e2f"
+        "hash": "4ae7894724ea9bc08972cb068de033b798c1c5f2d1c0071b0b9c7cdf09af0d20"
     },
     {
         "file": "openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py",
         "name": "getattr",
-        "hash": "7afbea12f235f22be6dbed3e2fa3a6f4c650b331dbbc1b139b3568f04abe3b6e"
+        "hash": "c22c5bb4c7df9491b409d0ddffba3d8b8c5e8360d199d5f75336ee81de76ab70"
     },
     {
         "file": "openhands-sdk/openhands/sdk/workspace/remote/base.py",
         "name": "getattr",
-        "hash": "7afbea12f235f22be6dbed3e2fa3a6f4c650b331dbbc1b139b3568f04abe3b6e"
+        "hash": "c22c5bb4c7df9491b409d0ddffba3d8b8c5e8360d199d5f75336ee81de76ab70"
     }
 ]

--- a/tests/cross/test_check_forbidden_dynamic_attributes.py
+++ b/tests/cross/test_check_forbidden_dynamic_attributes.py
@@ -120,3 +120,19 @@ def test_setattr_also_detected(checker, tmp_path: Path):
     """setattr is also forbidden."""
     f = _write_py(tmp_path / "set.py", 'setattr(obj, "attr", 1)\n')
     assert checker.main([str(f)]) == 1
+
+
+def test_deleted_baselined_file_is_stale(checker, tmp_path: Path):
+    """Deleting a baselined file must be caught even when checking other files.
+
+    Pre-commit does not pass deleted files to hooks, so the checker must flag
+    stale baseline entries for files that no longer exist — even when the
+    current run is checking a different (still-existing) file.
+    """
+    f = _write_py(tmp_path / "deleted.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])
+
+    f.unlink()  # simulate deletion
+
+    other = _write_py(tmp_path / "other.py", "x = 1\n")
+    assert checker.main([str(other)]) == 1

--- a/tests/cross/test_check_forbidden_dynamic_attributes.py
+++ b/tests/cross/test_check_forbidden_dynamic_attributes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -16,13 +17,14 @@ SCRIPT = (
 )
 
 
-def _load_module(tmp_path: Path):
+def _load_module(tmp_path: Path) -> Any:
     """Load the checker script as an importable module with an isolated baseline."""
     spec = importlib.util.spec_from_file_location("checker", SCRIPT)
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     # Override after exec so the module-level assignment doesn't clobber it.
-    module.BASELINE_FILE = tmp_path / "baseline.json"
+    module.BASELINE_FILE = tmp_path / "baseline.json"  # type: ignore[attr-defined]
     return module
 
 
@@ -31,7 +33,7 @@ def checker(tmp_path: Path):
     return _load_module(tmp_path)
 
 
-def _write_py(path: Path, body: str) -> None:
+def _write_py(path: Path, body: str) -> Path:
     path.write_text(body)
     return path
 

--- a/tests/cross/test_check_forbidden_dynamic_attributes.py
+++ b/tests/cross/test_check_forbidden_dynamic_attributes.py
@@ -138,3 +138,19 @@ def test_deleted_baselined_file_is_stale(checker, tmp_path: Path):
 
     other = _write_py(tmp_path / "other.py", "x = 1\n")
     assert checker.main([str(other)]) == 1
+
+
+def test_multiline_arg_change_is_caught(checker, tmp_path: Path):
+    """Editing arguments on a subsequent line of a multiline call must fail.
+
+    Because the baseline hashes the full call source segment (not just the
+    first physical line), changing arguments below the first line produces a
+    different hash and is correctly rejected as a new violation.
+    """
+    original = "v = getattr(\n    obj,\n    'attr',\n)\n"
+    f = _write_py(tmp_path / "multiline.py", original)
+    checker.main([str(f), "--update-baseline"])
+
+    # Change the argument on a subsequent line — same first line, different call.
+    _write_py(f, "v = getattr(\n    obj,\n    'other',\n)\n")
+    assert checker.main([str(f)]) == 1

--- a/tests/cross/test_check_forbidden_dynamic_attributes.py
+++ b/tests/cross/test_check_forbidden_dynamic_attributes.py
@@ -10,7 +10,7 @@ import pytest
 
 
 SCRIPT = (
-    Path(__file__).resolve().parents[1]
+    Path(__file__).resolve().parents[2]
     / "scripts"
     / "check_forbidden_dynamic_attributes.py"
 )
@@ -20,9 +20,9 @@ def _load_module(tmp_path: Path):
     """Load the checker script as an importable module with an isolated baseline."""
     spec = importlib.util.spec_from_file_location("checker", SCRIPT)
     module = importlib.util.module_from_spec(spec)
-    # Point BASELINE_FILE at a temp location so tests don't clobber the real one.
-    module.__dict__["BASELINE_FILE"] = tmp_path / "baseline.json"
     spec.loader.exec_module(module)
+    # Override after exec so the module-level assignment doesn't clobber it.
+    module.BASELINE_FILE = tmp_path / "baseline.json"
     return module
 
 

--- a/tests/test_check_forbidden_dynamic_attributes.py
+++ b/tests/test_check_forbidden_dynamic_attributes.py
@@ -1,0 +1,100 @@
+"""Regression tests for the forbidden dynamic attributes pre-commit hook."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "check_forbidden_dynamic_attributes.py"
+)
+
+
+def _load_module(tmp_path: Path):
+    """Load the checker script as an importable module with an isolated baseline."""
+    spec = importlib.util.spec_from_file_location("checker", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    # Point BASELINE_FILE at a temp location so tests don't clobber the real one.
+    module.__dict__["BASELINE_FILE"] = tmp_path / "baseline.json"
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def checker(tmp_path: Path):
+    return _load_module(tmp_path)
+
+
+def _write_py(path: Path, body: str) -> None:
+    path.write_text(body)
+    return path
+
+
+def test_clean_file_passes(checker, tmp_path: Path):
+    """A file with no forbidden calls produces no violations."""
+    f = _write_py(tmp_path / "clean.py", "x = 1\n")
+    assert checker.main([str(f)]) == 0
+
+
+def test_new_violation_fails(checker, tmp_path: Path):
+    """A getattr call not in the baseline is rejected."""
+    f = _write_py(tmp_path / "bad.py", 'v = getattr(obj, "attr")\n')
+    assert checker.main([str(f)]) == 1
+
+
+def test_baselined_violation_passes(checker, tmp_path: Path):
+    """A getattr call present in the baseline is accepted."""
+    f = _write_py(tmp_path / "ok.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])
+    assert checker.main([str(f)]) == 0
+
+
+def test_duplicate_baselined_line_is_rejected(checker, tmp_path: Path):
+    """Duplicating an already-baselined source line must still fail.
+
+    This is the key regression: a *set*-based comparison would accept the
+    second identical line, but a multiset (Counter) comparison correctly
+    rejects it because the current count exceeds the baseline count.
+    """
+    f = _write_py(tmp_path / "dup.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])  # baseline now has count 1
+
+    # Add a second identical line on a different line number.
+    _write_py(f, 'v = getattr(obj, "attr")\nw = getattr(obj, "attr")\n')
+    assert checker.main([str(f)]) == 1
+
+
+def test_stale_baseline_entry_fails(checker, tmp_path: Path):
+    """Removing a baselined call makes its baseline entry stale, which fails.
+
+    Stale entries must fail (not merely print a note) so removing a call
+    permanently shrinks the allowance instead of leaving a reusable slot.
+    """
+    f = _write_py(tmp_path / "stale.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])
+
+    # Remove the call; the baseline still records it.
+    _write_py(f, "v = 1\n")
+    assert checker.main([str(f)]) == 1
+
+
+def test_update_baseline_idempotent(checker, tmp_path: Path):
+    """Running --update-baseline twice produces the same file."""
+    f = _write_py(tmp_path / "idem.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])
+    first = json.loads(checker.BASELINE_FILE.read_text())
+    checker.main([str(f), "--update-baseline"])
+    second = json.loads(checker.BASELINE_FILE.read_text())
+    assert first == second
+
+
+def test_setattr_also_detected(checker, tmp_path: Path):
+    """setattr is also forbidden."""
+    f = _write_py(tmp_path / "set.py", 'setattr(obj, "attr", 1)\n')
+    assert checker.main([str(f)]) == 1

--- a/tests/test_check_forbidden_dynamic_attributes.py
+++ b/tests/test_check_forbidden_dynamic_attributes.py
@@ -84,6 +84,28 @@ def test_stale_baseline_entry_fails(checker, tmp_path: Path):
     assert checker.main([str(f)]) == 1
 
 
+def test_remove_then_reintroduce_is_caught(checker, tmp_path: Path):
+    """Reintroducing a removed call must fail.
+
+    Baseline one ``getattr``, replace it with ``x.y`` (check fails on stale
+    entry, forcing a baseline refresh), then restore the identical line.
+    Because the stale entry forced a refresh, the reintroduced call is no
+    longer covered and is correctly rejected.
+    """
+    f = _write_py(tmp_path / "reintro.py", 'v = getattr(obj, "attr")\n')
+    checker.main([str(f), "--update-baseline"])  # baseline count = 1
+
+    # Remove the call → stale entry → must fail.
+    _write_py(f, "v = obj.attr\n")
+    assert checker.main([str(f)]) == 1
+    # The developer is forced to refresh the baseline, which now records 0.
+    checker.main([str(f), "--update-baseline"])
+
+    # Reintroduce the identical call → now a *new* violation, not covered.
+    _write_py(f, 'v = getattr(obj, "attr")\n')
+    assert checker.main([str(f)]) == 1
+
+
 def test_update_baseline_idempotent(checker, tmp_path: Path):
     """Running --update-baseline twice produces the same file."""
     f = _write_py(tmp_path / "idem.py", 'v = getattr(obj, "attr")\n')


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Good rachet test here.

---

AGENT:
This PR was created by an AI agent (OpenHands) on behalf of the user.

## Why

Prevent new dynamic `getattr` and `setattr` calls from entering the SDK while the existing migration work is tracked separately.

## Summary

- Add an AST-based pre-commit checker that rejects `getattr` and `setattr` calls.
- Scope the hook to Python files under `openhands-sdk/`.
- Track the existing cleanup work in child issues #4903, #4904, and #4905.

## Issue Number

Closes #4902

## How to Test

- `uv run python scripts/check_forbidden_dynamic_attributes.py /tmp/sample.py` reports both forbidden calls and allows direct attribute access.
- `uv run pre-commit run --files .pre-commit-config.yaml scripts/check_forbidden_dynamic_attributes.py` runs the configured hooks; the checker itself passes, while the repository's existing SDK calls are intentionally tracked by the child issues.
- `uv run ruff check scripts/check_forbidden_dynamic_attributes.py`
- `uv run pycodestyle --max-line-length=88 --ignore=E203,E501,W503,E704 scripts/check_forbidden_dynamic_attributes.py`

## Video/Screenshots

Not applicable for this lint-only change.

## Design Doc

Not applicable.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The checker is intentionally introduced before cleanup so the remaining dynamic access is visible and can be removed in coherent follow-up PRs.








<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0453fe5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0453fe5-python \
  ghcr.io/openhands/agent-server:0453fe5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0453fe5-golang-amd64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-golang-amd64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-golang-amd64
ghcr.io/openhands/agent-server:0453fe5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0453fe5-golang-arm64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-golang-arm64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-golang-arm64
ghcr.io/openhands/agent-server:0453fe5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0453fe5-java-amd64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-java-amd64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-java-amd64
ghcr.io/openhands/agent-server:0453fe5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0453fe5-java-arm64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-java-arm64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-java-arm64
ghcr.io/openhands/agent-server:0453fe5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0453fe5-python-amd64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python-amd64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python-amd64
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0453fe5-python-arm64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python-arm64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python-arm64
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0453fe5-python-slim-amd64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python-slim-amd64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python-slim-amd64
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:0453fe5-python-slim-arm64
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python-slim-arm64
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python-slim-arm64
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:0453fe5-golang
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-golang
ghcr.io/openhands/agent-server:forbid-getattr-setattr-golang
ghcr.io/openhands/agent-server:0453fe5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0453fe5-java
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-java
ghcr.io/openhands/agent-server:forbid-getattr-setattr-java
ghcr.io/openhands/agent-server:0453fe5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0453fe5-python-slim
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python-slim
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python-slim
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:0453fe5-python
ghcr.io/openhands/agent-server:0453fe5190dd00ad2c083ed28d2edaeaa45edf4d-python
ghcr.io/openhands/agent-server:forbid-getattr-setattr-python
ghcr.io/openhands/agent-server:0453fe5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0453fe5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0453fe5-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->