### PR TITLE
feat: support Git identity in agent profiles

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -68,6 +68,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
 from openhands.sdk.mcp.utils import MCPToolProvider
 from openhands.sdk.observability import OPERATION_METADATA_KEY, observe
+from openhands.sdk.profiles.agent_profile import GitIdentity
 from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
@@ -268,6 +269,29 @@ def _create_conversation_worktree(
     )
 
 
+def _configure_git_identity(
+    workspace: Path,
+    git_identity: GitIdentity | None,
+) -> None:
+    """Configure Git identity for a conversation workspace.
+
+    When a profile-specific identity is provided, apply it to the workspace.
+    Otherwise, leave Git configuration untouched so the global Git identity
+    remains the fallback.
+    """
+    if git_identity is None:
+        return
+
+    run_git_command(
+        ["git", "config", "user.name", git_identity.name],
+        workspace,
+    )
+    run_git_command(
+        ["git", "config", "user.email", git_identity.email],
+        workspace,
+    )
+
+
 def _prepare_request_workspace(
     request: StartConversationRequest,
     conversation_id: UUID,
@@ -352,7 +376,7 @@ def _resolve_agent_from_profile(
     cipher: "Cipher | None",
     mcp_config: "dict[str, MCPServer]",
     acp_skill_sourcing: ACPSkillSourcing = "native",
-) -> "tuple[AgentBase, LaunchedAgentProfile]":
+) -> "tuple[AgentBase, LaunchedAgentProfile, GitIdentity | None]":
     """Load and resolve an agent profile by id, returning the built agent + provenance.
 
     Runs synchronously (call via ``asyncio.to_thread`` from async context).
@@ -375,6 +399,7 @@ def _resolve_agent_from_profile(
         get_agent_profile_store,
         get_llm_profile_store,
     )
+
     from openhands.sdk.profiles.resolver import ProfileNotFound, resolve_agent_profile
     from openhands.sdk.settings.model import OpenHandsAgentSettings
 
@@ -450,7 +475,7 @@ def _resolve_agent_from_profile(
         agent_profile_id=profile.id,
         revision=profile.revision,
     )
-    return agent, launched
+    return agent, launched, profile.git_identity
 
 
 def _compose_conversation_info(
@@ -1562,11 +1587,11 @@ class ConversationService:
                     f"Parent conversation {request.parent_conversation_id} belongs "
                     f"to a different workspace"
                 )
-
-        # Profile resolution and the load_memory stamp must happen before
+                # Profile resolution and the load_memory stamp must happen before
         # _prepare_request_workspace (which asserts request.agent is not None)
         # and before model_dump so the resolved agent is captured in request_data.
         launched_agent_profile: LaunchedAgentProfile | None = None
+        git_identity: GitIdentity | None = None
 
         from openhands.agent_server.persistence import (
             PersistedSettings,
@@ -1595,7 +1620,7 @@ class ConversationService:
 
         if request.agent_profile_id is not None:
             mcp_config = settings.agent_settings.mcp_config
-            resolved_agent, launched_agent_profile = await asyncio.to_thread(
+            resolved_agent, launched_agent_profile, git_identity = await asyncio.to_thread(
                 _resolve_agent_from_profile,
                 request.agent_profile_id,
                 self.cipher,
@@ -1635,6 +1660,11 @@ class ConversationService:
         request = _prepare_request_workspace(
             request, conversation_id, self.conversation_worktree_root
         )
+        if git_identity is not None:
+            _configure_git_identity(
+                Path(request.workspace.working_dir),
+                git_identity,
+            )
 
         managed_codex_credential = self._is_codex_agent(request.agent) and (
             CODEX_AUTH_SECRET_NAME in self._credential_bindings.get(conversation_id, {})

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -73,6 +73,17 @@ def build_profile_verification(
         critic_model_name=v.critic_model_name,
     )
 
+class GitIdentity(BaseModel):
+    """Git user identity applied to a conversation workspace."""
+
+    name: str = Field(
+        min_length=1,
+        description="Git user.name configured for the conversation workspace.",
+    )
+    email: str = Field(
+        min_length=1,
+        description="Git user.email configured for the conversation workspace.",
+    )
 
 class AgentProfileBase(BaseModel):
     """Shared identity + provenance fields for every ``AgentProfile`` variant.
@@ -110,6 +121,13 @@ class AgentProfileBase(BaseModel):
     # selects them by *exclusion* (``OpenHandsAgentProfile.disabled_skills``, a
     # deny-list) rather than by an allow-list of names that can dangle. See the
     # #4017 architecture discussion.
+    git_identity: GitIdentity | None = Field(
+        default=None,
+        description=(
+            "Optional Git user identity to configure in the conversation "
+            "workspace. When omitted, the user's global Git identity is used."
+        ),
+    )
     mcp_server_refs: list[str] | None = Field(
         default=None,
         description=(

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -47,8 +47,9 @@ from openhands.sdk.profiles.resolver import (
 from openhands.sdk.settings.model import ACPAgentSettings, OpenHandsAgentSettings
 from openhands.sdk.skills import Skill
 from openhands.sdk.workspace import LocalWorkspace
-
-
+from openhands.sdk.git.utils import run_git_command
+from openhands.sdk.git.exceptions import GitCommandError
+from openhands.sdk.profiles.agent_profile import GitIdentity
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -185,6 +186,15 @@ class TestResolveAgentFromProfile:
         # OpenHands profiles always discover the catalog (deny-list needs the
         # full set), threaded through to the resolver as available_skills.
         profile = _make_openhands_profile()
+        profile = profile.model_copy(
+            update={
+                "git_identity": GitIdentity(
+                    name="Profile User",
+                    email="profile@example.com",
+                )
+            }
+        )
+        assert isinstance(profile.git_identity, GitIdentity)
         agent = _make_agent()
 
         with (
@@ -208,13 +218,16 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = agent
             MockResolve.return_value = mock_config
 
-            result_agent, launched = _resolve_agent_from_profile(
+            result_agent, launched, git_identity = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
         assert result_agent is agent
         assert launched.agent_profile_id == profile.id
         assert launched.revision == profile.revision
+        assert git_identity is not None
+        assert git_identity.name == "Profile User"
+        assert git_identity.email == "profile@example.com"
         # OpenHands discovery always runs; its result is threaded through.
         MockDiscover.assert_called_once()
         assert MockResolve.call_args.kwargs["available_skills"] == []
@@ -250,7 +263,7 @@ class TestResolveAgentFromProfile:
             store_inst.name_for_id.return_value = profile.name
             store_inst.load.return_value = profile
 
-            result_agent, _ = _resolve_agent_from_profile(
+            result_agent, _, _ = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -377,7 +390,7 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = agent
             MockResolve.return_value = mock_config
 
-            result_agent, _ = _resolve_agent_from_profile(
+            result_agent, _, _ = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -408,7 +421,7 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = agent
             MockResolve.return_value = mock_config
 
-            result_agent, _ = _resolve_agent_from_profile(
+            result_agent, _, _ = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -440,7 +453,7 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = agent
             MockResolve.return_value = mock_config
 
-            result_agent, _ = _resolve_agent_from_profile(
+            result_agent, _, _ = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -472,7 +485,7 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = agent
             MockResolve.return_value = mock_config
 
-            result_agent, _ = _resolve_agent_from_profile(
+            result_agent, _, _ = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -553,7 +566,7 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = acp_agent
             MockResolve.return_value = mock_config
 
-            result_agent, launched = _resolve_agent_from_profile(
+            result_agent, launched, git_identity = _resolve_agent_from_profile(
                 profile.id, cipher=None, mcp_config={}
             )
 
@@ -726,6 +739,136 @@ async def _start_with_agent(
 
 class TestConversationServiceStartFromProfile:
     @pytest.mark.asyncio
+    async def test_start_from_profile_applies_git_identity_to_workspace(
+        self, tmp_path
+    ):
+        """A profile Git identity is applied to the conversation workspace."""
+        profile_id = uuid4()
+        agent = _make_agent()
+        launched_agent_profile = LaunchedAgentProfile(
+            agent_profile_id=profile_id,
+            revision=5,
+        )
+        git_identity = GitIdentity(
+            name="Profile User",
+            email="profile@example.com",
+        )
+        request = StartConversationRequest(
+            agent_profile_id=profile_id,
+            workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        )
+
+        with patch(
+            "openhands.agent_server.conversation_service._resolve_agent_from_profile",
+            return_value=(agent, launched_agent_profile, git_identity),
+        ):
+            service = ConversationService(conversations_dir=tmp_path)
+            service._event_services = {}
+
+            mock_es = AsyncMock(spec=EventService)
+            mock_state = ConversationState(
+                id=uuid4(),
+                agent=agent,
+                workspace=request.workspace,
+                execution_status=ConversationExecutionStatus.IDLE,
+            )
+            mock_es.get_state.return_value = mock_state
+            mock_es.stored = MagicMock(
+                launched_agent_profile=launched_agent_profile,
+                client_tools=[],
+                title=None,
+                metrics=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                forked_from_conversation_id=None,
+                forked_from_event_id=None,
+                parent_conversation_id=None,
+            )
+
+            with patch.object(
+                service,
+                "_start_event_service",
+                new_callable=AsyncMock,
+                return_value=mock_es,
+            ):
+                await service.start_conversation(request)
+
+        assert (
+            run_git_command(
+                ["git", "config", "--local", "user.name"],
+                tmp_path,
+            )
+            == "Profile User"
+        )
+        assert (
+            run_git_command(
+                ["git", "config", "--local", "user.email"],
+                tmp_path,
+            )
+            == "profile@example.com"
+        )
+    @pytest.mark.asyncio
+    async def test_start_from_profile_without_git_identity_uses_global_fallback(
+        self, tmp_path
+    ):
+        """A profile without Git identity leaves global Git config as fallback."""
+        profile_id = uuid4()
+        agent = _make_agent()
+        launched_agent_profile = LaunchedAgentProfile(
+            agent_profile_id=profile_id,
+            revision=5,
+        )
+        request = StartConversationRequest(
+            agent_profile_id=profile_id,
+            workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        )
+
+        run_git_command(["git", "init", "-b", "main"], tmp_path)
+
+        with patch(
+            "openhands.agent_server.conversation_service._resolve_agent_from_profile",
+            return_value=(agent, launched_agent_profile, None),
+        ):
+            service = ConversationService(conversations_dir=tmp_path)
+            service._event_services = {}
+
+            mock_es = AsyncMock(spec=EventService)
+            mock_state = ConversationState(
+                id=uuid4(),
+                agent=agent,
+                workspace=request.workspace,
+                execution_status=ConversationExecutionStatus.IDLE,
+            )
+            mock_es.get_state.return_value = mock_state
+            mock_es.stored = MagicMock(
+                launched_agent_profile=launched_agent_profile,
+                client_tools=[],
+                title=None,
+                metrics=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                forked_from_conversation_id=None,
+                forked_from_event_id=None,
+                parent_conversation_id=None,
+            )
+
+            with patch.object(
+                service,
+                "_start_event_service",
+                new_callable=AsyncMock,
+                return_value=mock_es,
+            ):
+                await service.start_conversation(request)
+
+            local_config = run_git_command(
+                ["git", "config", "--local", "--list"],
+                tmp_path,
+                expected_failure=True,
+            )
+
+            assert "user.name=" not in local_config
+            assert "user.email=" not in local_config
+    @pytest.mark.asyncio
     async def test_start_from_profile_stamps_launched_agent_profile_on_stored(
         self, tmp_path
     ):
@@ -750,7 +893,7 @@ class TestConversationServiceStartFromProfile:
 
         with patch(
             "openhands.agent_server.conversation_service._resolve_agent_from_profile",
-            return_value=(agent, launched_agent_profile),
+            return_value=(agent, launched_agent_profile, None),
         ):
             service = ConversationService(conversations_dir=tmp_path)
             service._event_services = {}

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -22,6 +22,7 @@ from openhands.agent_server.conversation_service import (
     AutoTitleSubscriber,
     ConversationService,
     _compose_conversation_info,
+    _configure_git_identity,
     _ConversationRecord,
     _get_worktree_start_point,
 )
@@ -55,6 +56,7 @@ from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 from openhands.tools.terminal.definition import TerminalAction, TerminalObservation
+from openhands.sdk.profiles.agent_profile import GitIdentity
 
 
 @pytest.fixture
@@ -1680,6 +1682,33 @@ class TestConversationServiceCountConversations:
 
 class TestConversationServiceStartConversation:
     """Test cases for ConversationService.start_conversation method."""
+
+    def test_configure_git_identity_sets_workspace_git_config(self, tmp_path):
+        """Test that a profile Git identity is applied to the workspace."""
+        repo_dir = tmp_path / "repo"
+        _init_git_repo(repo_dir)
+
+        identity = GitIdentity(
+            name="Profile User",
+            email="profile@example.com",
+        )
+
+        _configure_git_identity(repo_dir, identity)
+
+        assert (
+            run_git_command(
+                ["git", "config", "--local", "user.name"],
+                repo_dir,
+            )
+            == "Profile User"
+        )
+        assert (
+            run_git_command(
+                ["git", "config", "--local", "user.email"],
+                repo_dir,
+            )
+            == "profile@example.com"
+        )
 
     @pytest.mark.asyncio
     async def test_start_conversation_with_secrets(self, conversation_service):

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -259,7 +259,86 @@ def test_mcp_server_refs_null_vs_empty_are_distinct() -> None:
     assert (
         validate_agent_profile(use_none.model_dump(mode="json")).mcp_server_refs == []
     )
+# ---------------------------------------------------------------------------
+# Git identity
+# ---------------------------------------------------------------------------
 
+
+def test_git_identity_round_trips_for_openhands_profile() -> None:
+    profile = OpenHandsAgentProfile(
+        name="oh",
+        llm_profile_ref="default",
+        git_identity={"name": "Profile User", "email": "profile@example.com"},
+    )
+
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+
+    assert isinstance(reloaded, OpenHandsAgentProfile)
+    assert reloaded.git_identity is not None
+    assert reloaded.git_identity.name == "Profile User"
+    assert reloaded.git_identity.email == "profile@example.com"
+
+
+def test_git_identity_round_trips_for_acp_profile() -> None:
+    profile = ACPAgentProfile(
+        name="acp",
+        acp_server="claude-code",
+        git_identity={"name": "ACP User", "email": "acp@example.com"},
+    )
+
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+
+    assert isinstance(reloaded, ACPAgentProfile)
+    assert reloaded.git_identity is not None
+    assert reloaded.git_identity.name == "ACP User"
+    assert reloaded.git_identity.email == "acp@example.com"
+
+
+def test_git_identity_defaults_to_none() -> None:
+    openhands = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    acp = ACPAgentProfile(name="acp", acp_server="claude-code")
+
+    assert openhands.git_identity is None
+    assert acp.git_identity is None
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"name": "", "email": "user@example.com"},
+        {"name": "User", "email": ""},
+    ],
+)
+def test_git_identity_rejects_empty_name_or_email(
+    identity: dict[str, str],
+) -> None:
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {
+                "agent_kind": "openhands",
+                "name": "oh",
+                "llm_profile_ref": "default",
+                "git_identity": identity,
+            }
+        )
+
+
+def test_git_identity_is_persisted_in_profile_dump() -> None:
+    profile = OpenHandsAgentProfile(
+        name="oh",
+        llm_profile_ref="default",
+        git_identity={
+            "name": "Persisted User",
+            "email": "persisted@example.com",
+        },
+    )
+
+    dumped = profile.model_dump(mode="json")
+
+    assert dumped["git_identity"] == {
+        "name": "Persisted User",
+        "email": "persisted@example.com",
+    }
 
 def test_mcp_server_refs_default_is_null() -> None:
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="d")


### PR DESCRIPTION
HUMAN:

I manually tested the Git identity flow for Agent Profiles and ran the profile persistence and conversation-start regression tests. I verified that configured profile identities are applied to the workspace and that the global Git identity remains the fallback when no profile identity is configured.

---

AGENT:

## Why

Git identity is currently configured globally, so different Agent Profiles cannot use different Git commit identities. This change adds optional profile-specific Git identity while preserving the global Git configuration as the fallback.

## Summary

- Add optional `user.name` and `user.email` Git identity to Agent Profiles.
- Support the identity for both OpenHands and ACP profiles.
- Apply the profile identity to the conversation workspace.
- Preserve the global Git identity as the fallback when no profile identity is configured.
- Add validation and regression tests.

## Issue Number

Fixes OpenHands/OpenHands#17258

## How to Test

Run:

`python -m pytest tests\sdk\profiles\test_agent_profile.py tests\agent_server\test_agent_profile_conv_start.py -q`

Expected:

`81 passed`

Run:

`python -m pytest tests\agent_server\test_conversation_service.py -k "configure_git_identity" -q`

Expected:

`1 passed`

The tests verify profile persistence, OpenHands/ACP profile support, validation, profile resolution, fallback behavior, and workspace-local Git configuration.

## Video/Screenshots

N/A — backend/SDK change with automated test coverage.

## Design Doc

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is the SDK portion of OpenHands/OpenHands#17258. The feature requires coordinated changes across the SDK and other OpenHands components.