### PR TITLE
fix(mcp): graceful degradation on MCP server connection failure (#4891)

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/__init__.py
+++ b/openhands-sdk/openhands/sdk/mcp/__init__.py
@@ -12,7 +12,11 @@ from openhands.sdk.mcp.config import (
     MCPServer,
     to_fastmcp_mcp_config,
 )
-from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
+from openhands.sdk.mcp.exceptions import (
+    MCPConnectionError,
+    MCPError,
+    MCPTimeoutError,
+)
 
 
 if TYPE_CHECKING:
@@ -55,6 +59,7 @@ __all__ = [
     "MCPToolProvider",
     "create_mcp_tools",
     "to_fastmcp_mcp_config",
+    "MCPConnectionError",
     "MCPError",
     "MCPTimeoutError",
 ]

--- a/openhands-sdk/openhands/sdk/mcp/client.py
+++ b/openhands-sdk/openhands/sdk/mcp/client.py
@@ -7,8 +7,12 @@ from typing import TYPE_CHECKING, Any
 
 from fastmcp import Client as AsyncMCPClient
 
-from openhands.sdk.mcp.exceptions import MCPError
+from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.exceptions import MCPConnectionError, MCPError
 from openhands.sdk.utils.async_executor import AsyncExecutor
+
+
+logger = get_logger(__name__)
 
 
 if TYPE_CHECKING:
@@ -55,12 +59,66 @@ class MCPClient(AsyncMCPClient):
         """The MCP tools using this client connection (returns a copy)."""
         return list(self._tools)
 
+    def _extract_connection_target(
+        self,
+    ) -> tuple[str | None, str | None, dict[str, Any] | None]:
+        """Extract server name, URL/command target, and config dict if available."""
+        transport = getattr(self, "transport", None)
+        config_dict = None
+        if transport is not None:
+            config = getattr(transport, "config", None)
+            if config is not None:
+                if hasattr(config, "model_dump"):
+                    try:
+                        config_dict = config.model_dump()
+                    except Exception:
+                        pass
+                mcp_servers = getattr(config, "mcpServers", None)
+                if isinstance(mcp_servers, dict) and mcp_servers:
+                    name, srv = next(iter(mcp_servers.items()))
+                    url = getattr(srv, "url", None)
+                    if url:
+                        return name, str(url), config_dict
+                    cmd = getattr(srv, "command", None)
+                    if cmd:
+                        args = getattr(srv, "args", None)
+                        args_str = f" {' '.join(args)}" if args else ""
+                        return name, f"{cmd}{args_str}", config_dict
+                    return name, None, config_dict
+            url = getattr(transport, "url", None)
+            if url:
+                return None, str(url), config_dict
+        return None, None, config_dict
+
+    @staticmethod
+    def _troubleshooting_guidance() -> str:
+        return (
+            "Possible solutions:\n"
+            "  1. Check if the MCP server is running and accepting connections\n"
+            "  2. Verify network connectivity, firewall rules, and port configuration\n"
+            "  3. Verify the server URL or command and authentication credentials"
+        )
+
     async def connect(self) -> None:
         """Establish connection to the MCP server."""
         try:
             await self.__aenter__()
-        except RuntimeError as exc:
-            raise MCPError("MCP Connection Failure") from exc
+        except MCPError:
+            raise
+        except (RuntimeError, Exception) as exc:
+            server_name, target, config_dict = self._extract_connection_target()
+            cause = getattr(exc, "__cause__", None) or exc
+            guidance = self._troubleshooting_guidance()
+            msg = (
+                "Failed to connect to MCP server"
+                + (f" '{server_name}'" if server_name else "")
+                + (f" at '{target}'" if target else "")
+                + f": {cause}\n\n"
+                + f"{guidance}\n"
+            )
+            raise MCPConnectionError(
+                msg, server_name=server_name, url=target, config=config_dict
+            ) from exc
 
     def call_async_from_sync(
         self,
@@ -88,6 +146,25 @@ class MCPClient(AsyncMCPClient):
         """
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: fn(*args, **kwargs))
+
+    async def close(self) -> None:
+        """Close the MCP client and cleanup resources safely."""
+        # If the background session task already completed with an exception,
+        # fastmcp._disconnect() would await that failed task and re-raise the
+        # exception during cleanup. Clearing the failed task avoids mutating or
+        # chaining teardown exceptions onto the original error.
+        if hasattr(self, "_session_state"):
+            task = self._session_state.session_task
+            if task is not None and task.done() and not task.cancelled():
+                try:
+                    if task.exception() is not None:
+                        self._session_state.session_task = None
+                except Exception:
+                    pass
+        try:
+            await super().close()
+        except Exception as exc:
+            logger.debug("Error closing MCP client: %s", exc)
 
     def sync_close(self) -> None:
         """

--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -520,6 +520,14 @@ class MCPServer(_MCPBaseModel):
             "ACP subprocess."
         ),
     )
+    strict: bool = Field(
+        default=False,
+        description=(
+            "Whether connection failure to this server should abort agent "
+            "initialization (True) or degrade gracefully by logging a warning "
+            "and dropping its tools (False, default)."
+        ),
+    )
 
     @field_validator("env", "headers", mode="after")
     @classmethod
@@ -660,6 +668,7 @@ def _normalize_server_for_fastmcp(
     # already (see ``enabled_mcp_servers``) -- this only keeps the key from
     # leaking through the public ``to_fastmcp_mcp_config`` boundary.
     server.pop("enabled", None)
+    server.pop("strict", None)
     auth = server.pop("auth", None)
     raw_headers = server.get("headers")
     headers = dict(raw_headers) if isinstance(raw_headers, Mapping) else {}

--- a/openhands-sdk/openhands/sdk/mcp/exceptions.py
+++ b/openhands-sdk/openhands/sdk/mcp/exceptions.py
@@ -17,3 +17,25 @@ class MCPTimeoutError(MCPError):
         self.timeout = timeout
         self.config = config
         super().__init__(message)
+
+
+class MCPConnectionError(MCPError):
+    """Exception raised when an MCP server connection fails."""
+
+    server_name: str | None
+    url: str | None
+    config: dict | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        server_name: str | None = None,
+        url: str | None = None,
+        config: dict | None = None,
+    ):
+        self.server_name = server_name
+        self.url = url
+        self.config = config
+        super().__init__(message)
+

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -1,17 +1,24 @@
 """Utility functions for MCP integration."""
 
 import asyncio
+import contextlib
 import inspect
 import logging
-from collections.abc import Callable, Mapping, Sequence
-from typing import Protocol
+import sys
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from typing import Any, Protocol, Unpack
 
 import mcp.types
+from fastmcp import FastMCP
 from fastmcp.client.auth import OAuth
 from fastmcp.client.logging import LogMessage
 from fastmcp.client.messages import MessageHandler
+from fastmcp.client.transports import FastMCPTransport
+from fastmcp.client.transports.base import SessionKwargs
+from fastmcp.client.transports.config import MCPConfigTransport
 from fastmcp.mcp_config import MCPConfig as FastMCPConfig, RemoteMCPServer
 from key_value.aio.protocols import AsyncKeyValue
+from mcp import ClientSession
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp.client import MCPClient, ToolsReconciledCallback
@@ -22,7 +29,7 @@ from openhands.sdk.mcp.config import (
     enabled_mcp_servers,
     to_fastmcp_mcp_config,
 )
-from openhands.sdk.mcp.exceptions import MCPTimeoutError
+from openhands.sdk.mcp.exceptions import MCPConnectionError, MCPTimeoutError
 from openhands.sdk.mcp.tool import MCPToolDefinition
 
 
@@ -46,6 +53,7 @@ class MCPToolProvider(Protocol):
         mcp_config: dict[str, MCPServer],
         timeout: float = 30.0,
         *,
+        strict: bool = False,
         on_tools_changed: ToolsChangedCallback | None = None,
         on_tools_reconciled: ToolsReconciledCallback | None = None,
     ) -> MCPClient: ...
@@ -59,12 +67,14 @@ class DefaultMCPToolProvider:
         mcp_config: dict[str, MCPServer],
         timeout: float = 30.0,
         *,
+        strict: bool = False,
         on_tools_changed: ToolsChangedCallback | None = None,
         on_tools_reconciled: ToolsReconciledCallback | None = None,
     ) -> MCPClient:
         return create_mcp_tools(
             mcp_config,
             timeout,
+            strict=strict,
             on_tools_changed=on_tools_changed,
             on_tools_reconciled=on_tools_reconciled,
         )
@@ -312,10 +322,200 @@ class _ToolListChangedHandler(MessageHandler):
             )
 
 
+def _format_server_target(
+    spec: MCPServer | None, server_config: Any = None
+) -> str:
+    if spec is not None:
+        if spec.url:
+            return str(spec.url)
+        if spec.command:
+            args = f" {' '.join(spec.args)}" if spec.args else ""
+            return f"{spec.command}{args}"
+    if server_config is not None:
+        url = getattr(server_config, "url", None)
+        if url:
+            return str(url)
+        cmd = getattr(server_config, "command", None)
+        if cmd:
+            args = getattr(server_config, "args", None)
+            args_str = f" {' '.join(args)}" if args else ""
+            return f"{cmd}{args_str}"
+    return "unknown target"
+
+
+def _format_connection_troubleshooting_guidance() -> str:
+    return (
+        "Possible solutions:\n"
+        "  1. Check if the MCP server is running and accepting connections\n"
+        "  2. Verify network connectivity, firewall rules, and port configuration\n"
+        "  3. Verify the server URL or command and authentication credentials"
+    )
+
+
+def _format_connection_failure_message(
+    name: str, target: str, error: Exception | str
+) -> str:
+    guidance = _format_connection_troubleshooting_guidance()
+    return (
+        f"Failed to connect to MCP server '{name}' at '{target}': {error}\n\n"
+        f"{guidance}\n"
+    )
+
+
+def _format_multi_connection_failure_message(
+    failures: Sequence[tuple[str, str, Exception | str]],
+) -> str:
+    servers_desc = "\n".join(
+        f"  - {name} ({target}): {error}" for name, target, error in failures
+    )
+    guidance = _format_connection_troubleshooting_guidance()
+    return (
+        f"Failed to connect to MCP server(s):\n"
+        f"{servers_desc}\n\n"
+        f"{guidance}\n"
+    )
+
+
+class DegradableMCPConfigTransport(MCPConfigTransport):
+    """MCPConfig transport supporting per-server connection degradation."""
+
+    def __init__(
+        self,
+        config: FastMCPConfig,
+        server_specs: Mapping[str, MCPServer],
+        *,
+        strict: bool = False,
+        name_as_prefix: bool = True,
+    ):
+        super().__init__(config, name_as_prefix=name_as_prefix)
+        self.server_specs = server_specs
+        self.strict = strict
+
+    @property
+    def mcpServers(self) -> dict[str, Any]:
+        return self.config.mcpServers
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.config, name)
+
+    @contextlib.asynccontextmanager
+    async def connect_session(
+        self, **session_kwargs: Unpack[SessionKwargs]
+    ) -> AsyncIterator[ClientSession]:
+        # Single server: delegate directly to pre-created transport so that
+        # bidirectional notifications (notifications/tools/list_changed) and direct
+        # session semantics are preserved.
+        if len(self.config.mcpServers) == 1:
+            name, server_config = next(iter(self.config.mcpServers.items()))
+            spec = self.server_specs.get(name)
+            target = _format_server_target(spec, server_config)
+            is_strict = self.strict or (
+                spec.strict if spec and hasattr(spec, "strict") else False
+            )
+            cm = self.transport.connect_session(**session_kwargs)
+            try:
+                session = await cm.__aenter__()
+            except Exception as exc:
+                msg = _format_connection_failure_message(name, target, exc)
+                if is_strict:
+                    raise MCPConnectionError(
+                        msg,
+                        server_name=name,
+                        url=target,
+                        config=self.config.model_dump(),
+                    ) from exc
+                logger.warning(
+                    "Failed to connect to MCP server '%s' (%s). "
+                    "Skipping this server and continuing without its tools.\n"
+                    "Error: %s\n"
+                    "%s",
+                    name,
+                    target,
+                    exc,
+                    _format_connection_troubleshooting_guidance(),
+                )
+                empty_router = FastMCP[Any](name="EmptyRouter")
+                async with FastMCPTransport(mcp=empty_router).connect_session(
+                    **session_kwargs
+                ) as empty_session:
+                    yield empty_session
+                return
+
+            try:
+                yield session
+            except BaseException:
+                if not await cm.__aexit__(*sys.exc_info()):
+                    raise
+            else:
+                await cm.__aexit__(None, None, None)
+            return
+
+        # Multiple servers: create composite with mounted proxies for reachable servers
+        timeout = session_kwargs.get("read_timeout_seconds")
+        composite = FastMCP[Any](name="MCPRouter")
+        failed_servers: list[tuple[str, str, Exception]] = []
+
+        async with contextlib.AsyncExitStack() as stack:
+            for t in self._transports:
+                await t.close()
+            self._transports = []
+
+            for name, server_config in self.config.mcpServers.items():
+                spec = self.server_specs.get(name)
+                target = _format_server_target(spec, server_config)
+                is_strict = self.strict or (
+                    spec.strict if spec and hasattr(spec, "strict") else False
+                )
+                try:
+                    transport, _client, proxy = await self._create_proxy(
+                        name, server_config, timeout, stack
+                    )
+                except Exception as exc:
+                    failed_servers.append((name, target, exc))
+                    msg = _format_connection_failure_message(name, target, exc)
+                    if is_strict:
+                        raise MCPConnectionError(
+                            msg,
+                            server_name=name,
+                            url=target,
+                            config=self.config.model_dump(),
+                        ) from exc
+                    logger.warning(
+                        "Failed to connect to MCP server '%s' (%s). "
+                        "Skipping this server and continuing without its tools.\n"
+                        "Error: %s\n"
+                        "%s",
+                        name,
+                        target,
+                        exc,
+                        _format_connection_troubleshooting_guidance(),
+                    )
+                    continue
+
+                self._transports.append(transport)
+                composite.mount(proxy, namespace=name if self.name_as_prefix else None)
+
+            if not self._transports:
+                if self.strict or any(
+                    getattr(self.server_specs.get(n), "strict", False)
+                    for n, _, _ in failed_servers
+                ):
+                    multi_msg = _format_multi_connection_failure_message(failed_servers)
+                    raise MCPConnectionError(
+                        multi_msg, config=self.config.model_dump()
+                    )
+
+            async with FastMCPTransport(mcp=composite).connect_session(
+                **session_kwargs
+            ) as session:
+                yield session
+
+
 def create_mcp_tools(
     mcp_config: dict[str, MCPServer],
     timeout: float = 30.0,
     *,
+    strict: bool = False,
     on_tools_changed: ToolsChangedCallback | None = None,
     on_tools_reconciled: ToolsReconciledCallback | None = None,
     mcp_oauth_token_storage: AsyncKeyValue | None = None,
@@ -352,11 +552,16 @@ def create_mcp_tools(
         mcp_oauth_token_storage=mcp_oauth_token_storage,
         mcp_oauth_factory=mcp_oauth_factory,
     )
+    transport = DegradableMCPConfigTransport(
+        config,
+        mcp_config,
+        strict=strict,
+    )
     handler = _ToolListChangedHandler(
         client=None,  # type: ignore[arg-type]
         on_tools_changed=on_tools_changed,
     )
-    client = MCPClient(config, log_handler=log_handler, message_handler=handler)
+    client = MCPClient(transport, log_handler=log_handler, message_handler=handler)
     handler._client = client
     client._tools_reconciled_callback = on_tools_reconciled
 
@@ -381,6 +586,18 @@ def create_mcp_tools(
         raise MCPTimeoutError(
             error_msg, timeout=timeout, config=config.model_dump()
         ) from e
+    except MCPConnectionError as exc:
+        is_strict = strict or any(
+            getattr(spec, "strict", False) for spec in mcp_config.values()
+        )
+        if is_strict:
+            client.sync_close()
+            raise
+        logger.warning(
+            "%s\nContinuing without tools from this server.",
+            exc,
+        )
+        client._tools = []
     except BaseException:
         try:
             client.sync_close()

--- a/tests/sdk/conversation/test_local_conversation_mcp.py
+++ b/tests/sdk/conversation/test_local_conversation_mcp.py
@@ -1,15 +1,18 @@
 """Tests for how LocalConversation wires MCP servers into a running agent."""
 
+import socket
 from pathlib import Path
 from typing import Any, cast
 
 import mcp.types as mcp_types
+import pytest
 from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
+from openhands.sdk.mcp.exceptions import MCPConnectionError
 from openhands.sdk.mcp.tool import MCPToolDefinition
 from openhands.sdk.mcp.utils import MCPToolProvider
 
@@ -173,3 +176,70 @@ def test_provider_supports_on_tools_reconciled() -> None:
     assert not provider_supports_on_tools_reconciled(
         cast(MCPToolProvider, LegacyMCPToolProvider())
     )
+
+
+def test_unreachable_mcp_server_allows_agent_to_become_ready(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unreachable MCP server does not abort agent readiness."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    agent = Agent(
+        llm=LLM(model="test-model", api_key=SecretStr("test-key")),
+        tools=[],
+        mcp_config=coerce_mcp_config(
+            {"offline": {"url": f"http://127.0.0.1:{unused_port}/mcp"}}
+        ),
+    )
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+    )
+
+    with caplog.at_level("WARNING"):
+        conversation._ensure_agent_ready()
+
+    mcp_tools = [
+        t
+        for t in conversation.agent.tools_map.values()
+        if isinstance(t, MCPToolDefinition)
+    ]
+    assert mcp_tools == []
+    assert "offline" in caplog.text
+    assert str(unused_port) in caplog.text
+    conversation.close()
+
+
+def test_unreachable_mcp_server_strict_mode_raises(tmp_path: Path) -> None:
+    """When strict=True on MCPServer, unreachable server raises."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    agent = Agent(
+        llm=LLM(model="test-model", api_key=SecretStr("test-key")),
+        tools=[],
+        mcp_config=coerce_mcp_config(
+            {
+                "offline": {
+                    "url": f"http://127.0.0.1:{unused_port}/mcp",
+                    "strict": True,
+                }
+            }
+        ),
+    )
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+    )
+
+    with pytest.raises(MCPConnectionError) as exc_info:
+        conversation._ensure_agent_ready()
+
+    assert exc_info.value.server_name == "offline"
+    assert str(unused_port) in str(exc_info.value.url)
+    conversation.close()

--- a/tests/sdk/mcp/test_create_mcp_tool.py
+++ b/tests/sdk/mcp/test_create_mcp_tool.py
@@ -30,7 +30,11 @@ from openhands.sdk.mcp.config import (
     coerce_mcp_config,
     to_fastmcp_mcp_config,
 )
-from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
+from openhands.sdk.mcp.exceptions import (
+    MCPConnectionError,
+    MCPError,
+    MCPTimeoutError,
+)
 from openhands.sdk.mcp.utils import _prepare_mcp_config
 
 
@@ -742,3 +746,133 @@ def test_create_mcp_tools_timeout_error_message():
 
         assert exc_info.value.timeout == 30.0
         assert exc_info.value.config is not None
+
+
+def test_create_mcp_tools_unreachable_server_graceful_degradation(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Unreachable MCP server logs warning and returns 0 tools instead of raising."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    config = {
+        "mcpServers": {
+            "offline_server": {
+                "transport": "http",
+                "url": f"http://127.0.0.1:{unused_port}/mcp",
+            }
+        }
+    }
+
+    with caplog.at_level(logging.WARNING):
+        with create_mcp_tools(native_mcp_config(config), timeout=2.0) as client:
+            assert len(client.tools) == 0
+
+    assert "offline_server" in caplog.text
+    assert str(unused_port) in caplog.text
+    assert "Possible solutions" in caplog.text
+
+
+def test_create_mcp_tools_unreachable_server_strict_mode():
+    """When strict=True, an unreachable server raises MCPConnectionError."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    config = {
+        "mcpServers": {
+            "offline_server": {
+                "transport": "http",
+                "url": f"http://127.0.0.1:{unused_port}/mcp",
+            }
+        }
+    }
+
+    with pytest.raises(MCPConnectionError) as exc_info:
+        create_mcp_tools(native_mcp_config(config), timeout=2.0, strict=True)
+
+    err = exc_info.value
+    assert err.server_name == "offline_server"
+    assert str(unused_port) in str(err.url)
+    assert "offline_server" in str(err)
+    assert "Possible solutions" in str(err)
+    assert err.config is not None
+
+
+def test_create_mcp_tools_unreachable_server_spec_strict():
+    """When MCPServer has strict=True, unreachable server raises MCPConnectionError."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    config = {
+        "mcpServers": {
+            "strict_server": {
+                "transport": "http",
+                "url": f"http://127.0.0.1:{unused_port}/mcp",
+                "strict": True,
+            }
+        }
+    }
+
+    with pytest.raises(MCPConnectionError) as exc_info:
+        create_mcp_tools(native_mcp_config(config), timeout=2.0, strict=False)
+
+    err = exc_info.value
+    assert err.server_name == "strict_server"
+    assert str(unused_port) in str(err.url)
+    assert "Possible solutions" in str(err)
+
+
+def test_create_mcp_tools_mixed_servers_partial_failure(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Reachable tools are registered when an unreachable server fails."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    stdio_cfg = stdio_fetch_mcp_config()
+    combined_config = {
+        "mcpServers": {
+            "offline_server": {
+                "transport": "http",
+                "url": f"http://127.0.0.1:{unused_port}/mcp",
+            },
+            "fetch": stdio_cfg["mcpServers"]["fetch"],
+        }
+    }
+
+    with caplog.at_level(logging.WARNING):
+        with create_mcp_tools(
+            native_mcp_config(combined_config), timeout=5.0
+        ) as client:
+            tool_names = [t.name for t in client.tools]
+            assert any("fetch" in name for name in tool_names)
+
+    assert "offline_server" in caplog.text
+    assert str(unused_port) in caplog.text
+
+
+def test_default_tool_provider_supports_strict():
+    """DefaultMCPToolProvider passes strict flag through."""
+    from openhands.sdk.mcp.utils import DefaultMCPToolProvider
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        unused_port = s.getsockname()[1]
+
+    config = {
+        "mcpServers": {
+            "offline_server": {
+                "transport": "http",
+                "url": f"http://127.0.0.1:{unused_port}/mcp",
+            }
+        }
+    }
+
+    provider = DefaultMCPToolProvider()
+    with pytest.raises(MCPConnectionError):
+        provider.create_tools(native_mcp_config(config), timeout=2.0, strict=True)
+


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
Reviewed MCP connection failure degradation. Graceful fallback on unreachable servers allows LLM conversation initialization while preserving strict mode option.

---

AGENT:

## Why
When an MCP server configured in `mcp_config` is unreachable (e.g. offline endpoint, incorrect port, network partition), `create_mcp_tools()` previously threw an unhandled `MCPError` / `RuntimeError` during `_ensure_agent_ready()`. This completely aborted `send_message()` before the agent could initialize or call the LLM, leaving the user with a broken session even if other tools were functioning or the MCP server was optional. Furthermore, single-server failures lacked actionable troubleshooting guidance, and teardown errors during client disconnect masked the underlying connection failure in stack traces.

Fixes #4891

## Summary
- Graceful degradation by default: An unreachable MCP server logs a warning with its name, target URL/command, and actionable troubleshooting guidance (matching `MCPTimeoutError`), and its tools are dropped instead of aborting agent readiness.
- Strict mode opt-in: Added `strict: bool = False` to `create_mcp_tools`, `MCPToolProvider`, `DefaultMCPToolProvider`, and `MCPServer(strict=True)` so callers desiring fail-fast behavior can opt in per server or globally.
- Error clarity: Introduced `MCPConnectionError` in `openhands.sdk.mcp.exceptions` carrying `server_name`, `url`, and `config` attributes.
- Preserved single-server transport semantics: When a single server is configured and reachable, `DegradableMCPConfigTransport` connects directly without intermediate proxying, preserving full bidirectional `notifications/tools/list_changed` notifications and direct session persistence.
- Safe teardown: Overrode `MCPClient.close()` to safely clear completed failed session tasks prior to closing so teardown exceptions do not mask root connection causes.

## Issue Number
Fixes #4891

## How to Test
1. Run MCP test suite:
   ```bash
   uv run pytest tests/sdk/mcp/ tests/sdk/conversation/test_local_conversation_mcp.py -vv
   ```
2. Run linter and typecheck:
   ```bash
   uv run ruff check openhands-sdk/openhands/sdk/mcp/ tests/sdk/mcp/ tests/sdk/conversation/
   uv run pyright openhands-sdk/openhands/sdk/mcp/
   ```
3. Verified test cases cover:
   - Graceful degradation when single server is unreachable (0 tools, warning logged with troubleshooting steps, initialization completes).
   - Strict mode raises `MCPConnectionError` with target and troubleshooting guidance when `strict=True` or `MCPServer(strict=True)`.
   - Mixed configurations: reachable servers register tools successfully even if another server in the same configuration fails.
   - `LocalConversation._ensure_agent_ready()` completes and allows LLM interaction when an MCP server is down.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
