### PR TITLE
fix(sdk): separate user message and emoji list in title prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -116,10 +116,10 @@ def generate_title_with_llm(
                         text=(
                             f"Generate a title (maximum {max_length} characters) "
                             f"for a conversation that starts with this message:\n\n"
-                            f"{truncated_message}."
+                            f"{truncated_message}\n\n"
                             "Also make sure to include ONE most relevant emoji at "
-                            "the start of the title."
-                            f" Choose the emoji from this list:{emojis_descriptions} "
+                            "the start of the title. Choose the emoji from this "
+                            f"list:\n- {emojis_descriptions}\n"
                         )
                     )
                 ],

--- a/tests/sdk/conversation/test_generate_title.py
+++ b/tests/sdk/conversation/test_generate_title.py
@@ -239,6 +239,22 @@ def test_generate_title_empty_llm_response_fallback(mock_completion):
     assert title == "Help with testing"
 
 
+@patch("openhands.sdk.llm.llm.LLM.completion")
+def test_generate_title_user_prompt_is_properly_separated(mock_completion):
+    """The user message must be separated from the emoji instruction and the
+    emoji list must start on its own line, with the prompt ending in a
+    newline."""
+    custom_llm = LLM(model="gpt-4o-mini", api_key=SecretStr("key"), usage_id="fmt")
+    mock_completion.return_value = create_mock_llm_response("🐛 Fix bug")
+
+    generate_title_with_llm("test", custom_llm)
+
+    prompt = mock_completion.call_args.args[0][1].content[0].text
+    assert "test\n\nAlso make sure" in prompt
+    assert "list:\n- 💄 frontend:" in prompt
+    assert prompt.endswith("\n")
+
+
 def create_mock_model_response(content: str) -> ModelResponse:
     """A raw litellm ModelResponse, as returned by ``LLM._transport_call``."""
     return ModelResponse(


### PR DESCRIPTION
HUMAN:
Fix malformed prompt string in SDK title generation (message glued to instruction, emoji list not on its own line).

---

AGENT:

## Why

The LLM title-generation prompt in `generate_title_with_llm()` was built from
adjacent f-string segments with missing separators, producing malformed input
such as:

```
...starts with this message:

test.Also make sure to include ONE most relevant emoji at the start of the title. Choose the emoji from this list:💄 frontend: UI and style files
- 👔 backend: Business logic
...
```

Issues in the rendered prompt:
1. A stray `.` was appended directly after the user message, gluing it to the
   following instruction (`test.Also make sure...`). It also double-periods
   truncated messages (`...(truncated)..`).
2. The emoji list was glued to `Choose the emoji from this list:` (no newline),
   so the first entry was inline while the rest were `- ` prefixed.
3. The first emoji entry lacked the `- ` bullet prefix its siblings had (the
   list is built with `"\n- ".join(...)`, which only prefixes entries after the
   first).
4. The prompt did not end with a newline.

This can degrade title quality/confusion for models sensitive to prompt
formatting.

## Summary

- Rebuilt the user-message segment in `title_utils.py` with proper `\n\n`
  separation after the message (dropping the stray period), `\n- ` before the
  emoji list so every entry is a uniform bullet, and a trailing newline.
- Added a regression test asserting the formatted prompt separators.

## Issue Number

Fixes #4987

## How to Test

Reproduce the malformed prompt before the fix:

```bash
uv run python - <<'EOF'
from unittest.mock import patch
from pydantic import SecretStr
from openhands.sdk.llm import LLM
from openhands.sdk.conversation.title_utils import generate_title_with_llm

llm = LLM(model="gpt-4o-mini", api_key=SecretStr("k"), usage_id="t")
with patch("openhands.sdk.llm.llm.LLM.completion") as c:
    generate_title_with_llm("test", llm)
    print(c.call_args.args[0][1].content[0].text)
EOF
```

On `main`, the output contains `test.Also make sure` and
`list:\U0001f484 frontend` (glued, un-bulleted first entry); on this branch the
prompt ends with:

```
Also make sure to include ONE most relevant emoji at the start of the title. Choose the emoji from this list:
- 💄 frontend: UI and style files
- 👔 backend: Business logic
...
- ♻️ refactor: Code refactoring
```

Unit tests:

```bash
uv run pytest tests/sdk/conversation/test_generate_title.py -q
# 10 passed
```

The new test `test_generate_title_user_prompt_is_properly_separated` was
verified to fail against the pre-patch `title_utils.py` (stashed the source
change, ran the test, saw the assertion failure reproducing exactly the
malformed rendering above) and pass with the fix applied.

Pre-commit on changed files passes (ruff format/lint, pycodestyle, pyright).

## Video/Screenshots

See reproduction command output above; no UI change.

## Design Doc

Trivial string-formatting fix; no design doc needed.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Behavior-only prompt-text change; no API/schema changes. The TypeScript client
(`clients/typescript`) does not duplicate this prompt (it uses a simpler
already-separated prompt), so no mirror change is needed.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.37s · commit 67d7c63  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 2/2 files.  
**Limits:** Supplied code only; tests were not run. Probabilities are model estimates.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 1.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 2.0% | No direct hunk selected |
| Contract regression | 4.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 1.0% | No direct hunk selected |
| Unverified remote execution | 1.0% | No direct hunk selected |
| Privileged environment access | 1.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 1.0% | No direct hunk selected |
| Primary concern | None selected; confidence 97.0% | No primary concern to locate |

</details>


<!-- jev-input-signature f876a8bae81cd33d7054040ecffbc25f47fffa98810c600309932e497f4994ab -->
<!-- jev-fast-audit:end -->
