### PR TITLE
refactor(sdk): delegate plugin skills discovery to load_skills_from_dir

### DIFF
--- a/openhands-sdk/openhands/sdk/plugin/format/base.py
+++ b/openhands-sdk/openhands/sdk/plugin/format/base.py
@@ -18,7 +18,7 @@ from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.plugin.types import CommandDefinition, PluginManifest
-from openhands.sdk.skills.skill import Skill
+from openhands.sdk.skills.skill import Skill, load_skills_from_dir
 from openhands.sdk.skills.utils import find_skill_md
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.utils.path import to_posix_path
@@ -96,7 +96,14 @@ class PluginFormat(ABC):
         """
         skills_dir = plugin_dir / "skills"
         if skills_dir.is_dir():
-            return _load_skills_from_skills_dir(skills_dir)
+            repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
+                skills_dir, strict=False, recursive_md=False
+            )
+            return [
+                *repo_skills.values(),
+                *knowledge_skills.values(),
+                *agent_skills.values(),
+            ]
 
         root_skill_md = find_skill_md(plugin_dir)
         if root_skill_md is not None:
@@ -201,32 +208,6 @@ def _read_command_definitions(root: Path) -> list[CommandDefinition]:
                 logger.warning(f"Failed to load command from {item}: {e}")
 
     return commands
-
-
-def _load_skills_from_skills_dir(skills_dir: Path) -> list[Skill]:
-    """Load every skill under a plugin's ``skills/`` directory."""
-    skills: list[Skill] = []
-    for item in sorted(skills_dir.iterdir()):
-        if item.is_dir():
-            skill_md = find_skill_md(item)
-            if skill_md:
-                try:
-                    # Skill.load() discovers resources, no need to do it again
-                    skill = Skill.load(skill_md, skills_dir, strict=False)
-                    skills.append(skill)
-                    logger.debug(f"Loaded skill: {skill.name} from {skill_md}")
-                except Exception as e:
-                    logger.warning(f"Failed to load skill from {item}: {e}")
-        elif item.suffix == ".md" and item.name.lower() != "readme.md":
-            # Also support single .md files in skills/ directory
-            try:
-                skill = Skill.load(item, skills_dir, strict=False)
-                skills.append(skill)
-                logger.debug(f"Loaded skill: {skill.name} from {item}")
-            except Exception as e:
-                logger.warning(f"Failed to load skill from {item}: {e}")
-
-    return skills
 
 
 def _load_root_skill(plugin_dir: Path, skill_md: Path) -> list[Skill]:

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -847,6 +847,8 @@ class Skill(BaseModel):
 
 def load_skills_from_dir(
     skill_dir: str | Path,
+    strict: bool = True,
+    recursive_md: bool = True,
 ) -> tuple[dict[str, Skill], dict[str, Skill], dict[str, Skill]]:
     """Load all skills from the given directory.
 
@@ -858,6 +860,9 @@ def load_skills_from_dir(
 
     Args:
         skill_dir: Path to the skills directory (e.g. .openhands/skills)
+        strict: Whether to enforce strict AgentSkills name validation.
+        recursive_md: Whether to search all descendants for loose .md files.
+            When False, only immediate children of ``skill_dir`` are considered.
 
     Returns:
         Tuple of (repo_skills, knowledge_skills, agent_skills) dictionaries.
@@ -879,25 +884,39 @@ def load_skills_from_dir(
     # doesn't exist.
     skill_md_files = find_skill_md_directories(skill_dir)
     skill_md_dirs = {skill_md.parent for skill_md in skill_md_files}
-    regular_md_files = find_regular_md_files(skill_dir, skill_md_dirs)
+    regular_md_files = find_regular_md_files(
+        skill_dir, skill_md_dirs, recursive=recursive_md
+    )
 
     # Load SKILL.md files (auto-detected and validated in Skill.load)
-    # Wrap each load in try/except to ensure one bad skill doesn't break all loading
+    # Wrap each load in try/except to ensure one bad skill doesn't break all
+    # loading. Plugin loading relies on this per-skill isolation boundary for
+    # any failure, so one bad skill never breaks the whole load.
     for skill_md_path in skill_md_files:
         try:
             load_and_categorize(
-                skill_md_path, skill_dir, repo_skills, knowledge_skills, agent_skills
+                skill_md_path,
+                skill_dir,
+                repo_skills,
+                knowledge_skills,
+                agent_skills,
+                strict=strict,
             )
-        except (SkillError, OSError, yaml.YAMLError) as e:
+        except Exception as e:
             logger.warning(f"Failed to load skill from {skill_md_path}: {e}")
 
     # Load regular .md files
     for path in regular_md_files:
         try:
             load_and_categorize(
-                path, skill_dir, repo_skills, knowledge_skills, agent_skills
+                path,
+                skill_dir,
+                repo_skills,
+                knowledge_skills,
+                agent_skills,
+                strict=strict,
             )
-        except (SkillError, OSError, yaml.YAMLError) as e:
+        except Exception as e:
             logger.warning(f"Failed to load skill from {path}: {e}")
 
     total = len(repo_skills) + len(knowledge_skills) + len(agent_skills)

--- a/openhands-sdk/openhands/sdk/skills/utils.py
+++ b/openhands-sdk/openhands/sdk/skills/utils.py
@@ -458,12 +458,16 @@ def find_skill_md_directories(skill_dir: Path) -> list[Path]:
     return results
 
 
-def find_regular_md_files(skill_dir: Path, exclude_dirs: set[Path]) -> list[Path]:
+def find_regular_md_files(
+    skill_dir: Path, exclude_dirs: set[Path], recursive: bool = True
+) -> list[Path]:
     """Find regular .md skill files, excluding SKILL.md and files in excluded dirs.
 
     Args:
         skill_dir: Path to the skills directory.
         exclude_dirs: Set of directories to exclude (e.g., SKILL.md directories).
+        recursive: When True, search all descendants. When False, only consider
+            immediate children of ``skill_dir``.
 
     Returns:
         List of paths to regular .md skill files.
@@ -471,8 +475,18 @@ def find_regular_md_files(skill_dir: Path, exclude_dirs: set[Path]) -> list[Path
     files: list[Path] = []
     if not skill_dir.exists():
         return files
-    for f in sorted(skill_dir.rglob("*.md")):
-        is_readme = f.name == "README.md"
+    if recursive:
+        for f in sorted(skill_dir.rglob("*.md")):
+            is_readme = f.name == "README.md"
+            is_skill_md = f.name.lower() == "skill.md"
+            is_in_excluded_dir = any(f.is_relative_to(d) for d in exclude_dirs)
+            if not is_readme and not is_skill_md and not is_in_excluded_dir:
+                files.append(f)
+        return files
+    for f in sorted(skill_dir.iterdir()):
+        if not f.is_file() or f.suffix != ".md":
+            continue
+        is_readme = f.name.lower() == "readme.md"
         is_skill_md = f.name.lower() == "skill.md"
         is_in_excluded_dir = any(f.is_relative_to(d) for d in exclude_dirs)
         if not is_readme and not is_skill_md and not is_in_excluded_dir:
@@ -486,6 +500,7 @@ def load_and_categorize(
     repo_skills: dict[str, Skill],
     knowledge_skills: dict[str, Skill],
     agent_skills: dict[str, Skill],
+    strict: bool = True,
 ) -> None:
     """Load a skill and categorize it.
 
@@ -497,11 +512,12 @@ def load_and_categorize(
         repo_skills: Dictionary for skills with trigger=None (permanent context).
         knowledge_skills: Dictionary for skills with triggers (progressive).
         agent_skills: Dictionary for AgentSkills standard SKILL.md files.
+        strict: Whether to enforce strict AgentSkills name validation.
     """
     # Import here to avoid circular dependency
     from openhands.sdk.skills.skill import Skill
 
-    skill = Skill.load(path, skill_base_dir)
+    skill = Skill.load(path, skill_base_dir, strict=strict)
 
     # AgentSkills (SKILL.md directories) are a separate category from OpenHands skills.
     # They follow the AgentSkills standard and should be handled differently.

--- a/tests/sdk/plugin/test_plugin_skills_delegation.py
+++ b/tests/sdk/plugin/test_plugin_skills_delegation.py
@@ -1,0 +1,113 @@
+"""Tests for plugin skills discovery delegating to ``load_skills_from_dir``."""
+
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk.hooks import HookConfig
+from openhands.sdk.mcp.config import MCPServer
+from openhands.sdk.plugin.format.base import PluginFormat
+from openhands.sdk.plugin.types import CommandDefinition, PluginManifest
+from openhands.sdk.skills.exceptions import SkillValidationError
+from openhands.sdk.skills.skill import Skill, load_skills_from_dir
+from openhands.sdk.subagent.schema import AgentDefinition
+
+
+class _StubFormat(PluginFormat):
+    """Minimal concrete PluginFormat exposing only the shared load_skills."""
+
+    name = "stub-format"
+
+    @classmethod
+    def detect(cls, plugin_dir: Path) -> bool:
+        return False
+
+    def load_manifest(self, plugin_dir: Path) -> PluginManifest:
+        raise NotImplementedError
+
+    def load_mcp_config(self, plugin_dir: Path) -> dict[str, MCPServer]:
+        raise NotImplementedError
+
+    def load_hooks(self, plugin_dir: Path) -> HookConfig | None:
+        raise NotImplementedError
+
+    def load_agents(self, plugin_dir: Path) -> list[AgentDefinition]:
+        raise NotImplementedError
+
+    def load_commands(self, plugin_dir: Path) -> list[CommandDefinition]:
+        raise NotImplementedError
+
+
+def test_plugin_skills_nested_md_not_loaded_as_skills(tmp_path: Path):
+    """Nested .md files under a skill dir must not become skills."""
+    skill_dir = tmp_path / "skills" / "pdf-tools"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: pdf-tools\n---\n# PDF Tools")
+    (skill_dir / "references" / "notes.md").write_text("# Notes")
+
+    # A loose .md under a subdirectory WITHOUT SKILL.md is the real recursion
+    # hazard: a recursive scan would load it as a skill, the plugin contract
+    # forbids it ("do not recursively search deeper descendants").
+    shared = tmp_path / "skills" / "shared"
+    shared.mkdir(parents=True)
+    (shared / "notes.md").write_text("# Shared notes")
+
+    skills = _StubFormat().load_skills(tmp_path)
+
+    assert [s.name for s in skills] == ["pdf-tools"]
+
+
+def test_plugin_skills_relaxed_name_validation(tmp_path: Path):
+    """Plugin loading keeps strict=False so non-conforming names still load."""
+    skill_dir = tmp_path / "skills" / "Bad_Name"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: Bad_Name\n---\n# Bad")
+
+    skills = _StubFormat().load_skills(tmp_path)
+
+    assert [s.name for s in skills] == ["Bad_Name"]
+    # Contrast: strict loading rejects the same skill.
+    with pytest.raises(SkillValidationError):
+        Skill.load(skill_dir / "SKILL.md", tmp_path / "skills", strict=True)
+    repo, knowledge, agent = load_skills_from_dir(tmp_path / "skills")
+    assert "Bad_Name" not in {**repo, **knowledge, **agent}
+
+
+def test_plugin_skills_one_bad_skill_skips_only_itself(tmp_path: Path):
+    """A skill raising outside the old narrow catch set skips only itself."""
+    skills_dir = tmp_path / "skills"
+    good = skills_dir / "good"
+    broken = skills_dir / "broken"
+    good.mkdir(parents=True)
+    broken.mkdir(parents=True)
+    (good / "SKILL.md").write_text("---\nname: good\n---\n# Good")
+    (broken / "SKILL.md").write_bytes(b"---\nname: broken\n---\n# \xff\xfe")
+
+    skills = _StubFormat().load_skills(tmp_path)
+
+    assert [s.name for s in skills] == ["good"]
+
+
+def test_plugin_skills_loose_md_at_root(tmp_path: Path):
+    """A loose .md file directly under skills/ loads as a skill."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "loose-skill.md").write_text("# Loose")
+
+    skills = _StubFormat().load_skills(tmp_path)
+
+    assert [s.name for s in skills] == ["loose-skill"]
+
+
+def test_plugin_skills_empty_dir(tmp_path: Path):
+    """An empty skills/ dir yields no skills; root SKILL.md still loads."""
+    (tmp_path / "skills").mkdir(parents=True)
+    assert _StubFormat().load_skills(tmp_path) == []
+
+    plugin_root = tmp_path / "single"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "SKILL.md").write_text("---\nname: root-skill\n---\n# Root")
+
+    skills = _StubFormat().load_skills(plugin_root)
+
+    assert [s.name for s in skills] == ["root-skill"]


### PR DESCRIPTION
HUMAN: Automated contribution pipeline (scheduled cron round). Refactor requested in #4495; implementation delegated to an AI coding agent, then independently reviewed and verified (full test suite + mutation checks) by the pipeline operator.

AGENT: Delegate plugin skills discovery to the exported `load_skills_from_dir`.

## Why
The plugin format's private skills-directory scanner `_load_skills_from_skills_dir` structurally duplicates the publicly exported `load_skills_from_dir` (issue #4495). Both scan a `skills/` directory for `SKILL.md` directories and loose `.md` files. A sibling duplication (the plugin-format agents scanner) was already removed in favor of `load_agents_from_dir`; this completes the same cleanup for skills.

## Summary
- `load_skills_from_dir` gains two keyword knobs the plugin path needs:
  - `strict: bool = True` — threaded through `load_and_categorize` into `Skill.load`.
  - `recursive_md: bool = True` — threaded into `find_regular_md_files`; when `False`, only the immediate children of the skills directory are scanned for loose `.md` files, honoring the Agent Plugins requirement to not recursively search deeper descendants for additional skills.
- Per-skill failure isolation in `load_skills_from_dir` is widened to any `Exception` (previously `SkillError`/`OSError`/`yaml.YAMLError`), so one bad skill skips only itself — the guarantee the plugin loader previously provided.
- `PluginFormat.load_skills` now delegates to `load_skills_from_dir(skills_dir, strict=False, recursive_md=False)` and flattens the returned repo/knowledge/agent skill dicts into the plugin's `list[Skill]`; the private `_load_skills_from_skills_dir` scanner is deleted. `_load_root_skill` is kept (out of scope per the issue).
- All three existing callers (`load_user_skills`, `load_project_skills`, `_load_and_merge_from_dirs`) are unchanged and keep previous behavior through the new defaults.

## How to Test
- `uv run pytest tests/sdk/plugin tests/sdk/skills -q` — 597 passed.
- New file `tests/sdk/plugin/test_plugin_skills_delegation.py` (5 tests): nested `.md` under a non-SKILL.md subdirectory is not loaded as a skill; a non-conforming skill name still loads (`strict=False`); a skill whose file is invalid UTF-8 (raises `UnicodeDecodeError`, outside the old narrow catch set) skips only itself; a loose `.md` directly under `skills/` still loads; empty/absent `skills/` plus root `SKILL.md` handling.
- Mutation checks (revert one behavior at a time, the matching test fails): `recursive_md=True` -> nested-md test fails; `strict=True` -> relaxed-name test fails; narrow catch restored -> bad-skill test fails.
- `ruff check` and `ruff format --check` clean on all changed files.