### PR TITLE
fix(llm): remove LLM.modify_params past its v1.47.0 removal deadline

### DIFF
--- a/examples/01_standalone_sdk/37_llm_profile_store/profiles/fast.json
+++ b/examples/01_standalone_sdk/37_llm_profile_store/profiles/fast.json
@@ -14,7 +14,6 @@
   "max_output_tokens": 64000,
   "stream": false,
   "drop_params": true,
-  "modify_params": true,
   "disable_stop_word": false,
   "caching_prompt": true,
   "log_completions": false,

--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -142,7 +142,7 @@ def _deep_merge(
     return result
 
 
-PERSISTED_SETTINGS_SCHEMA_VERSION = 2
+PERSISTED_SETTINGS_SCHEMA_VERSION = 3
 
 
 class PersistedSettings(BaseModel):
@@ -331,7 +331,12 @@ class PersistedSettings(BaseModel):
 
         - **v1**: ``agent_settings`` + ``conversation_settings`` plus
           ``active_profile``.
-        - **v2** (current): adds the opaque ``misc_settings`` container.
+        - **v2**: adds the opaque ``misc_settings`` container.
+        - **v3** (current): nested ``agent_settings`` advanced to schema v6
+          (dropped the removed ``llm.modify_params`` field). Nested payloads
+          are migrated through ``validate_agent_settings`` in
+          ``_normalize_inputs``; the top-level bump keeps the file schema in
+          step with the nested shape change.
         """
         if not isinstance(data, dict):
             return cls.model_validate(data, context=context)

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -689,11 +689,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return data
         d = dict(data)
 
-        # ``modify_params`` was a compatibility field removed in v1.47.0 (LiteLLM
-        # parameter modification is enabled process-wide). Silently drop it so
-        # older serialized configs still load.
-        d.pop("modify_params", None)
-
         model_val = d.get("model")
         if not model_val:
             raise ValueError("model must be specified in LLM")

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -37,7 +37,6 @@ from openhands.sdk.llm.utils.runtime_metadata import (
     store_result,
 )
 from openhands.sdk.settings.metadata import SettingProminence, field_meta
-from openhands.sdk.utils.deprecation import warn_deprecated
 from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
 
 
@@ -471,19 +470,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         json_schema_extra=field_meta(),
     )
     drop_params: bool = Field(default=True, json_schema_extra=field_meta())
-    modify_params: bool = Field(
-        default=True,
-        description=(
-            "Compatibility field. LiteLLM parameter modification is enabled "
-            "process-wide so concurrent LLM calls do not mutate shared global state."
-        ),
-        deprecated=(
-            "Deprecated since v1.42.0 and scheduled for removal in v1.47.0. "
-            "LiteLLM parameter modification is enabled process-wide; remove this "
-            "argument."
-        ),
-        json_schema_extra=field_meta(),
-    )
     disable_vision: bool | None = Field(
         default=None,
         description="If model is vision capable, this option allows to disable image "
@@ -703,17 +689,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return data
         d = dict(data)
 
-        if "modify_params" in d:
-            warn_deprecated(
-                "LLM.modify_params",
-                deprecated_in="1.42.0",
-                removed_in="1.47.0",
-                details=(
-                    "LiteLLM parameter modification is enabled process-wide; "
-                    "remove this argument."
-                ),
-                stacklevel=3,
-            )
+        # ``modify_params`` was a compatibility field removed in v1.47.0 (LiteLLM
+        # parameter modification is enabled process-wide). Silently drop it so
+        # older serialized configs still load.
+        d.pop("modify_params", None)
 
         model_val = d.get("model")
         if not model_val:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -688,8 +688,11 @@ def _migrate_agent_settings_v5_to_v6(payload: dict[str, Any]) -> dict[str, Any]:
 
     ``LLM.modify_params`` was deprecated in v1.42.0 and removed in v1.47.0
     (LiteLLM parameter modification is enabled process-wide). Persisted payloads
-    written by older releases still carry ``llm.modify_params``; strip it so the
-    migrated payload validates against the current ``LLM`` schema.
+    written by older releases still carry ``llm.modify_params``; drop it here so
+    the migrated payload is a clean current-schema shape. (``LLM`` itself uses
+    ``extra="ignore"``, so an un-migrated field would also be dropped on load,
+    but migrations should still emit canonical payloads rather than lean on
+    lenient validation.)
     """
     migrated = dict(payload)
     llm = migrated.get("llm")

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -470,7 +470,7 @@ def _default_llm_settings() -> LLM:
 
 _RequestT = TypeVar("_RequestT")
 
-AGENT_SETTINGS_SCHEMA_VERSION = 5
+AGENT_SETTINGS_SCHEMA_VERSION = 6
 CONVERSATION_SETTINGS_SCHEMA_VERSION = 1
 
 
@@ -680,6 +680,24 @@ def _migrate_agent_settings_v4_to_v5(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(mcp_config, Mapping):
         migrated["mcp_config"] = _migrate_mcp_config_to_server_map(mcp_config)
     migrated["schema_version"] = 5
+    return migrated
+
+
+def _migrate_agent_settings_v5_to_v6(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop the deprecated ``llm.modify_params`` compatibility field.
+
+    ``LLM.modify_params`` was deprecated in v1.42.0 and removed in v1.47.0
+    (LiteLLM parameter modification is enabled process-wide). Persisted payloads
+    written by older releases still carry ``llm.modify_params``; strip it so the
+    migrated payload validates against the current ``LLM`` schema.
+    """
+    migrated = dict(payload)
+    llm = migrated.get("llm")
+    if isinstance(llm, Mapping):
+        llm = dict(llm)
+        llm.pop("modify_params", None)
+        migrated["llm"] = llm
+    migrated["schema_version"] = 6
     return migrated
 
 
@@ -978,6 +996,7 @@ _AGENT_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
     2: _migrate_agent_settings_v2_to_v3,
     3: _migrate_agent_settings_v3_to_v4,
     4: _migrate_agent_settings_v4_to_v5,
+    5: _migrate_agent_settings_v5_to_v6,
 }
 _CONVERSATION_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
     0: _migrate_conversation_settings_v0_to_v1,

--- a/tests/agent_server/telemetry/test_telemetry_settings_migration.py
+++ b/tests/agent_server/telemetry/test_telemetry_settings_migration.py
@@ -1,7 +1,10 @@
-"""Persisted settings stay at schema v2.
+"""Telemetry consent stays in ``misc_settings``.
 
-Consent lives in ``misc_settings.telemetry.consent``, which needs no schema
-change because ``misc_settings`` already exists and is already persisted.
+Consent lives in ``misc_settings.telemetry.consent``, which needs no typed
+field and no dedicated schema change because ``misc_settings`` already exists
+and is already persisted. (The persisted-settings schema version has since
+advanced for unrelated reasons — see ``PERSISTED_SETTINGS_SCHEMA_VERSION`` — but
+never because of consent.)
 """
 
 import pytest
@@ -13,21 +16,17 @@ from openhands.agent_server.persistence.models import (
 from openhands.agent_server.telemetry.policy import resolve
 
 
-def test_schema_version_was_not_bumped_for_consent():
-    assert PERSISTED_SETTINGS_SCHEMA_VERSION == 2
-
-
 def test_there_is_no_typed_consent_field():
     assert "telemetry_consent" not in PersistedSettings.model_fields
     assert "telemetry_consent_updated_at" not in PersistedSettings.model_fields
 
 
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("version", [1, 2, 3])
 def test_older_settings_still_load(version: int):
     settings = PersistedSettings.from_persisted(
         {"schema_version": version, "active_profile": "default"}
     )
-    assert settings.schema_version == 2
+    assert settings.schema_version == PERSISTED_SETTINGS_SCHEMA_VERSION
     assert settings.active_profile == "default"
     # No consent recorded anywhere means no consent.
     assert resolve(settings.misc_settings, env={}).enabled is False
@@ -51,4 +50,6 @@ def test_revoking_through_misc_settings_disables():
 
 def test_a_newer_schema_version_is_still_rejected():
     with pytest.raises(ValueError, match="newer than supported"):
-        PersistedSettings.from_persisted({"schema_version": 3})
+        PersistedSettings.from_persisted(
+            {"schema_version": PERSISTED_SETTINGS_SCHEMA_VERSION + 1}
+        )

--- a/tests/cross/test_check_persisted_settings_compat.py
+++ b/tests/cross/test_check_persisted_settings_compat.py
@@ -137,10 +137,10 @@ def test_collect_fixture_cases_and_validate_current_repo_fixtures() -> None:
         versions_by_surface.setdefault(case.surface_key, set()).add(case.version)
 
     assert versions_by_surface == {
-        "agent_settings": {1, 2, 3, 4, 5},
+        "agent_settings": {1, 2, 3, 4, 5, 6},
         "agent_profile": {1, 2},
         "conversation_settings": {1},
-        "persisted_settings": {1, 2},
+        "persisted_settings": {1, 2, 3},
     }
 
 

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -31,7 +31,6 @@ def test_llm_config_defaults():
     assert config.output_cost_per_token is None
     assert config.ollama_base_url is None
     assert config.drop_params is True
-    assert config.modify_params is True
     assert config.disable_vision is None
     assert config.disable_stop_word is False
     assert config.caching_prompt is True
@@ -65,7 +64,6 @@ def test_llm_config_custom_values():
         output_cost_per_token=0.002,
         ollama_base_url="http://localhost:11434",
         drop_params=False,
-        modify_params=False,
         disable_vision=True,
         disable_stop_word=True,
         caching_prompt=False,
@@ -97,7 +95,6 @@ def test_llm_config_custom_values():
     assert config.output_cost_per_token == 0.002
     assert config.ollama_base_url == "http://localhost:11434"
     assert config.drop_params is False
-    assert config.modify_params is False
     assert config.disable_vision is True
     assert config.disable_stop_word is True
     assert config.caching_prompt is False
@@ -313,7 +310,6 @@ def test_llm_config_boolean_fields():
     """Test boolean field handling."""
     config = LLM(
         model="gpt-4o-mini",
-        modify_params=False,
         disable_vision=True,
         disable_stop_word=False,
         caching_prompt=True,
@@ -323,7 +319,6 @@ def test_llm_config_boolean_fields():
     )
 
     assert config.drop_params is True
-    assert config.modify_params is False
     assert config.disable_vision is True
     assert config.disable_stop_word is False
     assert config.caching_prompt is True

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from deprecation import DeprecatedWarning
 from litellm import ChatCompletionMessageToolCall, CustomStreamWrapper
 from litellm.types.utils import (
     Choices,
@@ -79,7 +78,7 @@ def default_config():
     )
 
 
-async def test_modify_params_is_process_wide_and_calls_overlap(monkeypatch):
+async def test_litellm_modify_params_is_process_wide_and_calls_overlap(monkeypatch):
     active_calls = 0
     peak_active_calls = 0
     both_active = asyncio.Event()
@@ -98,10 +97,8 @@ async def test_modify_params_is_process_wide_and_calls_overlap(monkeypatch):
             active_calls -= 1
 
     monkeypatch.setattr(llm_module, "litellm_acompletion", completion)
-    with pytest.warns(DeprecatedWarning, match="LLM.modify_params"):
-        first = LLM(model="gpt-4o", api_key="test", modify_params=True)
-    with pytest.warns(DeprecatedWarning, match="LLM.modify_params"):
-        second = LLM(model="gpt-4o", api_key="test", modify_params=False)
+    first = LLM(model="gpt-4o", api_key="test")
+    second = LLM(model="gpt-4o", api_key="test")
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
 
     await asyncio.gather(

--- a/tests/sdk/persisted_settings_baselines/v3/persisted_settings.json
+++ b/tests/sdk/persisted_settings_baselines/v3/persisted_settings.json
@@ -1,0 +1,35 @@
+{
+  "__expected__": {
+    "schema_version": 3,
+    "active_profile": "fixture-v3-profile",
+    "agent_settings.schema_version": 6,
+    "agent_settings.agent_kind": "openhands",
+    "agent_settings.llm.model": "fixture-v3-persisted-llm",
+    "conversation_settings.max_iterations": 240,
+    "misc_settings.theme": "dark"
+  },
+  "schema_version": 3,
+  "agent_settings": {
+    "schema_version": 6,
+    "agent_kind": "openhands",
+    "llm": {
+      "model": "fixture-v3-persisted-llm"
+    },
+    "tools": [
+      {
+        "name": "TerminalTool",
+        "params": {}
+      }
+    ]
+  },
+  "conversation_settings": {
+    "schema_version": 1,
+    "max_iterations": 240,
+    "confirmation_mode": true,
+    "security_analyzer": "llm"
+  },
+  "active_profile": "fixture-v3-profile",
+  "misc_settings": {
+    "theme": "dark"
+  }
+}

--- a/tests/sdk/persisted_settings_baselines/v5/agent_settings_mcp_oauth.json
+++ b/tests/sdk/persisted_settings_baselines/v5/agent_settings_mcp_oauth.json
@@ -1,6 +1,6 @@
 {
   "__expected__": {
-    "schema_version": 5,
+    "schema_version": 6,
     "agent_kind": "openhands",
     "mcp_config.superhuman-mail.auth.strategy": "oauth2",
     "mcp_config.superhuman-mail.auth.state.tokens.access_token": "token-value",

--- a/tests/sdk/persisted_settings_baselines/v5/agent_settings_modify_params.json
+++ b/tests/sdk/persisted_settings_baselines/v5/agent_settings_modify_params.json
@@ -1,0 +1,12 @@
+{
+  "__expected__": {
+    "agent_kind": "openhands",
+    "llm.model": "fixture-v5-modify-params"
+  },
+  "schema_version": 5,
+  "agent_kind": "openhands",
+  "llm": {
+    "model": "fixture-v5-modify-params",
+    "modify_params": true
+  }
+}

--- a/tests/sdk/persisted_settings_baselines/v6/agent_settings_openhands.json
+++ b/tests/sdk/persisted_settings_baselines/v6/agent_settings_openhands.json
@@ -1,0 +1,23 @@
+{
+  "__expected__": {
+    "agent_kind": "openhands",
+    "llm.model": "fixture-v6-llm",
+    "tools": [
+      {
+        "name": "TerminalTool",
+        "params": {}
+      }
+    ]
+  },
+  "schema_version": 6,
+  "agent_kind": "openhands",
+  "llm": {
+    "model": "fixture-v6-llm"
+  },
+  "tools": [
+    {
+      "name": "TerminalTool",
+      "params": {}
+    }
+  ]
+}

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -531,6 +531,25 @@ def test_validate_agent_settings_migrates_legacy_openhands_proxy_llm() -> None:
     assert settings.llm.base_url is None
 
 
+def test_validate_agent_settings_migrates_v5_modify_params() -> None:
+    """Persisted ``llm.modify_params`` (removed in v1.47.0) is dropped on load."""
+    settings = validate_agent_settings(
+        {
+            "schema_version": 5,
+            "agent_kind": "openhands",
+            "llm": {
+                "model": "gpt-4o",
+                "modify_params": True,
+            },
+        }
+    )
+
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.schema_version == AGENT_SETTINGS_SCHEMA_VERSION
+    assert settings.llm.model == "gpt-4o"
+    assert "modify_params" not in settings.llm.model_dump()
+
+
 def test_validate_agent_settings_migrates_legacy_mcp_auth_shapes() -> None:
     settings = validate_agent_settings(
         {


### PR DESCRIPTION
HUMAN:

Ran the repo's deprecation gate and the affected tests locally; all green. See details below.

---

AGENT:
I am an AI agent (smolpaws) acting on behalf of Engel.

## Why

The **Deprecation deadlines** CI check (`.github/scripts/check_deprecations.py`) is failing on the default branch and on open PRs (e.g. #4917):

```
The following deprecated features have passed their removal deadline:
- [openhands-sdk] 'LLM.modify_params' (warn_call)
  deprecated in: 1.42.0
  removed in:    1.47.0
```

`LLM.modify_params` was deprecated in v1.42.0 and scheduled for removal in v1.47.0. The repo is now at **1.47.0**, so the gate correctly demands its removal.

## Summary

- Remove the deprecated `modify_params` field from `LLM` and its deprecation warning.
- On load, silently ignore a legacy `modify_params` key so older serialized configs still deserialize. LiteLLM parameter modification remains enabled process-wide via the module-level `litellm.modify_params = True` (unchanged), so behavior is preserved.
- Update `tests/sdk/llm/test_llm_completion.py` and `tests/sdk/config/test_llm_config.py` to stop passing/asserting the removed field; keep the process-wide-behavior test.
- Drop the stale `modify_params` key from the `37_llm_profile_store` example profile. The legacy conversation fixture (`v1_11_5_cli_default`) intentionally keeps it to verify old configs still load.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `30cf5832e42c` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1653 +1652,0 @@
-schema LLM-Input property modify_params optional schema=type="boolean" default=true
@@ -1710 +1708,0 @@
-schema LLM-Output property modify_params optional schema=type="boolean" default=true
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Fixes #4955

## How to Test

```bash
uv run --with packaging python .github/scripts/check_deprecations.py
uv run pytest tests/sdk/config/test_llm_config.py tests/sdk/llm/test_llm_completion.py tests/sdk/conversation/local/test_state_serialization.py -q
uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py tests/sdk/config/test_llm_config.py
```

Results locally: deprecation gate **passes** (`Checked 3 deprecation metadata entries across 4 package(s)`), **68 passed** across the three test files, ruff clean. Backward-compat deserialization of the legacy fixture still passes.

## Type

- [x] Bug fix




<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:96c1140-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-96c1140-python \
  ghcr.io/openhands/agent-server:96c1140-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:96c1140-golang-amd64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-golang-amd64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-golang-amd64
ghcr.io/openhands/agent-server:96c1140-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:96c1140-golang-arm64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-golang-arm64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-golang-arm64
ghcr.io/openhands/agent-server:96c1140-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:96c1140-java-amd64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-java-amd64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-java-amd64
ghcr.io/openhands/agent-server:96c1140-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:96c1140-java-arm64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-java-arm64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-java-arm64
ghcr.io/openhands/agent-server:96c1140-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:96c1140-python-amd64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python-amd64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python-amd64
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:96c1140-python-arm64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python-arm64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python-arm64
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:96c1140-python-slim-amd64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python-slim-amd64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python-slim-amd64
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:96c1140-python-slim-arm64
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python-slim-arm64
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python-slim-arm64
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:96c1140-golang
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-golang
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-golang
ghcr.io/openhands/agent-server:96c1140-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:96c1140-java
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-java
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-java
ghcr.io/openhands/agent-server:96c1140-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:96c1140-python-slim
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python-slim
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python-slim
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:96c1140-python
ghcr.io/openhands/agent-server:96c114016b71d97bb4364c6a44846eee0d3583c8-python
ghcr.io/openhands/agent-server:fix-remove-llm-modify-params-deprecation-python
ghcr.io/openhands/agent-server:96c1140-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `96c1140-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `96c1140-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->
