### PR TITLE
fix(tests): walk through the llm.<model> span in the auto-title trace assertion

### DIFF
--- a/tests/agent_server/test_auto_title_span_metadata.py
+++ b/tests/agent_server/test_auto_title_span_metadata.py
@@ -109,13 +109,36 @@ def _probe_auto_title_spans() -> dict[str, Any]:
     names_by_id = {
         span.context.span_id: span.name for span in spans if span.context is not None
     }
+    parent_id_by_id = {
+        span.context.span_id: (span.parent.span_id if span.parent else None)
+        for span in spans
+        if span.context is not None
+    }
+
+    def operation_parent(span: Any) -> str | None:
+        """Nearest ancestor that isn't the SDK's synthetic ``llm.<model>`` span.
+
+        Telemetry.on_request opens an ``llm.<model>`` span that stays current
+        while the call runs (so the authoritative cost can be attached before
+        lmnr ends its ``litellm.completion`` span). That span sits between the
+        operation span and ``litellm.completion``; skip it to recover the
+        operation the LLM call belongs to.
+        """
+        pid = span.parent.span_id if span.parent else None
+        while pid is not None and names_by_id.get(pid, "").startswith("llm."):
+            pid = parent_id_by_id.get(pid)
+        return names_by_id.get(pid) if pid is not None else None
+
     return {
         "title": stored.title,
         "conversation_trace_id": root_span.span.get_span_context().trace_id,
         "spans": [
             {
                 "name": span.name,
-                "parent": names_by_id.get(span.parent.span_id) if span.parent else None,
+                "parent": operation_parent(span),
+                "immediate_parent": (
+                    names_by_id.get(span.parent.span_id) if span.parent else None
+                ),
                 "trace_id": span.context.trace_id if span.context else None,
                 "attributes": dict(span.attributes or {}),
             }
@@ -144,6 +167,10 @@ def test_auto_title_llm_span_joins_the_conversation_trace() -> None:
     assert len(llm_spans) == 1
     title_llm = llm_spans[0]
 
+    # The SDK's synthetic ``llm.<model>`` cost span sits between the two now;
+    # ``parent`` walks through it to the operation the call belongs to, which is
+    # what "joined the conversation trace" actually means here.
+    assert title_llm["immediate_parent"].startswith("llm.")
     assert title_llm["parent"] == "conversation.generate_title"
     assert title_llm["trace_id"] == probe["conversation_trace_id"]
 


### PR DESCRIPTION
HUMAN:

Verified the span tree myself and confirmed the tracing is correct — it's the assertion that went stale, not the instrumentation.

---

AGENT:

## Why

`main` is red. `agent-server-tests` fails on every PR that touches an agent-server path:

```
tests/agent_server/test_auto_title_span_metadata.py::test_auto_title_llm_span_joins_the_conversation_trace
E   AssertionError: assert 'llm.gpt-4o' == 'conversation.generate_title'
```

#4836 gave `Telemetry.on_request` its own `llm.<model>` span, which stays current while the call runs so the authoritative cost can be attached before lmnr ends its `litellm.completion` span. That span now sits between the operation span and the LLM span:

```
conversation.generate_title
  └── llm.gpt-4o            ← added by #4836
        └── litellm.completion
```

**The tracing is correct.** The title LLM span is still in the conversation trace and still under `conversation.generate_title`; only the direct-parent assertion was stale.

`tests/sdk/conversation/test_utility_llm_span_metadata.py` was updated for exactly this in the same PR — it grew an `operation_parent()` helper that skips the `llm.` wrapper, plus a separate `immediate_parent`. The agent-server counterpart was missed.

### How it reached main past a required check

Worth recording, because it is not obvious and it is why #4836's author never saw this test fail.

`agent-server-tests` is path-gated — every step is `if: steps.changed.outputs.any_changed == 'true'` over `openhands-agent-server/**`, `tests/agent_server/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/tests.yml`. **When nothing matches, the job executes nothing and still reports `success`.**

| step | `fc9646ad8` (#4836) | `56b016e7f` (#4839) |
|---|---|---|
| Install deps | skipped | success |
| Run Agent Server tests | **skipped** | **failure** |
| job conclusion | **success** | failure |

#4836's diff is `openhands-sdk/**` + `tests/sdk/**` only, so the job was green having run nothing. #4839 touched agent-server paths, opening the gate, and so became the first commit to actually run this test since #4836 landed. **#4836 is the cause; #4839 is only the detector.**

The filter gap itself is broader than this PR fixes and is tracked separately in #4912.

## Summary

- `parent` now walks through the synthetic `llm.<model>` wrapper to the operation the call belongs to, matching the `operation_parent()` helper the sibling SDK test already uses rather than inventing a second convention.
- `immediate_parent` is added and asserted, so the test still fails if the LLM span detaches or the wrapper disappears silently.
- The `trace_id` and `title_generation` operation-attribute assertions are unchanged. No production code changes.

## Issue Number

Related to #4912 — this PR fixes the test breakage reported there; the CI path-filter gap in that issue is a separate change.

## How to Test

```bash
uv run pytest tests/agent_server/test_auto_title_span_metadata.py
```

Fails on `main`, passes on this branch. Verified it is not a local artifact by reproducing on a clean detached worktree at `fc9646ad8` with none of this branch's changes present — deterministic, 3/3 runs.

Full agent-server suite on this branch:

```
$ uv run pytest tests/agent_server/ -q
2101 passed, 13 deselected in 216.60s (0:03:36)
```

The span tree the probe actually emits, which is what the new assertions encode:

```
litellm.completion            parent=llm.gpt-4o                    same_trace=True
llm.gpt-4o                    parent=conversation.generate_title   same_trace=True
conversation.generate_title   parent=None                          same_trace=True
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Test-only change; no production code touched. Unblocks every PR whose diff opens the `agent-server-tests` gate, including #4864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
