### PR TITLE
fix(mcp): read fastmcp field renames without bumping the version floor

### DIFF
--- a/openhands-agent-server/openhands/agent_server/mcp_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_router.py
@@ -43,6 +43,7 @@ from openhands.agent_server.mcp_oauth_store import (
 )
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp import create_mcp_tools
+from openhands.sdk.mcp._compat import compat_attr
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.config import (
     MCPAuthCredential,
@@ -543,7 +544,9 @@ def _run_tool_call(
         for block in result.content
         if isinstance(block, mcp.types.TextContent)
     )
-    return MCPToolCallResult(is_error=bool(result.isError), text=text)
+    return MCPToolCallResult(
+        is_error=bool(compat_attr(result, "is_error", "isError")), text=text
+    )
 
 
 def _probe_mcp_server(

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -86,6 +86,7 @@ from openhands.sdk.tool import (
 if TYPE_CHECKING:
     from openhands.sdk.llm.llm import LLMCallContext
     from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.mcp._compat import compat_attr
 from openhands.sdk.mcp.tool import MCPToolDefinition
 from openhands.sdk.tool.builtins import (
     FinishAction,
@@ -109,7 +110,8 @@ def _tool_has_summary_param(tool: ToolDefinition) -> bool:
     if "summary" in tool.action_type.model_fields:
         return True
     if isinstance(tool, MCPToolDefinition):
-        props = tool.mcp_tool.inputSchema.get("properties", {})
+        input_schema = compat_attr(tool.mcp_tool, "input_schema", "inputSchema")
+        props = input_schema.get("properties", {})
         if "summary" in props:
             return True
     return False

--- a/openhands-sdk/openhands/sdk/mcp/_compat.py
+++ b/openhands-sdk/openhands/sdk/mcp/_compat.py
@@ -1,0 +1,24 @@
+"""Compatibility helpers for MCP SDK field renames across fastmcp versions.
+
+fastmcp 4.0 renamed several `mcp.types` fields to snake_case (``Tool.inputSchema`` ->
+``input_schema``, ``CallToolResult.isError`` -> ``is_error``,
+``ImageContent.mimeType`` -> ``mime_type``), keeping the old name as a
+deprecated compat property that logs a ``FastMCPDeprecationWarning`` on every access.
+
+We support ``fastmcp>=3.2.0`` (see openhands-sdk/pyproject.toml), where only the old
+name exists at all -- so the code can't just switch to the new name outright without
+breaking on the pinned floor, and reading the old name unconditionally means every
+caller on a newer fastmcp gets a deprecation warning on every tool call. Read whichever
+name the installed version actually provides instead of assuming either one.
+"""
+
+from typing import Any
+
+
+_MISSING = object()
+
+
+def compat_attr(obj: object, new_name: str, old_name: str) -> Any:
+    """Return ``getattr(obj, new_name)`` if present, else ``getattr(obj, old_name)``."""
+    val = getattr(obj, new_name, _MISSING)
+    return val if val is not _MISSING else getattr(obj, old_name)

--- a/openhands-sdk/openhands/sdk/mcp/definition.py
+++ b/openhands-sdk/openhands/sdk/mcp/definition.py
@@ -9,6 +9,7 @@ from rich.text import Text
 
 from openhands.sdk.llm import ImageContent, TextContent
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp._compat import compat_attr
 from openhands.sdk.tool import (
     Observation,
 )
@@ -66,9 +67,10 @@ class MCPToolObservation(Observation):
             if isinstance(block, mcp.types.TextContent):
                 content.append(TextContent(text=block.text))
             elif isinstance(block, mcp.types.ImageContent):
+                mime_type = compat_attr(block, "mime_type", "mimeType")
                 content.append(
                     ImageContent(
-                        image_urls=[f"data:{block.mimeType};base64,{block.data}"],
+                        image_urls=[f"data:{mime_type};base64,{block.data}"],
                     )
                 )
             else:
@@ -78,7 +80,7 @@ class MCPToolObservation(Observation):
 
         return cls(
             content=content,
-            is_error=result.isError,
+            is_error=compat_attr(result, "is_error", "isError"),
             tool_name=tool_name,
         )
 

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -19,6 +19,7 @@ from pydantic import Field, ValidationError
 
 from openhands.sdk.llm import TextContent
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp._compat import compat_attr
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.definition import MCPToolAction, MCPToolObservation
 from openhands.sdk.observability.laminar import observe
@@ -223,7 +224,11 @@ def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
 
     cache_key = (
         action_type.name,
-        json.dumps(action_type.inputSchema, sort_keys=True, separators=(",", ":")),
+        json.dumps(
+            compat_attr(action_type, "input_schema", "inputSchema"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
     )
     with _mcp_dynamic_action_type_lock:
         mcp_action_type = _mcp_dynamic_action_type.get(cache_key)
@@ -232,7 +237,9 @@ def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
             return mcp_action_type
 
         model_name = f"MCP{to_camel_case(action_type.name)}Action"
-        mcp_action_type = Schema.from_mcp_schema(model_name, action_type.inputSchema)
+        mcp_action_type = Schema.from_mcp_schema(
+            model_name, compat_attr(action_type, "input_schema", "inputSchema")
+        )
         _mcp_dynamic_action_type[cache_key] = mcp_action_type
         if len(_mcp_dynamic_action_type) > _MCP_ACTION_TYPE_CACHE_MAX:
             _mcp_dynamic_action_type.popitem(last=False)
@@ -367,7 +374,7 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
             raise ValueError("MCPTool.to_mcp_tool does not support overriding schemas")
 
         return super().to_mcp_tool(
-            input_schema=self.mcp_tool.inputSchema,
+            input_schema=compat_attr(self.mcp_tool, "input_schema", "inputSchema"),
             output_schema=self.observation_type.to_mcp_schema()
             if self.observation_type
             else None,
@@ -389,7 +396,9 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
 
         See: https://github.com/OpenHands/software-agent-sdk/issues/3955
         """
-        schema = copy.deepcopy(self.mcp_tool.inputSchema)
+        schema = copy.deepcopy(
+            compat_attr(self.mcp_tool, "input_schema", "inputSchema")
+        )
         # Resolve any $ref / anyOf nodes (unlikely in raw MCP schemas but
         # keeps the contract consistent with the parent implementation).
         schema = _process_schema_node(schema, schema.get("$defs", {}))

--- a/tests/sdk/mcp/test_compat.py
+++ b/tests/sdk/mcp/test_compat.py
@@ -1,0 +1,36 @@
+"""Tests for the fastmcp field-rename compat helper (see mcp/_compat.py)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from openhands.sdk.mcp._compat import compat_attr
+
+
+def test_compat_attr_prefers_the_new_name_when_present():
+    obj = SimpleNamespace(input_schema={"type": "object"}, inputSchema="stale")
+    assert compat_attr(obj, "input_schema", "inputSchema") == {"type": "object"}
+
+
+def test_compat_attr_falls_back_to_the_old_name_when_new_is_absent():
+    obj = SimpleNamespace(inputSchema={"type": "object"})
+    assert compat_attr(obj, "input_schema", "inputSchema") == {"type": "object"}
+
+
+def test_compat_attr_falls_back_on_a_spec_restricted_mock_without_the_new_name():
+    # MagicMock(spec=...) raises AttributeError for anything outside the spec,
+    # same as a real object built against an older fastmcp that lacks the field.
+    class _OldStyleTool:
+        inputSchema: dict
+
+    mock = MagicMock(spec=_OldStyleTool)
+    mock.inputSchema = {"type": "object"}
+    assert compat_attr(mock, "input_schema", "inputSchema") == {"type": "object"}
+
+
+def test_compat_attr_raises_when_neither_name_exists():
+    obj = SimpleNamespace()
+    try:
+        compat_attr(obj, "input_schema", "inputSchema")
+    except AttributeError:
+        return
+    raise AssertionError("expected AttributeError when neither attribute exists")


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Found this while building an app on top of the SDK — every MCP tool call was logging deprecation warnings that had nothing to do with my own code. Traced it to these five call sites and worked with an AI coding agent to investigate the two possible fixes; I reviewed the tests and the reasoning behind picking the compat shim over the version bump before opening this.

---

AGENT:

## Why

fastmcp 4.0 renamed three `mcp.types` fields to snake_case (`Tool.inputSchema` -> `input_schema`, `CallToolResult.isError` -> `is_error`, `ImageContent.mimeType` -> `mime_type`), keeping the old name as a deprecated compat property that logs `FastMCPDeprecationWarning` on every access. This repo pins `fastmcp>=3.2.0` with no upper bound, so every MCP tool call emits these warnings whenever a consumer's own dependency resolution lands on `fastmcp>=4.0` (the default outcome of a fresh, non-locked install). I hit this building on top of the SDK and traced it to five call sites still reading the old names: `mcp/tool.py` (x4), `mcp/definition.py` (x2), `agent/agent.py`, `agent_server/mcp_router.py`.

## Summary
- Add `compat_attr(obj, new_name, old_name)` in a new `mcp/_compat.py`, reading whichever field name the installed `mcp.types` object actually has.
- Use it at all five call sites instead of hardcoding either name.
- Add `tests/sdk/mcp/test_compat.py` covering: new name present, only old name present, a `spec=`-restricted `Mock` missing the new name (mirrors a real object on the old floor), and neither name present (should raise).

## Issue Number

Fixes #4925

## How to Test

Ran the relevant scope on the currently pinned `fastmcp==3.2.0` (no dependency change):

```
uv run pytest tests/sdk/mcp/ tests/sdk/agent/ tests/sdk/tool/ tests/agent_server/test_mcp_router.py -q
# 1238 passed, 6 deselected — identical count to main before this change
make format && make lint  # both pass; pre-commit (ruff, pycodestyle, pyright, the
                           # custom Tool-subclass-registration check) all pass
```

I also verified the other direction without touching the lockfile: installed `fastmcp==4.0.1`/`mcp==2.1.1` directly into the venv (bypassing `uv run`'s auto-resync) and confirmed `compat_attr(tool, "input_schema", "inputSchema")` returns the correct schema dict with **zero warnings** — i.e. the same code path is silent on both the pinned floor and a newer fastmcp.

I first tried the more obvious fix — bump the floor to `fastmcp>=4.0.0` and switch to the new names outright. Re-locking to `fastmcp==4.0.1` surfaced an **unrelated regression**: 4 tests failed (`test_stateful_mcp.py` — an HTTP session not being reused across calls, a per-session counter resetting instead of incrementing — and `test_mcp_tool_list_changed.py::test_list_changed_notification_reconciles_readded_agent_tool`). That's a real behavior difference in the MCP client's session lifecycle across fastmcp major versions, not a field rename, and felt like its own investigation rather than something to fold into this fix — so I backed the floor bump out and went with the compat shim instead, which needs no dependency change at all.

## Design Doc

Not included — this is a trivial, mechanical fix per CONTRIBUTING.md (attribute-name compatibility shim, no public API change).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No dependency version change (`pyproject.toml`/`uv.lock` untouched) — see "Why" above for why the more obvious floor-bump fix was reverted.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.56s · commit 5659245  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 14/14 hunks, 6/6 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 9.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature cdb85e0b7f7ca6631be0664b050388dd3619e40da37c390f177fd95751650ba0 -->
<!-- jev-fast-audit:end -->
