### PR TITLE
docs(codereview): require design docs for deep, high-risk PRs

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -151,6 +151,26 @@ Use COMMENT when you have feedback or concerns:
 
 If there are significant issues, leave detailed comments explaining the concerns—but let a human maintainer decide whether to block the PR.
 
+## Design Docs for Deep PRs
+
+A diff shows what changed line by line, not the design: the shape of the change, the API before and after, and why this approach. For a *deep* PR, expect a short design doc. The `pr-design-doc` skill in `.agents/skills/pr-design-doc/` produces a self-contained `.pr/` HTML page (big picture plus before/after, grounded to real code) linked from the PR description.
+
+A PR is "deep" when a reviewer cannot fully judge it from the diff in a couple of minutes, for example:
+
+- a new or changed public SDK API, the Agent Server REST contract, or an event/wire model;
+- a new module or subsystem, or a cross-cutting refactor or migration;
+- a behavior change in core logic (agent loop, conversation, tools, events, workspaces).
+
+Skip it for trivial PRs — a typo, a one-line guard, a config or dependency bump, a docs tweak, a small localized bug fix. If the diff is its own explanation, do not ask for a page.
+
+When a deep PR ships without a design doc, weigh the omission against the change's risk assessment:
+
+- **🔴 HIGH risk and deep, no design doc:** withhold approval. Leave a **COMMENT** review and ask for a design doc (or an equivalent write-up in the PR description) so a human can judge the proposal before merge.
+- **🟡 MEDIUM risk and deep, no design doc:** use judgment. Prefer to withhold approval and request one when the change is hard to reconstruct from the diff; a MEDIUM change that is small and self-evident does not need a page.
+- **🟢 LOW risk:** never block on a missing design doc.
+
+A design doc is a review aid, not a merge gate by itself. A well-written doc does not excuse real correctness, security, or architecture problems.
+
 ## Security
 
 ### Dependency freshness / supply-chain guardrail

--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -159,7 +159,8 @@ A PR is "deep" when a reviewer cannot fully judge it from the diff in a couple o
 
 - a new or changed public SDK API, the Agent Server REST contract, or an event/wire model;
 - a new module or subsystem, or a cross-cutting refactor or migration;
-- a behavior change in core logic (agent loop, conversation, tools, events, workspaces).
+- a behavior change in core logic (agent loop, conversation, tools, events, workspaces); or
+- a large diff (roughly 500+ lines changed) whose intent a reviewer cannot hold in their head at once, even if no single hunk is complex.
 
 Skip it for trivial PRs — a typo, a one-line guard, a config or dependency bump, a docs tweak, a small localized bug fix. If the diff is its own explanation, do not ask for a page.
 


### PR DESCRIPTION
HUMAN:
This is the requested docs-only follow-up connecting the merged PR design-doc skill to code-review expectations for deep changes.

---

AGENT:

## Why

The SDK repository already provides the `pr-design-doc` skill, but its automated review guide does not say when reviewers should expect design context. This follow-up makes that expectation explicit for deep, high-risk SDK and Agent Server changes while exempting small or self-explanatory diffs.

## Summary

- Define practical deep-PR signals for public SDK APIs, Agent Server contracts, event models, new subsystems, migrations, core behavior, and hard-to-reconstruct large changes.
- Tell the reviewer to use COMMENT rather than approval when important design context is missing, scaled by risk.
- Keep design docs advisory for low-risk or self-explanatory changes and preserve correctness, security, architecture, and eval review as the primary gates.

## Issue Number

Fixes #4950

## How to Test

From the PR head, the following lightweight validation passed:

```bash
git diff --check origin/main...pr-4946
grep -q '^triggers:' .agents/skills/custom-codereview-guide.md
```

The PR's focused change is Markdown-only. Existing SDK, Agent Server, API, integration, security, and platform checks pass. The unrelated deprecation-deadline check is failing on current `main` because SDK 1.47.0 reached an existing removal deadline; this PR does not touch that code.

## Video/Screenshots

Not applicable. This changes repository-local Markdown review guidance and has no product UI.

## Design Doc

Not included because this is a small, self-explanatory policy diff—the exact class the proposed guidance exempts.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Review identified one lifecycle concern still requiring author action: same-repository `.pr/` artifacts are removed as soon as an automated approval is submitted, which can make a branch-linked design doc disappear before a human maintainer reads it. The policy should require durable equivalent context in the PR description before approval, or otherwise reconcile cleanup timing.

---

_This PR description was updated by an AI agent (OpenHands) on behalf of @enyst._

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.38s · commit f928df9  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 1/1 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 3.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 4.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 95.0% | No primary concern to locate |

</details>


<!-- jev-input-signature e31f4cbe74dc1afd942886305cd245b22f1eaf08330150af87d3af53e600dace -->
<!-- jev-fast-audit:end -->
