### PR TITLE
fix: gate reasoning_effort on exact parameter support

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -47,6 +47,8 @@ def select_chat_options(
     if supports_reasoning_effort:
         if llm.reasoning_effort is not None:
             out["reasoning_effort"] = llm.reasoning_effort
+    else:
+        out.pop("reasoning_effort", None)
 
     model_name = llm._model_name_for_capabilities()
     if model_features.supports_sampling_params is False or (

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -112,6 +112,11 @@ REASONING_EFFORT_MODEL_OVERRIDES = {
     "kimi-k3": "moonshot/kimi-k3",
 }
 
+REASONING_EFFORT_UNSUPPORTED_MODELS: tuple[str, ...] = (
+    "minimax-m3",
+    "minimax/MiniMax-M3",
+)
+
 
 EXTENDED_THINKING_MODELS: list[str] = [
     # Anthropic Claude models with useful agent performance gains.
@@ -369,6 +374,13 @@ def _supports_reasoning_effort(
     override = _optional_bool(overrides, "supports_reasoning_effort")
     if override is not None:
         return override
+
+    key = (model_info or {}).get("key")
+    if model_matches(model, REASONING_EFFORT_UNSUPPORTED_MODELS) or model_matches(
+        key if isinstance(key, str) else None,
+        REASONING_EFFORT_UNSUPPORTED_MODELS,
+    ):
+        return False
 
     metadata_override = _optional_bool(model_info, "supports_reasoning_effort")
     if metadata_override is not None:

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -351,6 +351,42 @@ def _supports_responses_api(
     return model_matches(model, RESPONSES_API_MODELS)
 
 
+def _supported_openai_params_from_metadata(
+    model_info: Mapping[str, Any] | None,
+) -> frozenset[str] | None:
+    raw = (model_info or {}).get("supported_openai_params")
+    if not isinstance(raw, (list, tuple, set)):
+        return None
+    return frozenset(str(param) for param in raw)
+
+
+def _supports_reasoning_effort(
+    model: str | None,
+    model_info: Mapping[str, Any] | None,
+    overrides: Mapping[str, Any] | None,
+    supported_params: frozenset[str],
+) -> bool:
+    override = _optional_bool(overrides, "supports_reasoning_effort")
+    if override is not None:
+        return override
+
+    metadata_override = _optional_bool(model_info, "supports_reasoning_effort")
+    if metadata_override is not None:
+        return metadata_override
+
+    metadata_params = _supported_openai_params_from_metadata(model_info)
+    if metadata_params is not None:
+        return "reasoning_effort" in metadata_params
+
+    if _optional_bool(model_info, "supports_reasoning") is False:
+        return False
+
+    return (
+        model_matches(model, REASONING_EFFORT_MODEL_OVERRIDES)
+        or "reasoning_effort" in supported_params
+    )
+
+
 def get_features(
     model: str | None,
     model_info: Mapping[str, Any] | None = None,
@@ -358,15 +394,11 @@ def get_features(
 ) -> ModelFeatures:
     """Resolve model features from overrides, metadata, and fallbacks."""
     supported_params = _normalized_supported_openai_params(model)
-    supports_reasoning_effort = _resolved_bool(
-        "supports_reasoning_effort",
-        overrides=overrides,
-        metadata=model_info,
-        metadata_key="supports_reasoning",
-        fallback=(
-            model_matches(model, REASONING_EFFORT_MODEL_OVERRIDES)
-            or "reasoning_effort" in supported_params
-        ),
+    supports_reasoning_effort = _supports_reasoning_effort(
+        model,
+        model_info,
+        overrides,
+        supported_params,
     )
     thinking_mode = _thinking_mode(model, model_info, overrides)
     supports_sampling_params = _optional_bool(overrides, "supports_sampling_params")

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -371,16 +371,16 @@ def _supports_reasoning_effort(
     overrides: Mapping[str, Any] | None,
     supported_params: frozenset[str],
 ) -> bool:
-    override = _optional_bool(overrides, "supports_reasoning_effort")
-    if override is not None:
-        return override
-
     key = (model_info or {}).get("key")
     if model_matches(model, REASONING_EFFORT_UNSUPPORTED_MODELS) or model_matches(
         key if isinstance(key, str) else None,
         REASONING_EFFORT_UNSUPPORTED_MODELS,
     ):
         return False
+
+    override = _optional_bool(overrides, "supports_reasoning_effort")
+    if override is not None:
+        return override
 
     metadata_override = _optional_bool(model_info, "supports_reasoning_effort")
     if metadata_override is not None:

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -121,6 +121,23 @@ def test_minimax_m3_does_not_send_reasoning_effort_from_generic_reasoning_metada
     assert "reasoning_effort" not in out
 
 
+def test_minimax_m3_does_not_send_reasoning_effort_from_proxy_metadata():
+    llm = DummyLLM(
+        model="litellm_proxy/minimax-m3",
+        model_info={
+            "key": "minimax/MiniMax-M3",
+            "litellm_provider": "minimax",
+            "supports_reasoning": True,
+            "supported_openai_params": ["reasoning_effort", "thinking"],
+        },
+        reasoning_effort="high",
+    )
+
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    assert "reasoning_effort" not in out
+
+
 def test_kimi_k3_uses_reasoning_effort_and_strips_temp_top_p():
     llm = DummyLLM(
         model="litellm_proxy/moonshot/kimi-k3",

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -138,6 +138,30 @@ def test_minimax_m3_does_not_send_reasoning_effort_from_proxy_metadata():
     assert "reasoning_effort" not in out
 
 
+def test_minimax_m3_does_not_send_reasoning_effort_from_capability_override():
+    llm = DummyLLM(
+        model="openhands/minimax-m3",
+        capability_overrides={"supports_reasoning_effort": True},
+        reasoning_effort="high",
+    )
+
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    assert "reasoning_effort" not in out
+
+
+def test_minimax_m3_drops_caller_supplied_reasoning_effort():
+    llm = DummyLLM(model="openhands/minimax-m3", reasoning_effort=None)
+
+    out = select_chat_options(
+        llm,
+        user_kwargs={"reasoning_effort": "high"},
+        has_tools=True,
+    )
+
+    assert "reasoning_effort" not in out
+
+
 def test_kimi_k3_uses_reasoning_effort_and_strips_temp_top_p():
     llm = DummyLLM(
         model="litellm_proxy/moonshot/kimi-k3",

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -105,6 +105,22 @@ def test_kimi_k2_thinking_does_not_send_reasoning_effort():
     assert out.get("temperature") == 1.0
 
 
+def test_minimax_m3_does_not_send_reasoning_effort_from_generic_reasoning_metadata():
+    llm = DummyLLM(
+        model="minimax/MiniMax-M3",
+        model_info={
+            "litellm_provider": "minimax",
+            "supports_reasoning": True,
+            "supported_openai_params": ["thinking", "reasoning_split"],
+        },
+        reasoning_effort="high",
+    )
+
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    assert "reasoning_effort" not in out
+
+
 def test_kimi_k3_uses_reasoning_effort_and_strips_temp_top_p():
     llm = DummyLLM(
         model="litellm_proxy/moonshot/kimi-k3",

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -325,6 +325,20 @@ def test_generic_reasoning_metadata_does_not_enable_reasoning_effort():
     assert features.supports_reasoning_effort is False
 
 
+def test_minimax_m3_deny_guard_overrides_misleading_proxy_metadata():
+    features = get_features(
+        "litellm_proxy/minimax-m3",
+        model_info={
+            "key": "minimax/MiniMax-M3",
+            "litellm_provider": "minimax",
+            "supports_reasoning": True,
+            "supported_openai_params": ["reasoning_effort", "thinking"],
+        },
+    )
+
+    assert features.supports_reasoning_effort is False
+
+
 def test_exact_reasoning_effort_metadata_enables_reasoning_effort():
     features = get_features(
         "proxy/reasoning-model",

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -339,6 +339,15 @@ def test_minimax_m3_deny_guard_overrides_misleading_proxy_metadata():
     assert features.supports_reasoning_effort is False
 
 
+def test_minimax_m3_deny_guard_overrides_capability_override():
+    features = get_features(
+        "openhands/minimax-m3",
+        overrides={"supports_reasoning_effort": True},
+    )
+
+    assert features.supports_reasoning_effort is False
+
+
 def test_exact_reasoning_effort_metadata_enables_reasoning_effort():
     features = get_features(
         "proxy/reasoning-model",

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -312,6 +312,31 @@ def test_metadata_drives_adaptive_thinking_and_sampling():
     assert features.supports_prompt_cache is True
 
 
+def test_generic_reasoning_metadata_does_not_enable_reasoning_effort():
+    features = get_features(
+        "minimax/MiniMax-M3",
+        model_info={
+            "litellm_provider": "minimax",
+            "supports_reasoning": True,
+            "supported_openai_params": ["thinking", "reasoning_split"],
+        },
+    )
+
+    assert features.supports_reasoning_effort is False
+
+
+def test_exact_reasoning_effort_metadata_enables_reasoning_effort():
+    features = get_features(
+        "proxy/reasoning-model",
+        model_info={
+            "supports_reasoning": True,
+            "supported_openai_params": ["reasoning_effort"],
+        },
+    )
+
+    assert features.supports_reasoning_effort is True
+
+
 def test_gemini_metadata_does_not_enable_explicit_prompt_cache():
     features = get_features(
         "litellm_proxy/gemini-3.1-pro-preview",


### PR DESCRIPTION
## Summary

- stop treating generic `supports_reasoning` model metadata as proof that a model accepts `reasoning_effort`
- require exact `supports_reasoning_effort`, `supported_openai_params`, LiteLLM supported params, or SDK allowlist support before sending the parameter
- add regression coverage for MiniMax M3-style metadata where reasoning exists but `reasoning_effort` is unsupported

Fixes #4934

## Testing

- `uv run pytest tests/sdk/llm/test_model_features.py tests/sdk/llm/test_chat_options.py`
- `uv run python` smoke check confirmed `LLM(model='minimax/MiniMax-M3')` no longer includes `reasoning_effort` in chat options

---

This pull request was created by an AI agent (OpenHands) on behalf of Juan Michelini.


## HUMAN:

Tested locally with targeted SDK LLM unit tests and a MiniMax M3 chat-options smoke check. The first preview images still failed in staging, so this PR now includes an explicit MiniMax M3 guard for misleading proxy metadata, makes that guard win over explicit capability overrides, and strips caller-supplied reasoning_effort when unsupported.




<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| python-minimal | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| python | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:99c7932-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-99c7932-python \
  ghcr.io/openhands/agent-server:99c7932-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:99c7932-golang-amd64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-golang-amd64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-golang-amd64
ghcr.io/openhands/agent-server:99c7932-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:99c7932-golang-arm64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-golang-arm64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-golang-arm64
ghcr.io/openhands/agent-server:99c7932-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:99c7932-java-amd64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-java-amd64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-java-amd64
ghcr.io/openhands/agent-server:99c7932-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:99c7932-java-arm64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-java-arm64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-java-arm64
ghcr.io/openhands/agent-server:99c7932-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:99c7932-python-amd64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-amd64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-amd64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-amd64
ghcr.io/openhands/agent-server:99c7932-python-arm64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-arm64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-arm64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-arm64
ghcr.io/openhands/agent-server:99c7932-python-minimal-amd64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-minimal-amd64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-minimal-amd64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-minimal-amd64
ghcr.io/openhands/agent-server:99c7932-python-minimal-arm64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-minimal-arm64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-minimal-arm64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-minimal-arm64
ghcr.io/openhands/agent-server:99c7932-python-slim-amd64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-slim-amd64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-slim-amd64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-slim-amd64
ghcr.io/openhands/agent-server:99c7932-python-slim-arm64
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-slim-arm64
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-slim-arm64
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-slim-arm64
ghcr.io/openhands/agent-server:99c7932-golang
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-golang
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-golang
ghcr.io/openhands/agent-server:99c7932-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:99c7932-java
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-java
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-java
ghcr.io/openhands/agent-server:99c7932-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:99c7932-python-minimal
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-minimal
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-minimal
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-minimal
ghcr.io/openhands/agent-server:99c7932-python-slim
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python-slim
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python-slim
ghcr.io/openhands/agent-server:99c7932-python-node-runtime-slim
ghcr.io/openhands/agent-server:99c7932-python
ghcr.io/openhands/agent-server:99c79324d94bd17afc19dd26d58c3753066d3708-python
ghcr.io/openhands/agent-server:fix-minimax-m3-reasoning-effort-python
ghcr.io/openhands/agent-server:99c7932-python-node-runtime
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `99c7932-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `99c7932-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

