### PR TITLE
fix(typescript): forward ACP data-dir isolation

### DIFF
--- a/clients/typescript/src/__tests__/acp-providers.test.ts
+++ b/clients/typescript/src/__tests__/acp-providers.test.ts
@@ -1,4 +1,4 @@
-import { ACP_PROVIDERS, getAcpProvider } from '../index';
+import { ACP_PROVIDERS, ACP_SETTINGS_KEYS, getAcpProvider } from '../index';
 import type { ACPProviderKey } from '../index';
 
 /**
@@ -153,5 +153,11 @@ describe('ACP provider credential descriptors', () => {
       expect(getAcpProvider(null)).toBeNull();
       expect(getAcpProvider(undefined)).toBeNull();
     });
+  });
+});
+
+describe('ACP settings payload fields', () => {
+  it('forwards per-conversation data directory isolation', () => {
+    expect(ACP_SETTINGS_KEYS).toContain('acp_isolate_data_dir');
   });
 });

--- a/clients/typescript/src/models/acp.ts
+++ b/clients/typescript/src/models/acp.ts
@@ -155,4 +155,5 @@ export const ACP_SETTINGS_KEYS: readonly string[] = [
   'acp_session_mode',
   'acp_prompt_timeout',
   'acp_server',
+  'acp_isolate_data_dir',
 ];


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

the choice to add TypeScript client forward ontop of the ACP isolation in my view properly enables mutual connectivity and expand beyond the current one-way connection between clients. So it's a simple efficiency update that solves an issue.

---

AGENT:

## Why

`ACPAgentSettings` already exposes `acp_isolate_data_dir`, but the TypeScript client's `ACP_SETTINGS_KEYS` allow-list omits it. Downstream clients that filter ACP settings through this list therefore cannot forward the existing per-conversation CLI data-directory isolation setting.

## Summary

- Add `acp_isolate_data_dir` to the TypeScript ACP settings allow-list.
- Add a regression assertion covering the exported payload field.

## Issue Number

Fixes #4907

## How to Test

From `clients/typescript`:

```bash
npm install --ignore-scripts
npm test -- --runInBand src/__tests__/acp-providers.test.ts
npm run build
npm run lint -- --no-warn-ignored src/models/acp.ts src/__tests__/acp-providers.test.ts
npm run format:check -- --ignore-unknown
```

Observed:

- Focused suite: 18 tests passed.
- TypeScript build passed.
- ESLint completed with zero errors; eight pre-existing warnings were reported in unrelated files.
- Prettier check passed.

Regression proof: with only the production allow-list line reverted, the new test failed because `ACP_SETTINGS_KEYS` did not contain `acp_isolate_data_dir`. Restoring the line made it pass.

## Video/Screenshots

Not applicable: this is a TypeScript client payload allow-list change with no UI.

## Design Doc

Not applicable for this two-line compatibility fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is additive and preserves existing defaults. It enables downstream consumers such as Agent Canvas to forward the SDK's existing opt-in setting; downstream activation policy remains out of scope.

