### PR TITLE
fix(browser): keep recording controller stable on duplicate start

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/recording.py
+++ b/openhands-tools/openhands/tools/browser_use/recording.py
@@ -427,6 +427,9 @@ class RecordingSession:
             User-facing operation: returns error strings, logs at WARNING for
             unexpected errors (see Error Handling Policy in module docstring).
         """
+        if self._is_recording:
+            return "Already recording"
+
         if not self._scripts_injected:
             await self.inject_scripts(browser_session)
 

--- a/openhands-tools/openhands/tools/browser_use/server.py
+++ b/openhands-tools/openhands/tools/browser_use/server.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from browser_use.dom.markdown_extractor import extract_clean_markdown
 
 from openhands.sdk import get_logger
@@ -27,6 +29,9 @@ class CustomBrowserUseServer(LogSafeBrowserUseServer):
         self._injected_script_ids: list[str] = []
         # Recording session - encapsulates all recording state and logic
         self._recording_session: RecordingSession | None = None
+        # Serialize recording lifecycle transitions so a duplicate start cannot
+        # replace an active controller while it is awaiting browser I/O.
+        self._recording_lock = asyncio.Lock()
 
     @property
     def _is_recording(self) -> bool:
@@ -39,6 +44,11 @@ class CustomBrowserUseServer(LogSafeBrowserUseServer):
         Stops any active recording, saves remaining events, and releases resources.
         Should be called when the browser session is being closed.
         """
+        async with self._recording_lock:
+            await self._cleanup_recording_locked()
+
+    async def _cleanup_recording_locked(self) -> None:
+        """Cleanup recording resources while holding the lifecycle lock."""
         if self._recording_session is None:
             return
 
@@ -140,9 +150,14 @@ class CustomBrowserUseServer(LogSafeBrowserUseServer):
         if not self.browser_session:
             return "Error: No browser session active"
 
-        # Create a new recording session with output_dir
-        self._recording_session = RecordingSession(output_dir=output_dir)
-        return await self._recording_session.start(self.browser_session)
+        async with self._recording_lock:
+            if self._recording_session and self._recording_session.is_active:
+                return "Already recording"
+
+            # A stopped recording gets a fresh controller and output directory,
+            # while an active recording retains its original controller.
+            self._recording_session = RecordingSession(output_dir=output_dir)
+            return await self._recording_session.start(self.browser_session)
 
     async def _stop_recording(self) -> str:
         """Stop rrweb recording and save remaining events.
@@ -155,13 +170,14 @@ class CustomBrowserUseServer(LogSafeBrowserUseServer):
         if not self.browser_session:
             return "Error: No browser session active"
 
-        if not self._recording_session or not self._recording_session.is_active:
-            return "Error: Not recording. Call browser_start_recording first."
+        async with self._recording_lock:
+            if not self._recording_session or not self._recording_session.is_active:
+                return "Error: Not recording. Call browser_start_recording first."
 
-        result = await self._recording_session.stop(self.browser_session)
-        # Reset the session after stopping
-        self._recording_session.reset()
-        return result
+            result = await self._recording_session.stop(self.browser_session)
+            # Reset the session after stopping
+            self._recording_session.reset()
+            return result
 
     async def _get_storage(self) -> str:
         """Get browser storage (cookies, local storage, session storage)."""

--- a/tests/tools/browser_use/test_recording_flush.py
+++ b/tests/tools/browser_use/test_recording_flush.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 import tempfile
+from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -310,6 +311,214 @@ class TestConcurrentFlushSafety:
                 with open(filepath) as f:
                     events = json.load(f)
                 assert isinstance(events, list)
+
+
+class TestRecordingLifecycle:
+    """Tests for recording controller lifecycle serialization."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_start_keeps_real_session_and_flush_task(
+        self, server_with_mock_browser, mock_cdp_session, tmp_path
+    ):
+        """A duplicate start must retain the real session's sole flush task."""
+        mock_cdp_session.cdp_client.send.Page.addScriptToEvaluateOnNewDocument = (
+            AsyncMock(return_value={"identifier": "script-1"})
+        )
+        mock_cdp_session.cdp_client.send.Runtime.evaluate = AsyncMock(
+            side_effect=[
+                {"result": {"value": {"success": True}}},
+                {"result": {"value": {"status": "started"}}},
+                {"result": {"value": None}},
+                {"result": {"value": json.dumps({"events": [{"type": 3}]})}},
+                {"result": {"value": None}},
+            ]
+        )
+
+        first_result = await server_with_mock_browser._start_recording(str(tmp_path))
+        first_session = server_with_mock_browser._recording_session
+        first_task = first_session._flush_task
+
+        second_result = await server_with_mock_browser._start_recording(
+            str(tmp_path / "different-output")
+        )
+
+        assert first_result == "Recording started"
+        assert second_result == "Already recording"
+        assert server_with_mock_browser._recording_session is first_session
+        assert first_task is not None
+        assert not first_task.done()
+        assert mock_cdp_session.cdp_client.send.Runtime.evaluate.await_count == 3
+
+        await server_with_mock_browser._cleanup_recording()
+
+        assert first_task.done()
+        assert first_session._flush_task is None
+        assert server_with_mock_browser._recording_session is None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_start_keeps_active_controller(
+        self, server_with_mock_browser, monkeypatch
+    ):
+        """An active recording must not be replaced by a duplicate start."""
+
+        class FakeRecordingSession:
+            instances: ClassVar[list] = []
+
+            def __init__(self, output_dir=None):
+                self.output_dir = output_dir
+                self.is_active = False
+                self.start_calls = 0
+                self.stop_calls = 0
+                self.__class__.instances.append(self)
+
+            async def start(self, browser_session):
+                self.start_calls += 1
+                self.is_active = True
+                return "Recording started"
+
+            async def stop(self, browser_session):
+                self.stop_calls += 1
+                self.is_active = False
+                return "Recording stopped"
+
+            def reset(self):
+                self.is_active = False
+
+        monkeypatch.setattr(
+            "openhands.tools.browser_use.server.RecordingSession",
+            FakeRecordingSession,
+        )
+
+        first_result = await server_with_mock_browser._start_recording("first")
+        first_session = server_with_mock_browser._recording_session
+
+        second_result = await server_with_mock_browser._start_recording("second")
+
+        assert first_result == "Recording started"
+        assert second_result == "Already recording"
+        assert server_with_mock_browser._recording_session is first_session
+        assert len(FakeRecordingSession.instances) == 1
+        assert first_session.start_calls == 1
+
+        await server_with_mock_browser._cleanup_recording()
+        assert first_session.stop_calls == 1
+        assert server_with_mock_browser._recording_session is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_start_creates_one_controller(
+        self, server_with_mock_browser, monkeypatch
+    ):
+        """Concurrent starts must serialize around browser startup."""
+        start_entered = asyncio.Event()
+        release_start = asyncio.Event()
+
+        class FakeRecordingSession:
+            instances: ClassVar[list] = []
+
+            def __init__(self, output_dir=None):
+                self.output_dir = output_dir
+                self.is_active = False
+                self.__class__.instances.append(self)
+
+            async def start(self, browser_session):
+                start_entered.set()
+                await release_start.wait()
+                self.is_active = True
+                return "Recording started"
+
+            async def stop(self, browser_session):
+                self.is_active = False
+                return "Recording stopped"
+
+            def reset(self):
+                self.is_active = False
+
+        monkeypatch.setattr(
+            "openhands.tools.browser_use.server.RecordingSession",
+            FakeRecordingSession,
+        )
+
+        first_task = asyncio.create_task(
+            server_with_mock_browser._start_recording("first")
+        )
+        await start_entered.wait()
+        second_task = asyncio.create_task(
+            server_with_mock_browser._start_recording("second")
+        )
+        await asyncio.sleep(0)
+
+        assert len(FakeRecordingSession.instances) == 1
+
+        release_start.set()
+        first_result, second_result = await asyncio.gather(first_task, second_task)
+
+        assert first_result == "Recording started"
+        assert second_result == "Already recording"
+        assert (
+            server_with_mock_browser._recording_session
+            is FakeRecordingSession.instances[0]
+        )
+
+        await server_with_mock_browser._cleanup_recording()
+
+    @pytest.mark.asyncio
+    async def test_stop_then_start_creates_new_controller(
+        self, server_with_mock_browser, monkeypatch
+    ):
+        """A new recording run may use a fresh controller after stop."""
+
+        class FakeRecordingSession:
+            instances: ClassVar[list] = []
+
+            def __init__(self, output_dir=None):
+                self.output_dir = output_dir
+                self.is_active = False
+                self.__class__.instances.append(self)
+
+            async def start(self, browser_session):
+                self.is_active = True
+                return "Recording started"
+
+            async def stop(self, browser_session):
+                self.is_active = False
+                return "Recording stopped"
+
+            def reset(self):
+                self.is_active = False
+
+        monkeypatch.setattr(
+            "openhands.tools.browser_use.server.RecordingSession",
+            FakeRecordingSession,
+        )
+
+        await server_with_mock_browser._start_recording("first")
+        first_session = server_with_mock_browser._recording_session
+        assert await server_with_mock_browser._stop_recording() == "Recording stopped"
+
+        await server_with_mock_browser._start_recording("second")
+        second_session = server_with_mock_browser._recording_session
+
+        assert second_session is not first_session
+        assert first_session.output_dir == "first"
+        assert second_session.output_dir == "second"
+
+        await server_with_mock_browser._cleanup_recording()
+
+
+class TestRecordingSessionLifecycle:
+    """Tests for RecordingSession start idempotence."""
+
+    @pytest.mark.asyncio
+    async def test_start_when_active_returns_already_recording(
+        self, mock_browser_session
+    ):
+        session = RecordingSession()
+        session._is_recording = True
+
+        result = await session.start(mock_browser_session)
+
+        assert result == "Already recording"
+        mock_browser_session.get_or_create_cdp_session.assert_not_awaited()
 
 
 class TestRecordingIsolation:


### PR DESCRIPTION
## Why

`CustomBrowserUseServer._start_recording` replaced the active `RecordingSession` on every call. A duplicate `browser_start_recording` could therefore orphan the previous controller and its periodic flush task, splitting events across output directories while the old task continued running.

## Summary

- Keep the active recording controller and flush task when a duplicate start is requested.
- Serialize recording start, stop, and cleanup transitions with a lifecycle lock.
- Add regression coverage for sequential and concurrent duplicate starts, cleanup, stop-then-start isolation, and `RecordingSession.start()` idempotence.

## Issue Number

Fixes #4666

## How to Test

Commands run from the repository root after rebasing onto upstream `main` at `7a018907c9b6cac2ee7b205a1b4a5e3e0228e8e4`:

- `make build` — passed.
- `uv run pytest tests/tools/browser_use/test_recording_flush.py tests/tools/browser_use/test_browser_executor.py -q` — **38 passed**.
- `uv run pytest tests/tools/browser_use -q -m 'not e2e'` — **104 passed, 22 deselected**. The run emitted one existing `PytestUnknownMarkWarning` for the repository's `e2e` marker.
- `uv run pytest tests/tools/browser_use/test_browser_executor_e2e.py -q -m e2e -k 'test_start_recording or test_recording_captures_events'` — **2 passed, 20 deselected**. The run emitted the same existing marker warning.
- `uv run pre-commit run --files openhands-tools/openhands/tools/browser_use/recording.py openhands-tools/openhands/tools/browser_use/server.py tests/tools/browser_use/test_recording_flush.py` — all configured hooks passed: Ruff format, Ruff lint, pycodestyle, Pyright, import dependency rules, and tool registration.

The pre-fix reproduction at baseline `76c53aa0475519965f082697ea1259ee98359b60` failed because two consecutive starts both returned `Recording started`; after this change the second call returns `Already recording`, keeps the original controller and flush task, and cleanup completes that task.

## Video/Screenshots

No UI changes; the real browser e2e results above exercise the recording behavior through `BrowserToolExecutor`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The lifecycle lock is held across the async start/stop/cleanup transitions so a concurrent duplicate start cannot observe a partially initialized recording. A stopped recording still creates a fresh controller and output directory on the next start. The human-testing checkbox is intentionally left unchecked.
