### PR TITLE
fix(sdk): tolerate orphaned tool observations

### DIFF
--- a/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
+++ b/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
@@ -77,13 +77,17 @@ class ToolCallMatchingProperty(ViewPropertyBase):
         # tool calls -- these are any tool calls that have been introduced by an action
         # but not yet resolved by an observation. If there are any pending tool calls we
         # know we're between an action/observation pair.
+        action_tool_call_ids: set[ToolCallID] = set()
         pending_tool_call_ids: set[ToolCallID] = set()
 
         for index, event in enumerate(current_view_events):
             match event:
                 case ActionEvent():
+                    action_tool_call_ids.add(event.tool_call_id)
                     pending_tool_call_ids.add(event.tool_call_id)
-                case ObservationBaseEvent():
+                case ObservationBaseEvent() if (
+                    event.tool_call_id in action_tool_call_ids
+                ):
                     # Intentionally use remove(), not discard(): a second
                     # observation-like event for the same tool_call_id means the
                     # view has already violated the 1 action -> 1 result

--- a/tests/sdk/context/view/properties/test_tool_call_matching.py
+++ b/tests/sdk/context/view/properties/test_tool_call_matching.py
@@ -429,3 +429,15 @@ class TestToolCallMatchingPropertyManipulationIndices(TestToolCallMatchingBase):
 
         result = self.property.manipulation_indices(events)
         assert result == ManipulationIndices.complete(events)
+
+    def test_orphaned_observation_does_not_restrict_indices(self) -> None:
+        """An observation without an action does not create a protected interval."""
+        observation = create_autospec(ObservationEvent, instance=True)
+        observation.tool_call_id = "orphaned_call"
+        observation.id = "orphaned_observation"
+        message = message_event("Continue")
+        events: list[LLMConvertibleEvent] = [observation, message]
+
+        result = self.property.manipulation_indices(events)
+
+        assert result == ManipulationIndices.complete(events)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I reproduced the crash locally and reviewed the focused fix. It prevents malformed replay history from blocking later agent turns.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

An orphaned observation-like event can exist in a replayed view after a restart or partial history. `ToolCallMatchingProperty.manipulation_indices()` treated every observation as a pending action result and raised `KeyError`, blocking later context condensation and turns.

## Summary

- Track action IDs independently from pending action/result intervals.
- Ignore a never-paired observation while preserving the existing strict duplicate-result check.
- Add a regression test that verifies an orphan observation leaves every manipulation index available.

## Issue Number

Fixes #4591

## How to Test

The regression test failed before the fix with `KeyError: 'orphaned_call'` from `pending_tool_call_ids.remove()`.

```bash
uv run pytest tests/sdk/context/view/properties/test_tool_call_matching.py::TestToolCallMatchingPropertyManipulationIndices::test_orphaned_observation_does_not_restrict_indices -q
# 1 passed

uv run pytest tests/sdk/context -q
# 442 passed

uv run pytest tests/sdk -q
# 6124 passed, 9 skipped, 12 xfailed, 19 deselected

uv run pre-commit run --all-files
# all hooks passed
```

## Video/Screenshots

Not applicable; this is a deterministic SDK view-property regression with no visual surface.

## Design Doc

Not needed: this is a narrowly scoped invariant repair with no public API or persisted-schema change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The full SDK suite emitted pre-existing warning noise, including expected-failure coverage and the known bounded `AsyncExecutor` shutdown warning, but no test failures.
