### PR TITLE
feat: register deepseek-v4.1-flash as a verified model

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -221,6 +221,7 @@ SEND_REASONING_CONTENT_MODELS: list[str] = [
     "deepseek/deepseek-reasoner",
     "deepseek/deepseek-v4-pro",  # Dual-mode (Thinking/Non-Thinking)
     "deepseek/deepseek-v4-flash",  # Dual-mode (Thinking/Non-Thinking)
+    "deepseek/deepseek-v4.1-flash",  # Dual-mode (Thinking/Non-Thinking)
 ]
 
 # Match token -> canonical LiteLLM ID for vision metadata overrides.

--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -81,6 +81,7 @@ VERIFIED_DEEPSEEK_MODELS = [
     "deepseek-v4-pro",
     "deepseek-v4-flash",
     "deepseek-v4-flash-vision-exp",
+    "deepseek-v4.1-flash",
 ]
 
 VERIFIED_MOONSHOT_MODELS = [
@@ -168,6 +169,7 @@ VERIFIED_OPENHANDS_MODELS = [
     "deepseek-v4-pro",
     "deepseek-v4-flash",
     "deepseek-v4-flash-vision-exp",
+    "deepseek-v4.1-flash",
     "kimi-k3",
     "kimi-k2-thinking",
     "kimi-k2.7-code",


### PR DESCRIPTION
HUMAN:

Promote deepseek-v4.1-flash to the default model; the SDK needs to register it as verified.

---

AGENT:

## Why

`deepseek-v4.1-flash` is out and should become the OpenHands Cloud default model, replacing `deepseek-v4-flash`. The SDK is the single source of truth for the verified OpenHands model list and bare-name→provider mapping, so it must register the new model before the enterprise SaaS default (`openhands/deepseek-v4.1-flash`) can resolve. This is the SDK half of a coordinated cross-repo release (enterprise migration OpenHands/enterprise#348, frontend OpenHands/OpenHands#17259, saas-deploy OpenHands/saas-deploy#985/#986).

## Summary

- Add `deepseek-v4.1-flash` to `VERIFIED_DEEPSEEK_MODELS` and `VERIFIED_OPENHANDS_MODELS` (kept alongside `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp`).
- Add `deepseek/deepseek-v4.1-flash` to `SEND_REASONING_CONTENT_MODELS` (dual-mode thinking/non-thinking, same default feature settings as `deepseek-v4-flash`).

## Issue Number

Fixes #4941

## How to Test

```
cd openhands-sdk
python -c "from openhands.sdk.llm.utils.verified_models import VERIFIED_OPENHANDS_MODELS, VERIFIED_DEEPSEEK_MODELS; print('openhands:', 'deepseek-v4.1-flash' in VERIFIED_OPENHANDS_MODELS); print('deepseek:', 'deepseek-v4.1-flash' in VERIFIED_DEEPSEEK_MODELS); print('vision kept:', 'deepseek-v4-flash-vision-exp' in VERIFIED_DEEPSEEK_MODELS)"
```

Expected output:
```
openhands: True
deepseek: True
vision kept: True
```

Ran locally: module imports cleanly and all three assertions print `True`. The prior `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` entries are retained from `main`.

## Type

- [x] Feature

## Notes

`deepseek-v4.1-flash` is dual-mode (thinking/non-thinking) and mirrors `deepseek-v4-flash`'s feature entries. Merge this first so the enterprise SaaS can consume the new verified-model set.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| python-minimal | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| python | amd64, arm64 | `python-node-runtime` | [Link](https://hub.docker.com/_/python-node-runtime) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a6766c9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a6766c9-python \
  ghcr.io/openhands/agent-server:a6766c9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a6766c9-golang-amd64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-golang-amd64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-golang-amd64
ghcr.io/openhands/agent-server:a6766c9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a6766c9-golang-arm64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-golang-arm64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-golang-arm64
ghcr.io/openhands/agent-server:a6766c9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a6766c9-java-amd64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-java-amd64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-java-amd64
ghcr.io/openhands/agent-server:a6766c9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a6766c9-java-arm64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-java-arm64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-java-arm64
ghcr.io/openhands/agent-server:a6766c9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a6766c9-python-amd64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-amd64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-amd64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-amd64
ghcr.io/openhands/agent-server:a6766c9-python-arm64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-arm64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-arm64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-arm64
ghcr.io/openhands/agent-server:a6766c9-python-minimal-amd64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-minimal-amd64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-minimal-amd64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-minimal-amd64
ghcr.io/openhands/agent-server:a6766c9-python-minimal-arm64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-minimal-arm64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-minimal-arm64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-minimal-arm64
ghcr.io/openhands/agent-server:a6766c9-python-slim-amd64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-slim-amd64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-slim-amd64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-slim-amd64
ghcr.io/openhands/agent-server:a6766c9-python-slim-arm64
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-slim-arm64
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-slim-arm64
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-slim-arm64
ghcr.io/openhands/agent-server:a6766c9-golang
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-golang
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-golang
ghcr.io/openhands/agent-server:a6766c9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a6766c9-java
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-java
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-java
ghcr.io/openhands/agent-server:a6766c9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a6766c9-python-minimal
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-minimal
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-minimal
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-minimal
ghcr.io/openhands/agent-server:a6766c9-python-slim
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python-slim
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python-slim
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime-slim
ghcr.io/openhands/agent-server:a6766c9-python
ghcr.io/openhands/agent-server:a6766c93214c52ba15f429eb21eeee8ec5edc0d4-python
ghcr.io/openhands/agent-server:feat-deepseek-v4-1-flash-default-python
ghcr.io/openhands/agent-server:a6766c9-python-node-runtime
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a6766c9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a6766c9-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->