### PR TITLE
feat(acp): support combined model/effort ids for claude-code provider

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -566,6 +566,35 @@ def _codex_model_config_options(model: str) -> tuple[tuple[str, str], ...]:
     return ((_MODEL_CONFIG_OPTION_ID, model),)
 
 
+_CLAUDE_EFFORT_CONFIG_OPTION_ID: Final[str] = "effort"
+# Best-effort allowlist for deciding whether a combined Canvas id's suffix
+# *looks like* a Claude effort level, so it gets split off the model id
+# before being sent as `acp_model`. Not authoritative: the live session's
+# `configOptions` reports the real `supportedEffortLevels` for the current
+# model (dynamic per model/account) — see claude-agent-acp's
+# `buildConfigOptions()`. A value outside this set is sent as part of the
+# model id unsplit, which the ACP server will simply not recognise as a
+# model (same graceful-degradation posture as an unknown `available_models`
+# entry).
+_CLAUDE_REASONING_EFFORTS: Final[frozenset[str]] = frozenset(
+    {"low", "medium", "high", "max"}
+)
+
+
+def _claude_model_config_options(model: str) -> tuple[tuple[str, str], ...]:
+    """Map a combined Canvas Claude model id (``<model>/<effort>``) to
+    claude-agent-acp config options. Mirrors _codex_model_config_options,
+    using claude-agent-acp's own config id (``effort``, not
+    ``reasoning_effort``)."""
+    base_model, sep, effort = model.rpartition("/")
+    if sep and base_model and effort in _CLAUDE_REASONING_EFFORTS:
+        return (
+            (_MODEL_CONFIG_OPTION_ID, base_model),
+            (_CLAUDE_EFFORT_CONFIG_OPTION_ID, effort),
+        )
+    return ((_MODEL_CONFIG_OPTION_ID, model),)
+
+
 def _model_config_options(
     agent_name: str | None,
     model: str,
@@ -573,6 +602,8 @@ def _model_config_options(
     provider = detect_acp_provider_by_agent_name(agent_name or "")
     if provider is not None and provider.key == "codex":
         return _codex_model_config_options(model)
+    if provider is not None and provider.key == "claude-code":
+        return _claude_model_config_options(model)
     return ((_MODEL_CONFIG_OPTION_ID, model),)
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -32,6 +32,7 @@ from openhands.sdk.agent.acp_agent import (
     _auth_selection_failure_reason,
     _classify_acp_init_error,
     _classify_acp_turn_error,
+    _claude_model_config_options,
     _codex_model_config_options,
     _estimate_cost_from_tokens,
     _extract_session_models,
@@ -5399,6 +5400,22 @@ class TestCodexModelConfigOptions:
         )
 
 
+class TestClaudeModelConfigOptions:
+    def test_splits_combined_model_and_effort(self):
+        assert _claude_model_config_options("sonnet/high") == (
+            ("model", "sonnet"),
+            ("effort", "high"),
+        )
+
+    def test_leaves_bare_model_id_unchanged(self):
+        assert _claude_model_config_options("sonnet") == (("model", "sonnet"),)
+
+    def test_leaves_unrecognized_suffix_unchanged(self):
+        assert _claude_model_config_options("sonnet/ultrafast") == (
+            ("model", "sonnet/ultrafast"),
+        )
+
+
 # ---------------------------------------------------------------------------
 # ACP model overrides
 # ---------------------------------------------------------------------------
@@ -5456,6 +5473,30 @@ class TestMaybeSetSessionModel:
                 call(
                     config_id="reasoning_effort",
                     value="low",
+                    session_id="session-1",
+                ),
+            ]
+        )
+        assert conn.set_config_option.await_count == 2
+        assert applied is True
+
+    @pytest.mark.asyncio
+    async def test_claude_config_option_splits_effort(self):
+        conn = AsyncMock()
+        applied = await _maybe_set_session_model(
+            conn,
+            "claude-agent-acp",
+            "session-1",
+            "sonnet/high",
+            via_config_option=True,
+        )
+        conn.set_session_model.assert_not_called()
+        conn.set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="sonnet", session_id="session-1"),
+                call(
+                    config_id="effort",
+                    value="high",
                     session_id="session-1",
                 ),
             ]
@@ -5597,6 +5638,26 @@ class TestReapplySessionModelOnResume:
                 call(config_id="model", value="gpt-5.4", session_id="sess-1"),
                 call(
                     config_id="reasoning_effort",
+                    value="low",
+                    session_id="sess-1",
+                ),
+            ]
+        )
+        assert conn.set_config_option.await_count == 2
+        assert applied is True
+
+    @pytest.mark.asyncio
+    async def test_claude_reapply_splits_effort(self):
+        conn = AsyncMock()
+        applied = await _reapply_session_model_on_resume(
+            conn, "claude-agent-acp", "sess-1", "sonnet/low", via_config_option=True
+        )
+        conn.set_session_model.assert_not_called()
+        conn.set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="sonnet", session_id="sess-1"),
+                call(
+                    config_id="effort",
                     value="low",
                     session_id="sess-1",
                 ),
@@ -5813,6 +5874,24 @@ class TestSetACPModel:
             config_id="model", value="sonnet", session_id="sess-1"
         )
         assert agent._current_model_id == "sonnet"
+
+    def test_switches_claude_via_config_option_splits_effort(self):
+        agent = self._wire(_make_agent(), "claude-agent-acp", via_config_option=True)
+        agent.set_acp_model("sonnet/high")
+        _agent_conn(agent).set_config_option.assert_has_awaits(
+            [
+                call(config_id="model", value="sonnet", session_id="sess-1"),
+                call(
+                    config_id="effort",
+                    value="high",
+                    session_id="sess-1",
+                ),
+            ]
+        )
+        assert _agent_conn(agent).set_config_option.await_count == 2
+        _agent_conn(agent).set_session_model.assert_not_called()
+        assert agent.llm.model == "sonnet/high"
+        assert agent._current_model_id == "sonnet/high"
 
     def test_switch_method_not_found_raises_no_fallback(self):
         # No cross-mechanism fallback: a -32601 surfaces as a ValueError naming


### PR DESCRIPTION
## Summary
- Extends the `<model>/<effort>` id-splitting mechanism already used for the `codex` ACP provider to `claude-code`, using its own native `configOptions` id (`"effort"`, not `"reasoning_effort"`).
- `claude-agent-acp` (pinned `0.63.0`) already reports an `effort` config option per session (`EFFORT_CONFIG_ID`, confirmed by inspecting the published npm package); the SDK just wasn't dispatching to it for this provider.
- No schema, route, or frontend changes — purely additive change in `openhands-sdk/openhands/sdk/agent/acp_agent.py`'s `_model_config_options()` dispatcher.

Design docs (PRD/TECH/SPEC/sprint) written via a structured planning pipeline are available on request; happy to share if useful for review context.

## Test plan
- [x] `uv run ruff check openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py` — clean
- [x] `uv run pytest tests/sdk/agent/test_acp_agent.py -q` — 490 passed, no regressions
- [x] Added 3 unit tests (`TestClaudeModelConfigOptions`) mirroring `TestCodexModelConfigOptions`
- [x] Added 3 integration tests mirroring the existing Codex effort-split tests (`_maybe_set_session_model`, `_reapply_session_model_on_resume`, `set_acp_model`)