### PR TITLE
docs: remove stale run-eval AGENTS reference

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -137,9 +137,8 @@ When reviewing or QA-ing such a PR:
   3. The author's explicit confirmation (e.g. screenshot) that the model is
      reachable via the proxy.
 
-Real preflight blockers still apply (parameter conflicts on Claude, bad
-`litellm_extra_body`, unit-test failures, regressions on existing models —
-see `.github/run-eval/AGENTS.md` "What still IS a real preflight blocker").
+Real preflight blockers still apply: parameter conflicts on Claude, bad
+`litellm_extra_body`, unit-test failures, and regressions on existing models.
 
 ### When to COMMENT
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

This PR proposes a little fix for the context the agent got: we no longer have that file.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

The code-review guide points readers to `.github/run-eval/AGENTS.md`, but that file does not exist. The surrounding sentence already names the real preflight blockers, so the dead reference adds confusion without supplying further guidance.

## Summary

- Remove the nonexistent `.github/run-eval/AGENTS.md` pointer.
- Keep the concrete preflight blockers directly in the review guide.

## Issue Number

Fixes #4919

## How to Test

- Searched the repository for `.github/run-eval/AGENTS.md`; the only match was the removed reference, and the same search now returns no matches.
- Ran `uv run --no-sync pre-commit run --files .agents/skills/custom-codereview-guide.md`; the configured hooks completed and reported no applicable Markdown checks.

## Video/Screenshots

Not applicable; documentation-only change.

## Design Doc

Not applicable; this removes one stale documentation pointer.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

No evaluation is needed because this does not change runtime or review policy; it only removes a reference to a file that is absent.
