### PR TITLE
fix(workspace): secure DockerWorkspace host ports

### DIFF
--- a/openhands-workspace/openhands/workspace/docker/workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/workspace.py
@@ -1,11 +1,15 @@
 """Docker-based remote workspace implementation."""
 
 import os
+import secrets
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from urllib.request import urlopen
 
@@ -17,14 +21,24 @@ from openhands.sdk.workspace import PlatformType, RemoteWorkspace
 
 
 logger = get_logger(__name__)
-_SESSION_API_KEY_ENV_VARS = ("OH_SESSION_API_KEYS_0", "SESSION_API_KEY")
+_SESSION_API_KEY_ENV = "OH_SESSION_API_KEYS_0"
+_RESERVED_SESSION_API_KEY_ENVS = frozenset({_SESSION_API_KEY_ENV, "SESSION_API_KEY"})
 
 
-def _get_forwarded_session_api_key(forward_env: list[str]) -> str | None:
-    for name in _SESSION_API_KEY_ENV_VARS:
-        if name in forward_env and (value := os.environ.get(name)):
-            return value
-    return None
+@contextmanager
+def _session_api_key_env_file(api_key: str) -> Iterator[str]:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="openhands-docker-env-",
+        delete=False,
+    ) as env_file:
+        env_file.write(f"{_SESSION_API_KEY_ENV}={api_key}\n")
+
+    try:
+        yield env_file.name
+    finally:
+        os.unlink(env_file.name)
 
 
 def check_port_available(port: int) -> bool:
@@ -84,6 +98,13 @@ class DockerWorkspace(RemoteWorkspace):
         default="",
         description=("Remote host URL (set automatically during container startup)."),
     )
+    api_key: str | None = Field(
+        default_factory=lambda: secrets.token_urlsafe(32),
+        description=(
+            "Generated session API key used by the container and all workspace "
+            "connections."
+        ),
+    )
 
     # Docker-specific configuration
     server_image: str | None = Field(
@@ -96,18 +117,11 @@ class DockerWorkspace(RemoteWorkspace):
     )
     public: bool = Field(
         default=False,
-        description=(
-            "Whether to publish container ports on all host interfaces. Public "
-            "workspaces require a session API key."
-        ),
+        description="Whether to publish container ports on all host interfaces.",
     )
     forward_env: list[str] = Field(
-        default_factory=lambda: ["DEBUG", "SESSION_API_KEY", "OH_SESSION_API_KEYS_0"],
-        description=(
-            "Environment variables to forward to the container. The session "
-            "API key variables are forwarded so the sandboxed agent server can "
-            "authenticate network-bound requests."
-        ),
+        default_factory=lambda: ["DEBUG"],
+        description="Environment variables to forward to the container.",
     )
     volumes: list[str] = Field(
         default_factory=list,
@@ -163,17 +177,11 @@ class DockerWorkspace(RemoteWorkspace):
             raise ValueError("server_image must be provided")
         return self
 
-    @model_validator(mode="after")
-    def _validate_public_access(self):
-        if self.public and _get_forwarded_session_api_key(self.forward_env) is None:
-            raise ValueError(
-                "A public DockerWorkspace requires a forwarded "
-                "SESSION_API_KEY/OH_SESSION_API_KEYS_0 environment variable."
-            )
-        return self
-
     def model_post_init(self, context: Any) -> None:
         """Set up the Docker container and initialize the remote workspace."""
+        if not self.api_key:
+            object.__setattr__(self, "api_key", secrets.token_urlsafe(32))
+
         # Subclasses should call get_image() to get the image to use
         # This allows them to build or prepare the image before container startup
         image = self.get_image()
@@ -232,6 +240,8 @@ class DockerWorkspace(RemoteWorkspace):
         # Prepare Docker run flags
         flags: list[str] = []
         for key in self.forward_env:
+            if key in _RESERVED_SESSION_API_KEY_ENVS:
+                continue
             if key in os.environ:
                 flags += ["-e", f"{key}={os.environ[key]}"]
 
@@ -257,25 +267,29 @@ class DockerWorkspace(RemoteWorkspace):
             flags += ["--network", self.network]
 
         # Run container
-        run_cmd = [
-            "docker",
-            "run",
-            "-d",
-            "--platform",
-            self.platform,
-            "--rm",
-            "--ulimit",
-            "nofile=65536:65536",  # prevent "too many open files" errors
-            "--name",
-            f"agent-server-{uuid.uuid4()}",
-            *flags,
-            image,
-            "--host",
-            "0.0.0.0",
-            "--port",
-            "8000",
-        ]
-        proc = execute_command(run_cmd)
+        assert self.api_key is not None
+        with _session_api_key_env_file(self.api_key) as session_env_file:
+            run_cmd = [
+                "docker",
+                "run",
+                "-d",
+                "--platform",
+                self.platform,
+                "--rm",
+                "--ulimit",
+                "nofile=65536:65536",  # prevent "too many open files" errors
+                "--name",
+                f"agent-server-{uuid.uuid4()}",
+                "--env-file",
+                session_env_file,
+                *flags,
+                image,
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8000",
+            ]
+            proc = execute_command(run_cmd)
         if proc.returncode != 0:
             raise RuntimeError(f"Failed to run docker container: {proc.stderr}")
 
@@ -294,12 +308,6 @@ class DockerWorkspace(RemoteWorkspace):
         # Override parent's host initialization
         if not self.host:
             object.__setattr__(self, "host", f"http://127.0.0.1:{self.host_port}")
-        if self.api_key is None:
-            object.__setattr__(
-                self,
-                "api_key",
-                _get_forwarded_session_api_key(self.forward_env),
-            )
 
         # Wait for container to be healthy
         self._wait_for_health(timeout=self.health_check_timeout)

--- a/openhands-workspace/openhands/workspace/docker/workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/workspace.py
@@ -17,6 +17,14 @@ from openhands.sdk.workspace import PlatformType, RemoteWorkspace
 
 
 logger = get_logger(__name__)
+_SESSION_API_KEY_ENV_VARS = ("OH_SESSION_API_KEYS_0", "SESSION_API_KEY")
+
+
+def _get_forwarded_session_api_key(forward_env: list[str]) -> str | None:
+    for name in _SESSION_API_KEY_ENV_VARS:
+        if name in forward_env and (value := os.environ.get(name)):
+            return value
+    return None
 
 
 def check_port_available(port: int) -> bool:
@@ -86,12 +94,19 @@ class DockerWorkspace(RemoteWorkspace):
         default=None,
         description="Port to bind the container to. If None, finds available port.",
     )
+    public: bool = Field(
+        default=False,
+        description=(
+            "Whether to publish container ports on all host interfaces. Public "
+            "workspaces require a session API key."
+        ),
+    )
     forward_env: list[str] = Field(
         default_factory=lambda: ["DEBUG", "SESSION_API_KEY", "OH_SESSION_API_KEYS_0"],
         description=(
             "Environment variables to forward to the container. The session "
             "API key variables are forwarded so the sandboxed agent server can "
-            "authenticate network-bound requests when it binds 0.0.0.0."
+            "authenticate network-bound requests."
         ),
     )
     volumes: list[str] = Field(
@@ -146,6 +161,15 @@ class DockerWorkspace(RemoteWorkspace):
         """Ensure server_image is set when using DockerWorkspace directly."""
         if self.__class__ is DockerWorkspace and self.server_image is None:
             raise ValueError("server_image must be provided")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_public_access(self):
+        if self.public and _get_forwarded_session_api_key(self.forward_env) is None:
+            raise ValueError(
+                "A public DockerWorkspace requires a forwarded "
+                "SESSION_API_KEY/OH_SESSION_API_KEYS_0 environment variable."
+            )
         return self
 
     def model_post_init(self, context: Any) -> None:
@@ -215,11 +239,12 @@ class DockerWorkspace(RemoteWorkspace):
             flags += ["-v", volume]
             logger.info(f"Adding volume mount: {volume}")
 
-        ports = ["-p", f"{self.host_port}:8000"]
+        publish_host = "0.0.0.0" if self.public else "127.0.0.1"
+        ports = ["-p", f"{publish_host}:{self.host_port}:8000"]
         if self.extra_ports:
             ports += [
                 "-p",
-                f"{self.host_port + 1}:8001",  # VSCode
+                f"{publish_host}:{self.host_port + 1}:8001",  # VSCode
             ]
         flags += ports
 
@@ -269,7 +294,12 @@ class DockerWorkspace(RemoteWorkspace):
         # Override parent's host initialization
         if not self.host:
             object.__setattr__(self, "host", f"http://127.0.0.1:{self.host_port}")
-        object.__setattr__(self, "api_key", None)
+        if self.api_key is None:
+            object.__setattr__(
+                self,
+                "api_key",
+                _get_forwarded_session_api_key(self.forward_env),
+            )
 
         # Wait for container to be healthy
         self._wait_for_health(timeout=self.health_check_timeout)

--- a/tests/workspace/test_docker_workspace.py
+++ b/tests/workspace/test_docker_workspace.py
@@ -117,16 +117,27 @@ def test_removed_mount_dir_input_fails_loudly():
 
 
 def _start_docker_workspace(**kwargs):
+    docker_env: dict[str, str] = {}
+
+    def execute(cmd):
+        if cmd[:2] == ["docker", "run"]:
+            env_file = Path(cmd[cmd.index("--env-file") + 1])
+            name, value = env_file.read_text().strip().split("=", 1)
+            docker_env[name] = value
+        return Mock(returncode=0, stdout="container_123", stderr="")
+
     with (
         patch(
             "openhands.workspace.docker.workspace.check_port_available",
             return_value=True,
         ),
-        patch("openhands.workspace.docker.workspace.execute_command") as mock_exec,
+        patch(
+            "openhands.workspace.docker.workspace.execute_command",
+            side_effect=execute,
+        ) as mock_exec,
         patch.object(DockerWorkspace, "_wait_for_health"),
         patch("openhands.workspace.docker.workspace.RemoteWorkspace.model_post_init"),
     ):
-        mock_exec.return_value = Mock(returncode=0, stdout="container_123", stderr="")
         workspace = DockerWorkspace(
             server_image="test:latest",
             host_port=32100,
@@ -139,7 +150,7 @@ def _start_docker_workspace(**kwargs):
             if call.args[0][:2] == ["docker", "run"]
         )
         workspace._container_id = None
-    return workspace, run_cmd
+    return workspace, run_cmd, docker_env
 
 
 @pytest.mark.parametrize(
@@ -150,40 +161,44 @@ def _start_docker_workspace(**kwargs):
     ],
 )
 def test_docker_workspace_binds_host_ports_to_loopback_by_default(
-    monkeypatch, extra_ports, published_ports
+    extra_ports, published_ports
 ):
-    monkeypatch.delenv("SESSION_API_KEY", raising=False)
-    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
-
-    _, run_cmd = _start_docker_workspace(extra_ports=extra_ports)
+    _, run_cmd, _ = _start_docker_workspace(extra_ports=extra_ports)
 
     assert [run_cmd[index + 1] for index, arg in enumerate(run_cmd) if arg == "-p"] == (
         published_ports
     )
 
 
-@pytest.mark.parametrize("api_key", [None, "client-key-only"])
-def test_public_docker_workspace_requires_forwarded_session_api_key(
-    monkeypatch, api_key
-):
-    monkeypatch.delenv("SESSION_API_KEY", raising=False)
-    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
+def test_docker_workspace_generates_and_reuses_session_api_key():
+    workspace, run_cmd, docker_env = _start_docker_workspace()
 
-    with pytest.raises(ValidationError, match="public DockerWorkspace"):
-        with patch.object(DockerWorkspace, "_start_container"):
-            DockerWorkspace(server_image="test:latest", public=True, api_key=api_key)
+    assert workspace.api_key
+    assert docker_env == {"OH_SESSION_API_KEYS_0": workspace.api_key}
+    assert workspace._headers == {"X-Session-API-Key": workspace.api_key}
+    env_file = Path(run_cmd[run_cmd.index("--env-file") + 1])
+    assert not env_file.exists()
+    assert workspace.api_key not in run_cmd
 
 
-def test_public_docker_workspace_binds_all_interfaces_with_environment_key(
-    monkeypatch,
-):
-    monkeypatch.setenv("SESSION_API_KEY", "test-session-key")
-    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
+def test_docker_workspace_does_not_use_session_key_environment(monkeypatch):
+    monkeypatch.setenv("SESSION_API_KEY", "ambient-legacy-key")
+    monkeypatch.setenv("OH_SESSION_API_KEYS_0", "ambient-current-key")
 
-    workspace, run_cmd = _start_docker_workspace(public=True)
+    workspace, run_cmd, docker_env = _start_docker_workspace(
+        forward_env=["DEBUG", "SESSION_API_KEY", "OH_SESSION_API_KEYS_0"]
+    )
+
+    assert workspace.api_key not in {"ambient-legacy-key", "ambient-current-key"}
+    assert docker_env == {"OH_SESSION_API_KEYS_0": workspace.api_key}
+    assert all("ambient" not in arg for arg in run_cmd)
+
+
+def test_public_docker_workspace_binds_all_interfaces_with_generated_key():
+    workspace, run_cmd, docker_env = _start_docker_workspace(public=True)
 
     assert "0.0.0.0:32100:8000" in run_cmd
-    assert workspace.api_key == "test-session-key"
+    assert docker_env == {"OH_SESSION_API_KEYS_0": workspace.api_key}
 
 
 def test_cleanup_without_image_deletion(mock_docker_workspace):

--- a/tests/workspace/test_docker_workspace.py
+++ b/tests/workspace/test_docker_workspace.py
@@ -116,6 +116,76 @@ def test_removed_mount_dir_input_fails_loudly():
         )
 
 
+def _start_docker_workspace(**kwargs):
+    with (
+        patch(
+            "openhands.workspace.docker.workspace.check_port_available",
+            return_value=True,
+        ),
+        patch("openhands.workspace.docker.workspace.execute_command") as mock_exec,
+        patch.object(DockerWorkspace, "_wait_for_health"),
+        patch("openhands.workspace.docker.workspace.RemoteWorkspace.model_post_init"),
+    ):
+        mock_exec.return_value = Mock(returncode=0, stdout="container_123", stderr="")
+        workspace = DockerWorkspace(
+            server_image="test:latest",
+            host_port=32100,
+            detach_logs=False,
+            **kwargs,
+        )
+        run_cmd = next(
+            call.args[0]
+            for call in mock_exec.call_args_list
+            if call.args[0][:2] == ["docker", "run"]
+        )
+        workspace._container_id = None
+    return workspace, run_cmd
+
+
+@pytest.mark.parametrize(
+    ("extra_ports", "published_ports"),
+    [
+        (False, ["127.0.0.1:32100:8000"]),
+        (True, ["127.0.0.1:32100:8000", "127.0.0.1:32101:8001"]),
+    ],
+)
+def test_docker_workspace_binds_host_ports_to_loopback_by_default(
+    monkeypatch, extra_ports, published_ports
+):
+    monkeypatch.delenv("SESSION_API_KEY", raising=False)
+    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
+
+    _, run_cmd = _start_docker_workspace(extra_ports=extra_ports)
+
+    assert [run_cmd[index + 1] for index, arg in enumerate(run_cmd) if arg == "-p"] == (
+        published_ports
+    )
+
+
+@pytest.mark.parametrize("api_key", [None, "client-key-only"])
+def test_public_docker_workspace_requires_forwarded_session_api_key(
+    monkeypatch, api_key
+):
+    monkeypatch.delenv("SESSION_API_KEY", raising=False)
+    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
+
+    with pytest.raises(ValidationError, match="public DockerWorkspace"):
+        with patch.object(DockerWorkspace, "_start_container"):
+            DockerWorkspace(server_image="test:latest", public=True, api_key=api_key)
+
+
+def test_public_docker_workspace_binds_all_interfaces_with_environment_key(
+    monkeypatch,
+):
+    monkeypatch.setenv("SESSION_API_KEY", "test-session-key")
+    monkeypatch.delenv("OH_SESSION_API_KEYS_0", raising=False)
+
+    workspace, run_cmd = _start_docker_workspace(public=True)
+
+    assert "0.0.0.0:32100:8000" in run_cmd
+    assert workspace.api_key == "test-session-key"
+
+
 def test_cleanup_without_image_deletion(mock_docker_workspace):
     """Test that cleanup with cleanup_image=False does not delete the image."""
     workspace, mock_exec = mock_docker_workspace(cleanup_image=False)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN: When we start a DockerWorkspace, it is by default unauthenticated and exposed to the internet, which makes the user's workstation vulnerable

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`DockerWorkspace` currently publishes the Agent Server port on every host interface. Without a session API key, default construction can therefore expose an unauthenticated Agent Server to the local network or internet.

## Summary

- Publish Agent Server and optional VS Code host ports on `127.0.0.1` by default.
- Generate and store a unique session API key for each workspace instead of using ambient `SESSION_API_KEY` variables.
- Pass the key to Docker without exposing it in command arguments, then reuse it for all SDK connections; retain explicit `public=True` for remote exposure.

## Issue Number

Private security report; no public issue.

## How to Test

```bash
uv run pre-commit run --files \
  openhands-workspace/openhands/workspace/docker/workspace.py \
  tests/workspace/test_docker_workspace.py
uv run pytest -q tests/workspace/test_docker_workspace.py
uv run pytest -q tests/workspace
```

Results: pre-commit passed; 22 DockerWorkspace tests passed; 196 workspace tests passed. The suite emits one pre-existing `DockerWorkspace.__del__` thread-join warning.

I also built a minimal BusyBox health-server image and instantiated real `DockerWorkspace` containers while ambient session-key variables were set. Docker inspection confirmed that each container received its workspace's unique generated key, the SDK client stored that same key, and neither ambient key was used. `docker port` reported:

```text
default: 127.0.0.1:33183
public: 0.0.0.0:33411
```

## Video/Screenshots

Not applicable; this changes Docker port publication and credential wiring, which are covered by command output above.

## Design Doc

Not included; the change is limited to generated credential lifecycle, port publication, and tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Breaking change
- [ ] Docs / chore

## Notes

- Documentation PR: https://github.com/OpenHands/docs/pull/784
- The Agent Server must continue binding `0.0.0.0` inside the container so Docker NAT can reach it; the security boundary is the host-side published address.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:55fee6f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-55fee6f-python \
  ghcr.io/openhands/agent-server:55fee6f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:55fee6f-golang-amd64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-golang-amd64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-golang-amd64
ghcr.io/openhands/agent-server:55fee6f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:55fee6f-golang-arm64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-golang-arm64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-golang-arm64
ghcr.io/openhands/agent-server:55fee6f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:55fee6f-java-amd64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-java-amd64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-java-amd64
ghcr.io/openhands/agent-server:55fee6f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:55fee6f-java-arm64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-java-arm64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-java-arm64
ghcr.io/openhands/agent-server:55fee6f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:55fee6f-python-amd64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python-amd64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python-amd64
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:55fee6f-python-arm64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python-arm64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python-arm64
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:55fee6f-python-slim-amd64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python-slim-amd64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python-slim-amd64
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:55fee6f-python-slim-arm64
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python-slim-arm64
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python-slim-arm64
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:55fee6f-golang
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-golang
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-golang
ghcr.io/openhands/agent-server:55fee6f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:55fee6f-java
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-java
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-java
ghcr.io/openhands/agent-server:55fee6f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:55fee6f-python-slim
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python-slim
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python-slim
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:55fee6f-python
ghcr.io/openhands/agent-server:55fee6f6acb5cd322d017d01eb7acbee99a38c3e-python
ghcr.io/openhands/agent-server:security-docker-workspace-loopback-python
ghcr.io/openhands/agent-server:55fee6f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `55fee6f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `55fee6f-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->