### PR TITLE
docs: drop the dead .github/run-eval/AGENTS.md pointer

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -137,9 +137,8 @@ When reviewing or QA-ing such a PR:
   3. The author's explicit confirmation (e.g. screenshot) that the model is
      reachable via the proxy.
 
-Real preflight blockers still apply (parameter conflicts on Claude, bad
-`litellm_extra_body`, unit-test failures, regressions on existing models —
-see `.github/run-eval/AGENTS.md` "What still IS a real preflight blocker").
+Real preflight blockers still apply: parameter conflicts on Claude, bad
+`litellm_extra_body`, unit-test failures, and regressions on existing models.
 
 ### When to COMMENT
 


### PR DESCRIPTION
Fixes #4919.

`.agents/skills/custom-codereview-guide.md:142` pointed at `.github/run-eval/AGENTS.md`, which does not exist.

```diff
-Real preflight blockers still apply (parameter conflicts on Claude, bad
-`litellm_extra_body`, unit-test failures, regressions on existing models —
-see `.github/run-eval/AGENTS.md` "What still IS a real preflight blocker").
+Real preflight blockers still apply: parameter conflicts on Claude, bad
+`litellm_extra_body`, unit-test failures, and regressions on existing models.
```

The four blockers were already spelled out in the sentence, so only the pointer goes. It is reworded from a parenthetical aside into a plain list, because it is now the statement itself rather than a summary of one held somewhere else.

## Verified

```
$ uv run python -c 'from pathlib import Path; p = Path(".github/run-eval/AGENTS.md"); print(f"exists={p.exists()}")'
exists=False

$ ls .github/run-eval/
resolve_model_config.py
validate_sdk_ref.py

$ git log --oneline --all -- .github/run-eval/AGENTS.md
(no output)

$ grep -rn 'run-eval/AGENTS' .
(no output, after this change)
```

The `git log` line is the one worth noting: the file was not moved or renamed, it was never committed at that path, so there is nothing to relink to.

## Acceptance criteria

- [x] No repository instruction references `.github/run-eval/AGENTS.md`
- [x] The concrete model preflight blockers remain documented — all four, in the same sentence
- [x] Runtime and review-decision policy unchanged — one paragraph of a guide, no code

## Note

This PR was written with AI assistance.
