### PR TITLE
feat(tools): support per-subagent remote workspaces

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -516,6 +516,7 @@ def _compose_conversation_info(
     )
     return ConversationInfo(
         **state.model_dump(mode="json"),
+        max_budget_per_run=stored.max_budget_per_run,
         title=stored.title,
         metrics=stored.metrics,
         created_at=stored.created_at,

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1130,6 +1130,7 @@ class EventService:
             token_callbacks=([_token_streaming_callback] if streaming_enabled else []),
             stream_callbacks=[_publish_stream_progress],
             max_iteration_per_run=self.stored.max_iterations,
+            max_budget_per_run=self.stored.max_budget_per_run,
             stuck_detection=self.stored.stuck_detection,
             visualizer=None,
             secrets=self.stored.secrets,

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -143,6 +143,12 @@ class _ConversationInfoBase(BaseModel):
             "Maximum number of iterations the agent can perform in a single run."
         ),
     )
+    max_budget_per_run: float | None = Field(
+        default=None,
+        gt=0,
+        allow_inf_nan=False,
+        description="Maximum LLM cost in USD per run; None means no cost limit.",
+    )
     stuck_detection: bool = Field(
         default=True,
         description="Whether to enable stuck detection for the agent.",

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -88,6 +88,7 @@ class Conversation:
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        max_budget_per_run: float | None = None,
     ) -> "LocalConversation": ...
 
     @overload
@@ -117,6 +118,7 @@ class Conversation:
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        max_budget_per_run: float | None = None,
     ) -> "RemoteConversation": ...
 
     def __new__(
@@ -146,6 +148,7 @@ class Conversation:
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        max_budget_per_run: float | None = None,
     ) -> BaseConversation:
         from openhands.sdk.conversation.impl.local_conversation import LocalConversation
         from openhands.sdk.conversation.impl.remote_conversation import (
@@ -197,6 +200,7 @@ class Conversation:
                 token_callbacks=token_callbacks,
                 hook_config=hook_config,
                 max_iteration_per_run=max_iteration_per_run,
+                max_budget_per_run=max_budget_per_run,
                 stuck_detection=stuck_detection,
                 stuck_detection_thresholds=stuck_detection_thresholds,
                 visualizer=visualizer,
@@ -219,6 +223,7 @@ class Conversation:
             token_callbacks=token_callbacks,
             hook_config=hook_config,
             max_iteration_per_run=max_iteration_per_run,
+            max_budget_per_run=max_budget_per_run,
             stuck_detection=stuck_detection,
             stuck_detection_thresholds=stuck_detection_thresholds,
             visualizer=visualizer,

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1,6 +1,7 @@
 import asyncio
 import bisect
 import json
+import math
 import os
 import threading
 import time
@@ -694,6 +695,7 @@ class RemoteConversation(BaseConversation):
     agent: AgentBase
     _callbacks: list[ConversationCallbackType]
     max_iteration_per_run: int
+    max_budget_per_run: float | None
     workspace: RemoteWorkspace
     _client: httpx.Client
     _cleanup_initiated: bool
@@ -728,6 +730,7 @@ class RemoteConversation(BaseConversation):
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
         require_existing: bool = False,
+        max_budget_per_run: float | None = None,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -740,6 +743,8 @@ class RemoteConversation(BaseConversation):
             conversation_id: Optional existing conversation id to attach to
             require_existing: Fail if conversation_id is missing or the conversation
                       no longer exists, instead of creating a new conversation.
+            max_budget_per_run: Maximum LLM cost in USD per run. On attach, a supplied
+                      budget must match the server's persisted budget.
             callbacks: Optional callbacks to receive events (not yet streamed)
             max_iteration_per_run: Max iterations configured on server
             stuck_detection: Whether to enable stuck detection on server
@@ -770,10 +775,15 @@ class RemoteConversation(BaseConversation):
         """
         if require_existing and conversation_id is None:
             raise ValueError("require_existing needs a conversation_id")
+        if max_budget_per_run is not None and (
+            not math.isfinite(max_budget_per_run) or max_budget_per_run <= 0
+        ):
+            raise ValueError("max_budget_per_run must be a finite positive number")
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
         self._callbacks = callbacks or []
         self.max_iteration_per_run = max_iteration_per_run
+        self.max_budget_per_run = max_budget_per_run
         self.workspace = workspace
         self._client = workspace.client
         self._conversation_info_base_path = LEGACY_CONVERSATIONS_PATH
@@ -789,6 +799,7 @@ class RemoteConversation(BaseConversation):
         # persisted ``ClientAction_*`` events can be deserialized.
         attached_client_tools: list[ClientToolSpec] = []
 
+        server_budget: float | None = None
         should_create = conversation_id is None
         if conversation_id is not None:
             # Try to attach to existing conversation
@@ -808,6 +819,15 @@ class RemoteConversation(BaseConversation):
                 should_create = True
             else:
                 info = resp.json()
+                persisted_budget = info.get("max_budget_per_run")
+                if (
+                    max_budget_per_run is not None
+                    and persisted_budget != max_budget_per_run
+                ):
+                    raise ValueError(
+                        "Remote conversation budget does not match max_budget_per_run"
+                    )
+                self.max_budget_per_run = persisted_budget
                 agent_payload = info.get("agent")
                 if agent_payload is not None:
                     remote_agent = _validate_remote_agent(agent_payload)
@@ -872,6 +892,8 @@ class RemoteConversation(BaseConversation):
             }
             if user_id:
                 payload["user_id"] = user_id
+            if max_budget_per_run is not None:
+                payload["max_budget_per_run"] = max_budget_per_run
             if stuck_detection_thresholds is not None:
                 # Convert to StuckDetectionThresholds if dict, then serialize
                 if isinstance(stuck_detection_thresholds, Mapping):
@@ -891,6 +913,7 @@ class RemoteConversation(BaseConversation):
                 json=payload,
             )
             data = resp.json()
+            server_budget = data.get("max_budget_per_run")
             # Expect a ConversationInfo
             cid = data.get("id") or data.get("conversation_id")
             if not cid:
@@ -903,6 +926,12 @@ class RemoteConversation(BaseConversation):
 
         self.delete_on_close = delete_on_close if should_create else False
         try:
+            if should_create and max_budget_per_run is not None:
+                if server_budget != max_budget_per_run:
+                    raise ValueError(
+                        "Agent server did not acknowledge max_budget_per_run; "
+                        "upgrade the server before running a budgeted conversation."
+                    )
             # Register client tool action types locally so WebSocket/persisted
             # events with ClientAction_* action_type can be deserialized by the
             # event loop. This must cover both the specs the caller passed in and

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -729,7 +729,6 @@ class RemoteConversation(BaseConversation):
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
-        require_existing: bool = False,
         max_budget_per_run: float | None = None,
         **_: object,
     ) -> None:
@@ -741,8 +740,6 @@ class RemoteConversation(BaseConversation):
             plugins: Optional list of plugins to load on the server. Each plugin
                     is a PluginSource specifying source, ref, and repo_path.
             conversation_id: Optional existing conversation id to attach to
-            require_existing: Fail if conversation_id is missing or the conversation
-                      no longer exists, instead of creating a new conversation.
             max_budget_per_run: Maximum LLM cost in USD per run. On attach, a supplied
                       budget must match the server's persisted budget.
             callbacks: Optional callbacks to receive events (not yet streamed)
@@ -773,8 +770,6 @@ class RemoteConversation(BaseConversation):
             observability_span_name: Optional child span name for observability
                       backends. The root span remains named "conversation".
         """
-        if require_existing and conversation_id is None:
-            raise ValueError("require_existing needs a conversation_id")
         if max_budget_per_run is not None and (
             not math.isfinite(max_budget_per_run) or max_budget_per_run <= 0
         ):
@@ -810,11 +805,6 @@ class RemoteConversation(BaseConversation):
                 acceptable_status_codes={404},
             )
             if resp.status_code == 404:
-                if require_existing:
-                    raise ValueError(
-                        f"Remote conversation '{conversation_id}' no longer exists; "
-                        "cannot resume the subagent in its original workspace."
-                    )
                 # Conversation doesn't exist, we'll create it
                 should_create = True
             else:
@@ -952,153 +942,151 @@ class RemoteConversation(BaseConversation):
                 events_base_path=self._conversation_action_base_path,
             )
 
-            # Add default callback to maintain local event state
-            default_callback = self._state.events.create_default_callback()
-            self._callbacks.append(default_callback)
-
-            # Add callback to update state from websocket events
-            state_update_callback = self._state.create_state_update_callback()
-            self._callbacks.append(state_update_callback)
-
-            # Add callback to handle LLM completion logs
-            # Register callback if any LLM has log_completions enabled
-            if any(llm.log_completions for llm in agent.get_all_llms()):
-                llm_log_callback = self._create_llm_completion_log_callback()
-                self._callbacks.append(llm_log_callback)
-
-            # Handle visualization configuration
-            if isinstance(visualizer, ConversationVisualizerBase):
-                # Use custom visualizer instance
-                self._visualizer = visualizer
-                # Initialize the visualizer with conversation state
-                self._visualizer.initialize(self._state)
-                self._callbacks.append(self._visualizer.on_event)
-            elif isinstance(visualizer, type) and issubclass(
-                visualizer, ConversationVisualizerBase
-            ):
-                # Instantiate the visualizer class with appropriate parameters
-                self._visualizer = visualizer()
-                # Initialize with state
-                self._visualizer.initialize(self._state)
-                self._callbacks.append(self._visualizer.on_event)
-            else:
-                # No visualization (visualizer is None)
-                self._visualizer = None
-
-            # Add a callback that signals when run completes via WebSocket.
-            # The server's post-run full-state snapshot is the only authoritative
-            # WebSocket success signal. Per-field FINISHED is a hint because stop
-            # hooks can still revert it; per-field ERROR/STUCK remain immediate.
-            def run_complete_callback(event: Event) -> None:
-                if not isinstance(event, ConversationStateUpdateEvent):
-                    return
-
-                if event.key == "execution_status":
-                    try:
-                        status = ConversationExecutionStatus(event.value)
-                    except ValueError:
-                        return
-                    if status in (
-                        ConversationExecutionStatus.ERROR,
-                        ConversationExecutionStatus.STUCK,
-                    ):
-                        self._terminal_status_queue.put(status.value)
-                    return
-
-                if event.key != FULL_STATE_KEY:
-                    return
-
-                # Only accept full-state snapshots as run-completion signals when a
-                # run is actually in progress. The WS subscription delivers an
-                # initial full-state snapshot during connect(); if that snapshot
-                # carries a non-RUNNING status (e.g. "idle"), it could be picked up
-                # by _wait_for_run_completion() as the completion signal for the
-                # *next* run() invocation, causing blocking=True to return before the
-                # server has actually finished.
-                if not self._run_armed.is_set():
-                    return
-
-                raw_status = event.value.get("execution_status")
-                try:
-                    status = ConversationExecutionStatus(raw_status)
-                except ValueError:
-                    return
-
-                if status != ConversationExecutionStatus.RUNNING:
-                    self._terminal_status_queue.put(status.value)
-
-            # Compose all callbacks into a single callback
-            all_callbacks = self._callbacks + [run_complete_callback]
-            composed_callback = BaseConversation.compose_callbacks(all_callbacks)
-
-            # Initialize WebSocket client for callbacks
-            self._ws_client = WebSocketCallbackClient(
-                host=self.workspace.host,
-                conversation_id=str(self._id),
-                callback=composed_callback,
-                api_key=self.workspace.api_key,
-                on_reconnect=self._state.events.reconcile,
-            )
-            self._ws_client.start()
-
-            # Wait for WebSocket subscription to complete before allowing operations.
-            # This ensures events emitted during send_message() are not missed.
-            # The server sends a ConversationStateUpdateEvent after subscription.
-            ws_timeout = float(os.getenv("OPENHANDS_REMOTE_WS_READY_TIMEOUT", "30"))
-            if not self._ws_client.wait_until_ready(timeout=ws_timeout):
-                if os.getenv("OPENHANDS_REMOTE_WS_READY_REQUIRED", "true").lower() in (
-                    "0",
-                    "false",
-                    "no",
-                ):
-                    logger.warning(
-                        "WebSocket subscription did not become ready within %.1f "
-                        "seconds for conversation %s; continuing after REST "
-                        "reconciliation because OPENHANDS_REMOTE_WS_READY_REQUIRED "
-                        "is false.",
-                        ws_timeout,
-                        self._id,
-                    )
-                else:
-                    try:
-                        self._ws_client.stop()
-                    except Exception:
-                        pass
-                    finally:
-                        self._ws_client = None
-                    raise WebSocketConnectionError(
-                        conversation_id=self._id,
-                        timeout=ws_timeout,
-                    )
-
-            # Reconcile events after WebSocket is ready to catch any events that
-            # were emitted between the initial REST sync and WebSocket subscription.
-            # This is the "reconciliation" part of the subscription handshake.
-            self._state.events.reconcile()
-
-            # Initialize secrets if provided
-            if secrets:
-                # Convert dict[str, str] to dict[str, SecretValue]
-                secret_values: dict[str, SecretValue] = {
-                    k: v for k, v in secrets.items()
-                }
-                self.update_secrets(secret_values)
-
-            self._start_observability_span(
-                str(self._id),
-                span_name=observability_span_name,
-                user_id=user_id,
-                metadata=observability_metadata,
-                tags=observability_tags,
-                conversation_tags=tags,
-            )
-            # All hooks (including SessionStart/SessionEnd) are executed server-side.
-            # hook_config is sent in the creation payload.
-            self.delete_on_close = delete_on_close
-
         except BaseException:
             self.close()
             raise
+
+        # Add default callback to maintain local event state
+        default_callback = self._state.events.create_default_callback()
+        self._callbacks.append(default_callback)
+
+        # Add callback to update state from websocket events
+        state_update_callback = self._state.create_state_update_callback()
+        self._callbacks.append(state_update_callback)
+
+        # Add callback to handle LLM completion logs
+        # Register callback if any LLM has log_completions enabled
+        if any(llm.log_completions for llm in agent.get_all_llms()):
+            llm_log_callback = self._create_llm_completion_log_callback()
+            self._callbacks.append(llm_log_callback)
+
+        # Handle visualization configuration
+        if isinstance(visualizer, ConversationVisualizerBase):
+            # Use custom visualizer instance
+            self._visualizer = visualizer
+            # Initialize the visualizer with conversation state
+            self._visualizer.initialize(self._state)
+            self._callbacks.append(self._visualizer.on_event)
+        elif isinstance(visualizer, type) and issubclass(
+            visualizer, ConversationVisualizerBase
+        ):
+            # Instantiate the visualizer class with appropriate parameters
+            self._visualizer = visualizer()
+            # Initialize with state
+            self._visualizer.initialize(self._state)
+            self._callbacks.append(self._visualizer.on_event)
+        else:
+            # No visualization (visualizer is None)
+            self._visualizer = None
+
+        # Add a callback that signals when run completes via WebSocket.
+        # The server's post-run full-state snapshot is the only authoritative
+        # WebSocket success signal. Per-field FINISHED is a hint because stop
+        # hooks can still revert it; per-field ERROR/STUCK remain immediate.
+        def run_complete_callback(event: Event) -> None:
+            if not isinstance(event, ConversationStateUpdateEvent):
+                return
+
+            if event.key == "execution_status":
+                try:
+                    status = ConversationExecutionStatus(event.value)
+                except ValueError:
+                    return
+                if status in (
+                    ConversationExecutionStatus.ERROR,
+                    ConversationExecutionStatus.STUCK,
+                ):
+                    self._terminal_status_queue.put(status.value)
+                return
+
+            if event.key != FULL_STATE_KEY:
+                return
+
+            # Only accept full-state snapshots as run-completion signals when a
+            # run is actually in progress. The WS subscription delivers an
+            # initial full-state snapshot during connect(); if that snapshot
+            # carries a non-RUNNING status (e.g. "idle"), it could be picked up
+            # by _wait_for_run_completion() as the completion signal for the
+            # *next* run() invocation, causing blocking=True to return before the
+            # server has actually finished.
+            if not self._run_armed.is_set():
+                return
+
+            raw_status = event.value.get("execution_status")
+            try:
+                status = ConversationExecutionStatus(raw_status)
+            except ValueError:
+                return
+
+            if status != ConversationExecutionStatus.RUNNING:
+                self._terminal_status_queue.put(status.value)
+
+        # Compose all callbacks into a single callback
+        all_callbacks = self._callbacks + [run_complete_callback]
+        composed_callback = BaseConversation.compose_callbacks(all_callbacks)
+
+        # Initialize WebSocket client for callbacks
+        self._ws_client = WebSocketCallbackClient(
+            host=self.workspace.host,
+            conversation_id=str(self._id),
+            callback=composed_callback,
+            api_key=self.workspace.api_key,
+            on_reconnect=self._state.events.reconcile,
+        )
+        self._ws_client.start()
+
+        # Wait for WebSocket subscription to complete before allowing operations.
+        # This ensures events emitted during send_message() are not missed.
+        # The server sends a ConversationStateUpdateEvent after subscription.
+        ws_timeout = float(os.getenv("OPENHANDS_REMOTE_WS_READY_TIMEOUT", "30"))
+        if not self._ws_client.wait_until_ready(timeout=ws_timeout):
+            if os.getenv("OPENHANDS_REMOTE_WS_READY_REQUIRED", "true").lower() in (
+                "0",
+                "false",
+                "no",
+            ):
+                logger.warning(
+                    "WebSocket subscription did not become ready within %.1f "
+                    "seconds for conversation %s; continuing after REST "
+                    "reconciliation because OPENHANDS_REMOTE_WS_READY_REQUIRED "
+                    "is false.",
+                    ws_timeout,
+                    self._id,
+                )
+            else:
+                try:
+                    self._ws_client.stop()
+                except Exception:
+                    pass
+                finally:
+                    self._ws_client = None
+                raise WebSocketConnectionError(
+                    conversation_id=self._id,
+                    timeout=ws_timeout,
+                )
+
+        # Reconcile events after WebSocket is ready to catch any events that
+        # were emitted between the initial REST sync and WebSocket subscription.
+        # This is the "reconciliation" part of the subscription handshake.
+        self._state.events.reconcile()
+
+        # Initialize secrets if provided
+        if secrets:
+            # Convert dict[str, str] to dict[str, SecretValue]
+            secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
+            self.update_secrets(secret_values)
+
+        self._start_observability_span(
+            str(self._id),
+            span_name=observability_span_name,
+            user_id=user_id,
+            metadata=observability_metadata,
+            tags=observability_tags,
+            conversation_tags=tags,
+        )
+        # All hooks (including SessionStart/SessionEnd) are executed server-side.
+        # hook_config is sent in the creation payload.
+        self.delete_on_close = delete_on_close
 
     def _create_llm_completion_log_callback(self) -> ConversationCallbackType:
         """Create a callback that writes LLM completion logs to client filesystem."""

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -727,6 +727,7 @@ class RemoteConversation(BaseConversation):
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
         observability_span_name: str = "conversation",
+        require_existing: bool = False,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -737,6 +738,8 @@ class RemoteConversation(BaseConversation):
             plugins: Optional list of plugins to load on the server. Each plugin
                     is a PluginSource specifying source, ref, and repo_path.
             conversation_id: Optional existing conversation id to attach to
+            require_existing: Fail if conversation_id is missing or the conversation
+                      no longer exists, instead of creating a new conversation.
             callbacks: Optional callbacks to receive events (not yet streamed)
             max_iteration_per_run: Max iterations configured on server
             stuck_detection: Whether to enable stuck detection on server
@@ -765,6 +768,8 @@ class RemoteConversation(BaseConversation):
             observability_span_name: Optional child span name for observability
                       backends. The root span remains named "conversation".
         """
+        if require_existing and conversation_id is None:
+            raise ValueError("require_existing needs a conversation_id")
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
         self._callbacks = callbacks or []
@@ -774,6 +779,7 @@ class RemoteConversation(BaseConversation):
         self._conversation_info_base_path = LEGACY_CONVERSATIONS_PATH
         self._conversation_action_base_path = LEGACY_CONVERSATIONS_PATH
         self._cleanup_initiated = False
+        self._ws_client = None
         self._terminal_status_queue: Queue[str] = Queue()
         self._run_armed = threading.Event()
 
@@ -793,6 +799,11 @@ class RemoteConversation(BaseConversation):
                 acceptable_status_codes={404},
             )
             if resp.status_code == 404:
+                if require_existing:
+                    raise ValueError(
+                        f"Remote conversation '{conversation_id}' no longer exists; "
+                        "cannot resume the subagent in its original workspace."
+                    )
                 # Conversation doesn't exist, we'll create it
                 should_create = True
             else:
@@ -890,167 +901,175 @@ class RemoteConversation(BaseConversation):
 
             workspace.register_conversation(str(self._id))
 
-        # Register client tool action types locally so WebSocket/persisted
-        # events with ClientAction_* action_type can be deserialized by the
-        # event loop. This must cover both the specs the caller passed in and
-        # the specs the server already had persisted (when re-attaching), so a
-        # plain reattach by conversation_id can still sync persisted events.
-        seen_client_tool_names: set[str] = set()
-        for spec in [*(client_tools or []), *attached_client_tools]:
-            if spec.name in seen_client_tool_names:
-                continue
-            seen_client_tool_names.add(spec.name)
-            ClientTool.from_spec(spec)
+        self.delete_on_close = delete_on_close if should_create else False
+        try:
+            # Register client tool action types locally so WebSocket/persisted
+            # events with ClientAction_* action_type can be deserialized by the
+            # event loop. This must cover both the specs the caller passed in and
+            # the specs the server already had persisted (when re-attaching), so a
+            # plain reattach by conversation_id can still sync persisted events.
+            seen_client_tool_names: set[str] = set()
+            for spec in [*(client_tools or []), *attached_client_tools]:
+                if spec.name in seen_client_tool_names:
+                    continue
+                seen_client_tool_names.add(spec.name)
+                ClientTool.from_spec(spec)
 
-        # Initialize the remote state
-        self._state = RemoteState(
-            self._client,
-            str(self._id),
-            conversation_info_base_path=self._conversation_info_base_path,
-            events_base_path=self._conversation_action_base_path,
-        )
+            # Initialize the remote state
+            self._state = RemoteState(
+                self._client,
+                str(self._id),
+                conversation_info_base_path=self._conversation_info_base_path,
+                events_base_path=self._conversation_action_base_path,
+            )
 
-        # Add default callback to maintain local event state
-        default_callback = self._state.events.create_default_callback()
-        self._callbacks.append(default_callback)
+            # Add default callback to maintain local event state
+            default_callback = self._state.events.create_default_callback()
+            self._callbacks.append(default_callback)
 
-        # Add callback to update state from websocket events
-        state_update_callback = self._state.create_state_update_callback()
-        self._callbacks.append(state_update_callback)
+            # Add callback to update state from websocket events
+            state_update_callback = self._state.create_state_update_callback()
+            self._callbacks.append(state_update_callback)
 
-        # Add callback to handle LLM completion logs
-        # Register callback if any LLM has log_completions enabled
-        if any(llm.log_completions for llm in agent.get_all_llms()):
-            llm_log_callback = self._create_llm_completion_log_callback()
-            self._callbacks.append(llm_log_callback)
+            # Add callback to handle LLM completion logs
+            # Register callback if any LLM has log_completions enabled
+            if any(llm.log_completions for llm in agent.get_all_llms()):
+                llm_log_callback = self._create_llm_completion_log_callback()
+                self._callbacks.append(llm_log_callback)
 
-        # Handle visualization configuration
-        if isinstance(visualizer, ConversationVisualizerBase):
-            # Use custom visualizer instance
-            self._visualizer = visualizer
-            # Initialize the visualizer with conversation state
-            self._visualizer.initialize(self._state)
-            self._callbacks.append(self._visualizer.on_event)
-        elif isinstance(visualizer, type) and issubclass(
-            visualizer, ConversationVisualizerBase
-        ):
-            # Instantiate the visualizer class with appropriate parameters
-            self._visualizer = visualizer()
-            # Initialize with state
-            self._visualizer.initialize(self._state)
-            self._callbacks.append(self._visualizer.on_event)
-        else:
-            # No visualization (visualizer is None)
-            self._visualizer = None
+            # Handle visualization configuration
+            if isinstance(visualizer, ConversationVisualizerBase):
+                # Use custom visualizer instance
+                self._visualizer = visualizer
+                # Initialize the visualizer with conversation state
+                self._visualizer.initialize(self._state)
+                self._callbacks.append(self._visualizer.on_event)
+            elif isinstance(visualizer, type) and issubclass(
+                visualizer, ConversationVisualizerBase
+            ):
+                # Instantiate the visualizer class with appropriate parameters
+                self._visualizer = visualizer()
+                # Initialize with state
+                self._visualizer.initialize(self._state)
+                self._callbacks.append(self._visualizer.on_event)
+            else:
+                # No visualization (visualizer is None)
+                self._visualizer = None
 
-        # Add a callback that signals when run completes via WebSocket.
-        # The server's post-run full-state snapshot is the only authoritative
-        # WebSocket success signal. Per-field FINISHED is a hint because stop
-        # hooks can still revert it; per-field ERROR/STUCK remain immediate.
-        def run_complete_callback(event: Event) -> None:
-            if not isinstance(event, ConversationStateUpdateEvent):
-                return
+            # Add a callback that signals when run completes via WebSocket.
+            # The server's post-run full-state snapshot is the only authoritative
+            # WebSocket success signal. Per-field FINISHED is a hint because stop
+            # hooks can still revert it; per-field ERROR/STUCK remain immediate.
+            def run_complete_callback(event: Event) -> None:
+                if not isinstance(event, ConversationStateUpdateEvent):
+                    return
 
-            if event.key == "execution_status":
+                if event.key == "execution_status":
+                    try:
+                        status = ConversationExecutionStatus(event.value)
+                    except ValueError:
+                        return
+                    if status in (
+                        ConversationExecutionStatus.ERROR,
+                        ConversationExecutionStatus.STUCK,
+                    ):
+                        self._terminal_status_queue.put(status.value)
+                    return
+
+                if event.key != FULL_STATE_KEY:
+                    return
+
+                # Only accept full-state snapshots as run-completion signals when a
+                # run is actually in progress. The WS subscription delivers an
+                # initial full-state snapshot during connect(); if that snapshot
+                # carries a non-RUNNING status (e.g. "idle"), it could be picked up
+                # by _wait_for_run_completion() as the completion signal for the
+                # *next* run() invocation, causing blocking=True to return before the
+                # server has actually finished.
+                if not self._run_armed.is_set():
+                    return
+
+                raw_status = event.value.get("execution_status")
                 try:
-                    status = ConversationExecutionStatus(event.value)
+                    status = ConversationExecutionStatus(raw_status)
                 except ValueError:
                     return
-                if status in (
-                    ConversationExecutionStatus.ERROR,
-                    ConversationExecutionStatus.STUCK,
-                ):
+
+                if status != ConversationExecutionStatus.RUNNING:
                     self._terminal_status_queue.put(status.value)
-                return
 
-            if event.key != FULL_STATE_KEY:
-                return
+            # Compose all callbacks into a single callback
+            all_callbacks = self._callbacks + [run_complete_callback]
+            composed_callback = BaseConversation.compose_callbacks(all_callbacks)
 
-            # Only accept full-state snapshots as run-completion signals when a
-            # run is actually in progress. The WS subscription delivers an
-            # initial full-state snapshot during connect(); if that snapshot
-            # carries a non-RUNNING status (e.g. "idle"), it could be picked up
-            # by _wait_for_run_completion() as the completion signal for the
-            # *next* run() invocation, causing blocking=True to return before the
-            # server has actually finished.
-            if not self._run_armed.is_set():
-                return
+            # Initialize WebSocket client for callbacks
+            self._ws_client = WebSocketCallbackClient(
+                host=self.workspace.host,
+                conversation_id=str(self._id),
+                callback=composed_callback,
+                api_key=self.workspace.api_key,
+                on_reconnect=self._state.events.reconcile,
+            )
+            self._ws_client.start()
 
-            raw_status = event.value.get("execution_status")
-            try:
-                status = ConversationExecutionStatus(raw_status)
-            except ValueError:
-                return
+            # Wait for WebSocket subscription to complete before allowing operations.
+            # This ensures events emitted during send_message() are not missed.
+            # The server sends a ConversationStateUpdateEvent after subscription.
+            ws_timeout = float(os.getenv("OPENHANDS_REMOTE_WS_READY_TIMEOUT", "30"))
+            if not self._ws_client.wait_until_ready(timeout=ws_timeout):
+                if os.getenv("OPENHANDS_REMOTE_WS_READY_REQUIRED", "true").lower() in (
+                    "0",
+                    "false",
+                    "no",
+                ):
+                    logger.warning(
+                        "WebSocket subscription did not become ready within %.1f "
+                        "seconds for conversation %s; continuing after REST "
+                        "reconciliation because OPENHANDS_REMOTE_WS_READY_REQUIRED "
+                        "is false.",
+                        ws_timeout,
+                        self._id,
+                    )
+                else:
+                    try:
+                        self._ws_client.stop()
+                    except Exception:
+                        pass
+                    finally:
+                        self._ws_client = None
+                    raise WebSocketConnectionError(
+                        conversation_id=self._id,
+                        timeout=ws_timeout,
+                    )
 
-            if status != ConversationExecutionStatus.RUNNING:
-                self._terminal_status_queue.put(status.value)
+            # Reconcile events after WebSocket is ready to catch any events that
+            # were emitted between the initial REST sync and WebSocket subscription.
+            # This is the "reconciliation" part of the subscription handshake.
+            self._state.events.reconcile()
 
-        # Compose all callbacks into a single callback
-        all_callbacks = self._callbacks + [run_complete_callback]
-        composed_callback = BaseConversation.compose_callbacks(all_callbacks)
+            # Initialize secrets if provided
+            if secrets:
+                # Convert dict[str, str] to dict[str, SecretValue]
+                secret_values: dict[str, SecretValue] = {
+                    k: v for k, v in secrets.items()
+                }
+                self.update_secrets(secret_values)
 
-        # Initialize WebSocket client for callbacks
-        self._ws_client = WebSocketCallbackClient(
-            host=self.workspace.host,
-            conversation_id=str(self._id),
-            callback=composed_callback,
-            api_key=self.workspace.api_key,
-            on_reconnect=self._state.events.reconcile,
-        )
-        self._ws_client.start()
+            self._start_observability_span(
+                str(self._id),
+                span_name=observability_span_name,
+                user_id=user_id,
+                metadata=observability_metadata,
+                tags=observability_tags,
+                conversation_tags=tags,
+            )
+            # All hooks (including SessionStart/SessionEnd) are executed server-side.
+            # hook_config is sent in the creation payload.
+            self.delete_on_close = delete_on_close
 
-        # Wait for WebSocket subscription to complete before allowing operations.
-        # This ensures events emitted during send_message() are not missed.
-        # The server sends a ConversationStateUpdateEvent after subscription.
-        ws_timeout = float(os.getenv("OPENHANDS_REMOTE_WS_READY_TIMEOUT", "30"))
-        if not self._ws_client.wait_until_ready(timeout=ws_timeout):
-            if os.getenv("OPENHANDS_REMOTE_WS_READY_REQUIRED", "true").lower() in (
-                "0",
-                "false",
-                "no",
-            ):
-                logger.warning(
-                    "WebSocket subscription did not become ready within %.1f "
-                    "seconds for conversation %s; continuing after REST "
-                    "reconciliation because OPENHANDS_REMOTE_WS_READY_REQUIRED "
-                    "is false.",
-                    ws_timeout,
-                    self._id,
-                )
-            else:
-                try:
-                    self._ws_client.stop()
-                except Exception:
-                    pass
-                finally:
-                    self._ws_client = None
-                raise WebSocketConnectionError(
-                    conversation_id=self._id,
-                    timeout=ws_timeout,
-                )
-
-        # Reconcile events after WebSocket is ready to catch any events that
-        # were emitted between the initial REST sync and WebSocket subscription.
-        # This is the "reconciliation" part of the subscription handshake.
-        self._state.events.reconcile()
-
-        # Initialize secrets if provided
-        if secrets:
-            # Convert dict[str, str] to dict[str, SecretValue]
-            secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
-            self.update_secrets(secret_values)
-
-        self._start_observability_span(
-            str(self._id),
-            span_name=observability_span_name,
-            user_id=user_id,
-            metadata=observability_metadata,
-            tags=observability_tags,
-            conversation_tags=tags,
-        )
-        # All hooks (including SessionStart/SessionEnd) are executed server-side.
-        # hook_config is sent in the creation payload.
-        self.delete_on_close = delete_on_close
+        except BaseException:
+            self.close()
+            raise
 
     def _create_llm_completion_log_callback(self) -> ConversationCallbackType:
         """Create a callback that writes LLM completion logs to client filesystem."""

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -146,6 +146,12 @@ class ConversationConfig(BaseModel):
         description="If set, the max number of iterations the agent will run "
         "before stopping. This is useful to prevent infinite loops.",
     )
+    max_budget_per_run: float | None = Field(
+        default=None,
+        gt=0,
+        allow_inf_nan=False,
+        description="Maximum LLM cost in USD per run; None means no cost limit.",
+    )
     stuck_detection: bool = Field(
         default=True,
         description="If true, the conversation will use stuck detection to "

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -5,16 +5,25 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
+from openhands.sdk.conversation import BaseConversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
 from openhands.sdk.conversation.response_utils import get_agent_final_response
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.observability.laminar import detached_delegate_context
 from openhands.sdk.subagent import get_agent_factory
 from openhands.sdk.tool.tool import ToolExecutor
+from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.delegate.definition import DelegateObservation
+from openhands.tools.task.workspace import (
+    SubagentWorkspaceFactory,
+    close_workspace,
+    enter_workspace,
+)
 
 
 if TYPE_CHECKING:
@@ -42,10 +51,13 @@ class DelegateExecutor(ToolExecutor):
         self,
         max_children: int = 5,
         confirmation_handler: ConfirmationHandler | None = None,
+        workspace_factory: SubagentWorkspaceFactory | None = None,
     ):
         self._parent_conversation: LocalConversation | None = None
         # Map from user-friendly identifier to conversation
-        self._sub_agents: dict[str, LocalConversation] = {}
+        self._sub_agents: dict[str, BaseConversation] = {}
+        self._workspace_factory = workspace_factory
+        self._workspaces: dict[str, RemoteWorkspace] = {}
         self._max_children: int = max_children
         self._confirmation_handler = confirmation_handler
 
@@ -97,7 +109,7 @@ class DelegateExecutor(ToolExecutor):
             return "default"
         return action.agent_types[index].strip() or "default"
 
-    def _close_sub_agent(self, agent_id: str, conversation: LocalConversation) -> None:
+    def _close_sub_agent(self, agent_id: str, conversation: BaseConversation) -> None:
         try:
             conversation.close()
         except Exception as e:
@@ -107,9 +119,12 @@ class DelegateExecutor(ToolExecutor):
         for agent_id, conversation in list(self._sub_agents.items()):
             self._close_sub_agent(agent_id, conversation)
         self._sub_agents.clear()
+        for workspace in self._workspaces.values():
+            close_workspace(workspace)
+        self._workspaces.clear()
 
     def _run_until_finished(
-        self, agent_id: str, conversation: LocalConversation
+        self, agent_id: str, conversation: BaseConversation
     ) -> None:
         """Run a sub-agent conversation to completion, handling confirmations."""
         conversation.run()
@@ -162,7 +177,15 @@ class DelegateExecutor(ToolExecutor):
                 is_error=True,
             )
 
-        created_sub_agents: list[tuple[str, str, LocalConversation]] = []
+        if len(set(action.ids)) != len(action.ids):
+            return DelegateObservation.from_text(
+                text="Spawn IDs must be unique",
+                command=action.command,
+                is_error=True,
+            )
+
+        created_sub_agents: list[tuple[str, str, BaseConversation]] = []
+        created_workspaces: dict[str, RemoteWorkspace] = {}
         try:
             parent_conversation = self.parent_conversation
             parent_llm = parent_conversation.agent.llm
@@ -227,7 +250,38 @@ class DelegateExecutor(ToolExecutor):
                         factory.definition.max_iteration_per_run
                     )
 
-                sub_conversation = LocalConversation(**conv_kwargs)
+                workspace = (
+                    self._workspace_factory(agent_id, agent_type)
+                    if self._workspace_factory is not None
+                    else None
+                )
+                if workspace is not None:
+                    if workspace is parent_conversation.state.workspace or any(
+                        owned is workspace
+                        for owned in [
+                            *self._workspaces.values(),
+                            *created_workspaces.values(),
+                        ]
+                    ):
+                        raise ValueError("Each subagent must own a distinct workspace")
+                    enter_workspace(workspace)
+                    created_workspaces[agent_id] = workspace
+                    conv_kwargs["workspace"] = workspace
+                    conv_kwargs["delete_on_close"] = True
+
+                with detached_delegate_context() as link:
+                    conv_kwargs["observability_metadata"] = {
+                        "is_delegate": True,
+                        "task_id": agent_id,
+                        "subagent_type": agent_type,
+                        "parent_session_id": str(parent_conversation.state.id),
+                        **link,
+                    }
+                    conv_kwargs["observability_tags"] = ["delegate"]
+                    conversation_class = (
+                        LocalConversation if workspace is None else RemoteConversation
+                    )
+                    sub_conversation = conversation_class(**conv_kwargs)
                 created_sub_agents.append((agent_id, agent_type, sub_conversation))
 
                 # Apply permission_mode: explicit mode from definition,
@@ -244,6 +298,11 @@ class DelegateExecutor(ToolExecutor):
                 previous_conversation = self._sub_agents.get(agent_id)
                 if previous_conversation is not None:
                     self._close_sub_agent(agent_id, previous_conversation)
+                previous_workspace = self._workspaces.pop(agent_id, None)
+                if previous_workspace is not None:
+                    close_workspace(previous_workspace)
+                if agent_id in created_workspaces:
+                    self._workspaces[agent_id] = created_workspaces[agent_id]
                 self._sub_agents[agent_id] = sub_conversation
 
                 # Log what type of agent was created
@@ -269,6 +328,8 @@ class DelegateExecutor(ToolExecutor):
         except Exception as e:
             for agent_id, _, sub_conversation in created_sub_agents:
                 self._close_sub_agent(agent_id, sub_conversation)
+            for workspace in created_workspaces.values():
+                close_workspace(workspace)
             logger.error(f"Error: failed to spawn agents: {e}", exc_info=True)
             return DelegateObservation.from_text(
                 text=f"failed to spawn agents: {str(e)}",
@@ -322,7 +383,7 @@ class DelegateExecutor(ToolExecutor):
 
             def run_task(
                 agent_id: str,
-                conversation: LocalConversation,
+                conversation: BaseConversation,
                 task: str,
                 parent_name: str | None,
             ):
@@ -369,9 +430,12 @@ class DelegateExecutor(ToolExecutor):
             for agent_id in action.tasks:
                 if agent_id in self._sub_agents:
                     sub_conv = self._sub_agents[agent_id]
-                    parent_stats.usage_to_metrics[f"delegate:{agent_id}"] = (
-                        sub_conv.conversation_stats.get_combined_metrics()
-                    )
+                    try:
+                        parent_stats.usage_to_metrics[f"delegate:{agent_id}"] = (
+                            sub_conv.conversation_stats.get_combined_metrics()
+                        )
+                    except Exception:
+                        logger.warning("Failed to read subagent metrics", exc_info=True)
 
             # Collect results in the same order as the input tasks
             all_results = []

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -20,6 +20,7 @@ from openhands.sdk.tool.tool import ToolExecutor
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.delegate.definition import DelegateObservation
 from openhands.tools.task.workspace import (
+    SubagentWorkspace,
     SubagentWorkspaceFactory,
     close_workspace,
     enter_workspace,
@@ -250,10 +251,15 @@ class DelegateExecutor(ToolExecutor):
                         factory.definition.max_iteration_per_run
                     )
 
-                workspace = (
+                provisioned = (
                     self._workspace_factory(agent_id, agent_type)
                     if self._workspace_factory is not None
                     else None
+                )
+                workspace = (
+                    provisioned.workspace
+                    if isinstance(provisioned, SubagentWorkspace)
+                    else provisioned
                 )
                 if workspace is not None:
                     if workspace is parent_conversation.state.workspace or any(

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -20,7 +20,6 @@ from openhands.sdk.tool.tool import ToolExecutor
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.delegate.definition import DelegateObservation
 from openhands.tools.task.workspace import (
-    SubagentWorkspace,
     SubagentWorkspaceFactory,
     close_workspace,
     enter_workspace,
@@ -251,15 +250,10 @@ class DelegateExecutor(ToolExecutor):
                         factory.definition.max_iteration_per_run
                     )
 
-                provisioned = (
+                workspace = (
                     self._workspace_factory(agent_id, agent_type)
                     if self._workspace_factory is not None
                     else None
-                )
-                workspace = (
-                    provisioned.workspace
-                    if isinstance(provisioned, SubagentWorkspace)
-                    else provisioned
                 )
                 if workspace is not None:
                     if workspace is parent_conversation.state.workspace or any(

--- a/openhands-tools/openhands/tools/task/definition.py
+++ b/openhands-tools/openhands/tools/task/definition.py
@@ -32,7 +32,10 @@ if TYPE_CHECKING:
     from openhands.sdk.conversation.state import ConversationState
     from openhands.tools.task.impl import TaskExecutor
     from openhands.tools.task.manager import ConfirmationHandler
-    from openhands.tools.task.workspace import SubagentWorkspaceFactory
+    from openhands.tools.task.workspace import (
+        SubagentWorkspaceFactory,
+        SubagentWorkspaceResolver,
+    )
 
 
 class TaskAction(Action):
@@ -220,6 +223,7 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         conv_state: "ConversationState",  # noqa: ARG003
         confirmation_handler: "ConfirmationHandler | None" = None,
         workspace_factory: "SubagentWorkspaceFactory | None" = None,
+        workspace_resolver: "SubagentWorkspaceResolver | None" = None,
     ) -> list[ToolDefinition]:
         """Create the task tool.
 
@@ -233,6 +237,9 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
                 Return a dedicated RemoteWorkspace owned by this manager, or None
                 to run locally. Remote workspaces are retained for task resumes
                 and released when the tool closes.
+                Return SubagentWorkspace with a reference to enable restart recovery.
+            workspace_resolver: Reconnect a persisted SubagentWorkspaceReference to
+                its original workspace. Used after restart instead of the factory.
 
         Returns:
             List containing a single TaskTool.
@@ -254,6 +261,7 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         manager = TaskManager(
             confirmation_handler=confirmation_handler,
             workspace_factory=workspace_factory,
+            workspace_resolver=workspace_resolver,
         )
         task_executor = TaskExecutor(manager=manager)
 

--- a/openhands-tools/openhands/tools/task/definition.py
+++ b/openhands-tools/openhands/tools/task/definition.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from openhands.sdk.conversation.state import ConversationState
     from openhands.tools.task.impl import TaskExecutor
     from openhands.tools.task.manager import ConfirmationHandler
+    from openhands.tools.task.workspace import SubagentWorkspaceFactory
 
 
 class TaskAction(Action):
@@ -218,6 +219,7 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         cls,
         conv_state: "ConversationState",  # noqa: ARG003
         confirmation_handler: "ConfirmationHandler | None" = None,
+        workspace_factory: "SubagentWorkspaceFactory | None" = None,
     ) -> list[ToolDefinition]:
         """Create the task tool.
 
@@ -227,6 +229,10 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
                 confirmation policy requires user approval.  Receives
                 `(task_id, pending_actions)` and must return `True` to
                 approve or `False` to reject.
+            workspace_factory: Optional factory called with (task_id, agent_type).
+                Return a dedicated RemoteWorkspace owned by this manager, or None
+                to run locally. Remote workspaces are retained for task resumes
+                and released when the tool closes.
 
         Returns:
             List containing a single TaskTool.
@@ -245,7 +251,10 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
             task_tool_examples=task_tool_examples,
         )
 
-        manager = TaskManager(confirmation_handler=confirmation_handler)
+        manager = TaskManager(
+            confirmation_handler=confirmation_handler,
+            workspace_factory=workspace_factory,
+        )
         task_executor = TaskExecutor(manager=manager)
 
         tools: list[ToolDefinition] = []

--- a/openhands-tools/openhands/tools/task/definition.py
+++ b/openhands-tools/openhands/tools/task/definition.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     from openhands.tools.task.manager import ConfirmationHandler
     from openhands.tools.task.workspace import (
         SubagentWorkspaceFactory,
-        SubagentWorkspaceResolver,
     )
 
 
@@ -223,7 +222,6 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         conv_state: "ConversationState",  # noqa: ARG003
         confirmation_handler: "ConfirmationHandler | None" = None,
         workspace_factory: "SubagentWorkspaceFactory | None" = None,
-        workspace_resolver: "SubagentWorkspaceResolver | None" = None,
     ) -> list[ToolDefinition]:
         """Create the task tool.
 
@@ -237,9 +235,6 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
                 Return a dedicated RemoteWorkspace owned by this manager, or None
                 to run locally. Remote workspaces are retained for task resumes
                 and released when the tool closes.
-                Return SubagentWorkspace with a reference to enable restart recovery.
-            workspace_resolver: Reconnect a persisted SubagentWorkspaceReference to
-                its original workspace. Used after restart instead of the factory.
 
         Returns:
             List containing a single TaskTool.
@@ -261,7 +256,6 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         manager = TaskManager(
             confirmation_handler=confirmation_handler,
             workspace_factory=workspace_factory,
-            workspace_resolver=workspace_resolver,
         )
         task_executor = TaskExecutor(manager=manager)
 

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -39,7 +39,10 @@ from openhands.sdk.security import ConfirmationPolicyBase
 from openhands.sdk.subagent.registry import AgentFactory, get_agent_factory
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.task.workspace import (
+    SubagentWorkspace,
     SubagentWorkspaceFactory,
+    SubagentWorkspaceReference,
+    SubagentWorkspaceResolver,
     close_workspace,
     enter_workspace,
 )
@@ -89,6 +92,7 @@ class Task(BaseModel):
     remote_workspace: RemoteWorkspace | None = Field(default=None, exclude=True)
     remote: bool = False
     subagent_type: str | None = None
+    workspace_reference: SubagentWorkspaceReference | None = None
 
     def set_result(self, result: str) -> None:
         """Set task as successful."""
@@ -110,10 +114,12 @@ class TaskManager:
         self,
         confirmation_handler: ConfirmationHandler | None = None,
         workspace_factory: SubagentWorkspaceFactory | None = None,
+        workspace_resolver: SubagentWorkspaceResolver | None = None,
     ):
         self._parent_conversation: LocalConversation | None = None
         self._confirmation_handler = confirmation_handler
         self._workspace_factory = workspace_factory
+        self._workspace_resolver = workspace_resolver
 
         self._tasks: dict[str, Task] = {}
         self._tasks_lock = threading.Lock()
@@ -256,12 +262,17 @@ class TaskManager:
             conversation_id = self._tasks[resume].conversation_id
             workspace = self._tasks[resume].remote_workspace
             if stored_task.remote and workspace is None:
-                if self._workspace_factory is None:
+                if stored_task.workspace_reference is None:
                     raise ValueError(
-                        f"Remote task '{resume}' requires its workspace_factory "
+                        f"Remote task '{resume}' has no persisted workspace identity; "
+                        "cannot reconnect safely."
+                    )
+                if self._workspace_resolver is None:
+                    raise ValueError(
+                        f"Remote task '{resume}' requires a workspace_resolver "
                         "to reconnect to the original workspace."
                     )
-                workspace = self._workspace_factory(resume, subagent_type)
+                workspace = self._workspace_resolver(stored_task.workspace_reference)
                 if workspace is None:
                     raise ValueError(f"Remote workspace for task '{resume}' is gone")
                 if workspace is self.parent_conversation.state.workspace or any(
@@ -269,6 +280,11 @@ class TaskManager:
                 ):
                     raise ValueError("Each subagent must own a distinct workspace")
                 enter_workspace(workspace)
+                if workspace.working_dir != stored_task.workspace_reference.working_dir:
+                    close_workspace(workspace)
+                    raise ValueError(
+                        "Resolved workspace has a different working directory"
+                    )
                 stored_task.remote_workspace = workspace
             with detached_delegate_context() as link:
                 conversation_class = (
@@ -355,10 +371,20 @@ class TaskManager:
 
         with self._tasks_lock:
             task_id, conversation_id = self._generate_ids()
-            workspace = (
+            provisioned = (
                 self._workspace_factory(task_id, subagent_type)
                 if self._workspace_factory is not None
                 else None
+            )
+            reference = (
+                provisioned.reference
+                if isinstance(provisioned, SubagentWorkspace)
+                else None
+            )
+            workspace = (
+                provisioned.workspace
+                if isinstance(provisioned, SubagentWorkspace)
+                else provisioned
             )
             if workspace is not None:
                 if workspace is self.parent_conversation.state.workspace or any(
@@ -369,6 +395,12 @@ class TaskManager:
 
             sub_conversation = None
             try:
+                if reference is not None and workspace is not None:
+                    if reference.working_dir != workspace.working_dir:
+                        raise ValueError(
+                            "Workspace reference must describe the child's "
+                            "working directory"
+                        )
                 sub_conversation = self._get_conversation(
                     description=description,
                     max_iteration_per_run=effective_max_iter,
@@ -402,6 +434,7 @@ class TaskManager:
                 remote_workspace=workspace,
                 remote=workspace is not None,
                 subagent_type=subagent_type,
+                workspace_reference=reference,
             )
             self._persist_remote_tasks()
             return self._tasks[task_id]

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -19,10 +19,12 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from openhands.sdk import Agent
+from openhands.sdk.conversation import BaseConversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
 from openhands.sdk.conversation.response_utils import get_agent_final_response
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
@@ -35,6 +37,12 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import detached_delegate_context
 from openhands.sdk.security import ConfirmationPolicyBase
 from openhands.sdk.subagent.registry import AgentFactory, get_agent_factory
+from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.task.workspace import (
+    SubagentWorkspaceFactory,
+    close_workspace,
+    enter_workspace,
+)
 
 
 if TYPE_CHECKING:
@@ -73,11 +81,14 @@ class Task(BaseModel):
     )
     result: str | None = Field(default=None, description="Result of the task.")
     error: str | None = Field(default=None, description="Error if task failed.")
-    conversation: LocalConversation | None = Field(
+    conversation: BaseConversation | None = Field(
         default=None,
         exclude=True,
         description="Conversation state of the task.",
     )
+    remote_workspace: RemoteWorkspace | None = Field(default=None, exclude=True)
+    remote: bool = False
+    subagent_type: str | None = None
 
     def set_result(self, result: str) -> None:
         """Set task as successful."""
@@ -98,9 +109,11 @@ class TaskManager:
     def __init__(
         self,
         confirmation_handler: ConfirmationHandler | None = None,
+        workspace_factory: SubagentWorkspaceFactory | None = None,
     ):
         self._parent_conversation: LocalConversation | None = None
         self._confirmation_handler = confirmation_handler
+        self._workspace_factory = workspace_factory
 
         self._tasks: dict[str, Task] = {}
         self._tasks_lock = threading.Lock()
@@ -137,6 +150,24 @@ class TaskManager:
                 self._persistence_dir = Path(
                     tempfile.mkdtemp(prefix="openhands_tasks_")
                 )
+            manifest = self._persistence_dir / "remote_tasks.json"
+            if manifest.exists():
+                tasks = TypeAdapter(list[Task]).validate_json(manifest.read_text())
+                self._tasks.update({task.id: task for task in tasks})
+
+    def _persist_remote_tasks(self) -> None:
+        """Persist identities, never live workspace objects or credentials.
+
+        Call while holding _tasks_lock.
+        """
+        assert self._persistence_dir is not None
+        tasks = [task for task in self._tasks.values() if task.remote]
+        if not tasks:
+            return
+        manifest = self._persistence_dir / "remote_tasks.json"
+        temporary = manifest.with_suffix(".tmp")
+        temporary.write_bytes(TypeAdapter(list[Task]).dump_json(tasks))
+        temporary.replace(manifest)
 
     @property
     def parent_conversation(self) -> LocalConversation:
@@ -151,10 +182,18 @@ class TaskManager:
         """Generate a unique task ID, and a conversation ID."""
         task_number = len(self._tasks) + 1
         task_id = f"task_{task_number:08x}"
+        while task_id in self._tasks:
+            task_number += 1
+            task_id = f"task_{task_number:08x}"
         uuid_ = uuid.uuid4()
         return task_id, uuid_
 
     def _evict_task(self, task: Task) -> None:
+        if task.remote_workspace is not None:
+            # Retain the remote session and workspace until resume or parent close.
+            with self._tasks_lock:
+                self._persist_remote_tasks()
+            return
         if task.conversation:
             task.conversation.pause()
             task.conversation.close()
@@ -209,13 +248,39 @@ class TaskManager:
                     f"Available tasks: {', '.join(sorted(self._tasks))}"
                 )
 
+            stored_task = self._tasks[resume]
+            if stored_task.remote and stored_task.subagent_type is not None:
+                subagent_type = stored_task.subagent_type
             factory = get_agent_factory(subagent_type)
             worker_agent = self._get_sub_agent_from_factory(factory)
             conversation_id = self._tasks[resume].conversation_id
+            workspace = self._tasks[resume].remote_workspace
+            if stored_task.remote and workspace is None:
+                if self._workspace_factory is None:
+                    raise ValueError(
+                        f"Remote task '{resume}' requires its workspace_factory "
+                        "to reconnect to the original workspace."
+                    )
+                workspace = self._workspace_factory(resume, subagent_type)
+                if workspace is None:
+                    raise ValueError(f"Remote workspace for task '{resume}' is gone")
+                if workspace is self.parent_conversation.state.workspace or any(
+                    task.remote_workspace is workspace for task in self._tasks.values()
+                ):
+                    raise ValueError("Each subagent must own a distinct workspace")
+                enter_workspace(workspace)
+                stored_task.remote_workspace = workspace
             with detached_delegate_context() as link:
-                conversation = LocalConversation(
+                conversation_class = (
+                    LocalConversation if workspace is None else RemoteConversation
+                )
+                conversation_kwargs: dict = dict(
                     agent=worker_agent,
-                    workspace=self.parent_conversation.state.workspace.working_dir,
+                    workspace=(
+                        workspace
+                        if workspace is not None
+                        else self.parent_conversation.state.workspace.working_dir
+                    ),
                     persistence_dir=self._persistence_dir,
                     conversation_id=conversation_id,
                     hook_config=factory.definition.hooks,
@@ -224,12 +289,34 @@ class TaskManager:
                         task_id=resume, subagent_type=subagent_type, link=link
                     ),
                     observability_tags=["delegate"],
+                    **({"require_existing": True} if workspace is not None else {}),
                 )
+                try:
+                    conversation = conversation_class(**conversation_kwargs)
+                except BaseException:
+                    if workspace is not None and stored_task.conversation is None:
+                        close_workspace(workspace)
+                        stored_task.remote_workspace = None
+                    raise
 
-            self._set_confirmation_policy(
-                conversation,
-                factory.definition.get_confirmation_policy(),
-            )
+            try:
+                self._set_confirmation_policy(
+                    conversation,
+                    factory.definition.get_confirmation_policy(),
+                )
+            except BaseException:
+                try:
+                    conversation.close()
+                finally:
+                    if workspace is not None and stored_task.conversation is None:
+                        close_workspace(workspace)
+                        stored_task.remote_workspace = None
+                raise
+            if workspace is not None:
+                previous = self._tasks[resume].conversation
+                if isinstance(previous, RemoteConversation):
+                    previous.delete_on_close = False
+                    previous.close()
 
             self._tasks[resume] = self._tasks[resume].model_copy(
                 update={
@@ -237,6 +324,7 @@ class TaskManager:
                     "status": TaskStatus.RUNNING,
                 }
             )
+            self._persist_remote_tasks()
 
             return self._tasks[resume]
 
@@ -267,29 +355,55 @@ class TaskManager:
 
         with self._tasks_lock:
             task_id, conversation_id = self._generate_ids()
-
-            sub_conversation = self._get_conversation(
-                description=description,
-                max_iteration_per_run=effective_max_iter,
-                max_budget_per_run=effective_max_budget,
-                task_id=task_id,
-                subagent_type=subagent_type,
-                worker_agent=worker_agent,
-                conversation_id=conversation_id,
-                hook_config=factory.definition.hooks,
+            workspace = (
+                self._workspace_factory(task_id, subagent_type)
+                if self._workspace_factory is not None
+                else None
             )
+            if workspace is not None:
+                if workspace is self.parent_conversation.state.workspace or any(
+                    task.remote_workspace is workspace for task in self._tasks.values()
+                ):
+                    raise ValueError("Each subagent must own a distinct workspace")
+                enter_workspace(workspace)
 
-            self._set_confirmation_policy(
-                sub_conversation,
-                factory.definition.get_confirmation_policy(),
-            )
+            sub_conversation = None
+            try:
+                sub_conversation = self._get_conversation(
+                    description=description,
+                    max_iteration_per_run=effective_max_iter,
+                    max_budget_per_run=effective_max_budget,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    worker_agent=worker_agent,
+                    conversation_id=conversation_id,
+                    hook_config=factory.definition.hooks,
+                    remote_workspace=workspace,
+                )
+
+                self._set_confirmation_policy(
+                    sub_conversation,
+                    factory.definition.get_confirmation_policy(),
+                )
+            except BaseException:
+                try:
+                    if sub_conversation is not None:
+                        sub_conversation.close()
+                finally:
+                    if workspace is not None:
+                        close_workspace(workspace)
+                raise
 
             self._tasks[task_id] = Task(
                 id=task_id,
                 conversation_id=conversation_id,
                 conversation=sub_conversation,
                 status=TaskStatus.RUNNING,
+                remote_workspace=workspace,
+                remote=workspace is not None,
+                subagent_type=subagent_type,
             )
+            self._persist_remote_tasks()
             return self._tasks[task_id]
 
     def _get_conversation(
@@ -302,7 +416,8 @@ class TaskManager:
         worker_agent: Agent,
         hook_config: HookConfig | None = None,
         max_budget_per_run: float | None = None,
-    ) -> LocalConversation:
+        remote_workspace: RemoteWorkspace | None = None,
+    ) -> BaseConversation:
         parent = self.parent_conversation
         parent_visualizer = parent._visualizer
 
@@ -312,9 +427,16 @@ class TaskManager:
             visualizer = parent_visualizer.create_sub_visualizer(label)
 
         with detached_delegate_context() as link:
-            return LocalConversation(
+            conversation_class = (
+                LocalConversation if remote_workspace is None else RemoteConversation
+            )
+            conversation_kwargs: dict = dict(
                 agent=worker_agent,
-                workspace=parent.state.workspace.working_dir,
+                workspace=(
+                    remote_workspace
+                    if remote_workspace is not None
+                    else parent.state.workspace.working_dir
+                ),
                 visualizer=visualizer,
                 persistence_dir=self._persistence_dir,
                 conversation_id=conversation_id,
@@ -328,6 +450,7 @@ class TaskManager:
                 ),
                 observability_tags=["delegate"],
             )
+            return conversation_class(**conversation_kwargs)
 
     def _delegate_observability_metadata(
         self,
@@ -405,14 +528,18 @@ class TaskManager:
             task.set_error(str(e))
             logger.warning(f"Task {task.id} failed with error: {e}")
         finally:
-            self._update_parent_metrics(parent, task)
-            self._evict_task(task)
+            try:
+                self._update_parent_metrics(parent, task)
+            except Exception:
+                logger.warning("Failed to read subagent metrics", exc_info=True)
+            finally:
+                self._evict_task(task)
 
         return task
 
     @staticmethod
     def _run_stop_detail(
-        conversation: LocalConversation,
+        conversation: BaseConversation,
         status: ConversationExecutionStatus,
     ) -> str:
         """Why a sub-agent stopped without finishing (run-limit, stuck, paused, ...),
@@ -430,9 +557,7 @@ class TaskManager:
         partial = get_agent_final_response(conversation.state.events)
         return f"{reason}\nPartial result:\n{partial}" if partial else reason
 
-    def _run_until_finished(
-        self, task_id: str, conversation: LocalConversation
-    ) -> None:
+    def _run_until_finished(self, task_id: str, conversation: BaseConversation) -> None:
         """Run a sub-agent conversation to completion, handling confirmations."""
         conversation.run()
         while (
@@ -453,7 +578,7 @@ class TaskManager:
 
     def _set_confirmation_policy(
         self,
-        conversation: LocalConversation,
+        conversation: BaseConversation,
         confirmation_policy: ConfirmationPolicyBase | None,
     ) -> None:
         """
@@ -479,6 +604,18 @@ class TaskManager:
 
     def close(self) -> None:
         """Clean up temporary directory (if used) and remove all created tasks."""
+        with self._tasks_lock:
+            tasks = list(self._tasks.values())
+            self._tasks.clear()
+        for task in tasks:
+            try:
+                if task.conversation is not None:
+                    task.conversation.close()
+            except Exception:
+                logger.warning("Failed to close subagent conversation", exc_info=True)
+            finally:
+                if task.remote_workspace is not None:
+                    close_workspace(task.remote_workspace)
         # Only clean up when using a temp dir (parent had no persistence).
         # When the parent persists, subagent data lives under its directory.
         parent_persists = (
@@ -491,6 +628,3 @@ class TaskManager:
             and self._persistence_dir.exists()
         ):
             shutil.rmtree(self._persistence_dir, ignore_errors=True)
-
-        with self._tasks_lock:
-            self._tasks.clear()

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -5,9 +5,8 @@ The TaskManager class is responsible for creating, resuming,
 and running sub-agent tasks. In other words, it handles
 everything related to task management.
 
-The conversation linked to a completed task is persisted in
-a temporary directory, ensuring the state can be restored
-if the task is resumed for further work later.
+Local task conversations are persisted for resume. Remote task conversations
+and their owned workspaces are retained in memory until the manager closes.
 """
 
 import shutil
@@ -19,7 +18,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field
 
 from openhands.sdk import Agent
 from openhands.sdk.conversation import BaseConversation
@@ -39,10 +38,7 @@ from openhands.sdk.security import ConfirmationPolicyBase
 from openhands.sdk.subagent.registry import AgentFactory, get_agent_factory
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.task.workspace import (
-    SubagentWorkspace,
     SubagentWorkspaceFactory,
-    SubagentWorkspaceReference,
-    SubagentWorkspaceResolver,
     close_workspace,
     enter_workspace,
 )
@@ -90,9 +86,6 @@ class Task(BaseModel):
         description="Conversation state of the task.",
     )
     remote_workspace: RemoteWorkspace | None = Field(default=None, exclude=True)
-    remote: bool = False
-    subagent_type: str | None = None
-    workspace_reference: SubagentWorkspaceReference | None = None
 
     def set_result(self, result: str) -> None:
         """Set task as successful."""
@@ -114,15 +107,15 @@ class TaskManager:
         self,
         confirmation_handler: ConfirmationHandler | None = None,
         workspace_factory: SubagentWorkspaceFactory | None = None,
-        workspace_resolver: SubagentWorkspaceResolver | None = None,
     ):
         self._parent_conversation: LocalConversation | None = None
         self._confirmation_handler = confirmation_handler
         self._workspace_factory = workspace_factory
-        self._workspace_resolver = workspace_resolver
 
         self._tasks: dict[str, Task] = {}
         self._tasks_lock = threading.Lock()
+        self._pending_tasks: dict[str, RemoteWorkspace | None] = {}
+        self._closed = False
 
         # Set once in _ensure_parent: uses the parent's subagents dir
         # when the parent persists, otherwise a temporary directory.
@@ -146,34 +139,19 @@ class TaskManager:
         self._ensure_parent(conversation)
 
     def _ensure_parent(self, conversation: LocalConversation) -> None:
-        if self._parent_conversation is None:
-            self._parent_conversation = conversation
-            parent_persistence_dir = conversation.state.persistence_dir
-            if parent_persistence_dir is not None:
-                self._persistence_dir = Path(parent_persistence_dir) / _SUBAGENTS_DIR
-                self._persistence_dir.mkdir(parents=True, exist_ok=True)
-            else:
-                self._persistence_dir = Path(
-                    tempfile.mkdtemp(prefix="openhands_tasks_")
-                )
-            manifest = self._persistence_dir / "remote_tasks.json"
-            if manifest.exists():
-                tasks = TypeAdapter(list[Task]).validate_json(manifest.read_text())
-                self._tasks.update({task.id: task for task in tasks})
-
-    def _persist_remote_tasks(self) -> None:
-        """Persist identities, never live workspace objects or credentials.
-
-        Call while holding _tasks_lock.
-        """
-        assert self._persistence_dir is not None
-        tasks = [task for task in self._tasks.values() if task.remote]
-        if not tasks:
-            return
-        manifest = self._persistence_dir / "remote_tasks.json"
-        temporary = manifest.with_suffix(".tmp")
-        temporary.write_bytes(TypeAdapter(list[Task]).dump_json(tasks))
-        temporary.replace(manifest)
+        with self._tasks_lock:
+            if self._parent_conversation is None:
+                self._parent_conversation = conversation
+                parent_persistence_dir = conversation.state.persistence_dir
+                if parent_persistence_dir is not None:
+                    self._persistence_dir = (
+                        Path(parent_persistence_dir) / _SUBAGENTS_DIR
+                    )
+                    self._persistence_dir.mkdir(parents=True, exist_ok=True)
+                else:
+                    self._persistence_dir = Path(
+                        tempfile.mkdtemp(prefix="openhands_tasks_")
+                    )
 
     @property
     def parent_conversation(self) -> LocalConversation:
@@ -186,9 +164,9 @@ class TaskManager:
 
     def _generate_ids(self) -> tuple[str, uuid.UUID]:
         """Generate a unique task ID, and a conversation ID."""
-        task_number = len(self._tasks) + 1
+        task_number = len(self._tasks) + len(self._pending_tasks) + 1
         task_id = f"task_{task_number:08x}"
-        while task_id in self._tasks:
+        while task_id in self._tasks or task_id in self._pending_tasks:
             task_number += 1
             task_id = f"task_{task_number:08x}"
         uuid_ = uuid.uuid4()
@@ -196,9 +174,8 @@ class TaskManager:
 
     def _evict_task(self, task: Task) -> None:
         if task.remote_workspace is not None:
-            # Retain the remote session and workspace until resume or parent close.
-            with self._tasks_lock:
-                self._persist_remote_tasks()
+            # Remote task workspaces remain allocated for the lifetime of the
+            # TaskManager to support task resume.
             return
         if task.conversation:
             task.conversation.pause()
@@ -255,93 +232,38 @@ class TaskManager:
                 )
 
             stored_task = self._tasks[resume]
-            if stored_task.remote and stored_task.subagent_type is not None:
-                subagent_type = stored_task.subagent_type
+            if stored_task.remote_workspace is not None:
+                assert stored_task.conversation is not None
+                self._tasks[resume] = stored_task.model_copy(
+                    update={"status": TaskStatus.RUNNING}
+                )
+                return self._tasks[resume]
+
             factory = get_agent_factory(subagent_type)
             worker_agent = self._get_sub_agent_from_factory(factory)
-            conversation_id = self._tasks[resume].conversation_id
-            workspace = self._tasks[resume].remote_workspace
-            if stored_task.remote and workspace is None:
-                if stored_task.workspace_reference is None:
-                    raise ValueError(
-                        f"Remote task '{resume}' has no persisted workspace identity; "
-                        "cannot reconnect safely."
-                    )
-                if self._workspace_resolver is None:
-                    raise ValueError(
-                        f"Remote task '{resume}' requires a workspace_resolver "
-                        "to reconnect to the original workspace."
-                    )
-                workspace = self._workspace_resolver(stored_task.workspace_reference)
-                if workspace is None:
-                    raise ValueError(f"Remote workspace for task '{resume}' is gone")
-                if workspace is self.parent_conversation.state.workspace or any(
-                    task.remote_workspace is workspace for task in self._tasks.values()
-                ):
-                    raise ValueError("Each subagent must own a distinct workspace")
-                enter_workspace(workspace)
-                if workspace.working_dir != stored_task.workspace_reference.working_dir:
-                    close_workspace(workspace)
-                    raise ValueError(
-                        "Resolved workspace has a different working directory"
-                    )
-                stored_task.remote_workspace = workspace
             with detached_delegate_context() as link:
-                conversation_class = (
-                    LocalConversation if workspace is None else RemoteConversation
-                )
-                conversation_kwargs: dict = dict(
+                conversation = LocalConversation(
                     agent=worker_agent,
-                    workspace=(
-                        workspace
-                        if workspace is not None
-                        else self.parent_conversation.state.workspace.working_dir
-                    ),
+                    workspace=self.parent_conversation.state.workspace.working_dir,
                     persistence_dir=self._persistence_dir,
-                    conversation_id=conversation_id,
+                    conversation_id=stored_task.conversation_id,
                     hook_config=factory.definition.hooks,
                     delete_on_close=True,
                     observability_metadata=self._delegate_observability_metadata(
                         task_id=resume, subagent_type=subagent_type, link=link
                     ),
                     observability_tags=["delegate"],
-                    **({"require_existing": True} if workspace is not None else {}),
                 )
-                try:
-                    conversation = conversation_class(**conversation_kwargs)
-                except BaseException:
-                    if workspace is not None and stored_task.conversation is None:
-                        close_workspace(workspace)
-                        stored_task.remote_workspace = None
-                    raise
-
             try:
                 self._set_confirmation_policy(
-                    conversation,
-                    factory.definition.get_confirmation_policy(),
+                    conversation, factory.definition.get_confirmation_policy()
                 )
             except BaseException:
-                try:
-                    conversation.close()
-                finally:
-                    if workspace is not None and stored_task.conversation is None:
-                        close_workspace(workspace)
-                        stored_task.remote_workspace = None
+                conversation.close()
                 raise
-            if workspace is not None:
-                previous = self._tasks[resume].conversation
-                if isinstance(previous, RemoteConversation):
-                    previous.delete_on_close = False
-                    previous.close()
-
-            self._tasks[resume] = self._tasks[resume].model_copy(
-                update={
-                    "conversation": conversation,
-                    "status": TaskStatus.RUNNING,
-                }
+            self._tasks[resume] = stored_task.model_copy(
+                update={"conversation": conversation, "status": TaskStatus.RUNNING}
             )
-            self._persist_remote_tasks()
-
             return self._tasks[resume]
 
     def _create_task(
@@ -370,74 +292,71 @@ class TaskManager:
         )
 
         with self._tasks_lock:
+            if self._closed:
+                raise RuntimeError("TaskManager is closed")
             task_id, conversation_id = self._generate_ids()
+            self._pending_tasks[task_id] = None
+
+        workspace = None
+        sub_conversation = None
+        try:
             provisioned = (
                 self._workspace_factory(task_id, subagent_type)
                 if self._workspace_factory is not None
                 else None
             )
-            reference = (
-                provisioned.reference
-                if isinstance(provisioned, SubagentWorkspace)
-                else None
+            if provisioned is not None:
+                with self._tasks_lock:
+                    if provisioned is self.parent_conversation.state.workspace or any(
+                        owned is provisioned
+                        for owned in [
+                            *(task.remote_workspace for task in self._tasks.values()),
+                            *self._pending_tasks.values(),
+                        ]
+                    ):
+                        raise ValueError("Each subagent must own a distinct workspace")
+                    self._pending_tasks[task_id] = provisioned
+                # enter_workspace owns rollback if entering fails.
+                enter_workspace(provisioned)
+                workspace = provisioned
+
+            sub_conversation = self._get_conversation(
+                description=description,
+                max_iteration_per_run=effective_max_iter,
+                max_budget_per_run=effective_max_budget,
+                task_id=task_id,
+                subagent_type=subagent_type,
+                worker_agent=worker_agent,
+                conversation_id=conversation_id,
+                hook_config=factory.definition.hooks,
+                remote_workspace=workspace,
             )
-            workspace = (
-                provisioned.workspace
-                if isinstance(provisioned, SubagentWorkspace)
-                else provisioned
+            self._set_confirmation_policy(
+                sub_conversation, factory.definition.get_confirmation_policy()
             )
-            if workspace is not None:
-                if workspace is self.parent_conversation.state.workspace or any(
-                    task.remote_workspace is workspace for task in self._tasks.values()
-                ):
-                    raise ValueError("Each subagent must own a distinct workspace")
-                enter_workspace(workspace)
-
-            sub_conversation = None
-            try:
-                if reference is not None and workspace is not None:
-                    if reference.working_dir != workspace.working_dir:
-                        raise ValueError(
-                            "Workspace reference must describe the child's "
-                            "working directory"
-                        )
-                sub_conversation = self._get_conversation(
-                    description=description,
-                    max_iteration_per_run=effective_max_iter,
-                    max_budget_per_run=effective_max_budget,
-                    task_id=task_id,
-                    subagent_type=subagent_type,
-                    worker_agent=worker_agent,
-                    conversation_id=conversation_id,
-                    hook_config=factory.definition.hooks,
-                    remote_workspace=workspace,
-                )
-
-                self._set_confirmation_policy(
-                    sub_conversation,
-                    factory.definition.get_confirmation_policy(),
-                )
-            except BaseException:
-                try:
-                    if sub_conversation is not None:
-                        sub_conversation.close()
-                finally:
-                    if workspace is not None:
-                        close_workspace(workspace)
-                raise
-
-            self._tasks[task_id] = Task(
+            task = Task(
                 id=task_id,
                 conversation_id=conversation_id,
                 conversation=sub_conversation,
                 status=TaskStatus.RUNNING,
                 remote_workspace=workspace,
-                remote=workspace is not None,
-                subagent_type=subagent_type,
-                workspace_reference=reference,
             )
-            self._persist_remote_tasks()
-            return self._tasks[task_id]
+            with self._tasks_lock:
+                if self._closed:
+                    raise RuntimeError("TaskManager closed during task creation")
+                self._tasks[task_id] = task
+            return task
+        except BaseException:
+            try:
+                if sub_conversation is not None:
+                    sub_conversation.close()
+            finally:
+                if workspace is not None:
+                    close_workspace(workspace)
+            raise
+        finally:
+            with self._tasks_lock:
+                self._pending_tasks.pop(task_id, None)
 
     def _get_conversation(
         self,
@@ -638,6 +557,7 @@ class TaskManager:
     def close(self) -> None:
         """Clean up temporary directory (if used) and remove all created tasks."""
         with self._tasks_lock:
+            self._closed = True
             tasks = list(self._tasks.values())
             self._tasks.clear()
         for task in tasks:

--- a/openhands-tools/openhands/tools/task/workspace.py
+++ b/openhands-tools/openhands/tools/task/workspace.py
@@ -1,9 +1,6 @@
 """Ownership of workspaces provisioned for individual subagents."""
 
 from collections.abc import Callable
-from dataclasses import dataclass
-
-from pydantic import BaseModel, ConfigDict, Field
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.workspace import RemoteWorkspace
@@ -12,41 +9,11 @@ from openhands.sdk.workspace import RemoteWorkspace
 logger = get_logger(__name__)
 
 
-class SubagentWorkspaceReference(BaseModel):
-    """Durable provider identity, without credentials or a live workspace object."""
-
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-    provider: str = Field(min_length=1)
-    workspace_id: str = Field(min_length=1)
-    working_dir: str = Field(min_length=1)
-
-
-@dataclass(frozen=True)
-class SubagentWorkspace:
-    """A newly provisioned workspace and the identity needed to reconnect to it."""
-
-    workspace: RemoteWorkspace
-    reference: SubagentWorkspaceReference
-
-
-SubagentWorkspaceFactory = Callable[
-    [str, str], RemoteWorkspace | SubagentWorkspace | None
-]
+SubagentWorkspaceFactory = Callable[[str, str], RemoteWorkspace | None]
 """Create an owned workspace from (child ID, agent type), or None for local work.
 
 Return a fresh workspace for each child. The executor enters it and exits it on
 cleanup. Factories that fail during provisioning must clean up their own resources.
-Return SubagentWorkspace with a durable reference to support process restarts.
-"""
-
-SubagentWorkspaceResolver = Callable[
-    [SubagentWorkspaceReference], RemoteWorkspace | None
-]
-"""Reconnect to the referenced workspace; never provision a replacement.
-
-Retrieve current endpoints and credentials from the provider using the durable
-identity. Return None (or raise) when that workspace no longer exists.
 """
 
 

--- a/openhands-tools/openhands/tools/task/workspace.py
+++ b/openhands-tools/openhands/tools/task/workspace.py
@@ -1,6 +1,9 @@
 """Ownership of workspaces provisioned for individual subagents."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.workspace import RemoteWorkspace
@@ -8,11 +11,42 @@ from openhands.sdk.workspace import RemoteWorkspace
 
 logger = get_logger(__name__)
 
-SubagentWorkspaceFactory = Callable[[str, str], RemoteWorkspace | None]
+
+class SubagentWorkspaceReference(BaseModel):
+    """Durable provider identity, without credentials or a live workspace object."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: str = Field(min_length=1)
+    workspace_id: str = Field(min_length=1)
+    working_dir: str = Field(min_length=1)
+
+
+@dataclass(frozen=True)
+class SubagentWorkspace:
+    """A newly provisioned workspace and the identity needed to reconnect to it."""
+
+    workspace: RemoteWorkspace
+    reference: SubagentWorkspaceReference
+
+
+SubagentWorkspaceFactory = Callable[
+    [str, str], RemoteWorkspace | SubagentWorkspace | None
+]
 """Create an owned workspace from (child ID, agent type), or None for local work.
 
 Return a fresh workspace for each child. The executor enters it and exits it on
 cleanup. Factories that fail during provisioning must clean up their own resources.
+Return SubagentWorkspace with a durable reference to support process restarts.
+"""
+
+SubagentWorkspaceResolver = Callable[
+    [SubagentWorkspaceReference], RemoteWorkspace | None
+]
+"""Reconnect to the referenced workspace; never provision a replacement.
+
+Retrieve current endpoints and credentials from the provider using the durable
+identity. Return None (or raise) when that workspace no longer exists.
 """
 
 

--- a/openhands-tools/openhands/tools/task/workspace.py
+++ b/openhands-tools/openhands/tools/task/workspace.py
@@ -1,0 +1,35 @@
+"""Ownership of workspaces provisioned for individual subagents."""
+
+from collections.abc import Callable
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.workspace import RemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+SubagentWorkspaceFactory = Callable[[str, str], RemoteWorkspace | None]
+"""Create an owned workspace from (child ID, agent type), or None for local work.
+
+Return a fresh workspace for each child. The executor enters it and exits it on
+cleanup. Factories that fail during provisioning must clean up their own resources.
+"""
+
+
+def close_workspace(workspace: RemoteWorkspace) -> None:
+    """Release a child workspace, including its HTTP connection pool."""
+    try:
+        workspace.__exit__(None, None, None)
+    except Exception:
+        logger.warning("Failed to release subagent workspace", exc_info=True)
+    finally:
+        workspace.reset_client()
+
+
+def enter_workspace(workspace: RemoteWorkspace) -> None:
+    """Enter a newly owned workspace, rolling back partial initialization."""
+    try:
+        workspace.__enter__()
+    except BaseException:
+        close_workspace(workspace)
+        raise

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -183,7 +183,7 @@ def _assert_secret(value: "str | SecretStr", expected: str) -> None:
 
 
 @pytest.mark.parametrize("child_budget", [None, 0.5])
-def test_remote_subagent_budget_enforced_after_server_reload(
+def test_remote_subagent_budget_enforced_on_resume(
     server_env, monkeypatch, tmp_path, child_budget
 ):
     calls = []
@@ -241,10 +241,6 @@ def test_remote_subagent_budget_enforced_after_server_reload(
             for event in task.conversation.state.events
         )
 
-        task.conversation.delete_on_close = False
-        task.conversation.close()
-        response = workspace.client.post("/api/conversations/prepare-for-sandbox-pause")
-        response.raise_for_status()
         resumed = manager.start_task("Continue", resume=task.id)
         assert resumed.status == TaskStatus.ERROR
         assert isinstance(resumed.conversation, RemoteConversation)
@@ -260,6 +256,48 @@ def test_remote_subagent_budget_enforced_after_server_reload(
             )
             == 2
         )
+    finally:
+        manager.close()
+        parent.close()
+        _reset_registry_for_tests()
+
+
+@pytest.mark.parametrize("remote", [False, True])
+def test_subagent_workspace_factory_returns_result(
+    server_env, patched_llm, tmp_path, remote
+):
+    name = "live-remote-worker"
+    register_agent(
+        name,
+        lambda llm: Agent(llm=llm, tools=[]),
+        AgentDefinition(name=name, description="Worker"),
+    )
+    parent = LocalConversation(
+        agent=Agent(llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")), tools=[]),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    manager = TaskManager(
+        workspace_factory=lambda child, kind: RemoteWorkspace(
+            host=server_env["host"], working_dir=str(server_env["workspace_path"])
+        )
+        if remote
+        else None
+    )
+    try:
+        task = manager.start_task("Say hello", name, conversation=parent)
+        assert task.status == TaskStatus.COMPLETED
+        assert task.result == "Hello from patched LLM"
+        assert isinstance(
+            task.conversation, RemoteConversation if remote else LocalConversation
+        )
+        if remote:
+            assert task.conversation.workspace is not parent.workspace
+        resumed = manager.start_task("Say hello again", name, resume=task.id)
+        assert resumed.result == "Hello from patched LLM"
+        if remote:
+            assert resumed.conversation is task.conversation
+        assert len(patched_llm) == 2
     finally:
         manager.close()
         parent.close()

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -26,7 +26,7 @@ from pydantic import SecretStr
 
 from openhands.agent_server.__main__ import preload_modules
 from openhands.sdk import LLM, Agent, AgentContext, Conversation, Message, TextContent
-from openhands.sdk.conversation import RemoteConversation
+from openhands.sdk.conversation import LocalConversation, RemoteConversation
 from openhands.sdk.event import (
     ActionEvent,
     AgentErrorEvent,
@@ -40,7 +40,10 @@ from openhands.sdk.event import (
     PauseEvent,
     SystemPromptEvent,
 )
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+from openhands.sdk.llm import MessageToolCall
+from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.skills import Skill
 from openhands.sdk.subagent import AgentDefinition
 from openhands.sdk.subagent.registry import (
@@ -51,6 +54,7 @@ from openhands.sdk.subagent.registry import (
     register_agent_if_absent,
 )
 from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.task.manager import TaskManager, TaskStatus
 from openhands.workspace.docker.workspace import find_available_tcp_port
 
 
@@ -176,6 +180,90 @@ def _assert_secret(value: "str | SecretStr", expected: str) -> None:
         assert value.get_secret_value() == expected
     else:
         assert value == expected
+
+
+@pytest.mark.parametrize("child_budget", [None, 0.5])
+def test_remote_subagent_budget_enforced_after_server_reload(
+    server_env, monkeypatch, tmp_path, child_budget
+):
+    calls = []
+
+    async def completion(self, messages, tools=None, **kwargs):
+        calls.append(messages)
+        self.metrics.add_cost(2.0)
+        message = Message(
+            role="assistant",
+            content=[],
+            tool_calls=[
+                MessageToolCall(
+                    origin="completion",
+                    id=f"think-{len(calls)}",
+                    name="think",
+                    arguments='{"thought": "Continue working"}',
+                )
+            ],
+        )
+        return LLMResponse(
+            message=message,
+            metrics=self.metrics.get_snapshot(),
+            raw_response=ModelResponse(id=f"cost-{len(calls)}", choices=[]),
+        )
+
+    monkeypatch.setattr(LLM, "acompletion", completion)
+    name = "budgeted-remote-worker"
+    register_agent(
+        name,
+        lambda llm: Agent(llm=llm, tools=[]),
+        AgentDefinition(
+            name=name, description="Worker", max_budget_per_run=child_budget
+        ),
+    )
+    parent = LocalConversation(
+        agent=Agent(llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")), tools=[]),
+        workspace=tmp_path,
+        max_budget_per_run=1.0,
+        visualizer=None,
+    )
+    workspace = RemoteWorkspace(
+        host=server_env["host"], working_dir=str(server_env["workspace_path"])
+    )
+    manager = TaskManager(workspace_factory=lambda child, kind: workspace)
+    expected_budget = child_budget or 1.0
+    try:
+        task = manager.start_task("Keep working", name, conversation=parent)
+        assert task.status == TaskStatus.ERROR
+        assert len(calls) == 1
+        assert isinstance(task.conversation, RemoteConversation)
+        assert task.conversation.max_budget_per_run == expected_budget
+        assert any(
+            isinstance(event, ConversationErrorEvent)
+            and event.code == "MaxBudgetReached"
+            for event in task.conversation.state.events
+        )
+
+        task.conversation.delete_on_close = False
+        task.conversation.close()
+        response = workspace.client.post("/api/conversations/prepare-for-sandbox-pause")
+        response.raise_for_status()
+        resumed = manager.start_task("Continue", resume=task.id)
+        assert resumed.status == TaskStatus.ERROR
+        assert isinstance(resumed.conversation, RemoteConversation)
+        assert resumed.conversation.max_budget_per_run == expected_budget
+        assert (
+            len(
+                [
+                    event
+                    for event in resumed.conversation.state.events
+                    if isinstance(event, ConversationErrorEvent)
+                    and event.code == "MaxBudgetReached"
+                ]
+            )
+            == 2
+        )
+    finally:
+        manager.close()
+        parent.close()
+        _reset_registry_for_tests()
 
 
 def test_health_endpoints_return_ok_json(server_env):

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -59,6 +59,27 @@ uv run python tests/integration/run_infer.py --llm-config '{"model": "litellm_pr
 uv run python tests/integration/run_infer.py --llm-config '{"model": "litellm_proxy/anthropic/claude-opus-4-5", "extended_thinking": true}' --test-type condenser
 ```
 
+### Live Remote Subagent Test
+
+The remote-subagent scenario uses real LLM calls for both the local parent and
+its children, and provisions two independent Docker sandboxes through
+`workspace_factory`:
+
+```bash
+uv run python tests/integration/run_infer.py \
+  --llm-config '{"model": "litellm_proxy/anthropic/claude-sonnet-4-5-20250929"}' \
+  --eval-ids t10_remote_subagent_workspaces
+```
+
+Set `LLM_API_KEY` and `LLM_BASE_URL` as for the other integration tests. Docker
+must be running, and the LLM endpoint must be reachable from its containers.
+The test builds a minimal Agent Server image from the current checkout by default,
+without browser, VS Code, Docker-in-Docker, or bundled ACP providers;
+set `AGENT_SERVER_IMAGE` to reuse an image built from the same feature revision.
+It verifies child-specific file contents and results, in-session task resume,
+parent-file isolation, and container cleanup. Missing credentials or Docker are
+prerequisite failures, not a mocked fallback or a successful live run.
+
 ## Automated Testing with GitHub Actions
 
 Tests are automatically executed via GitHub Actions using two separate workflows:
@@ -99,6 +120,8 @@ These tests must pass for releases and verify that the agent can successfully co
 - **t06_github_pr_browsing** - Tests GitHub PR browsing
 - **t07_interactive_commands** - Tests interactive command handling
 - **t08_image_file_viewing** - Tests image file viewing capabilities
+- **t10_remote_subagent_workspaces** - Tests real-LLM Task delegation and resume
+  through a workspace factory provisioning independent Docker containers
 
 ### Behavior Tests (`b*.py`) - **Optional**
 

--- a/tests/integration/tests/t10_remote_subagent_workspaces.py
+++ b/tests/integration/tests/t10_remote_subagent_workspaces.py
@@ -1,0 +1,246 @@
+"""Real LLM delegation from a local parent into independently owned Docker sandboxes."""
+
+import json
+import os
+import platform
+import shlex
+import subprocess
+import time
+from pathlib import Path
+from threading import BoundedSemaphore
+from uuid import uuid4
+
+import httpx
+
+from openhands.agent_server.docker.build import BuildOptions, build
+from openhands.sdk import Agent
+from openhands.sdk.conversation.response_utils import get_agent_final_response
+from openhands.sdk.event import ActionEvent, ObservationEvent
+from openhands.sdk.subagent import AgentDefinition, register_agent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.workspace import PlatformType
+from openhands.tools.task.definition import TaskAction, TaskObservation, TaskToolSet
+from openhands.workspace import DockerWorkspace
+from tests.integration.base import BaseIntegrationTest, TestResult, get_tools_for_preset
+
+
+INSTRUCTION = """Use the task tool to launch exactly two NEW remote-worker tasks.
+Each child has its own sandbox containing input.json, with a token and a list of
+numbers. Tell each child to read that file, compute the sum, write result.txt
+containing exactly TOKEN:SUM followed by a newline, and return TOKEN:SUM to you.
+The token must come from the child's file, not from guessing. Have children use
+their terminal and finish tools. Launch both children in parallel if possible.
+
+After both finish, RESUME each of those task IDs; do not create replacement tasks.
+Every task call, including resume calls, must include a prompt describing the work.
+Ask each resumed child to read its existing result.txt and append exactly
+"resumed\\n" without inserting a blank line: the file already ends with a newline.
+The final file must contain exactly two lines: TOKEN:SUM and resumed, each ending
+with one newline. Have the child verify this and return its original TOKEN:SUM
+again. Finish by reporting both
+TOKEN:SUM values. Do not attempt to do the children's work in your local workspace.
+"""
+
+
+class RemoteSubagentWorkspacesTest(BaseIntegrationTest):
+    INSTRUCTION = INSTRUCTION
+
+    def __init__(self, *args, **kwargs):
+        self.workspaces: dict[str, DockerWorkspace] = {}
+        self.expected: dict[str, str] = {}
+        self.container_ids: list[str] = []
+        self.clients: list[httpx.Client] = []
+        self.server_image = ""
+        self._child_slots = BoundedSemaphore(2)
+        self.docker_platform: PlatformType = (
+            "linux/arm64"
+            if platform.machine().lower() in {"arm64", "aarch64"}
+            else "linux/amd64"
+        )
+        super().__init__(*args, **kwargs)
+
+    @property
+    def max_iteration_per_run(self) -> int:
+        return 20
+
+    @property
+    def tools(self) -> list[Tool]:
+        test = self
+
+        class RemoteTaskToolSet(TaskToolSet):
+            @classmethod
+            def create(
+                cls, conv_state, confirmation_handler=None, workspace_factory=None
+            ):
+                return super().create(
+                    conv_state,
+                    confirmation_handler=confirmation_handler,
+                    workspace_factory=test.create_workspace,
+                )
+
+        register_tool("integration_remote_tasks", RemoteTaskToolSet)
+        return [Tool(name="integration_remote_tasks")]
+
+    def setup(self) -> None:
+        subprocess.run(["docker", "info"], check=True, capture_output=True)
+        # Build this checkout, not a published image that may lack the feature.
+        self.server_image = (
+            os.environ.get("AGENT_SERVER_IMAGE")
+            or build(
+                BuildOptions(
+                    target="source-minimal",
+                    platforms=[self.docker_platform],
+                    install_acp_providers="",
+                    install_capabilities="",
+                    push=False,
+                )
+            )[0]
+        )
+        register_agent(
+            "remote-worker",
+            lambda llm: Agent(
+                llm=llm,
+                tools=get_tools_for_preset(self.tool_preset, enable_browser=False),
+            ),
+            AgentDefinition(
+                name="remote-worker",
+                description="Worker with an independently provisioned remote sandbox",
+                max_iteration_per_run=12,
+                max_budget_per_run=2.0,
+            ),
+        )
+        (Path(self.workspace) / "result.txt").write_text("parent sentinel\n")
+
+    def create_workspace(self, child_id: str, agent_type: str) -> DockerWorkspace:
+        assert agent_type == "remote-worker"
+        assert self._child_slots.acquire(blocking=False), (
+            "Only two child sandboxes are allowed; resume the existing tasks"
+        )
+        workspace = None
+        try:
+            workspace = DockerWorkspace(
+                server_image=self.server_image,
+                platform=self.docker_platform,
+                working_dir="/workspace",
+            )
+            token = uuid4().hex
+            numbers = [
+                int(token[offset : offset + 4], 16) for offset in range(0, 20, 4)
+            ]
+            payload = shlex.quote(json.dumps({"token": token, "numbers": numbers}))
+            result = workspace.execute_command(
+                f"printf %s {payload} > /workspace/input.json"
+            )
+            assert result.exit_code == 0, result.stderr
+            assert workspace._container_id is not None
+            self.container_ids.append(workspace._container_id)
+            self.clients.append(workspace.client)
+            self.expected[child_id] = f"{token}:{sum(numbers)}"
+            self.workspaces[child_id] = workspace
+            return workspace
+        except BaseException:
+            self._child_slots.release()
+            if workspace is not None:
+                try:
+                    workspace.__exit__(None, None, None)
+                finally:
+                    workspace.reset_client()
+            raise
+
+    def verify_result(self) -> TestResult:
+        assert len(self.workspaces) == 2, (
+            "Parent must create exactly two remote children"
+        )
+        assert len(set(self.container_ids)) == 2, (
+            "Children must own different containers"
+        )
+        assert len({workspace.host for workspace in self.workspaces.values()}) == 2
+        actions = [
+            event.action
+            for event in self.collected_events
+            if isinstance(event, ActionEvent) and isinstance(event.action, TaskAction)
+        ]
+        observations = [
+            event.observation
+            for event in self.collected_events
+            if isinstance(event, ObservationEvent)
+            and isinstance(event.observation, TaskObservation)
+        ]
+        assert len([action for action in actions if not action.resume]) == 2
+        assert {action.resume for action in actions if action.resume} == set(
+            self.workspaces
+        ), "Both original children must be resumed"
+        assert observations and all(not result.is_error for result in observations), [
+            result.text for result in observations
+        ]
+        final_response = get_agent_final_response(self.collected_events)
+        for child_id, workspace in self.workspaces.items():
+            expected = self.expected[child_id]
+            returned = [result for result in observations if result.task_id == child_id]
+            assert len(returned) >= 2 and all(
+                expected in result.text for result in returned
+            )
+            assert expected in final_response, (
+                "Parent must receive and report child results"
+            )
+            result = workspace.execute_command("cat /workspace/result.txt")
+            assert result.exit_code == 0, result.stderr
+            assert result.stdout == f"{expected}\nresumed\n", (
+                f"Unexpected file contents for {child_id}: {result.stdout!r}"
+            )
+            assert workspace.conversation_id is not None
+            response = workspace.client.get(
+                f"/api/conversations/{workspace.conversation_id}/events/search"
+            )
+            response.raise_for_status()
+            tool_names = {
+                event["tool_name"]
+                for event in response.json()["items"]
+                if event["kind"] == "ActionEvent"
+            }
+            assert {"terminal", "finish"} <= tool_names, tool_names
+        assert (Path(self.workspace) / "result.txt").read_text() == "parent sentinel\n"
+
+        self.conversation.close()
+        assert all(client.is_closed for client in self.clients)
+        for container_id in self.container_ids:
+            # Docker's --rm removal can finish after `docker stop` returns.
+            deadline = time.monotonic() + 10
+            while True:
+                remaining = subprocess.run(
+                    ["docker", "ps", "-aq", "--filter", f"id={container_id}"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if not remaining.stdout.strip():
+                    break
+                assert time.monotonic() < deadline, (
+                    f"Leaked child container {container_id}"
+                )
+                time.sleep(0.2)
+        return TestResult(
+            success=True,
+            reason="Real LLM parent delegated to two Docker children, resumed both, "
+            "received their private results, and released both sandboxes.",
+        )
+
+    def teardown(self):
+        try:
+            super().teardown()
+        finally:
+            # The runner reads self.llm.metrics; include the delegated LLM calls.
+            for child_id in self.workspaces:
+                metrics = self.conversation.conversation_stats.usage_to_metrics.get(
+                    f"task:{child_id}"
+                )
+                if metrics is not None:
+                    self.llm.metrics.merge(metrics)
+            # Retry infrastructure cleanup if the lifecycle assertion failed.
+            for workspace in self.workspaces.values():
+                try:
+                    if workspace._container_id is not None:
+                        workspace.__exit__(None, None, None)
+                finally:
+                    workspace.reset_client()

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,154 @@
+"""Transport fixtures for remote subagent execution."""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from openhands.sdk import Agent
+from openhands.sdk.conversation import LocalConversation, RemoteConversation
+from openhands.sdk.event import ActionEvent, MessageEvent
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.subagent.registry import _reset_registry_for_tests, register_agent
+from openhands.sdk.tool.builtins.finish import FinishAction, FinishTool
+from openhands.sdk.workspace import RemoteWorkspace
+
+
+@pytest.fixture
+def remote_subagents(monkeypatch, mock_llm, tmp_path):
+    """Run the real remote proxy against isolated in-memory agent servers."""
+    servers = {}
+    workspaces = []
+    lifecycle = []
+    options = SimpleNamespace(
+        confirm=False, fail_create=False, fail_policy=False, fail_events=False
+    )
+
+    def factory(child_id, agent_type):
+        host = f"https://child-{len(workspaces)}.example"
+        server = {
+            "conversations": {},
+            "creates": [],
+            "rejections": [],
+            "messages": [],
+        }
+        servers[host] = server
+
+        def request(request):
+            path = request.url.path
+            payload = json.loads(request.content) if request.content else {}
+            if request.method == "POST" and path == "/api/conversations":
+                if options.fail_create:
+                    return httpx.Response(400, json={"detail": "creation failed"})
+                cid = payload.get("conversation_id", str(uuid.uuid4()))
+                server["creates"].append(payload)
+                server["conversations"][cid] = {
+                    "id": cid,
+                    "execution_status": "idle",
+                    "stats": {},
+                    "events": [],
+                    "runs": 0,
+                    **payload,
+                }
+                return httpx.Response(200, json={"id": cid})
+            parts = path.split("/")
+            cid = parts[3]
+            state = server["conversations"].get(cid)
+            if state is None:
+                return httpx.Response(404, json={"detail": "conversation is gone"})
+            if request.method == "DELETE":
+                lifecycle.append((host, "delete"))
+                del server["conversations"][cid]
+            elif path.endswith("/events/search"):
+                if options.fail_events:
+                    return httpx.Response(400, json={"detail": "event sync failed"})
+                return httpx.Response(200, json={"items": state["events"]})
+            elif path.endswith("/confirmation_policy"):
+                if options.fail_policy:
+                    return httpx.Response(400, json={"detail": "policy failed"})
+                state["confirmation_policy"] = payload["policy"]
+            elif path.endswith("/events/respond_to_confirmation"):
+                server["rejections"].append(payload)
+            elif path.endswith("/events") and request.method == "POST":
+                server["messages"].append(payload)
+            elif path.endswith("/run"):
+                state["runs"] += 1
+                if options.confirm and state["runs"] == 1:
+                    action = FinishAction(message="Pending result")
+                    event = ActionEvent(
+                        thought=[],
+                        action=action,
+                        tool_name=FinishTool.name,
+                        tool_call_id="finish-call",
+                        tool_call=MessageToolCall(
+                            origin="completion",
+                            id="finish-call",
+                            name=FinishTool.name,
+                            arguments=action.model_dump_json(),
+                        ),
+                        llm_response_id="response",
+                    )
+                    state["execution_status"] = "waiting_for_confirmation"
+                else:
+                    event = MessageEvent(
+                        source="agent",
+                        llm_message=Message(
+                            role="assistant",
+                            content=[TextContent(text=f"Result {child_id}")],
+                        ),
+                    )
+                    state["execution_status"] = "finished"
+                state["events"].append(event.model_dump(mode="json"))
+            elif request.method == "GET":
+                return httpx.Response(200, json=state)
+            return httpx.Response(200, json={})
+
+        workspace = RemoteWorkspace(host=host, working_dir=f"/work/{child_id}")
+        workspace._client = httpx.Client(
+            base_url=host, transport=httpx.MockTransport(request)
+        )
+        workspaces.append(workspace)
+        return workspace
+
+    def enter(workspace):
+        lifecycle.append((workspace.host, "enter"))
+        return workspace
+
+    def leave(workspace, *args):
+        lifecycle.append((workspace.host, "exit"))
+
+    def wait(conversation, *args, **kwargs):
+        conversation.state.refresh_from_server()
+        conversation.state.events.reconcile()
+
+    monkeypatch.setattr(RemoteWorkspace, "__enter__", enter)
+    monkeypatch.setattr(RemoteWorkspace, "__exit__", leave)
+    monkeypatch.setattr(RemoteConversation, "_wait_for_run_completion", wait)
+    monkeypatch.setattr(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient",
+        Mock(),
+    )
+    _reset_registry_for_tests()
+    register_agent("remote-worker", lambda llm: Agent(llm=llm, tools=[]), "Worker")
+    parent = LocalConversation(
+        agent=Agent(llm=mock_llm, tools=[]),
+        workspace=str(tmp_path),
+        visualizer=None,
+        persistence_dir=tmp_path / "parent",
+        profile_store_dir=tmp_path / "profiles",
+    )
+    yield SimpleNamespace(
+        factory=factory,
+        servers=servers,
+        workspaces=workspaces,
+        lifecycle=lifecycle,
+        options=options,
+        parent=parent,
+    )
+    parent.close()
+    for workspace in workspaces:
+        workspace.reset_client()
+    _reset_registry_for_tests()

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -15,7 +15,6 @@ from openhands.sdk.llm import Message, MessageToolCall, TextContent
 from openhands.sdk.subagent.registry import _reset_registry_for_tests, register_agent
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishTool
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task.workspace import SubagentWorkspace, SubagentWorkspaceReference
 
 
 @pytest.fixture
@@ -24,9 +23,6 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
     servers = {}
     workspaces = []
     lifecycle = []
-    resources = {}
-    workspace_ids = {}
-    resolutions = []
     options = SimpleNamespace(
         confirm=False,
         fail_create=False,
@@ -36,7 +32,7 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
     )
 
     def factory(child_id, agent_type):
-        host = f"https://child-{len(workspaces)}.example"
+        host = f"https://child-{uuid.uuid4().hex}.example"
         server = {
             "conversations": {},
             "creates": [],
@@ -128,37 +124,6 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
         workspace._client = httpx.Client(
             base_url=host, transport=httpx.MockTransport(request)
         )
-        identity = str(uuid.uuid4())
-        workspace_ids[host] = identity
-        resources[identity] = (host, request)
-        workspaces.append(workspace)
-        return workspace
-
-    def persistent_factory(child_id, agent_type):
-        workspace = factory(child_id, agent_type)
-        return SubagentWorkspace(
-            workspace=workspace,
-            reference=SubagentWorkspaceReference(
-                provider="test-provider",
-                workspace_id=workspace_ids[workspace.host],
-                working_dir=workspace.working_dir,
-            ),
-        )
-
-    def resolver(reference):
-        resolutions.append(reference)
-        resource = resources.get(reference.workspace_id)
-        if resource is None:
-            return None
-        host, request = resource
-        workspace = RemoteWorkspace(
-            host=host,
-            working_dir=reference.working_dir,
-            api_key="fresh-credential-from-provider",
-        )
-        workspace._client = httpx.Client(
-            base_url=workspace.host, transport=httpx.MockTransport(request)
-        )
         workspaces.append(workspace)
         return workspace
 
@@ -191,10 +156,6 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
     )
     yield SimpleNamespace(
         factory=factory,
-        persistent_factory=persistent_factory,
-        resolver=resolver,
-        resolutions=resolutions,
-        resources=resources,
         servers=servers,
         workspaces=workspaces,
         lifecycle=lifecycle,

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -15,6 +15,7 @@ from openhands.sdk.llm import Message, MessageToolCall, TextContent
 from openhands.sdk.subagent.registry import _reset_registry_for_tests, register_agent
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishTool
 from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.task.workspace import SubagentWorkspace, SubagentWorkspaceReference
 
 
 @pytest.fixture
@@ -23,8 +24,15 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
     servers = {}
     workspaces = []
     lifecycle = []
+    resources = {}
+    workspace_ids = {}
+    resolutions = []
     options = SimpleNamespace(
-        confirm=False, fail_create=False, fail_policy=False, fail_events=False
+        confirm=False,
+        fail_create=False,
+        fail_policy=False,
+        fail_events=False,
+        acknowledge_budget=True,
     )
 
     def factory(child_id, agent_type):
@@ -53,7 +61,17 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
                     "runs": 0,
                     **payload,
                 }
-                return httpx.Response(200, json={"id": cid})
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": cid,
+                        "max_budget_per_run": (
+                            payload.get("max_budget_per_run")
+                            if options.acknowledge_budget
+                            else None
+                        ),
+                    },
+                )
             parts = path.split("/")
             cid = parts[3]
             state = server["conversations"].get(cid)
@@ -110,6 +128,37 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
         workspace._client = httpx.Client(
             base_url=host, transport=httpx.MockTransport(request)
         )
+        identity = str(uuid.uuid4())
+        workspace_ids[host] = identity
+        resources[identity] = (host, request)
+        workspaces.append(workspace)
+        return workspace
+
+    def persistent_factory(child_id, agent_type):
+        workspace = factory(child_id, agent_type)
+        return SubagentWorkspace(
+            workspace=workspace,
+            reference=SubagentWorkspaceReference(
+                provider="test-provider",
+                workspace_id=workspace_ids[workspace.host],
+                working_dir=workspace.working_dir,
+            ),
+        )
+
+    def resolver(reference):
+        resolutions.append(reference)
+        resource = resources.get(reference.workspace_id)
+        if resource is None:
+            return None
+        host, request = resource
+        workspace = RemoteWorkspace(
+            host=host,
+            working_dir=reference.working_dir,
+            api_key="fresh-credential-from-provider",
+        )
+        workspace._client = httpx.Client(
+            base_url=workspace.host, transport=httpx.MockTransport(request)
+        )
         workspaces.append(workspace)
         return workspace
 
@@ -142,6 +191,10 @@ def remote_subagents(monkeypatch, mock_llm, tmp_path):
     )
     yield SimpleNamespace(
         factory=factory,
+        persistent_factory=persistent_factory,
+        resolver=resolver,
+        resolutions=resolutions,
+        resources=resources,
         servers=servers,
         workspaces=workspaces,
         lifecycle=lifecycle,

--- a/tests/tools/test_remote_subagents.py
+++ b/tests/tools/test_remote_subagents.py
@@ -1,8 +1,7 @@
 """Task and Delegate behavior with independently owned remote workspaces."""
 
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import closing
-from pathlib import Path
+from threading import Barrier, Event
 
 import httpx
 import pytest
@@ -20,7 +19,13 @@ from openhands.tools.task.manager import TaskManager, TaskStatus
 
 def test_remote_tasks_return_results_and_resume(remote_subagents):
     env = remote_subagents
-    manager = TaskManager(workspace_factory=env.factory)
+    barrier = Barrier(2, timeout=10)
+
+    def factory(child_id, agent_type):
+        barrier.wait()
+        return env.factory(child_id, agent_type)
+
+    manager = TaskManager(workspace_factory=factory)
     manager.attach_parent(env.parent)
     try:
         with ThreadPoolExecutor(max_workers=2) as pool:
@@ -32,7 +37,9 @@ def test_remote_tasks_return_results_and_resume(remote_subagents):
             )
         assert isinstance(env.parent, LocalConversation)
         assert len(env.workspaces) == 2
-        for task, workspace in zip(tasks, env.workspaces):
+        for task in tasks:
+            workspace = task.remote_workspace
+            assert workspace is not None
             assert task.status == TaskStatus.COMPLETED
             assert task.result == f"Result {task.id}"
             assert isinstance(task.conversation, RemoteConversation)
@@ -47,7 +54,7 @@ def test_remote_tasks_return_results_and_resume(remote_subagents):
         resumed = manager.start_task("Follow up", resume=original.id)
         assert resumed.status == TaskStatus.COMPLETED
         assert resumed.conversation_id == original.conversation_id
-        assert resumed.conversation is not original.conversation
+        assert resumed.conversation is original.conversation
         assert len(env.workspaces) == 2
         assert len(env.servers[env.workspaces[0].host]["creates"]) == 1
     finally:
@@ -62,83 +69,57 @@ def test_remote_tasks_return_results_and_resume(remote_subagents):
         assert workspace._client is None
 
 
-def test_remote_task_manifest_reconnects_after_restart(remote_subagents):
+@pytest.mark.parametrize("close_during_setup", [False, True])
+def test_pending_workspace_ownership(remote_subagents, monkeypatch, close_during_setup):
     env = remote_subagents
-    first = TaskManager(workspace_factory=env.persistent_factory)
-    task = first.start_task("Initial task", "remote-worker", conversation=env.parent)
-    assert isinstance(task.conversation, RemoteConversation)
-    workspace = env.workspaces[0]
-    # Disconnect only the proxy, as happens when a client process goes away.
-    task.conversation.delete_on_close = False
-    task.conversation.close()
-    workspace.reset_client()
-    persistence_dir = Path(env.parent.state.persistence_dir).parent
-    env.parent.close()
-    parent = LocalConversation(
-        agent=env.parent.agent,
-        workspace=env.parent.state.workspace,
-        persistence_dir=persistence_dir,
-        conversation_id=env.parent.id,
-        visualizer=None,
-    )
-    restored = TaskManager(workspace_resolver=env.resolver)
-    restored.attach_parent(parent)
+    workspace = env.factory("worker", "remote-worker")
+    entered, release = Event(), Event()
+    original_enter = type(workspace).__enter__
+
+    def enter(workspace):
+        original_enter(workspace)
+        entered.set()
+        assert release.wait(10)
+        return workspace
+
+    monkeypatch.setattr(type(workspace), "__enter__", enter)
+    manager = TaskManager(workspace_factory=lambda child, kind: workspace)
+    manager.attach_parent(env.parent)
     try:
-        resumed = restored.start_task("Continue", resume=task.id)
-        assert resumed.status == TaskStatus.COMPLETED
-        assert resumed.conversation_id == task.conversation_id
-        assert resumed.remote_workspace is not workspace
-        assert resumed.workspace_reference == task.workspace_reference
-        assert env.resolutions == [task.workspace_reference]
-        assert resumed.remote_workspace is not None
-        assert resumed.remote_workspace.api_key == "fresh-credential-from-provider"
-        assert len(env.servers[workspace.host]["creates"]) == 1
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pending = pool.submit(manager.start_task, "Work", "remote-worker")
+            try:
+                assert entered.wait(10)
+                if close_during_setup:
+                    manager.close()
+                else:
+                    with pytest.raises(ValueError, match="distinct workspace"):
+                        manager.start_task("Duplicate", "remote-worker")
+                    assert env.lifecycle == [(workspace.host, "enter")]
+            finally:
+                release.set()
+            if close_during_setup:
+                with pytest.raises(RuntimeError, match="closed during task creation"):
+                    pending.result()
+            else:
+                assert pending.result().status == TaskStatus.COMPLETED
     finally:
-        restored.close()
-        parent.close()
+        manager.close()
+    assert [step for _, step in env.lifecycle] == ["enter", "delete", "exit"]
+    assert workspace._client is None
 
 
-@pytest.mark.parametrize("missing", ["identity", "sandbox"])
-def test_restart_never_uses_creation_factory_as_resolver(remote_subagents, missing):
+def test_missing_remote_task_never_creates_a_replacement(remote_subagents):
     env = remote_subagents
-    factory = env.factory if missing == "identity" else env.persistent_factory
-    first = TaskManager(workspace_factory=factory)
-    task = first.start_task("Work", "remote-worker", conversation=env.parent)
-    if task.workspace_reference is not None:
-        del env.resources[task.workspace_reference.workspace_id]
-    # A provisioning factory remains configured, but must never be used for resume.
-    restored = TaskManager(
-        workspace_factory=env.factory, workspace_resolver=env.resolver
-    )
-    try:
-        result = TaskExecutor(restored)(
-            TaskAction(prompt="Resume", resume=task.id), env.parent
-        )
-        assert result.is_error
-        assert (
-            "no persisted workspace identity" if missing == "identity" else "is gone"
-        ) in result.text
-        assert len(env.workspaces) == 1
-    finally:
-        restored.close()
-        first.close()
-
-
-@pytest.mark.parametrize("restart", [False, True])
-def test_missing_remote_task_never_creates_a_replacement(remote_subagents, restart):
-    env = remote_subagents
-    manager = TaskManager(workspace_factory=env.persistent_factory)
+    manager = TaskManager(workspace_factory=env.factory)
     task = manager.start_task("Initial", "remote-worker", conversation=env.parent)
     workspace = env.workspaces[0]
     server = env.servers[workspace.host]
     server["conversations"].clear()
-    if restart:
-        manager = TaskManager(workspace_resolver=env.resolver)
-        manager.attach_parent(env.parent)
     try:
         result = TaskExecutor(manager)(TaskAction(prompt="Resume", resume=task.id))
         assert result.is_error
-        assert "no longer exists" in result.text
+        assert "404" in result.text
         assert len(server["creates"]) == 1
     finally:
         manager.close()
@@ -264,34 +245,6 @@ def test_parent_tool_cleanup_releases_remote_children(remote_subagents):
         parent.close()
     assert env.lifecycle[-1][1] == "exit"
     assert not env.servers[env.workspaces[0].host]["conversations"]
-
-
-def test_reopened_parent_fails_cleanly_without_workspace_resolver(remote_subagents):
-    env = remote_subagents
-    manager = TaskManager(workspace_factory=env.persistent_factory)
-    task = manager.start_task("Work", "remote-worker", conversation=env.parent)
-    manager.close()
-    parent_id = env.parent.id
-    persistence_dir = Path(env.parent.state.persistence_dir).parent
-    env.parent.close()
-    with closing(
-        LocalConversation(
-            agent=env.parent.agent,
-            workspace=env.parent.state.workspace,
-            conversation_id=parent_id,
-            persistence_dir=persistence_dir,
-            visualizer=None,
-        )
-    ) as parent:
-        restored = TaskManager()
-        try:
-            result = TaskExecutor(restored)(
-                TaskAction(prompt="Resume", resume=task.id), parent
-            )
-            assert result.is_error
-            assert "requires a workspace_resolver" in result.text
-        finally:
-            restored.close()
 
 
 def test_reusing_a_workspace_is_rejected_without_closing_its_owner(remote_subagents):

--- a/tests/tools/test_remote_subagents.py
+++ b/tests/tools/test_remote_subagents.py
@@ -1,0 +1,267 @@
+"""Task and Delegate behavior with independently owned remote workspaces."""
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from pathlib import Path
+
+import httpx
+import pytest
+
+from openhands.sdk import Agent
+from openhands.sdk.conversation import LocalConversation, RemoteConversation
+from openhands.sdk.security import AlwaysConfirm
+from openhands.sdk.tool import Tool, register_tool
+from openhands.tools.delegate import DelegateExecutor
+from openhands.tools.delegate.definition import DelegateAction
+from openhands.tools.task.definition import TaskAction, TaskToolSet
+from openhands.tools.task.impl import TaskExecutor
+from openhands.tools.task.manager import TaskManager, TaskStatus
+
+
+def test_remote_tasks_return_results_and_resume(remote_subagents):
+    env = remote_subagents
+    manager = TaskManager(workspace_factory=env.factory)
+    manager.attach_parent(env.parent)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            tasks = list(
+                pool.map(
+                    lambda prompt: manager.start_task(prompt, "remote-worker"),
+                    ["First task", "Second task"],
+                )
+            )
+        assert isinstance(env.parent, LocalConversation)
+        assert len(env.workspaces) == 2
+        for task, workspace in zip(tasks, env.workspaces):
+            assert task.status == TaskStatus.COMPLETED
+            assert task.result == f"Result {task.id}"
+            assert isinstance(task.conversation, RemoteConversation)
+            assert task.conversation.workspace is workspace
+            payload = env.servers[workspace.host]["creates"][0]
+            assert payload["workspace"]["working_dir"] == workspace.working_dir
+            assert payload["observability_metadata"]["parent_session_id"] == str(
+                env.parent.id
+            )
+            assert payload["observability_metadata"]["task_id"] == task.id
+        original = tasks[0]
+        resumed = manager.start_task("Follow up", resume=original.id)
+        assert resumed.status == TaskStatus.COMPLETED
+        assert resumed.conversation_id == original.conversation_id
+        assert resumed.conversation is not original.conversation
+        assert len(env.workspaces) == 2
+        assert len(env.servers[env.workspaces[0].host]["creates"]) == 1
+    finally:
+        manager.close()
+    manager.close()
+    for workspace in env.workspaces:
+        assert [step for host, step in env.lifecycle if host == workspace.host] == [
+            "enter",
+            "delete",
+            "exit",
+        ]
+        assert workspace._client is None
+
+
+def test_remote_task_manifest_reconnects_after_restart(remote_subagents):
+    env = remote_subagents
+    first = TaskManager(workspace_factory=env.factory)
+    task = first.start_task("Initial task", "remote-worker", conversation=env.parent)
+    assert isinstance(task.conversation, RemoteConversation)
+    workspace = env.workspaces[0]
+    # Disconnect only the proxy, as happens when a client process goes away.
+    task.conversation.delete_on_close = False
+    task.conversation.close()
+    restored = TaskManager(workspace_factory=lambda child, kind: workspace)
+    restored.attach_parent(env.parent)
+    try:
+        resumed = restored.start_task("Continue", resume=task.id)
+        assert resumed.status == TaskStatus.COMPLETED
+        assert resumed.conversation_id == task.conversation_id
+        assert len(env.servers[workspace.host]["creates"]) == 1
+    finally:
+        restored.close()
+
+
+@pytest.mark.parametrize("restart", [False, True])
+def test_missing_remote_task_never_creates_a_replacement(remote_subagents, restart):
+    env = remote_subagents
+    manager = TaskManager(workspace_factory=env.factory)
+    task = manager.start_task("Initial", "remote-worker", conversation=env.parent)
+    workspace = env.workspaces[0]
+    server = env.servers[workspace.host]
+    server["conversations"].clear()
+    if restart:
+        manager = TaskManager(workspace_factory=lambda child, kind: workspace)
+        manager.attach_parent(env.parent)
+    try:
+        result = TaskExecutor(manager)(TaskAction(prompt="Resume", resume=task.id))
+        assert result.is_error
+        assert "no longer exists" in result.text
+        assert len(server["creates"]) == 1
+    finally:
+        manager.close()
+
+
+@pytest.mark.parametrize("tool", ["task", "delegate"])
+@pytest.mark.parametrize("approve", [True, False])
+def test_remote_confirmation_preserves_handler_behavior(
+    remote_subagents, tool, approve
+):
+    env = remote_subagents
+    env.options.confirm = True
+    env.parent.set_confirmation_policy(AlwaysConfirm())
+    confirmations = []
+
+    def confirm(child_id, actions):
+        confirmations.append((child_id, actions))
+        return approve
+
+    if tool == "task":
+        executor = TaskManager(
+            confirmation_handler=confirm, workspace_factory=env.factory
+        )
+        try:
+            result = executor.start_task(
+                "Work", "remote-worker", conversation=env.parent
+            )
+            assert result.status == TaskStatus.COMPLETED
+        finally:
+            executor.close()
+    else:
+        executor = DelegateExecutor(
+            confirmation_handler=confirm, workspace_factory=env.factory
+        )
+        try:
+            spawned = executor(
+                DelegateAction(
+                    command="spawn", ids=["worker"], agent_types=["remote-worker"]
+                ),
+                env.parent,
+            )
+            assert not spawned.is_error
+            result = executor(
+                DelegateAction(command="delegate", tasks={"worker": "Work"}), env.parent
+            )
+            assert "Agent worker: Result worker" in result.text
+        finally:
+            executor.close()
+    assert len(confirmations) == 1
+    assert len(confirmations[0][1]) == 1
+    server = env.servers[env.workspaces[0].host]
+    assert bool(server["rejections"]) is (not approve)
+
+
+def test_delegate_runs_independent_remote_children_and_cleans_up(remote_subagents):
+    env = remote_subagents
+    executor = DelegateExecutor(workspace_factory=env.factory)
+    try:
+        spawned = executor(
+            DelegateAction(
+                command="spawn", ids=["a", "b"], agent_types=["remote-worker"] * 2
+            ),
+            env.parent,
+        )
+        assert not spawned.is_error
+        result = executor(
+            DelegateAction(command="delegate", tasks={"a": "One", "b": "Two"}),
+            env.parent,
+        )
+        assert "1. Agent a: Result a\n2. Agent b: Result b" in result.text
+        assert len(env.workspaces) == 2
+        assert env.workspaces[0].host != env.workspaces[1].host
+    finally:
+        executor.close()
+    for workspace in env.workspaces:
+        assert [step for host, step in env.lifecycle if host == workspace.host] == [
+            "enter",
+            "delete",
+            "exit",
+        ]
+
+
+@pytest.mark.parametrize("tool", ["task", "delegate"])
+@pytest.mark.parametrize("failure", ["fail_create", "fail_policy", "fail_events"])
+def test_failed_remote_setup_releases_workspace(remote_subagents, tool, failure):
+    env = remote_subagents
+    setattr(env.options, failure, True)
+    if tool == "task":
+        executor = TaskManager(workspace_factory=env.factory)
+        with pytest.raises(httpx.HTTPStatusError, match="400 Bad Request"):
+            executor.start_task("Work", "remote-worker", conversation=env.parent)
+    else:
+        executor = DelegateExecutor(workspace_factory=env.factory)
+        result = executor(
+            DelegateAction(
+                command="spawn", ids=["worker"], agent_types=["remote-worker"]
+            ),
+            env.parent,
+        )
+        assert result.is_error
+    executor.close()
+    assert env.lifecycle[-1][1] == "exit"
+    assert env.workspaces[0]._client is None
+    assert not env.servers[env.workspaces[0].host]["conversations"]
+
+
+def test_parent_tool_cleanup_releases_remote_children(remote_subagents):
+    env = remote_subagents
+    tool = TaskToolSet.create(env.parent.state, workspace_factory=env.factory)[0]
+    register_tool("remote_tasks_test", tool)
+    parent = LocalConversation(
+        agent=Agent(llm=env.parent.agent.llm, tools=[Tool(name="remote_tasks_test")]),
+        workspace=env.parent.state.workspace,
+        visualizer=None,
+    )
+    try:
+        result = parent.execute_tool(
+            tool.name, TaskAction(prompt="Work", subagent_type="remote-worker")
+        )
+        assert not result.is_error
+        assert "Result task_00000001" in result.text
+    finally:
+        parent.close()
+    assert env.lifecycle[-1][1] == "exit"
+    assert not env.servers[env.workspaces[0].host]["conversations"]
+
+
+def test_reopened_parent_fails_cleanly_without_workspace_resolver(remote_subagents):
+    env = remote_subagents
+    manager = TaskManager(workspace_factory=env.factory)
+    task = manager.start_task("Work", "remote-worker", conversation=env.parent)
+    manager.close()
+    parent_id = env.parent.id
+    persistence_dir = Path(env.parent.state.persistence_dir).parent
+    env.parent.close()
+    with closing(
+        LocalConversation(
+            agent=env.parent.agent,
+            workspace=env.parent.state.workspace,
+            conversation_id=parent_id,
+            persistence_dir=persistence_dir,
+            visualizer=None,
+        )
+    ) as parent:
+        restored = TaskManager()
+        try:
+            result = TaskExecutor(restored)(
+                TaskAction(prompt="Resume", resume=task.id), parent
+            )
+            assert result.is_error
+            assert "requires its workspace_factory" in result.text
+        finally:
+            restored.close()
+
+
+def test_reusing_a_workspace_is_rejected_without_closing_its_owner(remote_subagents):
+    env = remote_subagents
+    workspace = env.factory("first", "remote-worker")
+    manager = TaskManager(workspace_factory=lambda child, kind: workspace)
+    try:
+        first = manager.start_task("Work", "remote-worker", conversation=env.parent)
+        with pytest.raises(ValueError, match="distinct workspace"):
+            manager.start_task("More work", "remote-worker")
+        assert "exit" not in [step for _, step in env.lifecycle]
+        resumed = manager.start_task("Continue", resume=first.id)
+        assert resumed.status == TaskStatus.COMPLETED
+    finally:
+        manager.close()

--- a/tests/tools/test_remote_subagents.py
+++ b/tests/tools/test_remote_subagents.py
@@ -64,34 +64,76 @@ def test_remote_tasks_return_results_and_resume(remote_subagents):
 
 def test_remote_task_manifest_reconnects_after_restart(remote_subagents):
     env = remote_subagents
-    first = TaskManager(workspace_factory=env.factory)
+    first = TaskManager(workspace_factory=env.persistent_factory)
     task = first.start_task("Initial task", "remote-worker", conversation=env.parent)
     assert isinstance(task.conversation, RemoteConversation)
     workspace = env.workspaces[0]
     # Disconnect only the proxy, as happens when a client process goes away.
     task.conversation.delete_on_close = False
     task.conversation.close()
-    restored = TaskManager(workspace_factory=lambda child, kind: workspace)
-    restored.attach_parent(env.parent)
+    workspace.reset_client()
+    persistence_dir = Path(env.parent.state.persistence_dir).parent
+    env.parent.close()
+    parent = LocalConversation(
+        agent=env.parent.agent,
+        workspace=env.parent.state.workspace,
+        persistence_dir=persistence_dir,
+        conversation_id=env.parent.id,
+        visualizer=None,
+    )
+    restored = TaskManager(workspace_resolver=env.resolver)
+    restored.attach_parent(parent)
     try:
         resumed = restored.start_task("Continue", resume=task.id)
         assert resumed.status == TaskStatus.COMPLETED
         assert resumed.conversation_id == task.conversation_id
+        assert resumed.remote_workspace is not workspace
+        assert resumed.workspace_reference == task.workspace_reference
+        assert env.resolutions == [task.workspace_reference]
+        assert resumed.remote_workspace is not None
+        assert resumed.remote_workspace.api_key == "fresh-credential-from-provider"
         assert len(env.servers[workspace.host]["creates"]) == 1
     finally:
         restored.close()
+        parent.close()
+
+
+@pytest.mark.parametrize("missing", ["identity", "sandbox"])
+def test_restart_never_uses_creation_factory_as_resolver(remote_subagents, missing):
+    env = remote_subagents
+    factory = env.factory if missing == "identity" else env.persistent_factory
+    first = TaskManager(workspace_factory=factory)
+    task = first.start_task("Work", "remote-worker", conversation=env.parent)
+    if task.workspace_reference is not None:
+        del env.resources[task.workspace_reference.workspace_id]
+    # A provisioning factory remains configured, but must never be used for resume.
+    restored = TaskManager(
+        workspace_factory=env.factory, workspace_resolver=env.resolver
+    )
+    try:
+        result = TaskExecutor(restored)(
+            TaskAction(prompt="Resume", resume=task.id), env.parent
+        )
+        assert result.is_error
+        assert (
+            "no persisted workspace identity" if missing == "identity" else "is gone"
+        ) in result.text
+        assert len(env.workspaces) == 1
+    finally:
+        restored.close()
+        first.close()
 
 
 @pytest.mark.parametrize("restart", [False, True])
 def test_missing_remote_task_never_creates_a_replacement(remote_subagents, restart):
     env = remote_subagents
-    manager = TaskManager(workspace_factory=env.factory)
+    manager = TaskManager(workspace_factory=env.persistent_factory)
     task = manager.start_task("Initial", "remote-worker", conversation=env.parent)
     workspace = env.workspaces[0]
     server = env.servers[workspace.host]
     server["conversations"].clear()
     if restart:
-        manager = TaskManager(workspace_factory=lambda child, kind: workspace)
+        manager = TaskManager(workspace_resolver=env.resolver)
         manager.attach_parent(env.parent)
     try:
         result = TaskExecutor(manager)(TaskAction(prompt="Resume", resume=task.id))
@@ -226,7 +268,7 @@ def test_parent_tool_cleanup_releases_remote_children(remote_subagents):
 
 def test_reopened_parent_fails_cleanly_without_workspace_resolver(remote_subagents):
     env = remote_subagents
-    manager = TaskManager(workspace_factory=env.factory)
+    manager = TaskManager(workspace_factory=env.persistent_factory)
     task = manager.start_task("Work", "remote-worker", conversation=env.parent)
     manager.close()
     parent_id = env.parent.id
@@ -247,7 +289,7 @@ def test_reopened_parent_fails_cleanly_without_workspace_resolver(remote_subagen
                 TaskAction(prompt="Resume", resume=task.id), parent
             )
             assert result.is_error
-            assert "requires its workspace_factory" in result.text
+            assert "requires a workspace_resolver" in result.text
         finally:
             restored.close()
 
@@ -263,5 +305,21 @@ def test_reusing_a_workspace_is_rejected_without_closing_its_owner(remote_subage
         assert "exit" not in [step for _, step in env.lifecycle]
         resumed = manager.start_task("Continue", resume=first.id)
         assert resumed.status == TaskStatus.COMPLETED
+    finally:
+        manager.close()
+
+
+def test_remote_budget_must_be_acknowledged_before_execution(remote_subagents):
+    env = remote_subagents
+    env.parent.max_budget_per_run = 1.0
+    env.options.acknowledge_budget = False
+    manager = TaskManager(workspace_factory=env.factory)
+    try:
+        with pytest.raises(ValueError, match="did not acknowledge max_budget_per_run"):
+            manager.start_task("Work", "remote-worker", conversation=env.parent)
+        server = env.servers[env.workspaces[0].host]
+        assert not server["messages"]
+        assert not server["conversations"]
+        assert env.lifecycle[-1][1] == "exit"
     finally:
         manager.close()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Currently, there are primitives that support executing agents in sandboxes/remotely. However, this feature is not extended to subagents. This PR provides that capacity, extending primitives for remote execution to subagents.

---

AGENT:

## Why

A local parent should be able to delegate work to isolated remote sandboxes without replacing its own workspace or introducing a scheduler/provider abstraction.

## Summary

- Add an optional `workspace_factory(child_id, agent_type) -> RemoteWorkspace | None` to TaskManager, TaskToolSet.create, and DelegateExecutor. Returning None preserves local execution.
- Own each remote child's conversation and workspace; preserve result delivery, confirmation approve/reject, tracing, and in-session Task resume. Provision outside the TaskManager lock with pending ownership reservations and failure cleanup.
- Forward `max_budget_per_run` through the remote request/server path, and add unit, real-server, and real-GPT-5-mini Docker coverage.

## Issue Number

No linked issue supplied.

## How to Test

Post-rebase validation on upstream `9c3571a6`, SDK feature head `a72b80ef`:

```bash
uv sync --frozen --dev
.venv/bin/pytest tests/tools/test_remote_subagents.py tests/tools/task tests/tools/delegate tests/sdk/conversation/remote tests/agent_server/test_models.py tests/agent_server/test_event_service.py tests/agent_server/test_conversation_service.py -q --disable-warnings --maxfail=3
.venv/bin/pytest tests/cross/test_remote_conversation_live_server.py -k 'remote_subagent or subagent_workspace_factory_returns_result' -q --disable-warnings --maxfail=2
```

Results: **489 passed** and **4 passed**, respectively. The cross-tests use real HTTP and WebSockets with a deterministic LLM and cover Task/Delegate result return and remote budget enforcement.

Real-model reproduction (Docker/Colima required):

```bash
# Set LLM_API_KEY securely in the environment; never put it in --llm-config.
export LLM_BASE_URL=https://api.openai.com/v1
uv run python tests/integration/run_infer.py \
  --llm-config '{"model":"openai/gpt-5-mini","reasoning_effort":"low","max_output_tokens":4096,"num_retries":1}' \
  --tool-preset gpt5 \
  --eval-ids t10_remote_subagent_workspaces
```

The test builds a minimal source image from the current checkout. To reuse a matching local image, set `AGENT_SERVER_IMAGE`.

**Observed real-model run before the final rebase:** local GPT-5-mini parent → two distinct Docker workspaces → remote child terminal/finish execution → resume both original tasks → exact private file contents/results → unchanged parent file → both HTTP clients closed and containers removed. **PASS**, 165.75 seconds, reported total cost **$0.0196272**. No LLM or transport mocking in this run.

That run used the feature source later committed as `58a5a2d1` and an SDK 1.46.0 image built from the same working tree. Its feature changes were rebased unchanged; the real paid Docker scenario has **not** been rerun with an SDK 1.47.0 image after the final rebase. The four real-server cross-tests above were rerun after rebase.

## Video/Screenshots

Non-UI feature. Representative real-model runner output:

```text
t10_remote_subagent_workspaces completed in 165.75s: PASS
Real LLM parent delegated to two Docker children, resumed both,
received their private results, and released both sandboxes.
Overall Success rate: 100.00% (1/1)
```

Local full report and logs:
`tests/integration/outputs/openai_gpt_5_mini_gpt5-mini-colima-minimal_N1_20260911_232029/`.
These generated artifacts are not tracked. They were checked for API-key-shaped text; none was present.

## Design Doc

The factory/ownership contract and examples are documented in the companion docs change:
[OpenHands/docs#791](https://github.com/OpenHands/docs/pull/791),
branch `feat/subagent-remote-workspaces`, commit `4a905c81`.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Remote Task workspaces remain allocated until TaskManager.close(); Delegate owns workspaces until close or child replacement.
- Resume is limited to the same manager instance. No manifests, persistent workspace identities, resolver API, cross-process restoration, or replacement provisioning on resume.
- A plain RemoteWorkspace does not destroy an externally managed server on exit; workspace subclasses own infrastructure teardown.
- Each factory result must represent a distinct sandbox. Object-identity checks reject sharing one workspace object; the factory must not wrap the same sandbox twice.
- Budgeted remote creation fails explicitly if the server does not acknowledge the budget.
- Formatting, Ruff, Pyright, import rules, tool registration, and diff whitespace checks passed.
- **Known upstream lint blocker:** the whole-SDK forbidden-dynamic-attributes hook fails identically on pristine upstream `9c3571a6` at `agent/stream_context.py:287` and `llm/utils/telemetry.py:264,270,272`. These files are unchanged by this PR. The same checker passes on the SDK files changed here. The full pre-commit run is therefore not green.
- GitHub CI and benchmark/evaluation review remain pending. Request the `integration-test` label and human review before merge.
