### PR TITLE
fix(terminal): make Windows PowerShell completion and interrupt recovery robust

### DIFF
--- a/openhands-tools/openhands/tools/terminal/descriptions.py
+++ b/openhands-tools/openhands/tools/terminal/descriptions.py
@@ -88,5 +88,8 @@ WINDOWS_TOOL_DESCRIPTION = "\n".join(
         "  one becomes unresponsive.",
         "* Resetting the terminal clears loaded modules, environment variables,",
         "  working directory changes, and running processes.",
+        "* If the shell exits or stops responding (for example after `C-c` could",
+        "  not stop a command), it is recreated automatically before your next",
+        "  command and the output tells you so.",
     ]
 )

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -437,7 +437,15 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         conversation: "LocalConversation | None" = None,
     ) -> TerminalObservation:
         """Execute *action* in single-session (non-pool) mode."""
-        if action.reset or self.session._closed:
+        # Self-heal: a session whose shell exited, was killed, or was declared
+        # unresponsive after a failed interrupt is replaced before the command
+        # is accepted, so the model never has to discover that itself.
+        if action.reset or self.session._closed or not self.session.is_alive():
+            if not action.reset and not self.session._closed:
+                logger.warning(
+                    "Terminal session is no longer alive; recreating it before "
+                    "running the next command"
+                )
             reset_result = self._reset_single_session()
 
             if action.command.strip():

--- a/openhands-tools/openhands/tools/terminal/terminal/interface.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/interface.py
@@ -158,6 +158,16 @@ class TerminalInterface(ABC):
             True if a command is running, False otherwise.
         """
 
+    def is_alive(self) -> bool:
+        """Check whether the backend can still accept commands.
+
+        Backends that own a shell process should return ``False`` once that
+        process has exited or stopped responding, so the session controller
+        can recreate the terminal instead of waiting on it.  The default
+        only reflects the initialized/closed flags.
+        """
+        return self._initialized and not self._closed
+
     @property
     def initialized(self) -> bool:
         """Check if the terminal is initialized."""

--- a/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
@@ -48,13 +48,35 @@ def _remove_command_prefix(command_output: str, command: str) -> str:
 
 
 def _remove_powershell_echo(command_output: str, command: str) -> str:
+    """Strip PowerShell's echo of the submitted command from its output.
+
+    When PowerShell reads commands from a pipe it echoes each input line; a
+    multiline command is echoed as its first line followed by one ``>> ``
+    continuation line per extra line (plus the blank line that submits it).
+    """
     command_output = command_output.lstrip()
     command = command.lstrip()
-    first_line = command_output.splitlines()[0] if command_output else ""
-    if command and command in first_line:
-        _, separator, rest = command_output.partition("\n")
-        command_output = rest if separator else ""
+    command_lines = command.splitlines() or [""]
+    lines = command_output.split("\n")
+    if command_lines[0] and command_lines[0] in lines[0]:
+        lines = lines[1:]
+        # Continuation echo: at most one ">> " line per extra command line,
+        # plus the blank line that terminates the multiline input.
+        budget = len(command_lines)
+        while budget and lines and lines[0].startswith(">> "):
+            lines = lines[1:]
+            budget -= 1
+        command_output = "\n".join(lines)
     return re.sub(r"(?:\r?\n)?PS [^\r\n]*>\s*$", "", command_output).lstrip()
+
+
+_UNRESPONSIVE_TERMINAL_SUFFIX = (
+    "\n[The terminal process exited or stopped responding while this command "
+    "was running, so its result is unknown. A new terminal session will be "
+    "created automatically for your next command; environment variables, "
+    "loaded modules and working-directory changes from the old session are "
+    "gone. Avoid top-level `exit` in terminal commands.]"
+)
 
 
 class TerminalSession(TerminalSessionBase):
@@ -136,6 +158,10 @@ class TerminalSession(TerminalSessionBase):
             TerminalCommandStatus.NO_CHANGE_TIMEOUT,
             TerminalCommandStatus.HARD_TIMEOUT,
         }
+
+    def is_alive(self) -> bool:
+        """Check whether the underlying terminal can still accept commands."""
+        return self._initialized and not self._closed and self.terminal.is_alive()
 
     def _is_special_key(self, command: str) -> bool:
         """Check if the command is a special key."""
@@ -370,6 +396,49 @@ class TerminalSession(TerminalSessionBase):
             metadata=metadata,
         )
 
+    def _handle_unresponsive_terminal(
+        self,
+        command: str,
+        terminal_content: str,
+        ps1_matches: list[re.Match],
+    ) -> TerminalObservation:
+        """Handle the shell exiting or wedging while a command was running.
+
+        The session is closed so the executor recreates it on the next call;
+        the observation tells the model what happened and that nothing is
+        still running.
+        """
+        logger.warning(
+            "Terminal backend is no longer alive while running a command; "
+            "closing the session so it is recreated on the next command"
+        )
+        raw_command_output = self._combine_outputs_between_matches(
+            terminal_content, ps1_matches
+        )
+        metadata = CmdOutputMetadata(exit_code=-1, working_dir=self._cwd)
+        metadata.suffix = _UNRESPONSIVE_TERMINAL_SUFFIX
+        command_output = self._get_command_output(
+            command,
+            raw_command_output,
+            metadata,
+            continue_prefix="[Below is the output of the previous command.]\n",
+            is_final=True,
+        )
+        command_output = maybe_truncate(
+            command_output, truncate_after=MAX_CMD_OUTPUT_SIZE
+        )
+        self.prev_status = TerminalCommandStatus.COMPLETED
+        self.prev_output = ""
+        self._query_filter.reset()
+        self.close()
+        return TerminalObservation.from_text(
+            command=command,
+            text=command_output,
+            metadata=metadata,
+            exit_code=metadata.exit_code,
+            is_error=True,
+        )
+
     def _ready_for_next_command(self) -> None:
         """Reset the content buffer for a new command."""
         # Clear the current content
@@ -431,6 +500,15 @@ class TerminalSession(TerminalSessionBase):
                 is_error=True,
             )
 
+        if not self.terminal.is_alive():
+            return self._handle_unresponsive_terminal(
+                command,
+                terminal_content=self.terminal.read_screen(),
+                ps1_matches=CmdOutputMetadata.matches_ps1_metadata(
+                    self.terminal.read_screen()
+                ),
+            )
+
         # If the previous command is not completed,
         # we need to check if the command is empty
         if self.prev_status not in {
@@ -483,17 +561,42 @@ class TerminalSession(TerminalSessionBase):
         last_change_time = start_time
         last_terminal_output = initial_terminal_output
 
-        # When prev command is still running, and we are trying to send a new command
+        # After a timeout the previous command may still be running, or it may
+        # have finished on its own while nobody was polling.  Ask the backend
+        # rather than guessing from the tail of the screen: for the PowerShell
+        # backend the screen never ends with the marker while the shell is
+        # busy, but a trailing prompt or a scrolled-off marker must not make a
+        # finished command look busy either.
+        previous_command_running = (
+            self.prev_status
+            in {
+                TerminalCommandStatus.HARD_TIMEOUT,
+                TerminalCommandStatus.NO_CHANGE_TIMEOUT,
+            }
+            and self.terminal.is_running()
+        )
         if (
             self.prev_status
             in {
                 TerminalCommandStatus.HARD_TIMEOUT,
                 TerminalCommandStatus.NO_CHANGE_TIMEOUT,
             }
-            and not last_terminal_output.rstrip().endswith(CMD_OUTPUT_PS1_END.rstrip())
-            and not is_input
-            and command != ""
+            and not previous_command_running
+            and is_input
         ):
+            # There is no process left to receive keystrokes (a Ctrl+C for
+            # a command that already finished is the common case), so report
+            # the finished command's result instead of typing into the shell.
+            logger.debug(
+                "Previous command already finished; treating input %r as a "
+                "request for its output",
+                command,
+            )
+            command = ""
+            is_input = False
+
+        # When prev command is still running, and we are trying to send a new command
+        if previous_command_running and not is_input and command != "":
             _ps1_matches = CmdOutputMetadata.matches_ps1_metadata(last_terminal_output)
             # Use initial_ps1_matches if _ps1_matches is empty,
             # otherwise use _ps1_matches. This handles the case where
@@ -593,6 +696,16 @@ class TerminalSession(TerminalSessionBase):
                     ps1_matches=ps1_matches,
                 )
                 return obs
+
+            # 1b) The shell itself is gone (exited, killed, or declared
+            # unresponsive by a failed interrupt): report immediately instead
+            # of waiting out the timeout and then rejecting every command.
+            if not self.terminal.is_alive():
+                return self._handle_unresponsive_terminal(
+                    command,
+                    terminal_content=cur_terminal_output,
+                    ps1_matches=ps1_matches,
+                )
 
             # Timeout checks should only trigger if a new prompt hasn't appeared yet.
 

--- a/openhands-tools/openhands/tools/terminal/terminal/windows_console.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/windows_console.py
@@ -1,0 +1,333 @@
+"""Win32 plumbing for the PowerShell terminal backend.
+
+Three things the backend needs that ``subprocess`` does not provide on
+Windows:
+
+* **Job objects** — the shell and everything it spawns are placed in a job
+  with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``.  That gives an exact,
+  race-free view of the process tree (``job_pids``) and an atomic teardown
+  (``terminate``) that cannot leak grandchildren, and it also ties the
+  tree's lifetime to the agent process.
+* **Console Ctrl+C delivery** — ``GenerateConsoleCtrlEvent`` only reaches
+  processes attached to the *caller's* console, and ``CTRL_C_EVENT`` can
+  only be broadcast, never targeted at a process group.  The shell runs on
+  its own hidden console (``CREATE_NO_WINDOW``), so a short-lived helper
+  process attaches to that console, ignores the event itself and broadcasts
+  ``CTRL_C_EVENT`` there.  Only the shell and its descendants share that
+  console, which makes this the Windows equivalent of ``killpg(SIGINT)``.
+* **Process termination** without spawning a PowerShell/WMI query.
+
+Everything here degrades gracefully: on failure the functions return
+``False``/empty and the caller falls back to coarser behaviour.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import subprocess
+import sys
+from ctypes import wintypes
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+IS_WINDOWS = sys.platform == "win32"
+
+# Source of the Ctrl+C helper.  It is executed with ``python -I -c`` so it
+# never imports anything from the SDK and starts in well under 100 ms.
+CTRL_C_HELPER_SOURCE = (
+    "import ctypes,sys\n"
+    "k=ctypes.WinDLL('kernel32',use_last_error=True)\n"
+    "k.AttachConsole.argtypes=[ctypes.c_uint32]\n"
+    "k.SetConsoleCtrlHandler.argtypes=[ctypes.c_void_p,ctypes.c_int]\n"
+    "k.GenerateConsoleCtrlEvent.argtypes=[ctypes.c_uint32,ctypes.c_uint32]\n"
+    "pid=int(sys.argv[1])\n"
+    "k.FreeConsole()\n"
+    "if not k.AttachConsole(pid):\n"
+    "    sys.exit(2)\n"
+    "k.SetConsoleCtrlHandler(None,1)\n"
+    "ok=k.GenerateConsoleCtrlEvent(0,0)\n"
+    "k.FreeConsole()\n"
+    "sys.exit(0 if ok else 3)\n"
+)
+
+if IS_WINDOWS:
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+    _JOB_OBJECT_BASIC_PROCESS_ID_LIST = 3
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+    _PROCESS_TERMINATE = 0x0001
+    _TH32CS_SNAPPROCESS = 0x00000002
+    _INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+    _MAX_JOB_PIDS = 1024
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [  # noqa: RUF012
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [  # noqa: RUF012
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [  # noqa: RUF012
+            ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", _IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    class _JOBOBJECT_BASIC_PROCESS_ID_LIST(ctypes.Structure):
+        _fields_ = [  # noqa: RUF012
+            ("NumberOfAssignedProcesses", wintypes.DWORD),
+            ("NumberOfProcessIdsInList", wintypes.DWORD),
+            ("ProcessIdList", ctypes.c_size_t * _MAX_JOB_PIDS),
+        ]
+
+    class _PROCESSENTRY32W(ctypes.Structure):
+        _fields_ = [  # noqa: RUF012
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * 260),
+        ]
+
+    _kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+    _kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    _kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    _kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    _kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _kernel32.QueryInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    _kernel32.QueryInformationJobObject.restype = wintypes.BOOL
+    _kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    _kernel32.TerminateJobObject.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+    _kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    _kernel32.TerminateProcess.restype = wintypes.BOOL
+    _kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    _kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    _kernel32.Process32FirstW.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_PROCESSENTRY32W),
+    ]
+    _kernel32.Process32FirstW.restype = wintypes.BOOL
+    _kernel32.Process32NextW.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_PROCESSENTRY32W),
+    ]
+    _kernel32.Process32NextW.restype = wintypes.BOOL
+
+
+class WindowsJob:
+    """A job object that owns a process tree and kills it when closed."""
+
+    def __init__(self) -> None:
+        self._handle: int | None = None
+        if not IS_WINDOWS:
+            return
+        handle = _kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            logger.warning("CreateJobObject failed: %s", ctypes.get_last_error())
+            return
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not _kernel32.SetInformationJobObject(
+            handle,
+            _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            logger.warning(
+                "SetInformationJobObject failed: %s", ctypes.get_last_error()
+            )
+            _kernel32.CloseHandle(handle)
+            return
+        self._handle = handle
+
+    @property
+    def active(self) -> bool:
+        return self._handle is not None
+
+    def assign(self, process_handle: int) -> bool:
+        """Put *process_handle* (a ``Popen._handle``) and its future children in the job."""  # noqa: E501
+        if self._handle is None:
+            return False
+        if not _kernel32.AssignProcessToJobObject(self._handle, process_handle):
+            logger.warning(
+                "AssignProcessToJobObject failed: %s", ctypes.get_last_error()
+            )
+            return False
+        return True
+
+    def pids(self) -> list[int] | None:
+        """Return every pid currently in the job, or ``None`` if unavailable."""
+        if self._handle is None:
+            return None
+        info = _JOBOBJECT_BASIC_PROCESS_ID_LIST()
+        ok = _kernel32.QueryInformationJobObject(
+            self._handle,
+            _JOB_OBJECT_BASIC_PROCESS_ID_LIST,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+            None,
+        )
+        if not ok:
+            return None
+        return [
+            int(info.ProcessIdList[i]) for i in range(info.NumberOfProcessIdsInList)
+        ]
+
+    def terminate(self) -> bool:
+        """Kill every process in the job at once."""
+        if self._handle is None:
+            return False
+        return bool(_kernel32.TerminateJobObject(self._handle, 1))
+
+    def close(self) -> None:
+        if self._handle is not None:
+            _kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def terminate_pid(pid: int) -> bool:
+    """TerminateProcess(pid).  Returns False if the process is gone or protected."""
+    if not IS_WINDOWS:
+        return False
+    handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
+    if not handle:
+        return False
+    try:
+        return bool(_kernel32.TerminateProcess(handle, 1))
+    finally:
+        _kernel32.CloseHandle(handle)
+
+
+def snapshot_processes() -> list[tuple[int, int, str]]:
+    """Return ``(pid, parent_pid, exe_name)`` for every process (Toolhelp32)."""
+    if not IS_WINDOWS:
+        return []
+    snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
+    if snap == _INVALID_HANDLE_VALUE or not snap:
+        return []
+    entries: list[tuple[int, int, str]] = []
+    try:
+        entry = _PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(_PROCESSENTRY32W)
+        ok = _kernel32.Process32FirstW(snap, ctypes.byref(entry))
+        while ok:
+            entries.append(
+                (
+                    int(entry.th32ProcessID),
+                    int(entry.th32ParentProcessID),
+                    entry.szExeFile,
+                )
+            )
+            ok = _kernel32.Process32NextW(snap, ctypes.byref(entry))
+    finally:
+        _kernel32.CloseHandle(snap)
+    return entries
+
+
+def descendant_pids(root_pid: int) -> list[int]:
+    """Descendants of *root_pid* by parent-pid walk (fallback when no job)."""
+    children: dict[int, list[int]] = {}
+    for pid, ppid, _name in snapshot_processes():
+        children.setdefault(ppid, []).append(pid)
+    result: list[int] = []
+    stack = [root_pid]
+    seen = {root_pid}
+    while stack:
+        current = stack.pop()
+        for child in children.get(current, []):
+            if child not in seen:
+                seen.add(child)
+                result.append(child)
+                stack.append(child)
+    return result
+
+
+def send_console_ctrl_c(pid: int, timeout: float = 5.0) -> bool:
+    """Broadcast CTRL_C_EVENT on the console that *pid* is attached to.
+
+    Runs a tiny helper process (see :data:`CTRL_C_HELPER_SOURCE`).  Returns
+    ``True`` when the event was generated.  A ``True`` result does not mean the
+    target reacted: processes that were created with
+    ``CREATE_NEW_PROCESS_GROUP`` or that ignore Ctrl+C will not.
+    """
+    if not IS_WINDOWS:
+        return False
+    python = sys.executable
+    if not python:
+        logger.debug("No sys.executable available for the Ctrl+C helper")
+        return False
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    try:
+        result = subprocess.run(
+            [python, "-I", "-c", CTRL_C_HELPER_SOURCE, str(pid)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+            startupinfo=startupinfo,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("Ctrl+C helper failed to run: %s", exc)
+        return False
+    if result.returncode != 0:
+        logger.debug(
+            "Ctrl+C helper exited with %s: %s",
+            result.returncode,
+            result.stderr.decode("utf-8", "replace").strip(),
+        )
+        return False
+    return True

--- a/openhands-tools/openhands/tools/terminal/terminal/windows_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/windows_terminal.py
@@ -1,11 +1,35 @@
-"""PowerShell-backed terminal backend for Windows."""
+"""PowerShell-backed terminal backend for Windows.
+
+Design notes (see ``windows_console`` for the Win32 side):
+
+* The command-completion sentinel is emitted by PowerShell's ``prompt``
+  function, exactly like the bash backends use ``PS1``.  A sentinel that is
+  appended to the command line itself is lost whenever the line does not run
+  to completion (Ctrl+C, ``throw``, ``-ErrorAction Stop``,
+  ``$ErrorActionPreference = 'Stop'``), which left the session believing the
+  command was still running forever.  A prompt-level sentinel reappears
+  whenever the shell is ready for input, no matter how the previous command
+  ended.
+* The shell gets a private hidden console (``CREATE_NO_WINDOW``) and is
+  **not** created with ``CREATE_NEW_PROCESS_GROUP``: that flag disables Ctrl+C
+  for the new process and everything it spawns.  Ctrl+C handling is also
+  re-enabled from inside the shell so it works regardless of what the agent
+  process itself inherited.
+* Interrupts escalate with bounded waits: console Ctrl+C -> terminate the
+  descendant process tree -> Ctrl+C again.  If the shell still does not come
+  back to a prompt it is declared unresponsive and the session controller
+  recreates it, so one bad command can never poison the session.
+* The shell and its descendants live in a job object, which gives an exact
+  process-tree view and an atomic teardown without WMI queries, and which
+  never kills the shell's own console host (that leaves PowerShell alive but
+  wedged).
+"""
 
 import codecs
 import json
 import os
 import platform
 import shutil
-import signal
 import subprocess
 import threading
 import time
@@ -16,12 +40,13 @@ from openhands.sdk.logger import get_logger
 from openhands.tools.terminal.constants import (
     CMD_OUTPUT_PS1_BEGIN,
     CMD_OUTPUT_PS1_END,
-    HISTORY_LIMIT,
 )
 from openhands.tools.terminal.env import (
     build_terminal_env,
     normalize_terminal_env,
 )
+from openhands.tools.terminal.metadata import CmdOutputMetadata
+from openhands.tools.terminal.terminal import windows_console
 from openhands.tools.terminal.terminal.interface import (
     TerminalInterface,
     parse_ctrl_key,
@@ -30,13 +55,25 @@ from openhands.tools.terminal.terminal.interface import (
 
 logger = get_logger(__name__)
 
-_READ_CHUNK_SIZE = 1024
+_READ_CHUNK_SIZE = 4096
 _READER_THREAD_TIMEOUT_SECONDS = 1.0
-_SCREEN_CLEAR_DELAY_SECONDS = 0.2
-_SETUP_DELAY_SECONDS = 0.5
-_SETUP_POLL_INTERVAL_SECONDS = 0.05
-_MAX_SETUP_WAIT_SECONDS = 2.0
-_INTERRUPT_GRACE_SECONDS = 0.5
+_PROMPT_POLL_INTERVAL_SECONDS = 0.05
+# Upper bound for the first prompt after start-up.  PowerShell 5.1 can take a
+# few seconds on a cold or loaded machine; this is a cap, not a wait.
+_STARTUP_PROMPT_TIMEOUT_SECONDS = 30.0
+# How long each interrupt escalation step waits for the prompt to come back.
+_INTERRUPT_PROMPT_WAIT_SECONDS = 3.0
+_CTRL_C_HELPER_TIMEOUT_SECONDS = 5.0
+_PROCESS_EXIT_WAIT_SECONDS = 5.0
+# Screen buffer budget in characters (the tmux backend keeps 10k lines).
+_OUTPUT_BUFFER_MAX_CHARS = 1_000_000
+
+_PS1_BEGIN_MARKER = CMD_OUTPUT_PS1_BEGIN.strip()
+_PS1_END_MARKER = CMD_OUTPUT_PS1_END.strip()
+# What the prompt function writes at the end of every metadata block.  The
+# leading newline is what distinguishes a real prompt from the same text
+# appearing inside an echoed command line.
+_PROMPT_END_SEQUENCE = "\n" + _PS1_END_MARKER
 
 _WINDOWS_SPECIALS: dict[str, str] = {
     "ENTER": "\n",
@@ -57,6 +94,72 @@ _WINDOWS_SPECIALS: dict[str, str] = {
 }
 
 
+def _ps_single_quote(text: str) -> str:
+    return "'" + text.replace("'", "''") + "'"
+
+
+def _ps_split_literal(text: str) -> str:
+    """Return a PowerShell expression that evaluates to *text*.
+
+    PowerShell echoes every line it reads from a pipe, so the init script must
+    not contain the marker strings verbatim or the echo itself would look like
+    a prompt.  Splitting the literal in two keeps the markers out of the echo.
+    """
+    half = len(text) // 2
+    return f"({_ps_single_quote(text[:half])} + {_ps_single_quote(text[half:])})"
+
+
+def build_powershell_init_script() -> str:
+    """Return the statements sent to a fresh PowerShell session.
+
+    Each statement is a complete single line so PowerShell never waits at the
+    ``>>`` continuation prompt while reading them from the stdin pipe.
+    """
+    # 1. Re-enable Ctrl+C for this process (and, by inheritance, everything it
+    #    spawns).  The flag is inherited from the parent and is set by
+    #    CREATE_NEW_PROCESS_GROUP, so we cannot rely on what we got.
+    enable_ctrl_c = (
+        "try { Add-Type -Namespace OpenHandsTerminal -Name ConsoleCtrl "
+        '-MemberDefinition \'[DllImport("kernel32.dll", SetLastError = true)] '
+        "public static extern bool SetConsoleCtrlHandler(System.IntPtr handler, "
+        "bool add);' -ErrorAction Stop; "
+        "[void][OpenHandsTerminal.ConsoleCtrl]::SetConsoleCtrlHandler("
+        "[System.IntPtr]::Zero, $false) } "
+        'catch { Write-Host "[openhands] Ctrl+C could not be enabled: $_" }'
+    )
+    # 2. UTF-8 in and out: the reader decodes UTF-8 and native tools emit it.
+    utf8 = (
+        "try { $oh_utf8 = New-Object System.Text.UTF8Encoding($false); "
+        "[Console]::OutputEncoding = $oh_utf8; $global:OutputEncoding = $oh_utf8 } "
+        "catch { }"
+    )
+    # 3. The prompt function emits the metadata block.  `$?` must be read
+    #    before anything else runs.  The END marker is the prompt string
+    #    itself, so the screen ends with it whenever the shell is idle.
+    begin = _ps_split_literal(_PS1_BEGIN_MARKER)
+    end = f'({_ps_split_literal(_PS1_END_MARKER)} + "`n")'
+    prompt = (
+        "function global:prompt { "
+        "$oh_ok = $?; "
+        "$oh_ec = $global:LASTEXITCODE; "
+        "$global:LASTEXITCODE = $null; "
+        "$oh_code = if ($null -ne $oh_ec) { $oh_ec } elseif ($oh_ok) { 0 } else { 1 }; "
+        "try { $oh_cwd = (Get-Location).Path.Replace('\\', '/') } "
+        "catch { $oh_cwd = $null }; "
+        "try { $oh_py = (Get-Command python -ErrorAction SilentlyContinue | "
+        "Select-Object -First 1 -ExpandProperty Source) } catch { $oh_py = $null }; "
+        "$oh_meta = @{ pid = $PID; exit_code = $oh_code; username = $env:USERNAME; "
+        "hostname = $env:COMPUTERNAME; working_dir = $oh_cwd; "
+        "py_interpreter_path = $oh_py }; "
+        "try { $oh_json = ConvertTo-Json $oh_meta -Compress } "
+        "catch { $oh_json = '{\"exit_code\":' + $oh_code + '}' }; "
+        f'Write-Host ("`n" + {begin} + "`n" + $oh_json); '
+        f"return {end} "
+        "}"
+    )
+    return "\n".join([enable_ctrl_c, utf8, prompt]) + "\n"
+
+
 class WindowsTerminal(TerminalInterface):
     """Persistent PowerShell session for Windows terminal execution."""
 
@@ -65,7 +168,6 @@ class WindowsTerminal(TerminalInterface):
     output_lock: threading.Lock
     reader_thread: threading.Thread | None
     shell_path: str
-    _command_running_event: threading.Event
     _stop_reader: threading.Event
     _decoder: codecs.IncrementalDecoder
 
@@ -78,14 +180,30 @@ class WindowsTerminal(TerminalInterface):
     ):
         super().__init__(work_dir, username)
         self.process = None
-        self.output_buffer = deque(maxlen=HISTORY_LIMIT)
+        self.output_buffer = deque()
         self.output_lock = threading.Lock()
         self.reader_thread = None
         self.shell_path = shell_path
         self._env = normalize_terminal_env(env)
-        self._command_running_event = threading.Event()
         self._stop_reader = threading.Event()
         self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        self._buffer_chars = 0
+        # Monotonic count of metadata blocks (prompts) seen on the stream, and
+        # the value it had when the current command was submitted.  A command
+        # is running exactly while ``_prompt_seq <= _seq_at_send``.
+        self._prompt_seq = 0
+        self._seq_at_send = 0
+        self._marker_carry = ""
+        self._job: windows_console.WindowsJob | None = None
+        # The shell and its own console host: never terminated by
+        # ``_kill_descendants`` (killing conhost wedges PowerShell).
+        self._protected_pids: set[int] = set()
+        self._wedged = False
+        self._interrupt_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
 
     def initialize(self) -> None:
         """Start a persistent PowerShell process and prepare prompt metadata."""
@@ -99,8 +217,9 @@ class WindowsTerminal(TerminalInterface):
             if startupinfo_cls is not None:
                 startupinfo = startupinfo_cls()
                 startupinfo.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
-            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            creationflags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            # A private hidden console for the shell and its children.  Do NOT
+            # add CREATE_NEW_PROCESS_GROUP: it disables Ctrl+C for the tree.
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
         env = build_terminal_env(self._env)
         env.setdefault("PYTHONIOENCODING", "utf-8")
@@ -118,97 +237,95 @@ class WindowsTerminal(TerminalInterface):
             startupinfo=startupinfo,
             creationflags=creationflags,
         )
+        self._attach_job()
 
         self._stop_reader.clear()
         self.reader_thread = threading.Thread(target=self._read_output, daemon=True)
         self.reader_thread.start()
         self._initialized = True
 
-        self._wait_for_startup_output()
+        self._write_to_stdin(build_powershell_init_script())
+        if not self._wait_for_prompt_after(0, _STARTUP_PROMPT_TIMEOUT_SECONDS):
+            logger.warning(
+                "PowerShell did not print its first prompt within %.0fs; "
+                "continuing with a seeded metadata block",
+                _STARTUP_PROMPT_TIMEOUT_SECONDS,
+            )
+        self._record_protected_pids()
         self.clear_screen()
         logger.debug("Windows terminal initialized with work dir: %s", self.work_dir)
 
-    def _wait_for_startup_output(self) -> None:
-        deadline = time.time() + _MAX_SETUP_WAIT_SECONDS
-        while time.time() < deadline:
-            time.sleep(_SETUP_POLL_INTERVAL_SECONDS)
-            with self.output_lock:
-                if self.output_buffer:
-                    break
-        time.sleep(_SETUP_DELAY_SECONDS)
-        self._get_buffered_output(clear=True)
+    def _attach_job(self) -> None:
+        if platform.system() != "Windows" or self.process is None:
+            return
+        handle = getattr(self.process, "_handle", None)
+        if handle is None:
+            return
+        job = windows_console.WindowsJob()
+        if job.active and job.assign(int(handle)):
+            self._job = job
+        else:
+            job.close()
+            logger.warning(
+                "Could not place PowerShell in a job object; falling back to "
+                "parent-pid process-tree enumeration"
+            )
 
-    def _preserve_latest_metadata_block(self) -> bool:
-        ps1_begin = CMD_OUTPUT_PS1_BEGIN.strip()
-        ps1_end = CMD_OUTPUT_PS1_END.strip()
-        with self.output_lock:
-            output = "".join(self.output_buffer)
-            start_index = output.rfind(ps1_begin)
-            end_index = output.rfind(ps1_end)
-            if start_index == -1 or end_index == -1 or end_index < start_index:
-                self.output_buffer.clear()
-                return False
-
-            end_index += len(ps1_end)
-            self.output_buffer.clear()
-            self.output_buffer.append(output[start_index:end_index] + "\n")
-            return True
-
-    def _seed_metadata_prompt(self) -> None:
-        env = os.environ
-        metadata = {
-            "pid": self.process.pid if self.process is not None else -1,
-            "exit_code": 0,
-            "username": env.get("USERNAME"),
-            "hostname": env.get("COMPUTERNAME"),
-            "working_dir": os.path.realpath(self.work_dir).replace("\\", "/"),
-            "py_interpreter_path": shutil.which("python"),
-        }
-        prompt = (
-            f"{CMD_OUTPUT_PS1_BEGIN.strip()}\n"
-            f"{json.dumps(metadata, separators=(',', ':'))}\n"
-            f"{CMD_OUTPUT_PS1_END.strip()}\n"
-        )
-        with self.output_lock:
-            self.output_buffer.clear()
-            self.output_buffer.append(prompt)
+    def _record_protected_pids(self) -> None:
+        if self.process is None:
+            return
+        protected = {self.process.pid}
+        if self._job is not None:
+            protected.update(self._job.pids() or [])
+        else:
+            for pid, ppid, name in windows_console.snapshot_processes():
+                if ppid == self.process.pid and name.lower() == "conhost.exe":
+                    protected.add(pid)
+        self._protected_pids = protected
 
     def close(self) -> None:
-        """Stop the PowerShell process and background reader."""
+        """Stop the PowerShell process tree and the background reader."""
         if self._closed:
             return
-
+        self._closed = True
         self._stop_reader.set()
-        self._terminate_child_processes()
 
-        if self.process is not None:
-            try:
-                if self.process.stdin is not None:
-                    self.process.stdin.close()
-            except (OSError, ValueError) as exc:
-                logger.debug("Error closing PowerShell stdin: %s", exc)
+        process = self.process
+        if process is not None:
+            if self._job is not None and process.poll() is None:
+                self._job.terminate()
+            elif process.poll() is None:
+                self._kill_descendants()
+                try:
+                    process.kill()
+                except OSError as exc:
+                    logger.debug("Error killing PowerShell process: %s", exc)
+            for stream in (process.stdin, process.stdout):
+                try:
+                    if stream is not None:
+                        stream.close()
+                except (OSError, ValueError) as exc:
+                    logger.debug("Error closing PowerShell pipe: %s", exc)
 
         if self.reader_thread and self.reader_thread.is_alive():
             self.reader_thread.join(timeout=_READER_THREAD_TIMEOUT_SECONDS)
 
-        if self.process is not None:
+        if process is not None:
             try:
-                if self.process.stdout is not None:
-                    self.process.stdout.close()
-            except (OSError, ValueError) as exc:
-                logger.debug("Error closing PowerShell stdout: %s", exc)
-            try:
-                self.process.terminate()
-                self.process.wait(timeout=5.0)
+                process.wait(timeout=_PROCESS_EXIT_WAIT_SECONDS)
             except subprocess.TimeoutExpired:
-                logger.warning("PowerShell process did not terminate, forcing kill")
-                self.process.kill()
+                logger.warning("PowerShell process did not exit after termination")
             except Exception as exc:
-                logger.debug("Error terminating PowerShell process: %s", exc)
-            finally:
-                self.process = None
+                logger.debug("Error waiting for PowerShell process: %s", exc)
+            self.process = None
 
-        self._closed = True
+        if self._job is not None:
+            self._job.close()
+            self._job = None
+
+    # ------------------------------------------------------------------
+    # Input
+    # ------------------------------------------------------------------
 
     def send_keys(self, text: str, enter: bool = True) -> None:
         """Send text or supported control sequences to the PowerShell session."""
@@ -229,11 +346,9 @@ class WindowsTerminal(TerminalInterface):
             return
 
         stripped_text = text.rstrip()
-        if stripped_text:
-            self._command_running_event.set()
-            command = f"{stripped_text}; {self._metadata_suffix()}"
-        else:
-            command = text
+        command = stripped_text if stripped_text else text
+        with self.output_lock:
+            self._seq_at_send = self._prompt_seq
 
         if enter:
             if "\n" in stripped_text or "\r" in stripped_text:
@@ -245,42 +360,6 @@ class WindowsTerminal(TerminalInterface):
                 command += "\n"
         self._write_to_stdin(command)
 
-    def _metadata_suffix(self) -> str:
-        ps1_begin = self._escape_single_quoted(CMD_OUTPUT_PS1_BEGIN.strip())
-        ps1_end = self._escape_single_quoted(CMD_OUTPUT_PS1_END.strip())
-        commands = [
-            "$oh1 = $?",
-            "$oh2 = $LASTEXITCODE",
-            f"Write-Host '{ps1_begin}'",
-            (
-                "$exit_code = if ($null -ne $oh2) { "
-                "$oh2 "
-                "} elseif ($oh1) { 0 } else { 1 }"
-            ),
-            (
-                "$py_path = (Get-Command python -ErrorAction SilentlyContinue | "
-                "Select-Object -ExpandProperty Source)"
-            ),
-            (
-                "$meta = @{"
-                "pid=$PID; "
-                "exit_code=$exit_code; "
-                "username=$env:USERNAME; "
-                "hostname=$env:COMPUTERNAME; "
-                "working_dir=(Get-Location).Path.Replace('\\', '/'); "
-                "py_interpreter_path=if ($py_path) { $py_path } else { $null }"
-                "}"
-            ),
-            "Write-Host (ConvertTo-Json $meta -Compress)",
-            f"Write-Host '{ps1_end}'",
-            "$global:LASTEXITCODE = $null",
-        ]
-        return "; ".join(commands)
-
-    @staticmethod
-    def _escape_single_quoted(text: str) -> str:
-        return text.replace("'", "''")
-
     def _write_to_stdin(self, text: str) -> None:
         if self.process is None or self.process.stdin is None:
             raise RuntimeError("PowerShell stdin is not available")
@@ -290,6 +369,10 @@ class WindowsTerminal(TerminalInterface):
         except (BrokenPipeError, OSError) as exc:
             logger.error("Failed to write to PowerShell stdin: %s", exc)
             raise RuntimeError("Failed to write to PowerShell session") from exc
+
+    # ------------------------------------------------------------------
+    # Output
+    # ------------------------------------------------------------------
 
     def _read_output(self) -> None:
         if self.process is None or self.process.stdout is None:
@@ -303,8 +386,7 @@ class WindowsTerminal(TerminalInterface):
                     break
                 decoded = self._decoder.decode(chunk, final=False)
                 if decoded:
-                    with self.output_lock:
-                        self.output_buffer.append(decoded)
+                    self._append_output(decoded)
             except (ValueError, OSError) as exc:
                 logger.debug("PowerShell output reading stopped: %s", exc)
                 break
@@ -315,16 +397,32 @@ class WindowsTerminal(TerminalInterface):
         try:
             final = self._decoder.decode(b"", final=True)
             if final:
-                with self.output_lock:
-                    self.output_buffer.append(final)
+                self._append_output(final)
         except Exception as exc:
             logger.debug("Error flushing PowerShell decoder: %s", exc)
+
+    def _append_output(self, decoded: str) -> None:
+        with self.output_lock:
+            self.output_buffer.append(decoded)
+            self._buffer_chars += len(decoded)
+            # Count prompts as they stream by; a marker may straddle two chunks.
+            joined = self._marker_carry + decoded
+            seen = joined.count(_PROMPT_END_SEQUENCE)
+            if seen:
+                self._prompt_seq += seen
+            self._marker_carry = joined[-(len(_PROMPT_END_SEQUENCE) - 1) :]
+            while (
+                self._buffer_chars > _OUTPUT_BUFFER_MAX_CHARS
+                and len(self.output_buffer) > 1
+            ):
+                self._buffer_chars -= len(self.output_buffer.popleft())
 
     def _get_buffered_output(self, clear: bool) -> str:
         with self.output_lock:
             output = "".join(self.output_buffer)
             if clear:
                 self.output_buffer.clear()
+                self._buffer_chars = 0
             return output
 
     def read_screen(self) -> str:
@@ -332,123 +430,173 @@ class WindowsTerminal(TerminalInterface):
         return self._get_buffered_output(clear=False)
 
     def clear_screen(self) -> None:
-        """Clear the visible screen and reset buffered output."""
+        """Drop everything except the latest metadata block."""
         if self.process is None or self.process.poll() is not None:
             return
-
         if not self._preserve_latest_metadata_block():
             self._seed_metadata_prompt()
-        time.sleep(_SCREEN_CLEAR_DELAY_SECONDS)
-        self._command_running_event.clear()
 
-    def _terminate_child_processes(self) -> bool:
-        """Terminate descendants of the persistent PowerShell process."""
-        if (
-            platform.system() != "Windows"
-            or self.process is None
-            or self.process.poll() is not None
-        ):
-            return False
-
-        script = f"""
-$root = {self.process.pid}
-$childrenByParent = @{{}}
-Get-CimInstance Win32_Process | ForEach-Object {{
-    $parentId = [int]$_.ParentProcessId
-    if (-not $childrenByParent.ContainsKey($parentId)) {{
-        $childrenByParent[$parentId] = New-Object System.Collections.Generic.List[int]
-    }}
-    $childrenByParent[$parentId].Add([int]$_.ProcessId)
-}}
-$toStop = New-Object System.Collections.Generic.List[int]
-function Add-Descendants([int]$processId) {{
-    if (-not $childrenByParent.ContainsKey($processId)) {{ return }}
-    foreach ($childId in $childrenByParent[$processId]) {{
-        if ($childId -eq $PID) {{ continue }}
-        $toStop.Add($childId)
-        Add-Descendants $childId
-    }}
-}}
-Add-Descendants $root
-for ($i = $toStop.Count - 1; $i -ge 0; $i--) {{
-    Stop-Process -Id $toStop[$i] -Force -ErrorAction SilentlyContinue
-}}
-if ($toStop.Count -gt 0) {{ exit 0 }} else {{ exit 1 }}
-"""
-        startupinfo = None
-        startupinfo_cls = getattr(subprocess, "STARTUPINFO", None)
-        if startupinfo_cls is not None:
-            startupinfo = startupinfo_cls()
-            startupinfo.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
-        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
-
-        try:
-            result = subprocess.run(
-                [self.shell_path, "-NoLogo", "-NoProfile", "-Command", script],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-                timeout=5.0,
-                startupinfo=startupinfo,
-                creationflags=creationflags,
-            )
-            return result.returncode == 0
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            logger.debug("Failed to terminate PowerShell child processes: %s", exc)
-            return False
-
-    def interrupt(self) -> bool:
-        """Interrupt the active command if the process is still alive."""
-        if self.process is None or self.process.poll() is not None:
-            return False
-
-        # Kill descendants while they are still attached to the persistent
-        # PowerShell process. CTRL_BREAK can interrupt the waiting script first,
-        # leaving launched child processes alive but no longer discoverable as
-        # descendants of the shell.
-        terminated_children = self._terminate_child_processes()
-
-        sent_ctrl_break = False
-        ctrl_break_event = getattr(signal, "CTRL_BREAK_EVENT", None)
-        if platform.system() == "Windows" and ctrl_break_event is not None:
-            try:
-                self.process.send_signal(ctrl_break_event)
-                sent_ctrl_break = True
-            except Exception as exc:
-                logger.debug("Failed to send CTRL_BREAK_EVENT: %s", exc)
-
-        if sent_ctrl_break:
-            time.sleep(_INTERRUPT_GRACE_SECONDS)
-
-        terminated_children = self._terminate_child_processes() or terminated_children
-        sent_ctrl_c_input = False
-        if not sent_ctrl_break and not terminated_children:
-            try:
-                self._write_to_stdin(_WINDOWS_SPECIALS["C-C"])
-                sent_ctrl_c_input = True
-            except RuntimeError as exc:
-                logger.debug("Failed to write Ctrl+C to PowerShell stdin: %s", exc)
+    def _preserve_latest_metadata_block(self) -> bool:
+        """Keep only the last well-formed metadata block in the buffer."""
+        with self.output_lock:
+            output = "".join(self.output_buffer)
+            matches = CmdOutputMetadata.matches_ps1_metadata(output)
+            if not matches:
+                self.output_buffer.clear()
+                self._buffer_chars = 0
                 return False
 
-        self._command_running_event.clear()
-        return sent_ctrl_break or terminated_children or sent_ctrl_c_input
+            block = output[matches[-1].start() : matches[-1].end()] + "\n"
+            self.output_buffer.clear()
+            self.output_buffer.append(block)
+            self._buffer_chars = len(block)
+            return True
+
+    def _seed_metadata_prompt(self) -> None:
+        env = os.environ
+        metadata = {
+            "pid": self.process.pid if self.process is not None else -1,
+            "exit_code": 0,
+            "username": env.get("USERNAME"),
+            "hostname": env.get("COMPUTERNAME"),
+            "working_dir": os.path.realpath(self.work_dir).replace("\\", "/"),
+            "py_interpreter_path": shutil.which("python"),
+        }
+        prompt = (
+            f"{_PS1_BEGIN_MARKER}\n"
+            f"{json.dumps(metadata, separators=(',', ':'))}\n"
+            f"{_PS1_END_MARKER}\n"
+        )
+        with self.output_lock:
+            self.output_buffer.clear()
+            self.output_buffer.append(prompt)
+            self._buffer_chars = len(prompt)
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    def _prompt_count(self) -> int:
+        with self.output_lock:
+            return self._prompt_seq
+
+    def _wait_for_prompt_after(self, seq: int, timeout: float) -> bool:
+        """Block until a prompt newer than *seq* has been printed."""
+        deadline = time.monotonic() + timeout
+        while True:
+            if self._prompt_count() > seq:
+                return True
+            if self.process is None or self.process.poll() is not None:
+                return False
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_PROMPT_POLL_INTERVAL_SECONDS)
 
     def is_running(self) -> bool:
         """Return whether a command is still running in the PowerShell session."""
         if not self._initialized or self.process is None:
             return False
         if self.process.poll() is not None:
-            self._command_running_event.clear()
             return False
+        with self.output_lock:
+            return self._prompt_seq <= self._seq_at_send
 
-        content = self.read_screen()
-        if CMD_OUTPUT_PS1_END.rstrip() in content:
-            self._command_running_event.clear()
-            return False
-        return self._command_running_event.is_set()
+    def is_alive(self) -> bool:
+        """Return whether the shell can still accept commands."""
+        return (
+            self._initialized
+            and not self._closed
+            and not self._wedged
+            and self.process is not None
+            and self.process.poll() is None
+        )
 
     def is_powershell(self) -> bool:
         return True
+
+    # ------------------------------------------------------------------
+    # Interrupt
+    # ------------------------------------------------------------------
+
+    def _kill_descendants(self) -> bool:
+        """Terminate every process under the shell except the shell and its conhost."""  # noqa: E501
+        if platform.system() != "Windows" or self.process is None:
+            return False
+        pids: list[int] | None = None
+        if self._job is not None:
+            pids = self._job.pids()
+        if pids is None:
+            pids = windows_console.descendant_pids(self.process.pid)
+        victims = [
+            pid
+            for pid in pids
+            if pid != self.process.pid and pid not in self._protected_pids
+        ]
+        killed = False
+        for pid in victims:
+            if windows_console.terminate_pid(pid):
+                killed = True
+        logger.debug("Terminated %d descendant process(es): %s", len(victims), victims)
+        return killed
+
+    def interrupt(self) -> bool:
+        """Interrupt the running command and wait for the prompt to come back.
+
+        Two things must both happen: the shell must return to a prompt, and
+        the command's process subtree must be gone (a child launched with
+        ``Start-Process`` runs on its own console, so Ctrl+C returns the
+        prompt but leaves the child alive — the tree kill is what stops it,
+        mirroring ``killpg(SIGINT)`` on POSIX).  So Ctrl+C and a descendant
+        sweep are always paired, and the step escalates on failure.  When the
+        shell still will not come back it is marked unresponsive
+        (``is_alive()`` -> ``False``) so the session controller recreates it
+        rather than retrying forever.
+        """
+        if self.process is None or self.process.poll() is not None:
+            return False
+
+        with self._interrupt_lock:
+            running = self.is_running()
+            seq = self._prompt_count()
+
+            delivered = windows_console.send_console_ctrl_c(
+                self.process.pid, timeout=_CTRL_C_HELPER_TIMEOUT_SECONDS
+            )
+            if not delivered:
+                logger.debug("Console Ctrl+C could not be delivered to PowerShell")
+            # Give Ctrl+C a moment to unwind the pipeline before enumerating the
+            # tree, so a child that reacts to Ctrl+C is not double-reported.
+            prompt_back = self._wait_for_prompt_after(
+                seq, _INTERRUPT_PROMPT_WAIT_SECONDS if running else 0.0
+            )
+            # Always take the subtree down: Ctrl+C does not reach children on
+            # their own console (Start-Process) or children that ignore it.
+            self._kill_descendants()
+
+            if not running:
+                # Nothing was running (idle Ctrl+C): make it idempotent.
+                return True
+            if prompt_back or self._wait_for_prompt_after(
+                seq, _INTERRUPT_PROMPT_WAIT_SECONDS
+            ):
+                return True
+
+            # Prompt still hasn't returned: try Ctrl+C once more after the tree
+            # has been torn down, then give up and let the session recreate us.
+            windows_console.send_console_ctrl_c(
+                self.process.pid, timeout=_CTRL_C_HELPER_TIMEOUT_SECONDS
+            )
+            if self._wait_for_prompt_after(seq, _INTERRUPT_PROMPT_WAIT_SECONDS):
+                return True
+
+            if self.process.poll() is not None:
+                return False
+            logger.warning(
+                "PowerShell did not return to a prompt after Ctrl+C and "
+                "process-tree termination; marking the terminal unresponsive"
+            )
+            self._wedged = True
+            return False
 
     def __enter__(self) -> "WindowsTerminal":
         self.initialize()

--- a/tests/tools/terminal/test_windows_terminal_recovery.py
+++ b/tests/tools/terminal/test_windows_terminal_recovery.py
@@ -1,0 +1,354 @@
+"""Regression tests for Windows PowerShell terminal recovery.
+
+These pin the invariant that a failed, timed-out, or interrupted command
+never leaves the session unable to run the next command.  They run only on
+Windows because they exercise the real PowerShell backend, Win32 Ctrl+C
+delivery, and job-object process-tree termination.
+
+See OpenHands/software-agent-sdk (Windows terminal recovery) and the
+corroborating product report OpenHands/OpenHands#17198.
+"""
+
+import os
+import platform
+import subprocess
+import tempfile
+import time
+from collections.abc import Generator
+
+import pytest
+
+from openhands.tools.terminal.definition import TerminalAction
+from openhands.tools.terminal.impl import TerminalExecutor
+from openhands.tools.terminal.terminal import create_terminal_session
+from openhands.tools.terminal.terminal.terminal_session import TerminalCommandStatus
+
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="Windows PowerShell recovery behavior only applies on Windows",
+)
+
+NO_CHANGE = 2
+
+
+@pytest.fixture
+def work_dir() -> Generator[str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
+
+
+def _pid_alive(pid: int) -> bool:
+    out = subprocess.run(
+        ["tasklist", "/FI", f"PID eq {pid}", "/NH"], capture_output=True, text=True
+    ).stdout
+    return str(pid) in out
+
+
+def _wait_pid_dead(pid: int, timeout: float = 10.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.1)
+    return not _pid_alive(pid)
+
+
+def _ready(session) -> None:
+    obs = session.execute(TerminalAction(command="Write-Output READY-CHECK"))
+    assert "READY-CHECK" in obs.text
+    assert obs.metadata.exit_code == 0
+    assert session.prev_status == TerminalCommandStatus.COMPLETED
+
+
+# --------------------------------------------------------------------------- #
+# Completion detection: exit code survives however the command ends
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("command", "expected_exit"),
+    [
+        pytest.param("cmd /c exit 7", 7, id="native-nonzero-exit"),
+        pytest.param(
+            "Get-Item C:\\no\\such\\path -ErrorAction Stop", 1, id="terminating-error"
+        ),
+        pytest.param("throw 'boom'", 1, id="throw"),
+        pytest.param(
+            "$ErrorActionPreference='Stop'; Get-Item C:\\no\\such -ErrorAction Stop",
+            1,
+            id="error-action-preference-stop",
+        ),
+        pytest.param("Write-Host -NoNewline no-trailing-newline", 0, id="no-newline"),
+    ],
+)
+def test_completion_detected_however_command_ends(
+    work_dir: str, command: str, expected_exit: int
+) -> None:
+    """A prompt-level sentinel reappears even when the command line aborts.
+
+    The previous design appended the sentinel to the command line, so a
+    terminating error skipped it and the session waited out the full
+    no-change timeout on a command that had actually finished.
+    """
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        start = time.time()
+        obs = session.execute(TerminalAction(command=command))
+        assert obs.metadata.exit_code == expected_exit, obs.metadata
+        assert session.prev_status == TerminalCommandStatus.COMPLETED
+        assert time.time() - start < NO_CHANGE, "completion was not detected promptly"
+        _ready(session)
+    finally:
+        session.close()
+
+
+# --------------------------------------------------------------------------- #
+# Interrupt recovers the session and kills the process subtree
+# --------------------------------------------------------------------------- #
+def test_ctrl_c_of_builtin_makes_session_ready(work_dir: str) -> None:
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        obs = session.execute(TerminalAction(command="Start-Sleep 120; 'never'"))
+        assert obs.metadata.exit_code == -1
+        assert session.prev_status == TerminalCommandStatus.NO_CHANGE_TIMEOUT
+        session.execute(TerminalAction(command="C-c", is_input=True))
+        assert session.prev_status not in (
+            TerminalCommandStatus.NO_CHANGE_TIMEOUT,
+            TerminalCommandStatus.HARD_TIMEOUT,
+        )
+        _ready(session)
+    finally:
+        session.close()
+
+
+def test_ctrl_c_kills_child_that_ignores_sigint(work_dir: str) -> None:
+    """Ctrl+C alone cannot stop a SIGINT-ignoring child; the tree kill must."""
+    pid_path = os.path.join(work_dir, "child.pid")
+    script = os.path.join(work_dir, "ignore_sigint.py")
+    with open(script, "w", encoding="utf-8") as f:
+        f.write(
+            "import os, signal, time\n"
+            "signal.signal(signal.SIGINT, signal.SIG_IGN)\n"
+            f"open(r'{pid_path}', 'w').write(str(os.getpid()))\n"
+            "time.sleep(120)\n"
+        )
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    child_pid: int | None = None
+    try:
+        session.initialize()
+        obs = session.execute(TerminalAction(command=f'& "{_python()}" "{script}"'))
+        assert obs.metadata.exit_code == -1
+        child_pid = _read_pid(pid_path)
+        assert _pid_alive(child_pid)
+        session.execute(TerminalAction(command="C-c", is_input=True, timeout=10))
+        assert _wait_pid_dead(child_pid), "SIGINT-ignoring child survived interrupt"
+        _ready(session)
+    finally:
+        if child_pid is not None:
+            subprocess.run(
+                ["taskkill", "/PID", str(child_pid), "/F"], capture_output=True
+            )
+        session.close()
+
+
+def test_interrupted_session_does_not_poison_later_commands(work_dir: str) -> None:
+    """Regression for OpenHands/OpenHands#17198.
+
+    Symptom: after one command is interrupted, *every* later command is
+    rejected with "previous command is still running" (or returns an empty
+    observation), so the agent reports the terminal is stuck and retries
+    forever.  Here we interrupt a long command and then run a batch of
+    ordinary commands; all of them must execute normally.
+    """
+    os.makedirs(os.path.join(work_dir, ".agents", "agents"), exist_ok=True)
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        # Poison attempt: long command -> soft timeout -> Ctrl+C.
+        assert (
+            session.execute(
+                TerminalAction(command="Start-Sleep 120")
+            ).metadata.exit_code
+            == -1
+        )
+        session.execute(TerminalAction(command="C-c", is_input=True))
+        # #17198's exact command plus ordinary neighbours must all run.
+        for cmd in (
+            "Get-ChildItem .agents/agents/",
+            "Write-Output first",
+            "Get-ChildItem .agents/agents/",
+            "Write-Output second",
+        ):
+            obs = session.execute(TerminalAction(command=cmd))
+            suffix = obs.metadata.suffix
+            assert "previous command is still running" not in suffix, (
+                f"{cmd!r} rejected as still-running (#17198): {suffix!r}"
+            )
+            assert obs.metadata.exit_code != -1, f"{cmd!r} never completed"
+        _ready(session)
+    finally:
+        session.close()
+
+
+def test_immediate_command_after_interrupt_is_not_rejected(work_dir: str) -> None:
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        assert (
+            session.execute(
+                TerminalAction(command="Start-Sleep 120")
+            ).metadata.exit_code
+            == -1
+        )
+        session.execute(TerminalAction(command="C-c", is_input=True))
+        obs = session.execute(TerminalAction(command="Write-Output immediately-after"))
+        assert "immediately-after" in obs.text
+        assert "NOT executed" not in obs.metadata.suffix
+        assert obs.metadata.exit_code == 0
+    finally:
+        session.close()
+
+
+def test_repeated_and_idle_interrupts_are_idempotent(work_dir: str) -> None:
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        session.execute(TerminalAction(command="Start-Sleep 120"))
+        for _ in range(3):
+            session.execute(TerminalAction(command="C-c", is_input=True))
+        _ready(session)
+        # a Ctrl+C with nothing running must be harmless
+        session.execute(TerminalAction(command="C-c", is_input=True))
+        _ready(session)
+    finally:
+        session.close()
+
+
+def test_input_after_command_finished_returns_output_not_rejection(
+    work_dir: str,
+) -> None:
+    """A timed-out command that finishes on its own must not wedge the next input."""
+    session = create_terminal_session(
+        work_dir=work_dir,
+        terminal_type="powershell",
+        no_change_timeout_seconds=NO_CHANGE,
+    )
+    try:
+        session.initialize()
+        obs = session.execute(
+            TerminalAction(command="Start-Sleep 3; Write-Output finished-alone")
+        )
+        assert obs.metadata.exit_code == -1
+        time.sleep(2.5)  # command completes with nobody polling
+        obs2 = session.execute(TerminalAction(command="", is_input=True))
+        assert "finished-alone" in obs2.text
+        assert obs2.metadata.exit_code == 0
+        _ready(session)
+    finally:
+        session.close()
+
+
+# --------------------------------------------------------------------------- #
+# Self-healing at the executor level
+# --------------------------------------------------------------------------- #
+def test_executor_recreates_session_after_shell_exits(work_dir: str) -> None:
+    """`exit` kills the shell; the next command must still run (new session)."""
+    ex = TerminalExecutor(
+        working_dir=work_dir,
+        no_change_timeout_seconds=NO_CHANGE,
+        terminal_type="powershell",
+    )
+    try:
+        ex(TerminalAction(command="exit"))
+        obs = ex(TerminalAction(command="Write-Output alive-again"))
+        assert "alive-again" in obs.text
+        assert obs.metadata.exit_code == 0
+    finally:
+        ex.close()
+
+
+def test_executor_recreates_session_after_shell_killed(work_dir: str) -> None:
+    ex = TerminalExecutor(
+        working_dir=work_dir,
+        no_change_timeout_seconds=NO_CHANGE,
+        terminal_type="powershell",
+    )
+    try:
+        pid_obs = ex(TerminalAction(command="Write-Output $PID"))
+        pid = int(pid_obs.text.strip().splitlines()[-1])
+        subprocess.run(["taskkill", "/PID", str(pid), "/F"], capture_output=True)
+        assert _wait_pid_dead(pid, 5)
+        obs = ex(TerminalAction(command="Write-Output healed"))
+        assert "healed" in obs.text
+        assert obs.metadata.exit_code == 0
+    finally:
+        ex.close()
+
+
+# --------------------------------------------------------------------------- #
+# Reset preserves configured env; sheds interactive env
+# --------------------------------------------------------------------------- #
+def test_reset_reinjects_configured_env_but_not_interactive(work_dir: str) -> None:
+    ex = TerminalExecutor(
+        working_dir=work_dir,
+        no_change_timeout_seconds=NO_CHANGE,
+        terminal_type="powershell",
+        env={"OH_CONFIGURED": "configured-value"},
+    )
+    try:
+        ex(TerminalAction(command="$env:OH_INTERACTIVE = 'interactive-value'"))
+        obs = ex(TerminalAction(command="", reset=True))
+        assert "reset" in obs.text.lower()
+        obs = ex(
+            TerminalAction(
+                command='Write-Output "c=$env:OH_CONFIGURED i=$env:OH_INTERACTIVE"'
+            )
+        )
+        assert "c=configured-value" in obs.text, obs.text
+        assert "i=interactive-value" not in obs.text, obs.text
+    finally:
+        ex.close()
+
+
+def _python() -> str:
+    import sys
+
+    return sys.executable
+
+
+def _read_pid(path: str, timeout: float = 10.0) -> int:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            data = open(path).read().strip()
+            if data:
+                return int(data)
+        except FileNotFoundError:
+            pass
+        time.sleep(0.1)
+    raise AssertionError("child never wrote its pid")

--- a/tests/tools/terminal/test_windows_terminal_send_keys.py
+++ b/tests/tools/terminal/test_windows_terminal_send_keys.py
@@ -82,12 +82,39 @@ def test_single_line_input_ends_with_exactly_one_newline(command: str) -> None:
 
 
 @pytest.mark.parametrize("command", MULTILINE_COMMANDS + SINGLE_LINE_COMMANDS)
-def test_metadata_suffix_is_submitted_with_the_command(command: str) -> None:
-    """The PS1 metadata suffix rides along, so the marker can be parsed back."""
+def test_command_is_submitted_verbatim_without_a_suffix(command: str) -> None:
+    """The metadata block comes from the prompt function, not from the command.
+
+    A suffix appended to the command line is lost whenever the line does not
+    run to completion (Ctrl+C, ``throw``, ``-ErrorAction Stop``), so nothing
+    may be attached to what the model asked to run.
+    """
     sent = _sent_text(command)
 
-    assert "$oh1 = $?" in sent
-    assert sent.startswith(command.rstrip())
+    assert sent.rstrip("\n") == command.rstrip()
+    assert "###PS1" not in sent
+
+
+def test_init_script_never_echoes_the_markers() -> None:
+    """PowerShell echoes every line read from a pipe.
+
+    If the init script contained the literal markers, the echo of the script
+    itself would be mistaken for a prompt.
+    """
+    from openhands.tools.terminal.constants import (
+        CMD_OUTPUT_PS1_BEGIN,
+        CMD_OUTPUT_PS1_END,
+    )
+    from openhands.tools.terminal.terminal.windows_terminal import (
+        build_powershell_init_script,
+    )
+
+    script = build_powershell_init_script()
+
+    assert CMD_OUTPUT_PS1_BEGIN.strip() not in script
+    assert CMD_OUTPUT_PS1_END.strip() not in script
+    # every statement is a complete line: no ">>" continuation over the pipe
+    assert all(line.count("{") == line.count("}") for line in script.splitlines())
 
 
 @pytest.mark.parametrize("command", MULTILINE_COMMANDS + SINGLE_LINE_COMMANDS)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Installed OpenHands/Agent Canvas on bare Windows via npm.

When using OpenHands native agent on windows, (I tried both GLM 5.3-flash via open router and chatgpt sol) constant agent errors occured related to the terminal, and I even had a agent get stuck in a loop of attempting to exit terminal/process via Ctr+C repeatedly, with no real output nor a timeout cancelling the tool actions.


-----

AGENT:

## Why

On native Windows, a persistent PowerShell terminal session (`WindowsTerminal`)
can become **permanently poisoned** by a single command that ends with a
terminating error or is interrupted. Afterwards every command is rejected with
*"the previous command is still running"*, and the agent burns its remaining
turns retrying. This reproduced identically with two different models, so it is a
harness/runtime issue, not model behaviour. It matches the downstream report
OpenHands/OpenHands#17198 ("[Command finished execution with no output]", then
the terminal being considered occupied and repeated Ctrl+C/reset failing).

Root cause (all Windows-only):

1. **Completion sentinel was appended to the command line.** The PS1 metadata
   block was sent as extra statements on the *same* line as the user command, so
   any command that did not run to completion — `throw`, `-ErrorAction Stop`,
   `$ErrorActionPreference = 'Stop'` — aborted the line before the sentinel ran.
   `###PS1END###` never appeared and the session believed the command was still
   running forever.
2. **The shell was spawned with `CREATE_NEW_PROCESS_GROUP`**, which disables
   Ctrl+C for the shell and its children. `CTRL_BREAK_EVENT` to a
   `CREATE_NO_WINDOW` process is dropped and writing `\x03` to stdin does
   nothing, so interrupts never reached the running command and child trees were
   left alive.
3. **No recovery path.** `prev_status` stayed `NO_CHANGE_TIMEOUT`/`HARD_TIMEOUT`
   after the process had exited, and a wedged shell could only be escaped by a
   full `reset` that discarded cwd/env.

## Summary

- Emit the completion sentinel from PowerShell's `prompt` function (like the bash
  backends use `PS1`) so it reappears whenever the shell is ready, however the
  previous command ended.
- Start the shell with `CREATE_NO_WINDOW` only and re-enable Ctrl+C inside it via
  `SetConsoleCtrlHandler`; deliver interrupts with a short-lived helper that
  `AttachConsole()`s and calls `GenerateConsoleCtrlEvent(CTRL_C_EVENT)` (Windows
  `killpg(SIGINT)` equivalent), escalating to job-object process-tree
  termination, all with bounded waits. New `windows_console.py` isolates the
  Win32 `ctypes` plumbing (job objects + Toolhelp32).
- Track command state with a monotonic prompt counter instead of screen-tail
  matching; add `TerminalInterface.is_alive()` so a shell that exited or stopped
  responding is recreated before the next command. `is_alive()` defaults to
  `initialized and not closed` and is only overridden on Windows, so
  tmux/subprocess/Linux behaviour is unchanged.

## Issue Number

Fixes #4963

Also addresses the downstream report OpenHands/OpenHands#17198 (cross-repository,
so no auto-closing keyword there).

## How to Test

Deterministic, no LLM — on native Windows:

```python
from openhands.tools.terminal.definition import TerminalAction
from openhands.tools.terminal.terminal import create_terminal_session

s = create_terminal_session(work_dir=".", terminal_type="powershell",
                            no_change_timeout_seconds=1)
s.initialize()
s.execute(TerminalAction(command="Start-Sleep 120"))     # soft timeout -> exit -1
s.execute(TerminalAction(command="C-c", is_input=True))  # interrupt
print(s.execute(TerminalAction(command="Get-ChildItem")).metadata.suffix)
# stock 1.46.0: "...the previous command is still running..."  (poisoned)
# patched:       normal listing, exit code 0
```

`throw`, `Get-Item <missing> -ErrorAction Stop`, and
`$ErrorActionPreference='Stop'` poison the stock session without any interrupt,
because their sentinel never ran.

Automated checks (run on Windows 11, PowerShell 5.1):

```
uv run pytest tests/tools/terminal        # 197 passed, 154 skipped (Windows-only cases run)
uv run pre-commit run --files <changed>   # ruff-format, ruff, pycodestyle, pyright,
                                          # import-rules, tool-registration: all pass
```

End-to-end evidence (beyond unit tests): the Agent Server was run from this
checkout via `OH_AGENT_SERVER_LOCAL_PATH` behind a real Agent Canvas stack on
native Windows, and two native models each completed a multi-step workload
containing terminating errors, a non-zero exit, an interrupted `Start-Sleep`, and
a top-level `exit` that killed the shell — with **zero** "no output" symptoms,
"still running" wedges, or manual resets; the `exit` case self-healed into a
fresh session. A targeted reproduction suite went from **7/20** (stock 1.46.0) to
**21/21**; a 300-cycle interrupt/recovery stress test showed 0 failures, 0 leaked
processes (powershell/conhost/python/cmd/ping/node), and flat ~0.5 s recovery
latency.

Windows-specific tests are guarded with
`skipif(platform.system() != "Windows")`, so they run only on the Windows CI job;
the send-keys/init-script tests are platform-independent.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Behavioural change is Windows-only; Linux/tmux/subprocess paths are unchanged
(the new `is_alive()` guard never triggers there, and using
`terminal.is_running()` instead of a screen-tail `endswith(PS1_END)` check is
equivalent for those backends). No public API is removed or changed. This touches
terminal execution, which the review guide flags as eval-relevant — noting that
the effect is confined to the native-Windows backend.
