### PR TITLE
fix(acp): tear down spawned server process group on shutdown (POSIX)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -23,6 +23,8 @@ import inspect
 import json
 import os
 import re
+import signal
+import sys
 import threading
 import time
 import uuid
@@ -2959,6 +2961,9 @@ class ACPAgent(AgentBase):
             # filtering reader that skips non-JSON-RPC lines some
             # ACP servers (e.g. claude-code-acp v0.1.x) write to
             # stdout.
+            spawn_kwargs: dict[str, Any] = {}
+            if sys.platform != "win32":
+                spawn_kwargs["start_new_session"] = True
             process = await asyncio.create_subprocess_exec(
                 command,
                 *args,
@@ -2967,6 +2972,7 @@ class ACPAgent(AgentBase):
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 limit=_STREAM_READER_LIMIT,
+                **spawn_kwargs,
             )
             assert process.stdin is not None
             assert process.stdout is not None
@@ -4443,10 +4449,7 @@ class ACPAgent(AgentBase):
         process = self._process
         if process is not None:
             try:
-                if process.returncode is None or not isinstance(
-                    process.returncode, int
-                ):
-                    process.terminate()
+                self._terminate_process_group(process)
                 if self._executor is not None:
                     self._executor.run_async(
                         self._wait_for_process,
@@ -4456,7 +4459,7 @@ class ACPAgent(AgentBase):
             except Exception as e:
                 logger.debug("Error terminating ACP process: %s", e)
                 try:
-                    process.kill()
+                    self._kill_process_group(process)
                     if self._executor is not None:
                         self._executor.run_async(
                             self._wait_for_process,
@@ -4494,6 +4497,44 @@ class ACPAgent(AgentBase):
                 failures["ACP executor"] = e
             self._executor = None
         return failures
+
+    @staticmethod
+    def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
+        """Terminate the process and its process group on POSIX systems."""
+        pid = getattr(process, "pid", None)
+        if sys.platform != "win32" and isinstance(pid, int):
+            try:
+                pgid = os.getpgid(pid)
+                if pgid != os.getpgrp():
+                    os.killpg(pgid, signal.SIGTERM)
+            except OSError:
+                try:
+                    if pid != os.getpgrp():
+                        os.killpg(pid, signal.SIGTERM)
+                except OSError:
+                    pass
+        if process.returncode is None or not isinstance(process.returncode, int):
+            with contextlib.suppress(ProcessLookupError):
+                process.terminate()
+
+    @staticmethod
+    def _kill_process_group(process: asyncio.subprocess.Process) -> None:
+        """Forcefully kill the process and its process group on POSIX systems."""
+        pid = getattr(process, "pid", None)
+        if sys.platform != "win32" and isinstance(pid, int):
+            try:
+                pgid = os.getpgid(pid)
+                if pgid != os.getpgrp():
+                    os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                try:
+                    if pid != os.getpgrp():
+                        os.killpg(pid, signal.SIGKILL)
+                except OSError:
+                    pass
+        if process.returncode is None or not isinstance(process.returncode, int):
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
 
     @staticmethod
     async def _wait_for_process(process: asyncio.subprocess.Process) -> None:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
+import signal
 import threading
 import time
 import uuid
@@ -3477,6 +3478,115 @@ class TestACPAgentCleanup:
             process,
             timeout=5.0,
         )
+
+    def test_close_terminates_process_group_on_posix(self):
+        agent = _make_agent()
+        mock_process = MagicMock()
+        mock_process.pid = 54321
+        mock_process.returncode = None
+        agent._process = mock_process
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        with (
+            patch("openhands.sdk.agent.acp_agent.sys.platform", "linux"),
+            patch(
+                "openhands.sdk.agent.acp_agent.os.getpgid", return_value=54321
+            ) as mock_getpgid,
+            patch("openhands.sdk.agent.acp_agent.os.getpgrp", return_value=12345),
+            patch("openhands.sdk.agent.acp_agent.os.killpg") as mock_killpg,
+        ):
+            agent.close()
+
+        mock_getpgid.assert_called_once_with(54321)
+        mock_killpg.assert_called_once_with(54321, signal.SIGTERM)
+        mock_process.terminate.assert_called_once()
+        mock_process.kill.assert_not_called()
+
+    def test_close_kills_process_group_on_timeout_or_error(self):
+        agent = _make_agent()
+        mock_process = MagicMock()
+        mock_process.pid = 54321
+        mock_process.returncode = None
+        mock_process.terminate.side_effect = OSError("still running")
+        agent._process = mock_process
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        with (
+            patch("openhands.sdk.agent.acp_agent.sys.platform", "linux"),
+            patch("openhands.sdk.agent.acp_agent.os.getpgid", return_value=54321),
+            patch("openhands.sdk.agent.acp_agent.os.getpgrp", return_value=12345),
+            patch("openhands.sdk.agent.acp_agent.os.killpg") as mock_killpg,
+        ):
+            agent.close()
+
+        assert mock_killpg.call_args_list == [
+            call(54321, signal.SIGTERM),
+            call(54321, signal.SIGKILL),
+        ]
+        mock_process.kill.assert_called_once()
+
+    def test_close_terminates_orphaned_process_group_when_leader_exited(self):
+        agent = _make_agent()
+        mock_process = MagicMock()
+        mock_process.pid = 54321
+        mock_process.returncode = 0
+        agent._process = mock_process
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        with (
+            patch("openhands.sdk.agent.acp_agent.sys.platform", "linux"),
+            patch(
+                "openhands.sdk.agent.acp_agent.os.getpgid",
+                side_effect=ProcessLookupError("No such process"),
+            ),
+            patch("openhands.sdk.agent.acp_agent.os.getpgrp", return_value=12345),
+            patch("openhands.sdk.agent.acp_agent.os.killpg") as mock_killpg,
+        ):
+            agent.close()
+
+        mock_killpg.assert_called_once_with(54321, signal.SIGTERM)
+        mock_process.terminate.assert_not_called()
+
+    def test_close_does_not_killpg_same_process_group(self):
+        agent = _make_agent()
+        mock_process = MagicMock()
+        mock_process.pid = 54321
+        mock_process.returncode = None
+        agent._process = mock_process
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        with (
+            patch("openhands.sdk.agent.acp_agent.sys.platform", "linux"),
+            patch("openhands.sdk.agent.acp_agent.os.getpgid", return_value=12345),
+            patch("openhands.sdk.agent.acp_agent.os.getpgrp", return_value=12345),
+            patch("openhands.sdk.agent.acp_agent.os.killpg") as mock_killpg,
+        ):
+            agent.close()
+
+        mock_killpg.assert_not_called()
+        mock_process.terminate.assert_called_once()
+
+    def test_close_skips_killpg_on_windows(self):
+        agent = _make_agent()
+        mock_process = MagicMock()
+        mock_process.pid = 54321
+        mock_process.returncode = None
+        agent._process = mock_process
+        agent._executor = MagicMock()
+        agent._conn = None
+
+        with (
+            patch("openhands.sdk.agent.acp_agent.sys.platform", "win32"),
+            patch("openhands.sdk.agent.acp_agent.os.killpg") as mock_killpg,
+        ):
+            agent.close()
+
+        mock_killpg.assert_not_called()
+        mock_process.terminate.assert_called_once()
 
     def test_finalizer_falls_back_when_thread_start_fails(self):
         agent = _make_agent()
@@ -10011,3 +10121,163 @@ class TestUnperformableAuthMethodLogging:
 
         assert "session creation may fail" in caplog.text
         assert "GEMINI_API_KEY is unset" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Process group shutdown / leaf process teardown (#4901)
+# ---------------------------------------------------------------------------
+
+
+class TestACPProcessGroupShutdown:
+    """Verify that ACP subprocess trees run in their own process group on POSIX
+    and that teardown terminates the entire process group.
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_acp_server_sets_start_new_session_on_posix(self, tmp_path):
+        from contextlib import ExitStack
+
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = TestACPFileSecretMaterialisation._make_conn()
+
+        captured_kwargs: dict[str, Any] = {}
+        mock_process = MagicMock(spec=asyncio.subprocess.Process)
+        mock_process.returncode = None
+        mock_process.wait = AsyncMock(return_value=0)
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+        mock_process.stderr = MagicMock()
+
+        async def _fake_exec(*_args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_process
+
+        async def _fake_noop(*_args, **_kwargs):
+            return None
+
+        agent._executor = AsyncExecutor()
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("openhands.sdk.agent.acp_agent.sys.platform", "linux")
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                    new=_fake_exec,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                    return_value=conn,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                    new=_fake_noop,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._log_acp_subprocess_stderr",
+                    new=_fake_noop,
+                )
+            )
+            agent._start_acp_server(state)
+
+        assert captured_kwargs.get("start_new_session") is True
+        agent._shutdown_runtime(discard_bindings=True)
+
+    @pytest.mark.asyncio
+    async def test_start_acp_server_omits_start_new_session_on_windows(self, tmp_path):
+        from contextlib import ExitStack
+
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = TestACPFileSecretMaterialisation._make_conn()
+
+        captured_kwargs: dict[str, Any] = {}
+        mock_process = MagicMock(spec=asyncio.subprocess.Process)
+        mock_process.returncode = None
+        mock_process.wait = AsyncMock(return_value=0)
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+        mock_process.stderr = MagicMock()
+
+        async def _fake_exec(*_args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_process
+
+        async def _fake_noop(*_args, **_kwargs):
+            return None
+
+        agent._executor = AsyncExecutor()
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("openhands.sdk.agent.acp_agent.sys.platform", "win32")
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                    new=_fake_exec,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                    return_value=conn,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                    new=_fake_noop,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._log_acp_subprocess_stderr",
+                    new=_fake_noop,
+                )
+            )
+            agent._start_acp_server(state)
+
+        assert "start_new_session" not in captured_kwargs
+        agent._shutdown_runtime(discard_bindings=True)
+
+    @pytest.mark.asyncio
+    async def test_terminate_process_group_e2e_reaps_descendants(self):
+        import subprocess
+
+        # Spawn a process that spawns background child sleeps
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            "sleep 10 & sleep 20 & wait",
+            start_new_session=True,
+        )
+        pgid = proc.pid
+        await asyncio.sleep(0.1)
+
+        # Confirm children exist in process group
+        ps_before = subprocess.run(
+            ["pgrep", "-g", str(pgid)], capture_output=True, text=True
+        )
+        pids_before = ps_before.stdout.strip().split()
+        assert len(pids_before) >= 2
+
+        ACPAgent._terminate_process_group(proc)
+        await proc.wait()
+        await asyncio.sleep(0.1)
+
+        ps_after = subprocess.run(
+            ["pgrep", "-g", str(pgid)], capture_output=True, text=True
+        )
+        assert ps_after.stdout.strip() == ""
+


### PR DESCRIPTION
HUMAN:

Noticed orphaned child processes (such as node and claude) lingering in the background after ACP runtime shutdown on Linux/POSIX. Adding process group creation and teardown to cleanly reap the entire subprocess tree.

---

AGENT:

## Why

Resolves #4910.
Addresses upstream gap discussed in issue 4901 reported by @MadMaksim.

On POSIX (Linux/macOS), `ACPAgent._shutdown_runtime`'s `process.terminate()`/`.kill()` targets only the top PID (`npm`/`npx`). Because the subprocess was spawned without `start_new_session=True`, deeper descendant processes (such as `sh -c` -> `node` -> `claude`) survive termination as orphans reparented to `init`, holding open memory and file handles indefinitely.

While #4409 addresses the Windows side via Win32 Job Objects, POSIX requires process-group creation (`start_new_session=True` / `setsid`) at spawn and process-group signaling (`os.killpg`) during shutdown.

## Summary

1. **Process Group Spawn (`_start_acp_server`)**:
   - On POSIX (`sys.platform != "win32"`), pass `start_new_session=True` to `asyncio.create_subprocess_exec` so the spawned command hierarchy runs in its own detached process group.
2. **Process Group Teardown (`_terminate_process_group` & `_kill_process_group`)**:
   - On POSIX, lookup `pgid = os.getpgid(process.pid)`. Guard against signaling the caller's own process group (`pgid != os.getpgrp()`), then signal the group via `os.killpg(pgid, signal.SIGTERM)` / `os.killpg(pgid, signal.SIGKILL)`.
   - If the leader has already exited (`ProcessLookupError` on `os.getpgid`), attempt `os.killpg(process.pid, ...)` directly to ensure any surviving grandchildren are reaped.
   - Fall back safely to `process.terminate()`/`process.kill()` with `contextlib.suppress(ProcessLookupError)`.
   - On Windows, behavior is completely untouched (`process.terminate()` / `process.kill()`).
3. **Comprehensive Unit & Integration Tests**:
   - `test_close_terminates_process_group_on_posix`: validates `os.killpg` with `SIGTERM` on POSIX.
   - `test_close_kills_process_group_on_timeout_or_error`: validates escalation to `SIGKILL`.
   - `test_close_terminates_orphaned_process_group_when_leader_exited`: validates reaping surviving grandchildren even if top PID already exited.
   - `test_close_does_not_killpg_same_process_group`: guards caller process group against accidental signaling.
   - `test_close_skips_killpg_on_windows`: ensures Windows uses standard PID termination.
   - `test_start_acp_server_sets_start_new_session_on_posix`: asserts `start_new_session=True` passed on POSIX.
   - `test_start_acp_server_omits_start_new_session_on_windows`: asserts omitted on Windows.
   - `test_terminate_process_group_e2e_reaps_descendants`: end-to-end test verifying multi-process child sleep hierarchies are reaped.

## Issue Number

Resolves #4910

## How to Test

Run the test suite and linters to verify process group creation, signal propagation, and graceful error handling:

```bash
uv run pytest tests/sdk/agent/test_acp_agent.py -k "TestACPProcessGroupShutdown or TestACPAgentCleanup"
uv run ruff check openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py
uv run pyright openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.52s · commit a2e3699  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 9/9 hunks, 2/2 files (missing context: 6).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 7.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 5.0% | No direct hunk selected |
| Contract regression | 10.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 5.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 94.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 87910c733b03c848adf259268d6fbf90433eb0324fcb64b9e961763d9e3a24cd -->
<!-- jev-fast-audit:end -->
