### PR TITLE
fix(sdk): generate titles with Responses and subscription streaming

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -15,6 +15,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
 
             - name: Set up Python
               uses: actions/setup-python@v6
@@ -26,6 +28,11 @@ jobs:
 
             - name: Install dependencies
               run: uv sync --frozen --group dev
+
+            - name: Ensure dynamic attribute baseline only shrinks
+              run: >-
+                  uv run python scripts/check_forbidden_dynamic_attributes.py
+                  --baseline-ref ${{ github.event.pull_request.base.sha || github.event.before }}
 
             - name: Run pre-commit (all files)
               run: uv run pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
             pass_filenames: true
             always_run: false
           - id: check-forbidden-dynamic-attributes
-            name: Forbid getattr and setattr in SDK
+            name: Forbid dynamic attribute access in SDK
             entry: uv run python scripts/check_forbidden_dynamic_attributes.py
             language: system
             files: ^openhands-sdk/.*\.py$

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -322,7 +322,7 @@ async def validate_profile(
 
             llm = await asyncio.to_thread(create_subscription_llm_from_config, llm)
 
-        # Mirror the runtime dispatch (see ``amake_llm_completion``) and stay
+        # Mirror the runtime dispatch (see ``LLM.agenerate``) and stay
         # async so provider I/O doesn't pin the FastAPI event loop.
         if llm.uses_responses_api():
             await llm.aresponses(messages=messages, max_tokens=1)

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -20,10 +20,8 @@ from openhands.sdk.agent.response_dispatch import (
 )
 from openhands.sdk.agent.stream_context import StreamContext
 from openhands.sdk.agent.utils import (
-    amake_llm_completion,
     aprepare_llm_messages,
     fix_malformed_tool_arguments,
-    make_llm_completion,
     normalize_tool_call,
     parse_tool_call_arguments,
     prepare_llm_messages,
@@ -536,7 +534,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             system_prompt=TextContent(text=self.static_system_message),
             # Tools are stored as ToolDefinition objects and converted to
             # OpenAI format with security_risk parameter during LLM completion.
-            # See make_llm_completion() in agent/utils.py for details.
+            # Agent calls always expose security risk prediction in tool schemas.
             tools=list(self.tools_map.values()),
             dynamic_context=TextContent(text=dynamic_context)
             if dynamic_context
@@ -727,10 +725,11 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         )
 
         try:
-            llm_response = make_llm_completion(
-                self.llm,
-                _messages,
+            llm_response = self.llm.generate(
+                messages=_messages,
                 tools=list(self.tools_map.values()),
+                store=False,
+                add_security_risk_prediction=True,
                 on_token=stream.token_callback,
                 call_context=call_context,
             )
@@ -844,7 +843,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         """Async variant of :meth:`step`.
 
         The LLM completion is performed asynchronously via
-        :func:`amake_llm_completion`.  Tool dispatch uses
+        :meth:`LLM.agenerate`.  Tool dispatch uses
         :meth:`_aexecute_actions` which runs each tool call in its own
         thread via :func:`asyncio.loop.run_in_executor` and schedules
         parallel calls with :func:`asyncio.gather`, keeping the event
@@ -934,10 +933,11 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             # and state snapshots aren't blocked for the whole response. No-op
             # unless the run loop holds the lock (e.g. direct astep() in tests).
             async with conversation._released_state_lock_during_io():
-                llm_response = await amake_llm_completion(
-                    self.llm,
-                    _messages,
+                llm_response = await self.llm.agenerate(
+                    messages=_messages,
                     tools=list(self.tools_map.values()),
+                    store=False,
+                    add_security_risk_prediction=True,
                     on_token=stream.token_callback,
                     call_context=call_context,
                 )

--- a/openhands-sdk/openhands/sdk/agent/stream_context.py
+++ b/openhands-sdk/openhands/sdk/agent/stream_context.py
@@ -282,9 +282,11 @@ def _split_chunk(
         delta = choice.delta
         if delta is None:
             continue
-        # getattr, not attribute access: litellm *deletes* reasoning_content
-        # when the provider omits it, declared field or not.
-        reasoning = getattr(delta, "reasoning_content", None)
+        reasoning = (
+            delta.reasoning_content
+            if "reasoning_content" in delta.model_fields_set
+            else None
+        )
         if isinstance(reasoning, str) and reasoning:
             out.append(("reasoning", reasoning, chunk.id, choice.index))
         if isinstance(delta.content, str) and delta.content:

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -12,7 +12,6 @@ import textwrap
 import types
 from collections.abc import Collection
 from typing import (
-    TYPE_CHECKING,
     Annotated,
     Any,
     Union,
@@ -25,16 +24,9 @@ from pydantic import BaseModel
 
 from openhands.sdk.context.condenser.base import CondenserBase
 from openhands.sdk.context.view import View
-from openhands.sdk.conversation.types import ConversationTokenCallbackType
 from openhands.sdk.event.base import LLMConvertibleEvent
 from openhands.sdk.event.condenser import Condensation
-from openhands.sdk.llm import LLM, LLMResponse, Message
-from openhands.sdk.tool import ToolDefinition
-
-
-if TYPE_CHECKING:
-    from openhands.sdk.llm.llm import LLMCallContext
-    from openhands.sdk.llm.streaming import AnyTokenCallbackType
+from openhands.sdk.llm import LLM, Message
 
 
 # Regex matching raw ASCII control characters (U+0000–U+001F) that are
@@ -641,47 +633,6 @@ def prepare_llm_messages(
     return messages
 
 
-def make_llm_completion(
-    llm: LLM,
-    messages: list[Message],
-    tools: list[ToolDefinition] | None = None,
-    on_token: ConversationTokenCallbackType | None = None,
-    call_context: LLMCallContext | None = None,
-) -> LLMResponse:
-    """Make an LLM completion call with the provided messages and tools.
-
-    Args:
-        llm: The LLM instance to use for completion
-        messages: The messages to send to the LLM
-        tools: Optional list of tools to provide to the LLM
-        on_token: Optional callback for streaming token updates
-        call_context: Per-conversation context for cache/session affinity.
-
-    Returns:
-        LLMResponse from the LLM completion call
-
-    Note:
-        Always exposes a 'security_risk' parameter in tool schemas via
-        add_security_risk_prediction=True. This ensures the schema remains
-        consistent, even if the security analyzer is disabled. Validation of
-        this field happens dynamically at runtime depending on the analyzer
-        configured. This allows weaker models to omit risk field and bypass
-        validation requirements when analyzer is disabled. For detailed logic,
-        see `_extract_security_risk` method in agent.py.
-
-        Summary field is always added to tool schemas for transparency and
-        explainability of agent actions.
-    """
-    return llm.generate(
-        messages=messages,
-        tools=tools or [],
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=on_token,
-        call_context=call_context,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Async variants
 # ---------------------------------------------------------------------------
@@ -715,21 +666,3 @@ async def aprepare_llm_messages(
         messages.extend(additional_messages)
 
     return messages
-
-
-async def amake_llm_completion(
-    llm: LLM,
-    messages: list[Message],
-    tools: list[ToolDefinition] | None = None,
-    on_token: AnyTokenCallbackType | None = None,
-    call_context: LLMCallContext | None = None,
-) -> LLMResponse:
-    """Async variant of :func:`make_llm_completion`."""
-    return await llm.agenerate(
-        messages=messages,
-        tools=tools or [],
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=on_token,
-        call_context=call_context,
-    )

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -672,24 +672,14 @@ def make_llm_completion(
         Summary field is always added to tool schemas for transparency and
         explainability of agent actions.
     """
-    if llm.uses_responses_api():
-        return llm.responses(
-            messages=messages,
-            tools=tools or [],
-            include=None,
-            store=False,
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
-    else:
-        return llm.completion(
-            messages=messages,
-            tools=tools or [],
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
+    return llm.generate(
+        messages=messages,
+        tools=tools or [],
+        store=False,
+        add_security_risk_prediction=True,
+        on_token=on_token,
+        call_context=call_context,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -735,21 +725,11 @@ async def amake_llm_completion(
     call_context: LLMCallContext | None = None,
 ) -> LLMResponse:
     """Async variant of :func:`make_llm_completion`."""
-    if llm.uses_responses_api():
-        return await llm.aresponses(
-            messages=messages,
-            tools=tools or [],
-            include=None,
-            store=False,
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
-    else:
-        return await llm.acompletion(
-            messages=messages,
-            tools=tools or [],
-            add_security_risk_prediction=True,
-            on_token=on_token,
-            call_context=call_context,
-        )
+    return await llm.agenerate(
+        messages=messages,
+        tools=tools or [],
+        store=False,
+        add_security_risk_prediction=True,
+        on_token=on_token,
+        call_context=call_context,
+    )

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -225,13 +225,8 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         # Do not pass extra_body explicitly. The LLM handles forwarding
         # litellm_extra_body only when it is non-empty.
-        from openhands.sdk.agent.utils import make_llm_completion
-
         try:
-            llm_response = make_llm_completion(
-                llm=self.llm,
-                messages=messages,
-            )
+            llm_response = self.llm.generate(messages=messages, store=False)
         except Exception as e:
             raise NoCondensationAvailableException(
                 f"Summarization LLM call failed: {e}"
@@ -423,13 +418,9 @@ class LLMSummarizingCondenser(RollingCondenser):
         )
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
-        from openhands.sdk.agent.utils import amake_llm_completion
 
         try:
-            llm_response = await amake_llm_completion(
-                llm=self.llm,
-                messages=messages,
-            )
+            llm_response = await self.llm.agenerate(messages=messages, store=False)
         except Exception as e:
             raise NoCondensationAvailableException(
                 f"Summarization LLM call failed: {e}"

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1626,8 +1626,7 @@ class LocalConversation(BaseConversation):
         thread an explicit ``call_context`` through the completion call
         (e.g. the condenser's dedicated LLM) still get correct per-
         conversation state.  The primary agent completion path threads
-        context explicitly via ``Agent.step()`` → ``make_llm_completion()``
-        → ``llm.completion(call_context=...)``.
+        context explicitly via ``Agent.step()`` → ``llm.generate(call_context=...)``.
 
         See #3443 for background.
         """
@@ -2859,7 +2858,7 @@ class LocalConversation(BaseConversation):
             return agent_response
 
         # Import here to avoid circular imports
-        from openhands.sdk.agent.utils import make_llm_completion, prepare_llm_messages
+        from openhands.sdk.agent.utils import prepare_llm_messages
 
         template_dir = (
             Path(__file__).parent.parent.parent / "context" / "prompts" / "templates"
@@ -2895,8 +2894,10 @@ class LocalConversation(BaseConversation):
             self.llm_registry.add(question_llm)
 
         # Pass agent tools so LLM can understand tool_calls in conversation history
-        response = make_llm_completion(
-            question_llm, messages, tools=list(self.agent.tools_map.values())
+        response = question_llm.generate(
+            messages=messages,
+            tools=list(self.agent.tools_map.values()),
+            store=False,
         )
 
         message = response.message

--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -126,12 +126,14 @@ def generate_title_with_llm(
             ),
         ]
 
-        # Force non-streaming: the title is consumed whole with no on_token
-        # callback, which a streaming LLM requires.
-        if llm.stream:
+        if llm.stream and not llm.requires_streaming:
             llm = llm.model_copy(update={"stream": False})
 
-        response = llm.completion(messages)
+        response = (
+            llm.responses(messages, store=False)
+            if llm.uses_responses_api()
+            else llm.completion(messages)
+        )
 
         # Extract the title from the response
         if response.message.content and isinstance(

--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -126,14 +126,7 @@ def generate_title_with_llm(
             ),
         ]
 
-        if llm.stream and not llm.requires_streaming:
-            llm = llm.model_copy(update={"stream": False})
-
-        response = (
-            llm.responses(messages, store=False)
-            if llm.uses_responses_api()
-            else llm.completion(messages)
-        )
+        response = llm.generate(messages, store=False)
 
         # Extract the title from the response
         if response.message.content and isinstance(

--- a/openhands-sdk/openhands/sdk/hooks/executor.py
+++ b/openhands-sdk/openhands/sdk/hooks/executor.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from openhands.sdk.agent.utils import make_llm_completion
 from openhands.sdk.conversation.visualizer import ConversationVisualizerBase
 from openhands.sdk.hooks.config import HookDefinition, HookType
 from openhands.sdk.hooks.types import HookDecision, HookEvent
@@ -359,7 +358,7 @@ class HookExecutor:
         ]
 
         try:
-            response = make_llm_completion(hook_llm, messages)
+            response = hook_llm.generate(messages=messages, store=False)
             raw = "\n".join(content_to_str(response.message.content))
         except Exception as e:
             logger.warning(

--- a/openhands-sdk/openhands/sdk/llm/cleanup_profile.py
+++ b/openhands-sdk/openhands/sdk/llm/cleanup_profile.py
@@ -127,12 +127,8 @@ def clean_outward_text(text: str, *, cipher: Cipher | None = None) -> str:
     if cleanup_llm is None:
         return text
 
-    # Imported lazily: ``agent.utils`` imports from ``openhands.sdk.llm``, so a
-    # module-level import here would create a circular import at package init.
-    from openhands.sdk.agent.utils import make_llm_completion
-
     try:
-        response = make_llm_completion(cleanup_llm, _cleanup_messages(text))
+        response = cleanup_llm.generate(messages=_cleanup_messages(text), store=False)
     except Exception as exc:
         logger.warning("Cleanup profile call failed; sending original text: %s", exc)
         return text
@@ -153,12 +149,10 @@ async def aclean_outward_text(text: str, *, cipher: Cipher | None = None) -> str
     if cleanup_llm is None:
         return text
 
-    # Imported lazily: ``agent.utils`` imports from ``openhands.sdk.llm``, so a
-    # module-level import here would create a circular import at package init.
-    from openhands.sdk.agent.utils import amake_llm_completion
-
     try:
-        response = await amake_llm_completion(cleanup_llm, _cleanup_messages(text))
+        response = await cleanup_llm.agenerate(
+            messages=_cleanup_messages(text), store=False
+        )
     except Exception as exc:
         logger.warning("Cleanup profile call failed; sending original text: %s", exc)
         return text

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1494,6 +1494,70 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
         return resp
 
+    def generate(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        include: list[str] | None = None,
+        store: bool | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: TokenCallbackType | None = None,
+        call_context: LLMCallContext | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        """Generate a response using the configured API mode."""
+        if self.uses_responses_api():
+            return self.responses(
+                messages=messages,
+                tools=tools,
+                include=include,
+                store=store,
+                add_security_risk_prediction=add_security_risk_prediction,
+                on_token=on_token,
+                call_context=call_context,
+                **kwargs,
+            )
+        return self.completion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            call_context=call_context,
+            **kwargs,
+        )
+
+    async def agenerate(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        include: list[str] | None = None,
+        store: bool | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: AnyTokenCallbackType | None = None,
+        call_context: LLMCallContext | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        """Async variant of :meth:`generate`."""
+        if self.uses_responses_api():
+            return await self.aresponses(
+                messages=messages,
+                tools=tools,
+                include=include,
+                store=store,
+                add_security_risk_prediction=add_security_risk_prediction,
+                on_token=on_token,
+                call_context=call_context,
+                **kwargs,
+            )
+        return await self.acompletion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            call_context=call_context,
+            **kwargs,
+        )
+
     # =========================================================================
     # Chat Completion API
     # =========================================================================

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -202,7 +202,7 @@ class LLMCallContext:
     """Per-conversation state threaded through the completion call chain.
 
     The primary path threads this explicitly:
-    ``Agent.step()`` → ``make_llm_completion()`` → ``llm.completion(call_context=...)``
+    ``Agent.step()`` → ``llm.generate(call_context=...)``
     → ``select_chat_options(call_context=...)``.
 
     A fallback copy is also stored as a ``PrivateAttr`` on :class:`LLM`

--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -251,26 +251,20 @@ class Telemetry(BaseModel):
         Single source of truth for both ``metrics`` and the span, so the trace
         and the app's cost cannot disagree about the buckets.
         """
-        cache_read = 0
-        p_details = getattr(usage, "prompt_tokens_details", None) or getattr(
-            usage, "input_tokens_details", None
-        )
-        if p_details is not None:
-            cache_read = int(getattr(p_details, "cached_tokens", 0) or 0)
-        # Kimi-K2-thinking populates usage.cached_tokens instead.
-        if not cache_read:
-            cache_read = int(getattr(usage, "cached_tokens", 0) or 0)
-        if not cache_read:
-            cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+        if isinstance(usage, Usage):
+            details = usage.prompt_tokens_details
+            if details is None:
+                return 0, 0
+            cache_write = (
+                details.cache_creation_tokens
+                if "cache_creation_tokens" in details.model_fields_set
+                else 0
+            )
+            return int(details.cached_tokens or 0), int(cache_write or 0)
 
-        # litellm mirrors this onto a private attr; the public one and the
-        # details dict are both populated on some provider shapes only.
-        cache_write = int(getattr(usage, "_cache_creation_input_tokens", 0) or 0)
-        if not cache_write:
-            cache_write = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
-        if not cache_write and p_details is not None:
-            cache_write = int(getattr(p_details, "cache_creation_tokens", 0) or 0)
-        return cache_read, cache_write
+        details = usage.input_tokens_details
+        cache_read = details.cached_tokens if details is not None else 0
+        return int(cache_read or 0), 0
 
     # ---------- Observability span ----------
     # These bracket one LLM call: ``on_request`` -> transport -> ``on_response``

--- a/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
@@ -246,9 +246,7 @@ class VisionInspectExecutor(ToolExecutor):
                 ],
             ),
         ]
-        from openhands.sdk.agent.utils import make_llm_completion
-
-        response = make_llm_completion(vision_llm, messages, tools=[])
+        response = vision_llm.generate(messages=messages, store=False)
         answer = next(
             (
                 content.text

--- a/openhands-tools/openhands/tools/ask_oracle/impl.py
+++ b/openhands-tools/openhands/tools/ask_oracle/impl.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-from openhands.sdk.agent.utils import make_llm_completion
 from openhands.sdk.llm import Message, TextContent
 from openhands.sdk.tool.tool import ToolExecutor
 from openhands.tools.ask_oracle.definition import (
@@ -96,7 +95,7 @@ class AskOracleExecutor(ToolExecutor[AskOracleAction, AskOracleObservation]):
         ]
 
         try:
-            llm_response = make_llm_completion(oracle_llm, messages)
+            llm_response = oracle_llm.generate(messages=messages, store=False)
         except Exception as exc:
             return AskOracleObservation.from_text(
                 text=(

--- a/scripts/check_forbidden_dynamic_attributes.py
+++ b/scripts/check_forbidden_dynamic_attributes.py
@@ -1,8 +1,9 @@
 """Reject new dynamic attribute access in SDK source files.
 
-Existing ``getattr``/``setattr`` calls are recorded in a committed baseline so
-the hook can be introduced before the cleanup work (tracked in #4903, #4904,
-#4905) is finished.  Only calls *not* present in the baseline are reported.
+Existing ``getattr``/``setattr`` and ``obj.__dict__.get`` calls are recorded
+in a committed baseline so the hook can be introduced before the cleanup work
+(tracked in #4903, #4904, #4905) is finished. Only calls *not* present in the
+baseline are reported.
 
 A violation is identified by its file path (relative to the repo root), the
 call name, and a hash of the full call source segment (not just the first
@@ -25,13 +26,28 @@ import argparse
 import ast
 import hashlib
 import json
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
 
 
 FORBIDDEN = {"getattr", "setattr"}
+DICT_GET = "__dict__.get"
 BASELINE_FILE = Path(__file__).with_name("forbidden_dynamic_attributes_baseline.json")
+
+
+def _forbidden_call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name) and node.func.id in FORBIDDEN:
+        return node.func.id
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "__dict__"
+    ):
+        return DICT_GET
+    return None
 
 
 def _segment_hash(source: str, node: ast.Call) -> str:
@@ -53,20 +69,43 @@ def violations(path: Path) -> list[tuple[int, str, str]]:
     tree = ast.parse(source, filename=str(path))
     result: list[tuple[int, str, str]] = []
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id in FORBIDDEN
-        ):
-            result.append((node.lineno, node.func.id, _segment_hash(source, node)))
+        if not isinstance(node, ast.Call):
+            continue
+        name = _forbidden_call_name(node)
+        if name is not None:
+            result.append((node.lineno, name, _segment_hash(source, node)))
     return result
 
 
-def _load_baseline() -> Counter[tuple[str, str, str]]:
+Baseline = Counter[tuple[str, str, str]]
+
+
+def _parse_baseline(content: str) -> Baseline:
+    data = json.loads(content)
+    return Counter((entry["file"], entry["name"], entry["hash"]) for entry in data)
+
+
+def _load_baseline() -> Baseline:
     if not BASELINE_FILE.exists():
         return Counter()
-    data = json.loads(BASELINE_FILE.read_text())
-    return Counter((entry["file"], entry["name"], entry["hash"]) for entry in data)
+    return _parse_baseline(BASELINE_FILE.read_text())
+
+
+def _load_baseline_from_git(ref: str) -> Baseline:
+    root = Path(__file__).resolve().parent.parent
+    relative_path = BASELINE_FILE.resolve().relative_to(root)
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{relative_path.as_posix()}"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _parse_baseline(result.stdout)
+
+
+def _baseline_additions(reference: Baseline, current: Baseline) -> Baseline:
+    return current - reference
 
 
 def _write_baseline(entries: list[tuple[str, str, str]]) -> None:
@@ -105,7 +144,25 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="Rewrite the baseline from the current violations and exit 0.",
     )
+    parser.add_argument(
+        "--baseline-ref",
+        help="Reject baseline entries not present at this Git reference.",
+    )
     args = parser.parse_args(argv)
+
+    if args.update_baseline and args.baseline_ref:
+        parser.error("--update-baseline cannot be combined with --baseline-ref")
+
+    if args.baseline_ref:
+        baseline = _load_baseline()
+        additions = _baseline_additions(
+            _load_baseline_from_git(args.baseline_ref), baseline
+        )
+        if additions:
+            for (file, name, _digest), count in sorted(additions.items()):
+                print(f"{file}: baseline adds {count} forbidden {name} allowance(s)")
+            print("error: the forbidden dynamic attributes baseline may only shrink")
+            return 1
 
     # When no paths are given (e.g. via pre-commit with pass_filenames: false),
     # auto-discover all SDK Python files so deletions are caught.

--- a/scripts/forbidden_dynamic_attributes_baseline.json
+++ b/scripts/forbidden_dynamic_attributes_baseline.json
@@ -387,17 +387,7 @@
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "47404691ad754f6d634e7663cdf0779890f4564efb5d7f832347c4761b5e5a11"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
         "hash": "5dc7e91a286b33029955a6749cd7bf00ce5065ef485585fe184f9c2a2e3d4717"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
-        "hash": "69e5e28543d27d551b8fa6322d51917f54fed9aa61f6f2ee608476736ad6c027"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
@@ -437,27 +427,12 @@
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "87bd2727ce5eef3fdf2a169d38b23a4615bed1edfacccf917f4e60d92e7dc6f0"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
         "hash": "a2f271f61f01e70e183a017e7b67de2171beff8bfefb09e604baaf48bb1f480f"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
         "name": "getattr",
-        "hash": "b6ac688d986e964a9a8cee6d47617e207a02740d7ae0648fb966eab33a048dc8"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
         "hash": "cb8eb6e82d059fb861a0bcc3820067d85b5dabb9ab199cf81186ec57d4d14f19"
-    },
-    {
-        "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",
-        "name": "getattr",
-        "hash": "cce9dbfcf2e3c10a5b17bbe043532e50bf7cbb4e0f6372fe808869daed684e77"
     },
     {
         "file": "openhands-sdk/openhands/sdk/llm/utils/telemetry.py",

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -3426,7 +3426,7 @@ class TestAutoTitle:
         """End-to-end: profile on disk → LLMProfileStore.load → title LLM call.
 
         Exercises the real wiring from AutoTitleSubscriber through LLMProfileStore
-        to LLM.completion. Only the network boundary (LLM.completion) is mocked,
+        to LLM.generate. Only the generic dispatch boundary (LLM.generate) is mocked,
         so this catches regressions in profile loading, LLM passthrough, and the
         agent-server → SDK integration — the unit tests above only exercise
         AutoTitleSubscriber in isolation.
@@ -3457,7 +3457,7 @@ class TestAutoTitle:
 
         calls: list[str] = []
 
-        def fake_completion(self_llm, _messages, **_kwargs):
+        def fake_generate(self_llm, _messages, **_kwargs):
             calls.append(self_llm.usage_id)
             msg = LiteLLMMessage(content="✨ Generated", role="assistant")
             choice = Choices(finish_reason="stop", index=0, message=msg)
@@ -3492,9 +3492,9 @@ class TestAutoTitle:
         request.addfinalizer(reset_stores)
 
         with patch(
-            "openhands.sdk.llm.llm.LLM.completion",
+            "openhands.sdk.llm.llm.LLM.generate",
             autospec=True,
-            side_effect=fake_completion,
+            side_effect=fake_generate,
         ):
             subscriber = AutoTitleSubscriber(service=service)
             await subscriber(self._user_message_event("Fix the login bug"))
@@ -3552,7 +3552,7 @@ class TestAutoTitle:
 
         seen_keys: list[str] = []
 
-        def fake_completion(self_llm, _messages, **_kwargs):
+        def fake_generate(self_llm, _messages, **_kwargs):
             seen_keys.append(
                 self_llm.api_key.get_secret_value() if self_llm.api_key else ""
             )
@@ -3586,9 +3586,9 @@ class TestAutoTitle:
         request.addfinalizer(reset_stores)
 
         with patch(
-            "openhands.sdk.llm.llm.LLM.completion",
+            "openhands.sdk.llm.llm.LLM.generate",
             autospec=True,
-            side_effect=fake_completion,
+            side_effect=fake_generate,
         ):
             subscriber = AutoTitleSubscriber(service=service)
             await subscriber(self._user_message_event("Fix the login bug"))

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1770,7 +1770,7 @@ def test_validate_profile_responses_api(client):
 
     Regression: the endpoint must route through ``aresponses`` for profiles
     where ``uses_responses_api()`` is true, matching the runtime dispatch used
-    by real conversations (`amake_llm_completion`) — otherwise preflight would
+    by real conversations (`LLM.agenerate`) — otherwise preflight would
     validate a different path than the server actually calls.
     """
     from unittest.mock import MagicMock

--- a/tests/cross/test_check_forbidden_dynamic_attributes.py
+++ b/tests/cross/test_check_forbidden_dynamic_attributes.py
@@ -124,6 +124,20 @@ def test_setattr_also_detected(checker, tmp_path: Path):
     assert checker.main([str(f)]) == 1
 
 
+def test_dunder_dict_get_also_detected(checker, tmp_path: Path):
+    """Direct instance dictionary lookup is also forbidden."""
+    f = _write_py(tmp_path / "dict_get.py", 'value = obj.__dict__.get("attr")\n')
+
+    assert checker.main([str(f)]) == 1
+
+
+def test_regular_dict_get_is_allowed(checker, tmp_path: Path):
+    """Ordinary mapping access is not dynamic attribute access."""
+    f = _write_py(tmp_path / "dict_get.py", 'value = data.get("key")\n')
+
+    assert checker.main([str(f)]) == 0
+
+
 def test_deleted_baselined_file_is_stale(checker, tmp_path: Path):
     """Deleting a baselined file must be caught even when checking other files.
 
@@ -154,3 +168,68 @@ def test_multiline_arg_change_is_caught(checker, tmp_path: Path):
     # Change the argument on a subsequent line — same first line, different call.
     _write_py(f, "v = getattr(\n    obj,\n    'other',\n)\n")
     assert checker.main([str(f)]) == 1
+
+
+def test_baseline_addition_is_rejected(checker):
+    """A baseline may never gain a new allowance."""
+    reference = checker.Counter({("a.py", "getattr", "old"): 1})
+    current = checker.Counter(
+        {
+            ("a.py", "getattr", "old"): 1,
+            ("b.py", "setattr", "new"): 1,
+        }
+    )
+
+    assert checker._baseline_additions(reference, current) == checker.Counter(
+        {("b.py", "setattr", "new"): 1}
+    )
+
+
+def test_baseline_removal_is_allowed(checker):
+    """Deleting an existing allowance preserves baseline monotonicity."""
+    reference = checker.Counter(
+        {
+            ("a.py", "getattr", "old"): 1,
+            ("b.py", "setattr", "removed"): 1,
+        }
+    )
+    current = checker.Counter({("a.py", "getattr", "old"): 1})
+
+    assert not checker._baseline_additions(reference, current)
+
+
+def test_duplicate_baseline_addition_is_rejected(checker):
+    """Increasing an existing allowance's multiplicity is also an addition."""
+    key = ("a.py", "getattr", "same")
+
+    assert checker._baseline_additions(
+        checker.Counter({key: 1}), checker.Counter({key: 2})
+    ) == checker.Counter({key: 1})
+
+
+def test_baseline_ref_option_rejects_addition(checker, tmp_path: Path, monkeypatch):
+    """The CLI guard fails before accepting an expanded baseline."""
+    key = ("added.py", "getattr", "new")
+    checker.BASELINE_FILE.write_text(
+        json.dumps([{"file": key[0], "name": key[1], "hash": key[2]}])
+    )
+    monkeypatch.setattr(
+        checker, "_load_baseline_from_git", lambda _ref: checker.Counter()
+    )
+    clean = _write_py(tmp_path / "clean.py", "x = 1\n")
+
+    assert checker.main([str(clean), "--baseline-ref", "base-sha"]) == 1
+
+
+def test_baseline_ref_option_allows_removal(checker, tmp_path: Path, monkeypatch):
+    """The CLI guard permits a baseline that is a strict subset."""
+    removed = ("removed.py", "getattr", "old")
+    checker.BASELINE_FILE.write_text("[]\n")
+    monkeypatch.setattr(
+        checker,
+        "_load_baseline_from_git",
+        lambda _ref: checker.Counter({removed: 1}),
+    )
+    clean = _write_py(tmp_path / "clean.py", "x = 1\n")
+
+    assert checker.main([str(clean), "--baseline-ref", "base-sha"]) == 0

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -1842,10 +1842,16 @@ def test_hook_config_sent_to_server(
         from openhands.sdk.llm.message import Message
         from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 
-        call_count["count"] += 1
+        is_title_call = not tools
+        if not is_title_call:
+            call_count["count"] += 1
 
-        # First call: return finish tool call (triggers PostToolUse and Stop hooks)
-        if call_count["count"] == 1:
+        if is_title_call:
+            litellm_msg = LiteLLMMessage.model_validate(
+                {"role": "assistant", "content": "Generated title"}
+            )
+        # First agent call triggers PostToolUse and Stop hooks.
+        elif call_count["count"] == 1:
             litellm_msg = LiteLLMMessage.model_validate(
                 {
                     "role": "assistant",
@@ -2060,9 +2066,15 @@ def test_agent_final_response_endpoint(server_env, monkeypatch: pytest.MonkeyPat
         from openhands.sdk.llm.message import Message
         from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 
-        call_count["count"] += 1
+        is_title_call = not tools
+        if not is_title_call:
+            call_count["count"] += 1
 
-        if call_count["count"] == 1:
+        if is_title_call:
+            litellm_msg = LiteLLMMessage.model_validate(
+                {"role": "assistant", "content": "Generated title"}
+            )
+        elif call_count["count"] == 1:
             litellm_msg = LiteLLMMessage.model_validate(
                 {
                     "role": "assistant",
@@ -2197,8 +2209,15 @@ def test_remote_state_exposes_invoked_skills(
         from openhands.sdk.llm.message import Message
         from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 
-        call_count["count"] += 1
-        if call_count["count"] == 1:
+        is_title_call = not tools
+        if not is_title_call:
+            call_count["count"] += 1
+
+        if is_title_call:
+            litellm_msg = LiteLLMMessage.model_validate(
+                {"role": "assistant", "content": "Generated title"}
+            )
+        elif call_count["count"] == 1:
             litellm_msg = LiteLLMMessage.model_validate(
                 {
                     "role": "assistant",

--- a/tests/sdk/agent/test_agent_step_responses_gating.py
+++ b/tests/sdk/agent/test_agent_step_responses_gating.py
@@ -13,6 +13,7 @@ from openhands.sdk.llm.utils.metrics import MetricsSnapshot, TokenUsage
 
 class DummyLLM(LLM):
     _calls: list[str] = PrivateAttr(default_factory=list)
+    _call_kwargs: list[dict] = PrivateAttr(default_factory=list)
     _force_responses: bool = PrivateAttr(default=False)
 
     def __init__(self, *, model: str, force_responses: bool):
@@ -25,6 +26,7 @@ class DummyLLM(LLM):
     # Minimal stubs; not actually invoking providers
     def completion(self, *, messages, tools=None, **kwargs) -> LLMResponse:  # type: ignore[override]
         self._calls.append("completion")
+        self._call_kwargs.append(kwargs)
         # Return an assistant message with no tool calls to end the step
         return LLMResponse(
             message=Message(role="assistant", content=[]),
@@ -39,6 +41,7 @@ class DummyLLM(LLM):
 
     def responses(self, *, messages, tools=None, **kwargs) -> LLMResponse:  # type: ignore[override]
         self._calls.append("responses")
+        self._call_kwargs.append(kwargs)
         return LLMResponse(
             message=Message(role="assistant", content=[]),
             metrics=MetricsSnapshot(
@@ -76,6 +79,14 @@ def test_agent_step_routes_to_responses_or_completion(force_responses, expected)
     agent.step(convo, on_event=on_event)
 
     assert llm._calls == [expected]
+    assert llm._call_kwargs == [
+        {
+            "add_security_risk_prediction": True,
+            "on_token": None,
+            "call_context": convo.get_llm_call_context(),
+            **({"include": None, "store": False} if force_responses else {}),
+        }
+    ]
     assert any(isinstance(e, MessageEvent) for e in events)
 
 

--- a/tests/sdk/agent/test_agent_utils.py
+++ b/tests/sdk/agent/test_agent_utils.py
@@ -1,37 +1,19 @@
-"""Tests for agent utility functions.
-
-This module tests the prepare_llm_messages and make_llm_completion utility
-functions that are used by the agent for message preparation and LLM calls.
-"""
+"""Tests for agent message preparation utilities."""
 
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import Field
 
-from openhands.sdk.agent.utils import (
-    amake_llm_completion,
-    make_llm_completion,
-    prepare_llm_messages,
-)
+from openhands.sdk.agent.utils import prepare_llm_messages
 from openhands.sdk.context.condenser.base import CondenserBase
 from openhands.sdk.context.view import View
 from openhands.sdk.event import Condensation, MessageEvent
-from openhands.sdk.llm import LLM, LLMResponse, Message, TextContent
-from openhands.sdk.tool import Action, Observation, ToolDefinition
+from openhands.sdk.llm import Message, TextContent
 
 
 # ---------------------------------------------------------------------------
 # Test fixtures and helpers
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def mock_llm():
-    """Create a mock LLM for testing."""
-    llm = Mock(spec=LLM)
-    llm.uses_responses_api.return_value = False
-    return llm
 
 
 @pytest.fixture
@@ -85,44 +67,6 @@ def sample_messages():
 def mock_condenser():
     """Create a mock condenser for testing."""
     return Mock(spec=CondenserBase)
-
-
-class MockAgentUtilsAction(Action):
-    """Mock action for agent utils testing."""
-
-    param1: str = Field(description="First parameter")
-
-
-class MockAgentUtilsObservation(Observation):
-    """Mock observation for agent utils testing."""
-
-    result: str = Field(description="Result of the action")
-
-    @property
-    def to_llm_content(self):
-        return [TextContent(text=self.result)]
-
-
-class MockAgentUtilsTool(
-    ToolDefinition[MockAgentUtilsAction, MockAgentUtilsObservation]
-):
-    """Mock tool definition for agent utils testing."""
-
-    @classmethod
-    def create(cls, conv_state=None, **params):
-        return [cls(**params)]
-
-
-@pytest.fixture
-def sample_tools():
-    """Create sample tool definitions for testing."""
-    return [
-        MockAgentUtilsTool(
-            description="A test tool for agent utils",
-            action_type=MockAgentUtilsAction,
-            observation_type=MockAgentUtilsObservation,
-        )
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -253,85 +197,4 @@ def test_prepare_llm_messages_does_not_rebuild_view(monkeypatch, sample_events) 
     )
     assert enforce_calls == 0, (
         "prepare_llm_messages must not call enforce_properties on the hot path"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Tests for make_llm_completion
-# ---------------------------------------------------------------------------
-
-
-def test_make_llm_completion_applies_agent_policy(
-    mock_llm, sample_messages, sample_tools
-):
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.generate.return_value = mock_response
-
-    result = make_llm_completion(mock_llm, sample_messages, tools=sample_tools)
-
-    assert result == mock_response
-    mock_llm.generate.assert_called_once_with(
-        messages=sample_messages,
-        tools=sample_tools,
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-def test_make_llm_completion_normalizes_missing_tools(mock_llm, sample_messages):
-    make_llm_completion(mock_llm, sample_messages)
-
-    assert mock_llm.generate.call_args.kwargs["tools"] == []
-
-
-@pytest.mark.asyncio
-async def test_amake_llm_completion_applies_agent_policy(
-    mock_llm, sample_messages, sample_tools
-):
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.agenerate.return_value = mock_response
-
-    result = await amake_llm_completion(mock_llm, sample_messages, tools=sample_tools)
-
-    assert result == mock_response
-    mock_llm.agenerate.assert_awaited_once_with(
-        messages=sample_messages,
-        tools=sample_tools,
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Integration tests
-# ---------------------------------------------------------------------------
-
-
-@patch("openhands.sdk.event.base.LLMConvertibleEvent.events_to_messages")
-def test_prepare_llm_messages_and_make_llm_completion_integration(
-    mock_events_to_messages, sample_events, sample_messages, mock_llm
-):
-    """Test integration between prepare_llm_messages and make_llm_completion."""
-    mock_events_to_messages.return_value = sample_messages
-    view = View(events=sample_events)
-
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.generate.return_value = mock_response
-
-    messages = prepare_llm_messages(view)
-    result = make_llm_completion(mock_llm, messages)
-
-    assert messages == sample_messages
-    assert result == mock_response
-    mock_llm.generate.assert_called_once_with(
-        messages=sample_messages,
-        tools=[],
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
     )

--- a/tests/sdk/agent/test_agent_utils.py
+++ b/tests/sdk/agent/test_agent_utils.py
@@ -9,7 +9,11 @@ from unittest.mock import Mock, patch
 import pytest
 from pydantic import Field
 
-from openhands.sdk.agent.utils import make_llm_completion, prepare_llm_messages
+from openhands.sdk.agent.utils import (
+    amake_llm_completion,
+    make_llm_completion,
+    prepare_llm_messages,
+)
 from openhands.sdk.context.condenser.base import CondenserBase
 from openhands.sdk.context.view import View
 from openhands.sdk.event import Condensation, MessageEvent
@@ -257,97 +261,18 @@ def test_prepare_llm_messages_does_not_rebuild_view(monkeypatch, sample_events) 
 # ---------------------------------------------------------------------------
 
 
-def test_make_llm_completion_with_completion_api(mock_llm, sample_messages):
-    """Test make_llm_completion using completion API."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = False
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
-
-    # Call function
-    result = make_llm_completion(mock_llm, sample_messages)
-
-    # Verify results
-    assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.completion.assert_called_once_with(
-        messages=sample_messages,
-        tools=[],
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-    mock_llm.responses.assert_not_called()
-
-
-def test_make_llm_completion_with_responses_api(mock_llm, sample_messages):
-    """Test make_llm_completion using responses API."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = True
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.responses.return_value = mock_response
-
-    # Call function
-    result = make_llm_completion(mock_llm, sample_messages)
-
-    # Verify results
-    assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.responses.assert_called_once_with(
-        messages=sample_messages,
-        tools=[],
-        include=None,
-        store=False,
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-    mock_llm.completion.assert_not_called()
-
-
-def test_make_llm_completion_with_tools_completion_api(
+def test_make_llm_completion_applies_agent_policy(
     mock_llm, sample_messages, sample_tools
 ):
-    """Test make_llm_completion with tools using completion API."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = False
     mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
+    mock_llm.generate.return_value = mock_response
 
-    # Call function
     result = make_llm_completion(mock_llm, sample_messages, tools=sample_tools)
 
-    # Verify results
     assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.completion.assert_called_once_with(
+    mock_llm.generate.assert_called_once_with(
         messages=sample_messages,
         tools=sample_tools,
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-def test_make_llm_completion_with_tools_responses_api(
-    mock_llm, sample_messages, sample_tools
-):
-    """Test make_llm_completion with tools using responses API."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = True
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.responses.return_value = mock_response
-
-    # Call function
-    result = make_llm_completion(mock_llm, sample_messages, tools=sample_tools)
-
-    # Verify results
-    assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.responses.assert_called_once_with(
-        messages=sample_messages,
-        tools=sample_tools,
-        include=None,
         store=False,
         add_security_risk_prediction=True,
         on_token=None,
@@ -355,63 +280,26 @@ def test_make_llm_completion_with_tools_responses_api(
     )
 
 
-def test_make_llm_completion_with_none_tools(mock_llm, sample_messages):
-    """Test make_llm_completion with None tools parameter."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = False
+def test_make_llm_completion_normalizes_missing_tools(mock_llm, sample_messages):
+    make_llm_completion(mock_llm, sample_messages)
+
+    assert mock_llm.generate.call_args.kwargs["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_amake_llm_completion_applies_agent_policy(
+    mock_llm, sample_messages, sample_tools
+):
     mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
+    mock_llm.agenerate.return_value = mock_response
 
-    # Call function
-    result = make_llm_completion(mock_llm, sample_messages, tools=None)
+    result = await amake_llm_completion(mock_llm, sample_messages, tools=sample_tools)
 
-    # Verify results
     assert result == mock_response
-    mock_llm.completion.assert_called_once_with(
+    mock_llm.agenerate.assert_awaited_once_with(
         messages=sample_messages,
-        tools=[],
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-def test_make_llm_completion_with_empty_tools_list(mock_llm, sample_messages):
-    """Test make_llm_completion with empty tools list."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = False
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
-
-    # Call function
-    result = make_llm_completion(mock_llm, sample_messages, tools=[])
-
-    # Verify results
-    assert result == mock_response
-    mock_llm.completion.assert_called_once_with(
-        messages=sample_messages,
-        tools=[],
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-def test_make_llm_completion_empty_messages(mock_llm):
-    """Test make_llm_completion with empty messages list."""
-    # Setup mock
-    mock_llm.uses_responses_api.return_value = False
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
-
-    # Call function
-    result = make_llm_completion(mock_llm, [])
-
-    # Verify results
-    assert result == mock_response
-    mock_llm.completion.assert_called_once_with(
-        messages=[],
-        tools=[],
+        tools=sample_tools,
+        store=False,
         add_security_risk_prediction=True,
         on_token=None,
         call_context=None,
@@ -431,71 +319,19 @@ def test_prepare_llm_messages_and_make_llm_completion_integration(
     mock_events_to_messages.return_value = sample_messages
     view = View(events=sample_events)
 
-    # Setup mocks for make_llm_completion
-    mock_llm.uses_responses_api.return_value = False
     mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
+    mock_llm.generate.return_value = mock_response
 
-    # Call functions in sequence (simulating real usage)
     messages = prepare_llm_messages(view)
     result = make_llm_completion(mock_llm, messages)
 
-    # Verify results
     assert messages == sample_messages
     assert result == mock_response
-    mock_llm.completion.assert_called_once_with(
+    mock_llm.generate.assert_called_once_with(
         messages=sample_messages,
         tools=[],
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-
-
-def test_make_llm_completion_api_selection():
-    """Test that make_llm_completion correctly selects between completion and responses APIs."""  # noqa: E501
-    # Test completion API selection
-    mock_llm = Mock(spec=LLM)
-    mock_llm.uses_responses_api.return_value = False
-    mock_response = Mock(spec=LLMResponse)
-    mock_llm.completion.return_value = mock_response
-
-    messages = [
-        Message(
-            role="user",
-            content=[TextContent(text="Hello, test message")],
-        )
-    ]
-
-    result = make_llm_completion(mock_llm, messages)
-
-    assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.completion.assert_called_once_with(
-        messages=messages,
-        tools=[],
-        add_security_risk_prediction=True,
-        on_token=None,
-        call_context=None,
-    )
-    mock_llm.responses.assert_not_called()
-
-    # Reset mocks and test responses API selection
-    mock_llm.reset_mock()
-    mock_llm.uses_responses_api.return_value = True
-    mock_llm.responses.return_value = mock_response
-
-    result = make_llm_completion(mock_llm, messages)
-
-    assert result == mock_response
-    mock_llm.uses_responses_api.assert_called_once()
-    mock_llm.responses.assert_called_once_with(
-        messages=messages,
-        tools=[],
-        include=None,
         store=False,
         add_security_risk_prediction=True,
         on_token=None,
         call_context=None,
     )
-    mock_llm.completion.assert_not_called()

--- a/tests/sdk/agent/test_message_during_streaming_arun.py
+++ b/tests/sdk/agent/test_message_during_streaming_arun.py
@@ -67,7 +67,7 @@ class _InjectingAsyncLLM(LLM):
     def __init__(self):
         super().__init__(model=MODEL, usage_id="test-llm")
 
-    def uses_responses_api(self) -> bool:  # keep amake_llm_completion on acompletion
+    def uses_responses_api(self) -> bool:  # keep agenerate on acompletion
         return False
 
     async def acompletion(self, *, messages, tools=None, **kwargs):  # type: ignore[override]

--- a/tests/sdk/agent/test_stream_context.py
+++ b/tests/sdk/agent/test_stream_context.py
@@ -39,9 +39,9 @@ def _chunk(
     delta_kwargs: dict = {"role": "assistant"}
     if content is not None:
         delta_kwargs["content"] = content
-    delta = Delta(**delta_kwargs)
     if reasoning_content is not None:
-        object.__setattr__(delta, "reasoning_content", reasoning_content)
+        delta_kwargs["reasoning_content"] = reasoning_content
+    delta = Delta(**delta_kwargs)
     choice = StreamingChoices(delta=delta, index=index, finish_reason=None)
     return ModelResponseStream(id=chunk_id, choices=[choice], model="test-model")
 

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -57,10 +57,10 @@ def mock_llm() -> LLM:
         raw_response.id = "mock-llm-response-id"
         return LLMResponse(message=message, metrics=metrics, raw_response=raw_response)
 
-    mock_llm.completion.return_value = create_completion_result(
+    mock_llm.generate.return_value = create_completion_result(
         "Summary of forgotten events"
     )
-    mock_llm.acompletion = AsyncMock(return_value=mock_llm.completion.return_value)
+    mock_llm.agenerate = AsyncMock(return_value=mock_llm.generate.return_value)
     mock_llm.uses_responses_api = lambda: False
     mock_llm.requires_streaming = False
     mock_llm.format_messages_for_llm = lambda messages: messages
@@ -99,8 +99,8 @@ def mock_llm() -> LLM:
     # Helper method to set mock response content
     def set_mock_response_content(content: str):
         result = create_completion_result(content)
-        mock_llm.completion.return_value = result
-        mock_llm.acompletion = AsyncMock(return_value=result)
+        mock_llm.generate.return_value = result
+        mock_llm.agenerate = AsyncMock(return_value=result)
 
     mock_llm.set_mock_response_content = set_mock_response_content
 
@@ -156,7 +156,7 @@ def test_condense_returns_view_when_no_condensation_needed(mock_llm: LLM) -> Non
     assert isinstance(result, View)
     assert result == view
     # LLM should not be called
-    cast(MagicMock, mock_llm.completion).assert_not_called()
+    cast(MagicMock, mock_llm.generate).assert_not_called()
 
 
 def test_condense_returns_condensation_when_needed(mock_llm: LLM) -> None:
@@ -185,24 +185,7 @@ def test_condense_returns_condensation_when_needed(mock_llm: LLM) -> None:
     assert len(result.forgotten_event_ids) > 0
 
     # LLM should be called once
-    cast(MagicMock, mock_llm.completion).assert_called_once()
-
-
-def test_condense_uses_responses_api_when_required(mock_llm: LLM) -> None:
-    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=3)
-    cast(Any, mock_llm).set_mock_response_content("Summary from responses")
-    mock_llm.uses_responses_api = lambda: True
-    cast(Any, mock_llm.responses).return_value = cast(
-        Any, mock_llm.completion
-    ).return_value
-
-    view = View.from_events([message_event(f"Event {i}") for i in range(11)])
-    result = condenser.condense(view)
-
-    assert isinstance(result, Condensation)
-    assert result.summary == "Summary from responses"
-    cast(MagicMock, mock_llm.responses).assert_called_once()
-    cast(MagicMock, mock_llm.completion).assert_not_called()
+    cast(MagicMock, mock_llm.generate).assert_called_once()
 
 
 def test_get_condensation_with_previous_summary(mock_llm: LLM) -> None:
@@ -243,7 +226,7 @@ def test_get_condensation_with_previous_summary(mock_llm: LLM) -> None:
     assert result.summary == "Updated summary"
 
     # Verify that the LLM was called with the previous summary
-    completion_mock = cast(MagicMock, mock_llm.completion)
+    completion_mock = cast(MagicMock, mock_llm.generate)
     completion_mock.assert_called_once()
     call_args = completion_mock.call_args
     messages = call_args[1]["messages"]  # Get keyword arguments
@@ -273,7 +256,7 @@ def test_invalid_config(mock_llm: LLM) -> None:
 
 
 def test_get_condensation_does_not_pass_extra_body(mock_llm: LLM) -> None:
-    """Condenser should not pass extra_body to llm.completion.
+    """Condenser should not pass extra_body to llm.generate.
 
     This prevents providers like 1p Anthropic from rejecting the request with
     "extra_body: Extra inputs are not permitted".
@@ -288,7 +271,7 @@ def test_get_condensation_does_not_pass_extra_body(mock_llm: LLM) -> None:
     assert isinstance(result, Condensation)
 
     # Ensure completion was called without an explicit extra_body kwarg
-    completion_mock = cast(MagicMock, mock_llm.completion)
+    completion_mock = cast(MagicMock, mock_llm.generate)
     assert completion_mock.call_count == 1
 
 
@@ -310,11 +293,11 @@ def test_condense_with_agent_llm(mock_llm: LLM) -> None:
     assert isinstance(result, Condensation)
 
     # Verify the condenser still uses its own LLM for summarization
-    completion_mock = cast(MagicMock, mock_llm.completion)
+    completion_mock = cast(MagicMock, mock_llm.generate)
     assert completion_mock.call_count == 1
 
     # Agent LLM should not be called for completion (condenser uses its own LLM)
-    assert not agent_llm.completion.called
+    assert not agent_llm.generate.called
     _, kwargs = completion_mock.call_args
     assert "extra_body" not in kwargs
 
@@ -362,7 +345,7 @@ def test_condense_with_token_limit_exceeded(mock_llm: LLM) -> None:
     assert isinstance(result, Condensation)
 
     # Verify the condenser used its own LLM for summarization
-    completion_mock = cast(MagicMock, mock_llm.completion)
+    completion_mock = cast(MagicMock, mock_llm.generate)
     assert completion_mock.call_count == 1
 
     # Verify forgotten events were calculated based on token reduction
@@ -614,7 +597,7 @@ def test_condense_with_all_three_reasons(mock_llm: LLM) -> None:
     assert len(result.forgotten_event_ids) > 0
 
     # Verify the condenser used its own LLM for summarization
-    completion_mock = cast(MagicMock, mock_llm.completion)
+    completion_mock = cast(MagicMock, mock_llm.generate)
     assert completion_mock.call_count == 1
 
 
@@ -673,7 +656,7 @@ def test_generate_condensation_raises_on_zero_events(mock_llm: LLM) -> None:
         )
 
     # Verify the LLM was never called
-    cast(MagicMock, mock_llm.completion).assert_not_called()
+    cast(MagicMock, mock_llm.generate).assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -825,7 +808,7 @@ def test_condense_with_soft_requirement_and_no_condensation_available(
         assert isinstance(result, View)
         assert result == view
         # LLM should not be called
-        cast(MagicMock, mock_llm.completion).assert_not_called()
+        cast(MagicMock, mock_llm.generate).assert_not_called()
 
 
 def test_minimum_progress_default_value(mock_llm: LLM) -> None:
@@ -917,7 +900,7 @@ def test_generate_condensation_wraps_llm_errors(mock_llm: LLM) -> None:
     """LLM failures in _generate_condensation raise NoCondensationAvailableException."""  # noqa: E501
     condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=2)
 
-    cast(MagicMock, mock_llm.completion).side_effect = RuntimeError("boom")
+    cast(MagicMock, mock_llm.generate).side_effect = RuntimeError("boom")
 
     events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
     view = View.from_events(events)
@@ -931,7 +914,7 @@ async def test_agenerate_condensation_wraps_llm_errors(mock_llm: LLM) -> None:
     """Async variant: LLM failures surface as NoCondensationAvailableException."""
     condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=2)
 
-    cast(MagicMock, mock_llm.acompletion).side_effect = RuntimeError("boom")
+    cast(MagicMock, mock_llm.agenerate).side_effect = RuntimeError("boom")
 
     events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
     view = View.from_events(events)
@@ -951,8 +934,8 @@ def test_llm_error_triggers_hard_context_reset(mock_llm: LLM) -> None:
 
     # First call (get_condensation path) fails; second call
     # (hard_context_reset path) succeeds.
-    success_response = cast(Any, mock_llm).completion.return_value
-    cast(MagicMock, mock_llm.completion).side_effect = [
+    success_response = cast(Any, mock_llm).generate.return_value
+    cast(MagicMock, mock_llm.generate).side_effect = [
         RuntimeError("context window exceeded"),
         success_response,
     ]
@@ -961,7 +944,7 @@ def test_llm_error_triggers_hard_context_reset(mock_llm: LLM) -> None:
 
     assert isinstance(result, Condensation)
     assert result.summary == "Summary of forgotten events"
-    assert cast(MagicMock, mock_llm.completion).call_count == 2
+    assert cast(MagicMock, mock_llm.generate).call_count == 2
 
 
 def _streaming_llm() -> LLM:

--- a/tests/sdk/conversation/test_generate_title.py
+++ b/tests/sdk/conversation/test_generate_title.py
@@ -1,5 +1,9 @@
 """Tests for the generate_title method in Conversation class."""
 
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +17,8 @@ from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.title_utils import generate_title_with_llm
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import LLM, LLMResponse, Message, MetricsSnapshot, TextContent
+from openhands.sdk.llm.auth.credentials import CredentialStore, OAuthCredentials
+from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
 
 
 def create_test_agent() -> Agent:
@@ -287,3 +293,138 @@ def test_generate_title_disables_streaming_when_llm_streams(mock_transport):
     assert mock_transport.call_args.kwargs["enable_streaming"] is False
     assert mock_transport.call_args.kwargs["on_token"] is None
     assert streaming_llm.stream is True
+
+
+@pytest.fixture
+def title_http_server():
+    requests = []
+    title = "Fix title transport"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append((self.path, body))
+            if self.path == "/v1/responses":
+                response = {
+                    "id": "resp_title",
+                    "object": "response",
+                    "created_at": 1,
+                    "status": "completed",
+                    "model": "gpt-5.6-luna",
+                    "output": [
+                        {
+                            "id": "msg_title",
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": title,
+                                    "annotations": [],
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 4,
+                        "total_tokens": 14,
+                    },
+                }
+                if body.get("stream"):
+                    payload = (
+                        "event: response.completed\ndata: "
+                        + json.dumps(
+                            {
+                                "type": "response.completed",
+                                "sequence_number": 1,
+                                "response": response,
+                            }
+                        )
+                        + "\n\n"
+                    ).encode()
+                    content_type = "text/event-stream"
+                else:
+                    payload = json.dumps(response).encode()
+                    content_type = "application/json"
+            else:
+                payload = json.dumps(
+                    {
+                        "id": "chat_title",
+                        "object": "chat.completion",
+                        "created": 1,
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "finish_reason": "stop",
+                                "message": {"role": "assistant", "content": title},
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 4,
+                            "total_tokens": 14,
+                        },
+                    }
+                ).encode()
+                content_type = "application/json"
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("mode", ["chat", "responses", "subscription"])
+def test_title_uses_real_http_transport(title_http_server, tmp_path, mode):
+    base_url, requests = title_http_server
+    if mode == "subscription":
+        auth = OpenAISubscriptionAuth(
+            credential_store=CredentialStore(tmp_path / "auth")
+        )
+        llm = auth.create_llm(
+            model="gpt-5.6-luna",
+            credentials=OAuthCredentials(
+                vendor="openai",
+                access_token="local-test-token",
+                refresh_token="unused-test-token",
+                expires_at=int(time.time() * 1000) + 3600000,
+            ),
+        )
+        llm = llm.model_copy(update={"base_url": base_url, "num_retries": 0})
+    else:
+        llm = LLM(
+            model="openai/gpt-4o-mini",
+            api_key=SecretStr("local-test-key"),
+            base_url=base_url,
+            api_mode=mode,
+            stream=True,
+            num_retries=0,
+        )
+    errors = []
+    assert (
+        generate_title_with_llm("Fix the title", llm, on_error=errors.append)
+        == "Fix title transport"
+    )
+    assert not errors
+    assert len(requests) == 1
+    path, body = requests[0]
+    assert path == ("/v1/chat/completions" if mode == "chat" else "/v1/responses")
+    assert bool(body.get("stream")) == (mode == "subscription")
+    if mode != "chat":
+        assert body["store"] is False

--- a/tests/sdk/llm/test_cleanup_profile.py
+++ b/tests/sdk/llm/test_cleanup_profile.py
@@ -103,7 +103,7 @@ def test_returns_cleaned_text_from_cleanup_profile(
     assert result == "Done! I appreciate the nudge."
     # Stateless call: only a system + user message, no tools, no history.
     assert [message.role for message in cleanup_llm.last_messages] == ["system", "user"]
-    assert cleanup_llm.last_tools == []
+    assert cleanup_llm.last_tools is None
     assert "repair" in _message_text(cleanup_llm.last_messages[0]).lower()
     assert original in _message_text(cleanup_llm.last_messages[1])
 

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from litellm.exceptions import (
@@ -42,6 +42,77 @@ def test_llm_init_with_default_config(default_llm):
     )
     assert isinstance(default_llm.metrics, Metrics)
     assert default_llm.metrics.model_name == "gpt-4o"
+
+
+@pytest.mark.parametrize("api_mode", ["chat", "responses"])
+def test_generate_dispatches_to_configured_api(default_llm, api_mode):
+    llm = default_llm.model_copy(update={"api_mode": api_mode})
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = Mock(spec=LLMResponse)
+
+    with (
+        patch.object(LLM, "completion", return_value=response) as completion,
+        patch.object(LLM, "responses", return_value=response) as responses,
+    ):
+        assert llm.generate(messages, store=False) is response
+
+    if api_mode == "responses":
+        responses.assert_called_once_with(
+            messages=messages,
+            tools=None,
+            include=None,
+            store=False,
+            add_security_risk_prediction=False,
+            on_token=None,
+            call_context=None,
+        )
+        completion.assert_not_called()
+    else:
+        completion.assert_called_once_with(
+            messages=messages,
+            tools=None,
+            add_security_risk_prediction=False,
+            on_token=None,
+            call_context=None,
+        )
+        responses.assert_not_called()
+
+
+@pytest.mark.parametrize("api_mode", ["chat", "responses"])
+@pytest.mark.asyncio
+async def test_agenerate_dispatches_to_configured_api(default_llm, api_mode):
+    llm = default_llm.model_copy(update={"api_mode": api_mode})
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = Mock(spec=LLMResponse)
+
+    with (
+        patch.object(
+            LLM, "acompletion", AsyncMock(return_value=response)
+        ) as completion,
+        patch.object(LLM, "aresponses", AsyncMock(return_value=response)) as responses,
+    ):
+        assert await llm.agenerate(messages, store=False) is response
+
+    if api_mode == "responses":
+        responses.assert_awaited_once_with(
+            messages=messages,
+            tools=None,
+            include=None,
+            store=False,
+            add_security_risk_prediction=False,
+            on_token=None,
+            call_context=None,
+        )
+        completion.assert_not_awaited()
+    else:
+        completion.assert_awaited_once_with(
+            messages=messages,
+            tools=None,
+            add_security_risk_prediction=False,
+            on_token=None,
+            call_context=None,
+        )
+        responses.assert_not_awaited()
 
 
 @patch("openhands.sdk.llm.utils.model_info.httpx.get")

--- a/tests/sdk/llm/test_llm_span_cost.py
+++ b/tests/sdk/llm/test_llm_span_cost.py
@@ -89,8 +89,11 @@ def test_span_cost_agrees_with_metrics(exporter):
 
 
 def test_cache_buckets_survive_absent_prompt_tokens_details():
-    usage = Usage(prompt_tokens=100, completion_tokens=5)
-    object.__setattr__(usage, "cache_creation_input_tokens", 42)
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=5,
+        cache_creation_input_tokens=42,
+    )
     assert Telemetry._cache_buckets(usage)[1] == 42
 
 

--- a/tests/sdk/llm/test_llm_telemetry.py
+++ b/tests/sdk/llm/test_llm_telemetry.py
@@ -183,14 +183,12 @@ class TestTelemetryTokenUsage:
         """Test token usage recording with cache write tokens."""
         from litellm import Usage
 
-        usage = Usage.model_construct(
+        usage = Usage(
             prompt_tokens=100,
             completion_tokens=50,
             total_tokens=150,
-            model_extra={"cache_creation_input_tokens": 30},
+            cache_creation_input_tokens=30,
         )
-        # Set the attribute that telemetry code expects
-        usage._cache_creation_input_tokens = 30
 
         basic_telemetry._record_usage(usage, "test-id", 4096)
 

--- a/tests/tools/ask_oracle/test_ask_oracle.py
+++ b/tests/tools/ask_oracle/test_ask_oracle.py
@@ -164,7 +164,7 @@ def test_ask_oracle_tool_returns_oracle_recommendation(
     assert "The tool needs an Oracle profile name." in _message_text(
         oracle_llm.last_messages[1]
     )
-    assert oracle_llm.last_tools == []
+    assert oracle_llm.last_tools is None
     assert conversation.agent.llm.model == "default-model"
     assert conversation.state.agent.llm.model == "default-model"
 


### PR DESCRIPTION
HUMAN:

User request, quoted verbatim from @neubig: “OK, create the new PRs and stack 3403 on top of the conversation-scoped API one.” Follow-up: “OK, perform that separation. And update the PR.” Later follow-up: “Don’t we have a make_llm_completion function that could be used here instead?” Clarification: remove `make_llm_completion` / `amake_llm_completion`, migrate callers to generic LLM dispatch, and keep agent-only policy out of generic generation.

AGENT:

## Why

Responses-capable and subscription models need correct API dispatch and streaming behavior for title generation and other auxiliary LLM calls. API-mode selection belongs in the generic `LLM` abstraction; agent response policy should remain explicit at the agent call site.

## Summary

- Add `LLM.generate()` and `LLM.agenerate()` to select Responses or Chat Completions from configured API mode.
- Generate conversation titles through `LLM.generate(store=False)`, including mandatory subscription streaming.
- Remove `make_llm_completion()` and `amake_llm_completion()`.
- Migrate agent steps, condensation, hook evaluation, cleanup, vision inspection, Ask Oracle, and conversation questions to direct `generate()` / `agenerate()` calls.
- Keep `tools`, `store=False`, callbacks, call context, and `add_security_risk_prediction=True` explicit only on actual agent-response calls.
- Replace stacked-base dynamic attribute calls instead of adding allowances, shrinking the baseline from 131 to 122 entries.
- Treat `obj.__dict__.get(...)` as forbidden dynamic attribute access while allowing ordinary mapping `.get(...)`.
- Read LiteLLM cache accounting through its normalized, typed `Usage` and `ResponseAPIUsage` detail fields instead of dynamic/private storage.
- Enforce in CI that `scripts/forbidden_dynamic_attributes_baseline.json` may only lose entries, never add them, relative to the PR base or previous main commit.

## How to Test

- `uv run pytest -q tests/sdk/llm/test_llm.py tests/sdk/agent/test_agent_utils.py tests/sdk/agent/test_agent_step_responses_gating.py tests/sdk/agent/test_message_during_streaming_arun.py tests/sdk/agent/test_non_multimodal_image_input.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py tests/sdk/conversation/test_generate_title.py tests/sdk/llm/test_cleanup_profile.py tests/sdk/hooks/test_executor.py tests/sdk/hooks/test_integration.py tests/tools/ask_oracle/test_ask_oracle.py` — 257 passed.
- `uv run pytest -q tests/agent_server/test_profiles_router.py -k 'preflight or validate or subscription'` — 12 passed.
- `uv run pytest -q tests/cross/test_check_forbidden_dynamic_attributes.py tests/sdk/agent/test_stream_context.py tests/sdk/llm/test_llm_telemetry.py tests/sdk/llm/test_llm_span_cost.py` — 83 passed.
- `uv run python scripts/check_forbidden_dynamic_attributes.py --baseline-ref origin/fix/async-secret-masking` — passed; current baseline is a strict subset.
- `uv run pre-commit run --all-files --show-diff-on-failure` — all hooks passed.
- Full local SDK execution reached 6,184 passed, 7 skipped, and 12 xfailed; four failures were caused by this Agent Canvas environment’s injected user memory, `/tmp` being inside a Git repository, local user-agent lookup, and a WebSocket readiness environment override. The same affected change-specific tests pass in isolation.

## Scope

The independent diff contains generic LLM dispatch, title-generation transport fixes, direct caller migration, wrapper removal, focused policy/dispatch tests, and stacked-base pre-commit remediation.

## Issue Number

Split from existing PR #3403 at the author’s request; no separate issue was created.

_This PR description was updated by an AI agent (OpenHands) on behalf of @neubig._









<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5bb59cc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5bb59cc-python \
  ghcr.io/openhands/agent-server:5bb59cc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5bb59cc-golang-amd64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-golang-amd64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-golang-amd64
ghcr.io/openhands/agent-server:5bb59cc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5bb59cc-golang-arm64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-golang-arm64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-golang-arm64
ghcr.io/openhands/agent-server:5bb59cc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5bb59cc-java-amd64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-java-amd64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-java-amd64
ghcr.io/openhands/agent-server:5bb59cc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5bb59cc-java-arm64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-java-arm64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-java-arm64
ghcr.io/openhands/agent-server:5bb59cc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5bb59cc-python-amd64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python-amd64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python-amd64
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5bb59cc-python-arm64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python-arm64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python-arm64
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5bb59cc-python-slim-amd64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python-slim-amd64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python-slim-amd64
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:5bb59cc-python-slim-arm64
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python-slim-arm64
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python-slim-arm64
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:5bb59cc-golang
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-golang
ghcr.io/openhands/agent-server:fix-subscription-title-generation-golang
ghcr.io/openhands/agent-server:5bb59cc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5bb59cc-java
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-java
ghcr.io/openhands/agent-server:fix-subscription-title-generation-java
ghcr.io/openhands/agent-server:5bb59cc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5bb59cc-python-slim
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python-slim
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python-slim
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:5bb59cc-python
ghcr.io/openhands/agent-server:5bb59ccb3aaf33aa24d78f94bbab396119ca1c5b-python
ghcr.io/openhands/agent-server:fix-subscription-title-generation-python
ghcr.io/openhands/agent-server:5bb59cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5bb59cc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5bb59cc-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->




