### PR TITLE
fix(agent-server): rollback failed deferred initialization

### DIFF
--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -28,8 +29,11 @@ from openhands.agent_server.server_details_router import mark_initialization_com
 from openhands.agent_server.telemetry import (
     build_telemetry_sink,
     emit_server_started,
+    service as telemetry_service,
     shutdown_telemetry_sink,
 )
+from openhands.agent_server.telemetry.factory import DiagnosticEventFactory
+from openhands.agent_server.telemetry.sink import TelemetrySink
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability import maybe_init_laminar
 
@@ -186,6 +190,56 @@ def _build_initialized_config(base: Config, req: InitRequest) -> Config:
     return base.model_copy(update=updates)
 
 
+def _stage_env(env: dict[str, str] | None, previous: dict[str, str | None]) -> None:
+    """Apply the request's environment variables, recording what they replaced.
+
+    ``previous`` is filled in place and must already be registered for restore,
+    because a key rejected part-way through the loop (Windows refuses names
+    containing ``=``) would otherwise leave its predecessors applied.
+    """
+    for key, value in (env or {}).items():
+        previous[key] = os.environ.get(key)
+        os.environ[key] = value
+
+
+def _restore_env(previous: dict[str, str | None]) -> None:
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+async def _restore_telemetry(
+    previous_sink: TelemetrySink | None,
+    previous_event_factory: DiagnosticEventFactory | None,
+) -> None:
+    """Undo ``build_telemetry_sink``'s process-wide publication.
+
+    The dormant server's values are snapshotted before the build and put back
+    here, so a rolled-back attempt leaves the sink, the event factory and the
+    consent decision other modules read exactly as it found them.
+    """
+    if telemetry_service._telemetry_sink is not previous_sink:
+        await shutdown_telemetry_sink()
+    telemetry_service._telemetry_sink = previous_sink
+    telemetry_service._event_factory = previous_event_factory
+
+
+async def _retire_telemetry_sink(sink: TelemetrySink | None) -> None:
+    """Close the dormant server's sink once its replacement is committed.
+
+    ``shutdown_telemetry_sink`` closes whatever is currently published, which
+    by then is the replacement, so the previous sink is closed directly here.
+    """
+    if sink is None:
+        return
+    try:
+        await sink.aclose()
+    except Exception as exc:
+        logger.debug("Telemetry shutdown failed: %s", type(exc).__name__)
+
+
 class InitService:
     """Tracks dormant→ready transition and serialises /api/init calls.
 
@@ -220,55 +274,8 @@ class InitService:
             self._state = "initializing"
             self._error = None
         try:
-            new_config = _build_initialized_config(self._base_config, req)
-            if req.env:
-                # Setting env vars before services boot lets things like
-                # the cipher pick up OH_SECRET_KEY-style overrides, and
-                # tools pick up credentials.
-                for key, value in req.env.items():
-                    os.environ[key] = value
-            maybe_init_laminar()
-
-            # Must precede get_instance(), which captures the sink. The
-            # matching emit_server_started() is deferred until the ``ready``
-            # transition below: emitting here would produce a server_started
-            # for an init that later fails and rolls back to dormant, leaving
-            # an unpaired start and letting a retry emit a second one.
-            await shutdown_telemetry_sink()
-            self._app.state.telemetry_sink = await build_telemetry_sink(new_config)
-
-            # Reset the module-level singleton so other call sites that go
-            # through ``get_default_conversation_service`` see the new
-            # instance built from the merged config.
-            from openhands.agent_server import conversation_service as cs_mod
-
-            service = ConversationService.get_instance(new_config)
-            cs_mod._conversation_service = service
-
-            bash_svc = BashEventService(bash_events_dir=new_config.bash_events_dir)
-            await bash_svc.__aenter__()
-            self._entered_bash_service = bash_svc
-
-            await service.__aenter__()
-            self._entered_service = service
-            self._app.state.config = new_config
-            self._app.state.conversation_service = service
-            self._app.state.bash_event_service = bash_svc
-
-            # Re-derive root_path from the merged config so Doc URLS are valid
-            from openhands.agent_server.api import _get_root_path
-
-            new_root_path = _get_root_path(new_config)
-            self._app.root_path = new_root_path
-
-            mark_initialization_complete()
-            self._state = "ready"
-            # Emitted only now that init has actually succeeded, so a failed
-            # attempt never produces a start and a retry cannot double-emit.
-            emit_server_started()
-            logger.info("deferred_init: server transitioned to ready")
-            return self.snapshot()
-        except Exception as exc:  # pragma: no cover - logged + re-raised
+            return await self._build_runtime(req)
+        except Exception as exc:
             logger.exception("deferred_init: /api/init failed; rolling back to dormant")
             self._error = f"{type(exc).__name__}: {exc}"
             self._state = "dormant"
@@ -276,6 +283,69 @@ class InitService:
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=self._error,
             ) from exc
+
+    async def _build_runtime(self, req: InitRequest) -> InitStatus:
+        """Stage the per-user runtime, then publish it at one commit point.
+
+        Everything provisional is registered on ``stack``, so a failure unwinds
+        it in reverse order before ``initialize`` rolls back to ``dormant``.
+        Bootstrap state is overwritten only after the last fallible step has
+        succeeded, which is what makes ``dormant`` a promise that no staged
+        service, credential, sink or singleton is still live.
+        """
+        async with AsyncExitStack() as stack:
+            new_config = _build_initialized_config(self._base_config, req)
+            # Registered before staging so a key the loop rejects still rolls
+            # back. Setting env vars before the services boot lets the cipher
+            # pick up OH_SECRET_KEY-style overrides and tools pick up
+            # credentials.
+            staged_env: dict[str, str | None] = {}
+            stack.callback(_restore_env, staged_env)
+            _stage_env(req.env, staged_env)
+            maybe_init_laminar()
+
+            boot_sink = telemetry_service._telemetry_sink
+            boot_event_factory = telemetry_service._event_factory
+            stack.push_async_callback(_restore_telemetry, boot_sink, boot_event_factory)
+            new_sink = await build_telemetry_sink(new_config)
+
+            service = ConversationService.get_instance(new_config)
+            bash_svc = BashEventService(bash_events_dir=new_config.bash_events_dir)
+            await stack.enter_async_context(bash_svc)
+            await stack.enter_async_context(service)
+
+            # Re-derive root_path from the merged config so Doc URLS are valid
+            from openhands.agent_server.api import _get_root_path
+
+            new_root_path = _get_root_path(new_config)
+
+            # Commit point: nothing past here can fail, so the runtime built
+            # above becomes authoritative in one step.
+            from openhands.agent_server import conversation_service as cs_mod
+
+            # Other call sites go through ``get_default_conversation_service``,
+            # which must see the instance built from the merged config.
+            cs_mod._conversation_service = service
+            self._app.state.config = new_config
+            self._app.state.conversation_service = service
+            self._app.state.bash_event_service = bash_svc
+            self._app.state.telemetry_sink = new_sink
+            self._app.root_path = new_root_path
+
+            mark_initialization_complete()
+            self._state = "ready"
+            # Emitted only now that init has actually succeeded, so a failed
+            # attempt never produces a start and a retry cannot double-emit.
+            emit_server_started()
+            # Ownership passes to teardown() here. The handoff is the last thing
+            # that happens so nothing can raise while a service is reachable
+            # both from the stack and from ``teardown()``.
+            self._entered_bash_service = bash_svc
+            self._entered_service = service
+            stack.pop_all()
+            await _retire_telemetry_sink(boot_sink)
+            logger.info("deferred_init: server transitioned to ready")
+            return self.snapshot()
 
     async def teardown(self) -> None:
         """Tear down the conversation service if /api/init succeeded.

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -6,13 +6,19 @@ Background: https://github.com/OpenHands/software-agent-sdk/issues/2523
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
+import openhands.agent_server.api as api_mod
+import openhands.agent_server.init_router as init_mod
+from openhands.agent_server import conversation_service as cs_mod
 from openhands.agent_server.api import api_lifespan, create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.init_router import (
@@ -20,6 +26,8 @@ from openhands.agent_server.init_router import (
     InitService,
     _build_initialized_config,
 )
+from openhands.agent_server.telemetry import service as telemetry_service
+from openhands.agent_server.telemetry.sink import NoOpTelemetrySink
 
 
 @pytest.fixture(autouse=True)
@@ -508,3 +516,408 @@ async def test_lifespan_teardown_releases_conversation_service_after_init(
     assert init_svc._entered_bash_service is None
     _reset_conversation_singleton()
     _reset_bash_singleton()
+
+
+# ---------------------------------------------------------------------------
+# #4658: a failed /api/init must unwind everything it staged and leave the
+# server back in a clean `dormant` state.
+# ---------------------------------------------------------------------------
+
+_INJECTED_FAILURE = "injected init failure"
+
+# Staged by every request built through ``_init_request`` so each failure phase
+# also has to undo an environment mutation.
+_STAGED_ENV = "DEFERRED_INIT_STAGED"
+
+# Each name is the step whose failure is injected: the injector raises at that
+# step, so everything before it has already completed. Between them the phases
+# cover a failure at every point in the resource-entry sequence.
+_FAILURE_PHASES = (
+    "env",  # env staged; failure before laminar init
+    "telemetry",  # failure building the sink; nothing published yet
+    "conversation_service_factory",  # failure before the service is built
+    "bash_service_factory",  # conversation service built; bash not constructed
+    "bash_service_enter",  # bash constructed; its entry failed
+    "conversation_service_enter",  # bash entered, conversation entry failed
+    "root_path",  # both services entered, nothing published yet
+)
+
+
+def _init_request(
+    tmp_path: Path,
+    name: str = "runtime",
+    conversations_path: Path | None = None,
+) -> InitRequest:
+    return InitRequest(
+        env={_STAGED_ENV: name},
+        conversations_path=conversations_path or tmp_path / name / "convs",
+        bash_events_dir=tmp_path / name / "bash",
+    )
+
+
+def _occupied_path(tmp_path: Path) -> Path:
+    """A path that already exists as a *file*, so a real ``mkdir`` fails."""
+    path = tmp_path / "occupied"
+    path.write_text("not a directory")
+    return path
+
+
+def _fail_once(original) -> Callable[..., Any]:
+    """Wrap a sync callable so its first call raises, then delegate as usual.
+
+    The failure clears itself so the retry inside each test exercises the
+    normal path again.
+    """
+    state = {"pending": True}
+
+    def wrapper(*args, **kwargs):
+        if state["pending"]:
+            state["pending"] = False
+            raise RuntimeError(_INJECTED_FAILURE)
+        return original(*args, **kwargs)
+
+    return wrapper
+
+
+def _fail_once_async(original) -> Callable[..., Any]:
+    """Async counterpart of ``_fail_once``."""
+    state = {"pending": True}
+
+    async def wrapper(*args, **kwargs):
+        if state["pending"]:
+            state["pending"] = False
+            raise RuntimeError(_INJECTED_FAILURE)
+        return await original(*args, **kwargs)
+
+    return wrapper
+
+
+def _inject_failure(phase: str, tmp_path: Path, monkeypatch) -> InitRequest:
+    """Install a one-shot failure for ``phase`` and return the request to send."""
+    if phase == "env":
+        monkeypatch.setattr(
+            init_mod, "maybe_init_laminar", _fail_once(init_mod.maybe_init_laminar)
+        )
+    elif phase == "telemetry":
+        monkeypatch.setattr(
+            init_mod,
+            "build_telemetry_sink",
+            _fail_once_async(init_mod.build_telemetry_sink),
+        )
+    elif phase == "bash_service_enter":
+        # The object is constructed but never entered, so this is the only
+        # phase where a live service exists that the stack must *not* unwind.
+        monkeypatch.setattr(
+            init_mod.BashEventService,
+            "__aenter__",
+            _fail_once_async(init_mod.BashEventService.__aenter__),
+        )
+    elif phase == "conversation_service_factory":
+        monkeypatch.setattr(
+            init_mod.ConversationService,
+            "get_instance",
+            _fail_once(init_mod.ConversationService.get_instance),
+        )
+    elif phase == "bash_service_factory":
+        monkeypatch.setattr(
+            init_mod, "BashEventService", _fail_once(init_mod.BashEventService)
+        )
+    elif phase == "root_path":
+        monkeypatch.setattr(
+            api_mod, "_get_root_path", _fail_once(api_mod._get_root_path)
+        )
+    elif phase == "conversation_service_enter":
+        # Real filesystem failure: the conversation service cannot create its
+        # persistence directory, and it is entered after the bash service.
+        return _init_request(tmp_path, conversations_path=_occupied_path(tmp_path))
+    else:
+        raise AssertionError(f"unknown failure phase: {phase}")
+    return _init_request(tmp_path)
+
+
+def _record_hook(original, label: str, events: list[str]) -> Callable[..., Any]:
+    """Record ``label`` once ``original`` completes without raising."""
+
+    async def wrapper(self, *args, **kwargs):
+        result = await original(self, *args, **kwargs)
+        events.append(label)
+        return result
+
+    return wrapper
+
+
+@pytest.fixture
+def service_lifecycle(monkeypatch):
+    """Record the __aenter__/__aexit__ calls InitService drives on the two
+    services, so enter/exit balance and teardown order stay observable."""
+    from openhands.agent_server.bash_service import BashEventService
+    from openhands.agent_server.conversation_service import ConversationService
+
+    events: list[str] = []
+    for label, cls in (
+        ("bash", BashEventService),
+        ("conversation", ConversationService),
+    ):
+        for hook in ("__aenter__", "__aexit__"):
+            monkeypatch.setattr(
+                cls, hook, _record_hook(getattr(cls, hook), f"{label}.{hook}", events)
+            )
+    return events
+
+
+@pytest.fixture
+def clean_process_state():
+    """Isolate the process-wide state InitService mutates, so a failing test
+    cannot poison later tests."""
+    _reset_conversation_singleton()
+    _reset_bash_singleton()
+    telemetry_service.reset_telemetry_sink()
+    os.environ.pop(_STAGED_ENV, None)
+    yield
+    _reset_conversation_singleton()
+    _reset_bash_singleton()
+    telemetry_service.reset_telemetry_sink()
+    os.environ.pop(_STAGED_ENV, None)
+
+
+class TestDeferredInitRollback:
+    """A failed /api/init must not leave a partially initialized runtime."""
+
+    @pytest.mark.asyncio
+    async def test_failed_init_restores_staged_runtime_state(
+        self, tmp_path, monkeypatch, clean_process_state
+    ):
+        monkeypatch.setenv("DEFERRED_INIT_PREEXISTING", "before")
+        monkeypatch.delenv("DEFERRED_INIT_STAGED", raising=False)
+
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "boot" / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        boot_sink = NoOpTelemetrySink()
+        telemetry_service._telemetry_sink = boot_sink
+        singleton_before = cs_mod._conversation_service
+
+        try:
+            with pytest.raises(HTTPException) as excinfo:
+                await svc.initialize(
+                    InitRequest(
+                        env={
+                            "DEFERRED_INIT_PREEXISTING": "after",
+                            "DEFERRED_INIT_STAGED": "staged",
+                        },
+                        conversations_path=_occupied_path(tmp_path),
+                        bash_events_dir=tmp_path / "runtime" / "bash",
+                    )
+                )
+
+            assert excinfo.value.status_code == 500
+            assert svc.state == "dormant"
+            assert svc.snapshot().error is not None
+
+            # The staged environment is rolled back, including a pre-existing
+            # value the failed request overwrote.
+            assert os.environ["DEFERRED_INIT_PREEXISTING"] == "before"
+            assert "DEFERRED_INIT_STAGED" not in os.environ
+
+            # Nothing the failed attempt built stayed externally visible.
+            assert app.state.config is base
+            assert not hasattr(app.state, "telemetry_sink")
+            assert not hasattr(app.state, "conversation_service")
+            assert not hasattr(app.state, "bash_event_service")
+            assert cs_mod._conversation_service is singleton_before
+            assert telemetry_service._telemetry_sink is boot_sink
+
+            # Entered resources were unwound, not retained for teardown.
+            assert svc._entered_service is None
+            assert svc._entered_bash_service is None
+
+            # The pod is a clean dormant server again: a retry succeeds.
+            result = await svc.initialize(_init_request(tmp_path, "retry"))
+            assert result.state == "ready"
+        finally:
+            await svc.teardown()
+
+    @pytest.mark.asyncio
+    async def test_env_key_rejected_mid_staging_rolls_back_earlier_keys(
+        self, tmp_path, monkeypatch, clean_process_state
+    ):
+        """A key the OS rejects part-way through staging must not strand the
+        keys the same request already applied.
+
+        ``os.environ`` rejects embedded nulls on every platform, and it does so
+        only once it reaches that key -- by which point the earlier ones are
+        already set.
+        """
+        monkeypatch.setenv("DEFERRED_INIT_PREEXISTING", "before")
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "boot" / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        try:
+            with pytest.raises(HTTPException) as excinfo:
+                await svc.initialize(
+                    InitRequest(
+                        env={
+                            "DEFERRED_INIT_PREEXISTING": "after",
+                            "DEFERRED_INIT_REJECTED": "a\x00b",
+                        },
+                        conversations_path=tmp_path / "runtime" / "convs",
+                        bash_events_dir=tmp_path / "runtime" / "bash",
+                    )
+                )
+
+            assert excinfo.value.status_code == 500
+            assert svc.state == "dormant"
+            assert os.environ["DEFERRED_INIT_PREEXISTING"] == "before"
+            assert "DEFERRED_INIT_REJECTED" not in os.environ
+        finally:
+            await svc.teardown()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("phase", _FAILURE_PHASES)
+    async def test_failure_at_each_entry_phase_unwinds_exactly_once(
+        self, tmp_path, monkeypatch, clean_process_state, service_lifecycle, phase
+    ):
+        monkeypatch.delenv(_STAGED_ENV, raising=False)
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "boot" / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        boot_sink = NoOpTelemetrySink()
+        telemetry_service._telemetry_sink = boot_sink
+
+        request = _inject_failure(phase, tmp_path, monkeypatch)
+        try:
+            with pytest.raises(HTTPException) as excinfo:
+                await svc.initialize(request)
+
+            assert excinfo.value.status_code == 500, phase
+            assert svc.state == "dormant", phase
+
+            entered = [e for e in service_lifecycle if e.endswith("__aenter__")]
+            exited = [e for e in service_lifecycle if e.endswith("__aexit__")]
+            assert len(entered) == len(set(entered)), (
+                f"a resource was entered more than once: {service_lifecycle}"
+            )
+            assert sorted(e.split(".")[0] for e in exited) == sorted(
+                e.split(".")[0] for e in entered
+            ), f"entered resources must be exited exactly once: {service_lifecycle}"
+
+            # No staged environment or runtime escaped the rollback.
+            assert _STAGED_ENV not in os.environ, phase
+            assert app.state.config is base, phase
+            assert not hasattr(app.state, "telemetry_sink"), phase
+            assert not hasattr(app.state, "conversation_service"), phase
+            assert not hasattr(app.state, "bash_event_service"), phase
+            assert cs_mod._conversation_service is None, phase
+            assert telemetry_service._telemetry_sink is boot_sink, phase
+            assert svc._entered_service is None, phase
+            assert svc._entered_bash_service is None, phase
+
+            # Retrying from the rolled-back dormant state succeeds.
+            result = await svc.initialize(_init_request(tmp_path, "retry"))
+            assert result.state == "ready", phase
+        finally:
+            await svc.teardown()
+
+        # Across the failed attempt, the retry and teardown, every resource that
+        # was entered was exited exactly once. A retry that double-entered, or a
+        # teardown that double-exited, would break the balance here.
+        entered = sorted(
+            e.split(".")[0] for e in service_lifecycle if e.endswith("__aenter__")
+        )
+        exited = sorted(
+            e.split(".")[0] for e in service_lifecycle if e.endswith("__aexit__")
+        )
+        assert exited == entered, (
+            f"enter/exit balance broken across retry + teardown: {service_lifecycle}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_teardown_after_successful_init_keeps_service_exit_order(
+        self, tmp_path, clean_process_state, service_lifecycle
+    ):
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "boot" / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        result = await svc.initialize(_init_request(tmp_path))
+        assert result.state == "ready"
+        assert service_lifecycle == ["bash.__aenter__", "conversation.__aenter__"]
+
+        await svc.teardown()
+        assert service_lifecycle[-2:] == [
+            "conversation.__aexit__",
+            "bash.__aexit__",
+        ]
+        assert svc._entered_service is None
+        assert svc._entered_bash_service is None
+
+    def test_failed_init_over_http_rolls_back_and_allows_retry(self, tmp_path):
+        """Drive the failure through the real REST contract + lifespan."""
+        _reset_conversation_singleton()
+        telemetry_service.reset_telemetry_sink()
+        cfg = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "boot" / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = create_app(cfg)
+        with TestClient(app) as client:
+            try:
+                boot_sink = app.state.telemetry_sink
+                boot_root_path = app.root_path
+
+                resp = client.post(
+                    "/api/init",
+                    json={
+                        "env": {"DEFERRED_INIT_E2E": "staged"},
+                        "conversations_path": str(_occupied_path(tmp_path)),
+                        "bash_events_dir": str(tmp_path / "runtime" / "bash"),
+                        # A per-user web_url would move root_path if the failed
+                        # attempt had already published the merged config.
+                        "web_url": "https://example.com/user-1/",
+                    },
+                )
+                assert resp.status_code == 500
+                assert client.get("/api/init").json()["state"] == "dormant"
+
+                # The pod is still dormant and nothing was staged.
+                assert client.get("/api/conversations/count").status_code == 503
+                assert app.state.telemetry_sink is boot_sink
+                assert not hasattr(app.state, "conversation_service")
+                assert app.root_path == boot_root_path
+                assert os.environ.get("DEFERRED_INIT_E2E") is None
+
+                # The orchestrator can retry the same pod.
+                resp = client.post(
+                    "/api/init",
+                    json={
+                        "conversations_path": str(tmp_path / "u" / "convs"),
+                        "bash_events_dir": str(tmp_path / "u" / "bash"),
+                    },
+                )
+                assert resp.status_code == 200
+                assert resp.json()["state"] == "ready"
+                assert client.get("/api/conversations/count").status_code == 200
+            finally:
+                os.environ.pop("DEFERRED_INIT_E2E", None)
+                _reset_conversation_singleton()
+                telemetry_service.reset_telemetry_sink()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I reproduced the partial-initialization leak from #4658 on current `main`, reviewed the rollback behavior and regression evidence, and am submitting this focused fix for the deferred initialization failure path.

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

`POST /api/init` published staged runtime state as initialization progressed, while the failure path reset only the service state and error fields.

As a result, a failed deferred initialization could return `InitService` to `dormant` while leaving state from the failed attempt live, including:

- request-provided environment variables;
- the telemetry sink;
- the module-level conversation-service singleton;
- entered conversation and bash services;
- `app.state`;
- `app.root_path`.

A later retry could therefore start from a partially initialized runtime and overwrite the only cleanup reference for a resource entered by the failed attempt.

This change makes deferred initialization transactional: runtime state is staged first, published at a single commit point only after all required initialization succeeds, and fully unwound on failure.

## Summary

- Stage deferred-initialization resources on an `AsyncExitStack` and transfer ownership to normal teardown only after successful initialization.
- Restore staged environment, telemetry, service globals, entered resources, and application state when initialization fails.
- Add lifecycle regression coverage for rollback at each initialization phase, retry after failure, successful initialization, and teardown ordering.

## Issue Number

Fixes #4658

## How to Test

I reproduced the original issue against the pristine base commit and then reran the same reproduction against this branch.

### End-to-end reproduction

On pristine `main`:

```text
http_status=500
state_after_failure=dormant
env_after_failure=leaked-from-failed-init
conversation_singleton_replaced=True
bash_service_still_retained=True
telemetry_sink_published=True
```

With this change:

```text
http_status=500
state_after_failure=dormant
env_after_failure=None
conversation_singleton_replaced=False
bash_service_still_retained=False
telemetry_sink_published=False
```

The HTTP failure contract is unchanged, but the failed initialization no longer leaves staged runtime state live.

### Focused lifecycle tests

```bash
uv run pytest \
  tests/agent_server/test_init_router.py \
  tests/agent_server/telemetry/test_telemetry_init_lifecycle.py \
  --basetemp=.pytest_basetemp \
  -q
```

Result:

```text
31 passed
```

### Additional relevant Agent Server tests

A broader relevant Agent Server test selection completed with:

```text
306 passed
```

A full `tests/agent_server/` fixed-vs-pristine comparison showed no failures introduced by this change. The remaining failures/errors were identical on both trees and environment-dependent.

### OpenAPI compatibility

The repository's Agent Server OpenAPI exporter was run before and after the change.

The generated outputs were byte-identical:

```text
sha256:
07325ca235cc4448b59cb8b7c4451390a7052eba57acb1c5e77022d30a523628
```

This confirms no REST/OpenAPI contract drift.

### Static and repository checks

The changed files passed:

- Ruff format
- Ruff lint
- pycodestyle
- pyright
- import dependency checks
- tool registration checks
- `git diff --check`

The repository-wide `check-forbidden-dynamic-attributes` hook does not run cleanly on this Windows checkout because its baseline stores POSIX paths while the local discovery step produces Windows path separators. The hook does not inspect either file changed by this PR. This is a pre-existing Windows-specific issue; CI runs the hook on Linux, where the path formats match.

## Video/Screenshots

N/A — this is an Agent Server lifecycle / rollback bug fix with no UI changes.

The before/after reproduction above demonstrates the runtime behavior directly.

## Design Doc

Not included.

This is a bounded bug fix that keeps the existing Python and REST/OpenAPI contracts unchanged. The issue already describes the transactional rollback direction, and the implementation is limited to the deferred initialization lifecycle plus regression tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally does not broaden into adjacent lifecycle or persistence changes.

In particular:

- `get_settings_store(config)` / `get_secrets_store(config)` retain their existing process-lifetime, first-initialization semantics. Changing that contract would require a separate persistence-layer design change.
- Coordination between `teardown()` and an initialization already in flight is unchanged.
- Failures occurring inside `ConversationService.__aenter__()` after it has begun allocating its own internal resources remain outside this PR's scope.

These are separate concerns from the deferred-initialization rollback required by #4658.
