### PR TITLE
feat(agent-server): let a launch supply skills to a resolved profile

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -68,6 +68,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.observability import OPERATION_METADATA_KEY, observe
+from openhands.sdk.skills import Skill
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
@@ -127,6 +128,37 @@ def _append_system_message_suffix(agent: AgentBase, addition: str) -> AgentBase:
     existing_suffix = (context.system_message_suffix or "").strip()
     suffix = f"{existing_suffix}\n\n{addition}" if existing_suffix else addition
     updated_context = context.model_copy(update={"system_message_suffix": suffix})
+    return agent.model_copy(update={"agent_context": updated_context})
+
+
+def _merge_launch_skills(agent: AgentBase, additions: list[Skill]) -> AgentBase:
+    """Merge deployment-supplied skills into a resolved agent's context.
+
+    For a client whose skill catalog is its own (Agent Canvas bundles the public
+    catalog at build time rather than cloning it): an ``agent_profile_id`` launch
+    sends no ``agent_settings``, so this is its only channel.
+
+    The resolved agent wins on a name collision — its skills came from the
+    profile and the server's own sources, which are the more authoritative view
+    — and the context's ``disabled_skills`` deny-list is re-applied afterwards,
+    so an addition cannot turn back on something the profile turned off.
+    ``AgentContext`` rejects duplicate names, hence the explicit de-duplication
+    rather than a concatenation.
+    """
+    context = agent.agent_context or AgentContext()
+    existing = {skill.name for skill in context.skills}
+    disabled = set(context.disabled_skills)
+    merged = [
+        *context.skills,
+        *(
+            skill
+            for skill in additions
+            if skill.name not in existing and skill.name not in disabled
+        ),
+    ]
+    if len(merged) == len(context.skills):
+        return agent
+    updated_context = context.model_copy(update={"skills": merged})
     return agent.model_copy(update={"agent_context": updated_context})
 
 
@@ -1630,6 +1662,10 @@ class ConversationService:
         if suffix:
             request = request.model_copy(
                 update={"agent": _append_system_message_suffix(request.agent, suffix)}
+            )
+        if additions and additions.skills and request.agent is not None:
+            request = request.model_copy(
+                update={"agent": _merge_launch_skills(request.agent, additions.skills)}
             )
 
         request = _prepare_request_workspace(

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -39,6 +39,7 @@ from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
     NeverConfirm,
 )
+from openhands.sdk.skills import Skill
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.utils.models import kind_of
@@ -86,6 +87,19 @@ class AgentLaunchAdditions(BaseModel):
         description=(
             "Deployment-controlled text appended to the resolved agent's "
             "system-message suffix."
+        ),
+    )
+    skills: list[Skill] | None = Field(
+        default=None,
+        description=(
+            "Deployment-supplied skills merged into the resolved agent's "
+            "context. For a client that ships its own skill catalog and so "
+            "cannot rely on the server's: an ``agent_profile_id`` launch sends "
+            "no ``agent_settings``, leaving it no other way to supply them. "
+            "Merged by name — a skill the resolved agent already carries wins, "
+            "and the profile's ``disabled_skills`` deny-list still applies, so "
+            "this cannot reintroduce something the profile turned off. None "
+            "(the default) adds nothing."
         ),
     )
 

--- a/tests/agent_server/test_agent_launch_additions.py
+++ b/tests/agent_server/test_agent_launch_additions.py
@@ -9,11 +9,13 @@ from pydantic import ValidationError
 from openhands.agent_server.conversation_service import (
     ConversationService,
     _append_system_message_suffix,
+    _merge_launch_skills,
 )
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import LaunchedAgentProfile, StoredConversation
 from openhands.sdk import LLM, Agent, AgentContext
 from openhands.sdk.agent.acp_agent import ACPAgent
+from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.request import (
     AgentLaunchAdditions,
     StartConversationRequest,
@@ -22,6 +24,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.skills import Skill
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -167,3 +170,64 @@ async def test_launch_additions_apply_after_agent_resolution(profile_launch, tmp
     assert [tool.name for tool in restored_agent.tools] == ["canvas_ui_client"]
     restored = StoredConversation.model_validate(stored.model_dump(mode="json"))
     assert restored.client_tools == [_CANVAS_UI]
+
+
+def _skill(name: str) -> Skill:
+    return Skill(name=name, content=f"# {name}")
+
+
+def _skill_names(agent: AgentBase) -> list[str]:
+    context = agent.agent_context
+    assert context is not None
+    return sorted(skill.name for skill in context.skills)
+
+
+def _agent_with(skills: list[Skill], disabled: list[str] | None = None) -> Agent:
+    return Agent(
+        llm=LLM(model="gpt-4o", api_key="k", usage_id="agent"),
+        tools=[],
+        agent_context=AgentContext(skills=skills, disabled_skills=disabled or []),
+    )
+
+
+class TestMergeLaunchSkills:
+    """Deployment-supplied skills for clients that ship their own catalog.
+
+    An ``agent_profile_id`` launch sends no ``agent_settings``, so a client whose
+    skills are bundled rather than server-discovered has no other channel
+    (software-agent-sdk#3979).
+    """
+
+    def test_adds_skills_the_resolved_agent_lacks(self):
+        merged = _merge_launch_skills(
+            _agent_with([_skill("github")]), [_skill("docker")]
+        )
+        assert _skill_names(merged) == ["docker", "github"]
+
+    def test_the_resolved_agent_wins_a_name_collision(self):
+        # Its skills came from the profile and the server's own sources — the
+        # more authoritative view — and AgentContext rejects duplicate names.
+        agent = _agent_with([_skill("github")])
+        merged = _merge_launch_skills(agent, [_skill("github")])
+        assert _skill_names(merged) == ["github"]
+
+    def test_the_profile_deny_list_still_wins(self):
+        # An addition must not turn back on what the profile turned off.
+        merged = _merge_launch_skills(
+            _agent_with([], disabled=["docker"]),
+            [_skill("docker"), _skill("code-review")],
+        )
+        assert _skill_names(merged) == ["code-review"]
+
+    def test_no_additions_leaves_the_agent_untouched(self):
+        agent = _agent_with([_skill("github")])
+        assert _merge_launch_skills(agent, []) is agent
+
+    def test_an_agent_without_a_context_still_receives_them(self):
+        agent = Agent(llm=LLM(model="gpt-4o", api_key="k", usage_id="agent"), tools=[])
+        merged = _merge_launch_skills(agent, [_skill("docker")])
+        assert _skill_names(merged) == ["docker"]
+
+    def test_the_field_defaults_to_none(self):
+        # Every existing caller must keep sending no skills at all.
+        assert AgentLaunchAdditions().skills is None


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
-->

---

AGENT:

## Why

A client whose public-skill catalog is its own has no way to supply it on the `agent_profile_id` path: that launch sends no `agent_settings`, and the server resolves skills from its own sources.

Agent Canvas is that client. It bundles the public catalog from `@openhands/extensions` at build time and sets `load_public_skills: false` so the server does not also clone it — deliberately, because a build-time bundle has no clone latency. The consequence, measured on a stock local stack:

| launch path | public skills |
|---|---|
| inline `agent_settings` | the **11** default-enabled catalog skills the client injects |
| `agent_profile_id` | **0** — `discover_profile_skills()` reads a git clone of the extensions repo, unpopulated in a dev environment |

That gap is why Agent Canvas routes its seeded `default` profile around the profile path entirely, which in turn is why per-profile fields set on `default` save cleanly and are then ignored at launch. Details and measurements in #3979.

## Summary

- `AgentLaunchAdditions.skills: list[Skill] | None` — deployment-supplied skills, on the channel already carrying deployment context, applied at the same point in `start_conversation`.
- `_merge_launch_skills()` merges by name with two rules that keep it from becoming a back door:
  - **the resolved agent wins a collision** — its skills came from the profile and the server's own sources, the more authoritative view (and `AgentContext` rejects duplicate names, so the merge must de-duplicate rather than concatenate);
  - **the context's `disabled_skills` deny-list is re-applied**, so an addition cannot turn back on something the profile turned off.
- Defaults to `None`; an agent with no context still receives them.

This is deliberately a *channel*, not a decision about which catalog wins. #3979 is where that gets settled — option (2) in the comment there. If the server clone ends up owning the catalog instead, this field costs nothing to leave unused.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `57f5cc9f4a67` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -827,0 +828 @@
+schema AgentLaunchAdditions property skills optional schema=anyOf=[type="array" items=Skill-Input,type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Part of #3979

## How to Test

```bash
uv run pytest tests/agent_server tests/sdk/profiles tests/sdk/conversation -q   # 3070 passed
uv run pre-commit run --files $(git diff --name-only origin/main)
```

## Video/Screenshots

The three semantics, against real `Agent` / `AgentContext` objects on this branch:

```
merge, collision keeps resolved : ['docker', 'github']     # additions: docker + github; agent already had github
deny-list still wins            : ['code-review']          # additions: docker + code-review; profile disabled docker
no additions is identity        : True
```

`tests/agent_server/test_agent_launch_additions.py` covers each, plus an agent with no `agent_context` and the `None` default that keeps every existing caller unchanged.

Suite: **3070 passed**. One unrelated error — `test_build_with_telemetry` shells out to `docker buildx build --push ghcr.io/...`, which cannot run on this machine.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Ordering.** Skills merge after the suffix append, so a deployment can send both in one launch; neither reads the other.
- **Not a policy change.** The server still resolves skills exactly as before when `skills` is omitted, which is every caller today.
- **Client follow-up:** Agent Canvas sends the field and stops routing its `default` profile around the profile path — OpenHands/OpenHands#17279 is the sibling fix that moved the `<RUNTIME_SERVICES>` suffix onto the same channel, and records why the skills half could not go with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b8e39ad-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b8e39ad-python \
  ghcr.io/openhands/agent-server:b8e39ad-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b8e39ad-golang-amd64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-golang-amd64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-golang-amd64
ghcr.io/openhands/agent-server:b8e39ad-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b8e39ad-golang-arm64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-golang-arm64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-golang-arm64
ghcr.io/openhands/agent-server:b8e39ad-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b8e39ad-java-amd64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-java-amd64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-java-amd64
ghcr.io/openhands/agent-server:b8e39ad-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b8e39ad-java-arm64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-java-arm64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-java-arm64
ghcr.io/openhands/agent-server:b8e39ad-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b8e39ad-python-amd64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python-amd64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python-amd64
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b8e39ad-python-arm64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python-arm64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python-arm64
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b8e39ad-python-slim-amd64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python-slim-amd64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python-slim-amd64
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:b8e39ad-python-slim-arm64
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python-slim-arm64
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python-slim-arm64
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:b8e39ad-golang
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-golang
ghcr.io/openhands/agent-server:feat-launch-additions-skills-golang
ghcr.io/openhands/agent-server:b8e39ad-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b8e39ad-java
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-java
ghcr.io/openhands/agent-server:feat-launch-additions-skills-java
ghcr.io/openhands/agent-server:b8e39ad-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b8e39ad-python-slim
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python-slim
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python-slim
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:b8e39ad-python
ghcr.io/openhands/agent-server:b8e39ad941fe0dbc7a77d574e37bdb6130cf052e-python
ghcr.io/openhands/agent-server:feat-launch-additions-skills-python
ghcr.io/openhands/agent-server:b8e39ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b8e39ad-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b8e39ad-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->