### PR TITLE
fix(agent-server): resolve linked providers for plaintext profile reads

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -69,7 +69,7 @@ class ProfileListResponse(BaseModel):
 
 
 class ProfileDetailResponse(BaseModel):
-    """``config.api_key`` is always nulled; use ``api_key_set`` instead."""
+    """Secrets are nulled unless explicitly requested via X-Expose-Secrets."""
 
     name: str
     config: dict[str, Any]
@@ -171,7 +171,8 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
 
     Use the ``X-Expose-Secrets`` header to control secret exposure:
     - ``encrypted``: Returns cipher-encrypted values (safe for frontend clients)
-    - ``plaintext``: Returns raw secret values (backend clients only!)
+    - ``plaintext``: Resolves linked providers and returns raw secret values
+      for backend clients constructing a runnable LLM configuration
     - (absent): Returns nulled ``api_key`` with ``api_key_set`` indicator
     """
     expose_mode = parse_expose_secrets_header(request)
@@ -180,10 +181,11 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
     store = get_llm_profile_store()
     try:
         with store_errors():
-            # Display the profile exactly as stored: don't inject the linked
-            # provider's credentials, and don't fail a read when the reference
-            # dangles. Effective key presence is reported via ``api_key_set``.
-            llm = store.load(name, cipher=cipher, resolve_provider=False)
+            # Runtime reads need current provider credentials. Editor reads
+            # retain the stored reference, including dangling references.
+            llm = store.load(
+                name, cipher=cipher, resolve_provider=expose_mode == "plaintext"
+            )
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -16,7 +16,10 @@ from openhands.agent_server.persistence import reset_stores
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.auth.credentials import OAuthCredentials
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.sdk.llm.provider_connection_store import ProviderConnectionStore
+from openhands.sdk.llm.provider_connection_store import (
+    ProviderConnection,
+    ProviderConnectionStore,
+)
 from openhands.sdk.profiles import AgentProfileStore, OpenHandsAgentProfile
 
 
@@ -244,7 +247,14 @@ def test_provider_connection_key_shared_by_linked_profiles(client):
 
     detail = client.get("/api/profiles/sonnet-4").json()
     assert detail["config"]["api_key"] is None
+    assert detail["config"]["base_url"] is None
     assert detail["api_key_set"] is True
+
+    runtime = client.get(
+        "/api/profiles/sonnet-4", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()["config"]
+    assert runtime["api_key"] == "sk-ant-old"
+    assert runtime["base_url"] == "https://api.anthropic.com"
 
     activated = client.post("/api/profiles/sonnet-4/activate")
     assert activated.status_code == 200
@@ -271,6 +281,11 @@ def test_provider_connection_key_shared_by_linked_profiles(client):
         "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
     ).json()
     assert settings["agent_settings"]["llm"]["api_key"] == "sk-ant-old"
+
+    runtime = client.get(
+        "/api/profiles/sonnet-4", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()["config"]
+    assert runtime["api_key"] == "sk-ant-new"
 
     # Re-activating re-resolves the connection and applies the rotated key.
     activated = client.post("/api/profiles/sonnet-4/activate")
@@ -1127,6 +1142,51 @@ def test_get_profile_with_plaintext_header_exposes_secrets(
     body = response.json()
     # Secret should be exposed
     assert body["config"]["api_key"] == "sk-test-secret-key"
+
+
+@pytest.mark.parametrize("expose_mode", [None, "encrypted", "plaintext"])
+def test_linked_profile_with_encrypted_provider_credentials(
+    client_with_cipher, store, temp_profiles_dir, cipher, expose_mode
+):
+    """Only runtime reads resolve a provider's encrypted-at-rest credentials."""
+    provider_store = ProviderConnectionStore(
+        base_dir=temp_profiles_dir.parent / "provider-connections"
+    )
+    provider_store.create(
+        ProviderConnection(
+            id="automation-provider",
+            display_name="Automation provider",
+            api_key=SecretStr("sk-linked-secret"),
+            base_url="https://provider.example/v1",
+            created_at=1,
+            updated_at=1,
+        ),
+        cipher=cipher,
+    )
+    store.save(
+        "linked-profile",
+        LLM(model="gpt-4o", provider_connection_id="automation-provider"),
+        cipher=cipher,
+    )
+
+    response = client_with_cipher.get(
+        "/api/profiles/linked-profile",
+        headers={"X-Expose-Secrets": expose_mode} if expose_mode else {},
+    )
+
+    assert response.status_code == 200
+    config = response.json()["config"]
+    assert config["provider_connection_id"] == "automation-provider"
+    if expose_mode == "plaintext":
+        assert config["api_key"] == "sk-linked-secret"
+        assert config["base_url"] == "https://provider.example/v1"
+    else:
+        assert config["api_key"] is None
+        assert config["base_url"] is None
+    # Reading runtime credentials must not copy them into the stored profile.
+    stored = store.load("linked-profile", cipher=cipher, resolve_provider=False)
+    assert stored.api_key is None
+    assert stored.base_url is None
 
 
 def test_get_profile_with_encrypted_header_encrypts_secrets(

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -2362,6 +2362,66 @@ def test_workspace_default_llm_resolves_active_profile_despite_settings_drift(
         assert explicit_llm.usage_id == "profile:explicit-model"
 
 
+def test_workspace_named_llm_resolves_current_provider_credentials(
+    tmp_path, monkeypatch
+):
+    """Selecting a linked profile resolves credentials without activating it."""
+    with live_server_env(tmp_path, monkeypatch) as env:
+        workspace = RemoteWorkspace(
+            host=env["host"], working_dir=str(env["workspace_path"])
+        )
+        with httpx.Client(base_url=env["host"], timeout=10.0) as client:
+            settings_before = client.get("/api/settings").json()
+            connection = client.post(
+                "/api/llm/provider-connections",
+                json={
+                    "display_name": "Automation provider",
+                    "provider": "openai",
+                    "api_key": "sk-provider-old",
+                    "base_url": "https://provider.example/v1",
+                },
+            )
+            assert connection.status_code == 201
+            connection_id = connection.json()["id"]
+            saved = client.post(
+                "/api/profiles/automation-model",
+                json={
+                    "llm": {
+                        "model": "openai/gpt-4o-mini",
+                        "provider_connection_id": connection_id,
+                    }
+                },
+            )
+            assert saved.status_code == 201
+
+            detail = client.get("/api/profiles/automation-model").json()
+            assert detail["config"]["api_key"] is None
+            assert detail["config"]["base_url"] is None
+            assert detail["api_key_set"] is True
+
+            selected = workspace.get_llm(profile_name="automation-model")
+            assert selected.model == "openai/gpt-4o-mini"
+            assert selected.base_url == "https://provider.example/v1"
+            assert selected.api_key is not None
+            _assert_secret(selected.api_key, "sk-provider-old")
+
+            rotated = client.patch(
+                f"/api/llm/provider-connections/{connection_id}",
+                json={"api_key": "sk-provider-new"},
+            )
+            assert rotated.status_code == 200
+            selected = workspace.get_llm(profile_name="automation-model")
+            assert selected.api_key is not None
+            _assert_secret(selected.api_key, "sk-provider-new")
+
+            settings_after = client.get("/api/settings").json()
+            assert settings_after["active_profile"] == settings_before["active_profile"]
+            assert (
+                settings_after["agent_settings"]["llm"]
+                == settings_before["agent_settings"]["llm"]
+            )
+
+
 def test_settings_and_secrets_api_with_live_server(server_env):
     """End-to-end test for settings and secrets API endpoints.
 


### PR DESCRIPTION
HUMAN:
This PR proposes an addition to assist PR 547 on extensions/ repo to show the LLM profile of an Automation.

<!--
Human author: please replace this comment with a short note before marking ready for review.
-->

---

AGENT:
I am an AI agent (smolpaws) acting on behalf of Engel.

## Why

OpenHands/extensions#547 selects a named LLM profile and passes its configuration to a new conversation, but plaintext profile reads currently omit a linked provider's API key and base URL.

## Summary

- Resolve linked providers for `GET /api/profiles/{name}` with `X-Expose-Secrets: plaintext`.
- Preserve stored profiles, active defaults, and the existing unresolved behavior of ordinary and encrypted editor reads.
- Cover encrypted provider storage and credential rotation, plus real HTTP selection through `RemoteWorkspace.get_llm(profile_name=...)`.

## Issue Number

Supports OpenHands/extensions#548 and OpenHands/automation#430.

## How to Test

```bash
uv run pytest tests/agent_server/test_profiles_router.py -q
uv run pytest tests/cross/test_remote_conversation_live_server.py -k 'workspace_named_llm_resolves_current_provider_credentials or workspace_default_llm_resolves_active_profile_despite_settings_drift' -q
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/profiles_router.py tests/agent_server/test_profiles_router.py tests/cross/test_remote_conversation_live_server.py
```

Results: **106 profile tests passed; both live-server tests passed; all applicable pre-commit hooks passed**.
The live test starts Uvicorn, creates a provider and profile through HTTP, selects the profile through the SDK, rotates the provider key, and confirms the next selection uses that key while the active default is unchanged.
The existing shared-provider test failed on the original route because the plaintext API key was `None`, then passed with this fix.

## Type

- [x] Bug fix

## Notes

This dependency must reach the deployed Agent Server before the extensions#547 follow-up can run provider-linked profiles. No external LLM calls are used by these tests.


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:edc90a4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-edc90a4-python \
  ghcr.io/openhands/agent-server:edc90a4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:edc90a4-golang-amd64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-golang-amd64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-golang-amd64
ghcr.io/openhands/agent-server:edc90a4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:edc90a4-golang-arm64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-golang-arm64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-golang-arm64
ghcr.io/openhands/agent-server:edc90a4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:edc90a4-java-amd64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-java-amd64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-java-amd64
ghcr.io/openhands/agent-server:edc90a4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:edc90a4-java-arm64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-java-arm64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-java-arm64
ghcr.io/openhands/agent-server:edc90a4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:edc90a4-python-amd64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python-amd64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python-amd64
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:edc90a4-python-arm64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python-arm64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python-arm64
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:edc90a4-python-slim-amd64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python-slim-amd64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python-slim-amd64
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:edc90a4-python-slim-arm64
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python-slim-arm64
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python-slim-arm64
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:edc90a4-golang
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-golang
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-golang
ghcr.io/openhands/agent-server:edc90a4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:edc90a4-java
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-java
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-java
ghcr.io/openhands/agent-server:edc90a4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:edc90a4-python-slim
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python-slim
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python-slim
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:edc90a4-python
ghcr.io/openhands/agent-server:edc90a46285ab611b85e6cef8b463dead3fcefe5-python
ghcr.io/openhands/agent-server:fix-plaintext-profile-provider-resolution-python
ghcr.io/openhands/agent-server:edc90a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `edc90a4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `edc90a4-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.64s · commit edc90a4  
**Strongest signal:** Sensitive data disclosure · 29% estimated likelihood.  
**Evidence:** [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191).  
**Coverage:** complete supplied coverage; 8/8 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 8.0% | No direct hunk selected |
| Weakened authorization | 16.0% | [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191) |
| Contract regression | 18.0% | [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191) |
| Data loss | 5.0% | No direct hunk selected |
| Sensitive data disclosure | 29.0% | [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191) |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 11.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 4.0% | No direct hunk selected |
| Security assessment bypass | 20.0% | [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191) |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | Sensitive data disclosure; confidence 79.0% | [F001H003 · openhands-agent-server/openhands/agent\_server/profiles\_router.py:181–191](https://github.com/OpenHands/software-agent-sdk/blob/edc90a46285ab611b85e6cef8b463dead3fcefe5/openhands-agent-server/openhands/agent_server/profiles_router.py#L181-L191) |

</details>


<!-- jev-input-signature 0840aeec2d839178dd148cac81ffb5a434a2d861b0da6a385a1b4387a0c2d824 -->
<!-- jev-fast-audit:end -->
