### PR TITLE
feat(agent-server): serve durable conversation history

### DIFF
--- a/.github/agent-server-openapi-weak-schema-allowlist.json
+++ b/.github/agent-server-openapi-weak-schema-allowlist.json
@@ -552,12 +552,6 @@
     "owner": "OpenHands OSS"
   },
   {
-    "pointer": "/paths/~1api~1conversations~1{conversation_id}~1events~1search/get/responses/200/content/application~1json/schema",
-    "kind": "empty-object-schema",
-    "reason": "This existing endpoint has an opaque or non-JSON response contract and is tracked by the weak-type ratchet.",
-    "owner": "OpenHands OSS"
-  },
-  {
     "pointer": "/paths/~1api~1conversations~1{conversation_id}~1workspace/get/responses/200/content/application~1json/schema",
     "kind": "empty-object-schema",
     "reason": "This existing endpoint has an opaque or non-JSON response contract and is tracked by the weak-type ratchet.",

--- a/clients/typescript/src/client/conversation-client.ts
+++ b/clients/typescript/src/client/conversation-client.ts
@@ -167,6 +167,10 @@ export class ConversationClient {
     return response.data;
   }
 
+  /**
+   * Search retained event history without provisioning or contacting a runtime.
+   * Ordering and `next_page_id` pagination match the persisted event log.
+   */
   async searchEvents(
     conversationId: string,
     options: ConversationEventSearchOptions = {}
@@ -178,6 +182,7 @@ export class ConversationClient {
     return response.data;
   }
 
+  /** Read one retained event without provisioning or contacting a runtime. */
   async getEvent(conversationId: string, eventId: string): Promise<ConversationEvent> {
     const response = await this.client.get<ConversationEvent>(
       `/api/conversations/${conversationId}/events/${eventId}`
@@ -288,6 +293,7 @@ export class ConversationClient {
     return response.data;
   }
 
+  /** Count retained events without provisioning or contacting a runtime. */
   async getEventCount(
     conversationId: string,
     options: ConversationEventCountOptions = {}

--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -370,6 +370,22 @@ workspace/
     └── (agent files and outputs)
 ```
 
+### Retained conversation history
+
+Conversation metadata and events under `conversations/{conversation_id}` are durable
+control-plane data. The outer server serves the event search, count, single-event,
+and batch-event GET endpoints directly from this storage. These reads never create,
+resume, or contact a conversation runtime, so history remains available when a
+runtime is missing or its ownership metadata has been lost.
+
+Events are returned in persisted append order (or its reverse for descending
+searches), and `next_page_id` continues to identify the first event on the next
+page. Archiving retains metadata and events; unarchiving changes visibility but
+does not start a runtime. Permanent conversation deletion removes retained metadata
+and events, after which history endpoints return `404`. Workspace export is not
+part of the retained-history contract.
+
+
 ## Development
 
 For development, the server runs with auto-reload enabled by default. Any changes to the source code will automatically restart the server.

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -50,7 +50,7 @@ from openhands.agent_server.docker_runtime.routers import (
     docker_workspace_proxy_router,
 )
 from openhands.agent_server.docker_runtime.runtime_route import ConversationRuntimeRoute
-from openhands.agent_server.event_router import event_router
+from openhands.agent_server.event_router import event_history_router, event_router
 from openhands.agent_server.file_router import file_discovery_router, file_router
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
@@ -442,6 +442,7 @@ def _add_api_routes(app: FastAPI) -> None:
     api_router.include_router(file_discovery_router)
     api_router.include_router(tool_router)
     api_router.include_router(create_runtime_router(ConversationRuntimeRoute))
+    api_router.include_router(event_history_router)
     if config.conversation_runtime == "docker":
         api_router.include_router(docker_global_proxy_router)
         api_router.include_router(docker_conversation_proxy_router)

--- a/openhands-agent-server/openhands/agent_server/dependencies.py
+++ b/openhands-agent-server/openhands/agent_server/dependencies.py
@@ -6,6 +6,7 @@ from fastapi.security import APIKeyCookie, APIKeyHeader
 from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.event_history_service import EventHistoryService
 from openhands.agent_server.event_service import EventService
 
 
@@ -99,3 +100,16 @@ async def get_event_service(
             detail=f"Conversation not found: {conversation_id}",
         )
     return event_service
+
+
+def get_event_history_service(
+    conversation_id: UUID,
+    request: Request,
+) -> EventHistoryService:
+    conversation_dir = request.app.state.config.conversations_path / conversation_id.hex
+    if not (conversation_dir / "meta.json").is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation not found: {conversation_id}",
+        )
+    return EventHistoryService.from_conversation_dir(conversation_dir)

--- a/openhands-agent-server/openhands/agent_server/dependencies.py
+++ b/openhands-agent-server/openhands/agent_server/dependencies.py
@@ -102,14 +102,19 @@ async def get_event_service(
     return event_service
 
 
-def get_event_history_service(
+async def get_event_history_service(
     conversation_id: UUID,
     request: Request,
-) -> EventHistoryService:
+) -> EventHistoryService | EventService:
     conversation_dir = request.app.state.config.conversations_path / conversation_id.hex
-    if not (conversation_dir / "meta.json").is_file():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Conversation not found: {conversation_id}",
-        )
-    return EventHistoryService.from_conversation_dir(conversation_dir)
+    if conversation_dir.is_dir():
+        return EventHistoryService.from_conversation_dir(conversation_dir)
+    conversation_service = getattr(request.app.state, "conversation_service", None)
+    if conversation_service is not None:
+        event_service = await conversation_service.get_event_service(conversation_id)
+        if event_service is not None:
+            return event_service
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Conversation not found: {conversation_id}",
+    )

--- a/openhands-agent-server/openhands/agent_server/event_history_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_history_service.py
@@ -1,0 +1,196 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from openhands.agent_server.models import EventPage, EventSortOrder
+from openhands.sdk import Event
+from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.event.llm_convertible.message import MessageEvent
+from openhands.sdk.io import LocalFileStore
+from openhands.sdk.llm.message import content_to_str
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EventHistoryService:
+    """Read retained conversation events without activating a runtime."""
+
+    events: EventLog
+    conversation_id: str
+
+    @classmethod
+    def from_conversation_dir(cls, conversation_dir: Path) -> "EventHistoryService":
+        return cls(
+            events=EventLog(LocalFileStore(str(conversation_dir))),
+            conversation_id=conversation_dir.name,
+        )
+
+    def _get_event_sync(self, event_id: str) -> Event | None:
+        try:
+            return self.events[self.events.get_index(event_id)]
+        except KeyError:
+            return None
+
+    async def get_event(self, event_id: str) -> Event | None:
+        return await asyncio.to_thread(self._get_event_sync, event_id)
+
+    def _event_matches_body(self, event: Event, body: str) -> bool:
+        if not isinstance(event, MessageEvent):
+            return False
+        text_parts = content_to_str(event.llm_message.content)
+        if event.extended_content:
+            text_parts.extend(content_to_str(event.extended_content))
+        if event.reasoning_content:
+            text_parts.append(event.reasoning_content)
+        return body.lower() in " ".join(text_parts).lower()
+
+    def _event_matches_filters(
+        self,
+        event: Event,
+        kind: str | None,
+        source: str | None,
+        body: str | None,
+        timestamp_gte: str | None,
+        timestamp_lt: str | None,
+    ) -> bool:
+        return not (
+            (
+                kind is not None
+                and f"{event.__class__.__module__}.{event.__class__.__name__}" != kind
+            )
+            or (source is not None and event.source != source)
+            or (timestamp_gte is not None and event.timestamp < timestamp_gte)
+            or (timestamp_lt is not None and event.timestamp >= timestamp_lt)
+            or (body is not None and not self._event_matches_body(event, body))
+        )
+
+    def _read_event(self, index: int) -> Event | None:
+        try:
+            return self.events[index]
+        except (FileNotFoundError, UnicodeDecodeError, ValidationError) as exc:
+            logger.warning(
+                "Skipping unreadable event at index %d for conversation %s (%s)",
+                index,
+                self.conversation_id,
+                type(exc).__name__,
+            )
+            return None
+
+    def _search_events_sync(
+        self,
+        page_id: str | None,
+        limit: int,
+        kind: str | None,
+        source: str | None,
+        body: str | None,
+        sort_order: EventSortOrder,
+        timestamp_gte: datetime | None,
+        timestamp_lt: datetime | None,
+    ) -> EventPage:
+        total = len(self.events)
+        start_index: int | None = None
+        if page_id:
+            try:
+                start_index = self.events.get_index(page_id)
+            except KeyError:
+                pass
+
+        reverse = sort_order == EventSortOrder.TIMESTAMP_DESC
+        if start_index is None:
+            start_index = total - 1 if reverse else 0
+        indices = range(start_index, -1, -1) if reverse else range(start_index, total)
+        timestamp_gte_str = timestamp_gte.isoformat() if timestamp_gte else None
+        timestamp_lt_str = timestamp_lt.isoformat() if timestamp_lt else None
+
+        items: list[Event] = []
+        next_page_id: str | None = None
+        for index in indices:
+            event = self._read_event(index)
+            if event is None or not self._event_matches_filters(
+                event,
+                kind,
+                source,
+                body,
+                timestamp_gte_str,
+                timestamp_lt_str,
+            ):
+                continue
+            if len(items) >= limit:
+                next_page_id = event.id
+                break
+            items.append(event)
+        return EventPage(items=items, next_page_id=next_page_id)
+
+    async def search_events(
+        self,
+        page_id: str | None = None,
+        limit: int = 100,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+        sort_order: EventSortOrder = EventSortOrder.TIMESTAMP,
+        timestamp__gte: datetime | None = None,
+        timestamp__lt: datetime | None = None,
+    ) -> EventPage:
+        return await asyncio.to_thread(
+            self._search_events_sync,
+            page_id,
+            limit,
+            kind,
+            source,
+            body,
+            sort_order,
+            timestamp__gte,
+            timestamp__lt,
+        )
+
+    def _count_events_sync(
+        self,
+        kind: str | None,
+        source: str | None,
+        body: str | None,
+        timestamp_gte: datetime | None,
+        timestamp_lt: datetime | None,
+    ) -> int:
+        timestamp_gte_str = timestamp_gte.isoformat() if timestamp_gte else None
+        timestamp_lt_str = timestamp_lt.isoformat() if timestamp_lt else None
+        return sum(
+            event is not None
+            and self._event_matches_filters(
+                event,
+                kind,
+                source,
+                body,
+                timestamp_gte_str,
+                timestamp_lt_str,
+            )
+            for event in (self._read_event(index) for index in range(len(self.events)))
+        )
+
+    async def count_events(
+        self,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+        timestamp__gte: datetime | None = None,
+        timestamp__lt: datetime | None = None,
+    ) -> int:
+        return await asyncio.to_thread(
+            self._count_events_sync,
+            kind,
+            source,
+            body,
+            timestamp__gte,
+            timestamp__lt,
+        )
+
+    async def batch_get_events(self, event_ids: list[str]) -> list[Event | None]:
+        return await asyncio.gather(
+            *(self.get_event(event_id) for event_id in event_ids)
+        )

--- a/openhands-agent-server/openhands/agent_server/event_router.py
+++ b/openhands-agent-server/openhands/agent_server/event_router.py
@@ -15,10 +15,15 @@ from fastapi import (
 )
 from starlette.responses import JSONResponse
 
-from openhands.agent_server.dependencies import get_event_service
+from openhands.agent_server.dependencies import (
+    get_event_history_service,
+    get_event_service,
+)
+from openhands.agent_server.event_history_service import EventHistoryService
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
     ConfirmationResponseRequest,
+    EventPage,
     EventSortOrder,
     SendMessageRequest,
     Success,
@@ -27,6 +32,9 @@ from openhands.sdk import Message
 from openhands.sdk.event import Event
 
 
+event_history_router = APIRouter(
+    prefix="/conversations/{conversation_id}/events", tags=["Events"]
+)
 event_router = APIRouter(
     prefix="/conversations/{conversation_id}/events", tags=["Events"]
 )
@@ -62,7 +70,11 @@ def normalize_datetime_to_server_timezone(dt: datetime) -> datetime:
         return dt
 
 
-@event_router.get("/search", responses={404: {"description": "Conversation not found"}})
+@event_history_router.get(
+    "/search",
+    response_model=EventPage,
+    responses={404: {"description": "Conversation not found"}},
+)
 async def search_conversation_events(
     page_id: Annotated[
         str | None,
@@ -98,7 +110,7 @@ async def search_conversation_events(
         datetime | None,
         Query(title="Filter: event timestamp < this datetime"),
     ] = None,
-    event_service: EventService = Depends(get_event_service),
+    event_service: EventHistoryService = Depends(get_event_history_service),
 ) -> JSONResponse:
     """Search / List local events"""
     assert limit > 0
@@ -136,7 +148,9 @@ async def search_conversation_events(
     )
 
 
-@event_router.get("/count", responses={404: {"description": "Conversation not found"}})
+@event_history_router.get(
+    "/count", responses={404: {"description": "Conversation not found"}}
+)
 async def count_conversation_events(
     kind: Annotated[
         str | None,
@@ -160,7 +174,7 @@ async def count_conversation_events(
         datetime | None,
         Query(title="Filter: event timestamp < this datetime"),
     ] = None,
-    event_service: EventService = Depends(get_event_service),
+    event_service: EventHistoryService = Depends(get_event_history_service),
 ) -> int:
     """Count local events matching the given filters"""
     # Normalize timezone-aware datetimes to server timezone
@@ -180,10 +194,12 @@ async def count_conversation_events(
     return count
 
 
-@event_router.get("/{event_id}", responses={404: {"description": "Item not found"}})
+@event_history_router.get(
+    "/{event_id}", responses={404: {"description": "Item not found"}}
+)
 async def get_conversation_event(
     event_id: str,
-    event_service: EventService = Depends(get_event_service),
+    event_service: EventHistoryService = Depends(get_event_history_service),
 ) -> Event:
     """Get a local event given an id"""
     event = await event_service.get_event(event_id)
@@ -192,10 +208,10 @@ async def get_conversation_event(
     return event
 
 
-@event_router.get("")
+@event_history_router.get("")
 async def batch_get_conversation_events(
     event_ids: list[str],
-    event_service: EventService = Depends(get_event_service),
+    event_service: EventHistoryService = Depends(get_event_history_service),
 ) -> list[Event | None]:
     """Get a batch of local events given their ids, returning null for any
     missing item."""

--- a/tests/agent_server/docker_runtime/test_docker_routers.py
+++ b/tests/agent_server/docker_runtime/test_docker_routers.py
@@ -38,7 +38,10 @@ from openhands.agent_server.models import (
     ConversationRuntimeStatus,
 )
 from openhands.agent_server.utils import utc_now
-from openhands.sdk import LLM, Agent
+from openhands.sdk import LLM, Agent, Message, TextContent
+from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.event import MessageEvent
+from openhands.sdk.io import LocalFileStore
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -230,12 +233,18 @@ class _StubRegistry:
             and (directory / "base_state.json").is_file()
             and self.provisioning.manifest_path(cid).is_file()
         )
+        if cid in self._workspaces:
+            runtime_status = ConversationRuntimeStatus.AVAILABLE
+        elif (
+            (directory / "meta.json").is_file()
+            and (directory / "base_state.json").is_file()
+            and not self.provisioning.manifest_path(cid).is_file()
+        ):
+            runtime_status = ConversationRuntimeStatus.OWNERSHIP_LOST
+        else:
+            runtime_status = ConversationRuntimeStatus.MISSING
         return ConversationRuntimeInfo(
-            runtime_status=(
-                ConversationRuntimeStatus.AVAILABLE
-                if cid in self._workspaces
-                else ConversationRuntimeStatus.MISSING
-            ),
+            runtime_status=runtime_status,
             can_resume=can_resume,
         )
 
@@ -287,6 +296,28 @@ def docker_app(tmp_path, monkeypatch):
             yield client, app
         finally:
             client.close()
+
+
+def _persist_history(
+    registry: _StubRegistry, cid: UUID, count: int = 3
+) -> list[MessageEvent]:
+    directory = registry.conversation_dir(cid)
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "meta.json").write_text("{}")
+    events = [
+        MessageEvent(
+            source="user",
+            llm_message=Message(
+                role="user", content=[TextContent(text=f"message {index}")]
+            ),
+            timestamp=f"2026-08-14T06:00:0{index}",
+        )
+        for index in range(count)
+    ]
+    event_log = EventLog(LocalFileStore(str(directory)))
+    for event in events:
+        event_log.append(event)
+    return events
 
 
 # ---------------------------------------------------------------------------
@@ -365,6 +396,7 @@ def test_delete_proxies_then_stops_container_and_removes_host_state(docker_app):
     assert app.state.docker_registry.get(cid) is None
     assert not conversation_dir.exists()
     assert not workspace_dir.exists()
+    assert client.get(f"/api/conversations/{cid}/events/search").status_code == 404
 
 
 def test_archive_stops_owned_runtime_and_unarchive_stays_cold(docker_app):
@@ -797,24 +829,51 @@ def test_customization_without_conversation(docker_app):
     assert not app.state.docker_registry._workspaces
 
 
-def test_event_search_is_served_by_container(docker_app):
+def test_event_history_is_served_from_retained_storage_without_runtime(docker_app):
     client, app = docker_app
+    registry = app.state.docker_registry
     cid = uuid4()
-    app.state.docker_registry.preregister(cid)
-    response = client.get(f"/api/conversations/{cid}/events/search")
-    assert response.status_code == 200
-    assert response.json()["items"][0]["id"] == "inner-event"
+    events = _persist_history(registry, cid)
+
+    first = client.get(f"/api/conversations/{cid}/events/search", params={"limit": 2})
+    assert first.status_code == 200
+    assert [item["id"] for item in first.json()["items"]] == [
+        events[0].id,
+        events[1].id,
+    ]
+    assert first.json()["next_page_id"] == events[2].id
+
+    second = client.get(
+        f"/api/conversations/{cid}/events/search",
+        params={"limit": 2, "page_id": first.json()["next_page_id"]},
+    )
+    assert [item["id"] for item in second.json()["items"]] == [events[2].id]
+    descending = client.get(
+        f"/api/conversations/{cid}/events/search",
+        params={"limit": 2, "sort_order": "TIMESTAMP_DESC"},
+    ).json()
+    assert [item["id"] for item in descending["items"]] == [
+        events[2].id,
+        events[1].id,
+    ]
+    assert descending["next_page_id"] == events[0].id
+
+    assert client.get(f"/api/conversations/{cid}/events/count").json() == 3
+    assert (
+        client.get(f"/api/conversations/{cid}/events/{events[1].id}").json()["id"]
+        == events[1].id
+    )
+    assert registry.get(cid) is None
 
 
 @pytest.mark.parametrize(
     "path",
     [
-        "/api/conversations/{cid}/events/search",
         "/api/bash/sessions?cid={cid}",
         "/api/conversations/{cid}/workspace/index.html",
     ],
 )
-def test_persisted_conversation_recovers_after_registry_restart(docker_app, path):
+def test_runtime_route_recovers_after_registry_restart(docker_app, path):
     client, app = docker_app
     registry = app.state.docker_registry
     cid = uuid4()
@@ -931,6 +990,24 @@ def test_selected_project_is_not_silently_replaced(docker_app, tmp_path):
     assert selected_file.read_text() == "selected project contents"
 
 
+def test_archived_event_history_remains_readable_without_runtime(docker_app):
+    client, app = docker_app
+    registry = app.state.docker_registry
+    cid = uuid4()
+    events = _persist_history(registry, cid)
+    (registry.conversation_dir(cid) / "meta.json").write_text(
+        '{"archived_at":"2026-08-14T00:00:00+00:00"}'
+    )
+
+    response = client.get(f"/api/conversations/{cid}/events/search")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["items"]] == [
+        event.id for event in events
+    ]
+    assert registry.get(cid) is None
+
+
 @pytest.mark.skipif(
     os.environ.get("RUN_DOCKER_BOUNDARY_TESTS") != "1",
     reason="Requires an existing local agent-server Docker image",
@@ -1010,16 +1087,24 @@ def test_inner_key_cannot_authenticate_outer_api(docker_app_with_auth):
     assert response.status_code == 401
 
 
-def test_legacy_recovery_fails_without_deleting_state(docker_app):
+def test_event_history_survives_runtime_ownership_loss(docker_app):
     client, app = docker_app
+    registry = app.state.docker_registry
     cid = uuid4()
-    directory = app.state.docker_registry.conversation_dir(cid)
-    directory.mkdir(parents=True)
-    (directory / "meta.json").write_text("{}")
-    (directory / "base_state.json").write_text("{}")
+    events = _persist_history(registry, cid)
+    (registry.conversation_dir(cid) / "base_state.json").write_text("{}")
+
     response = client.get(f"/api/conversations/{cid}/events/search")
-    assert response.status_code == 409
-    assert (directory / "base_state.json").read_text() == "{}"
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["items"]] == [
+        event.id for event in events
+    ]
+    assert (
+        registry.runtime_info(cid).runtime_status
+        == ConversationRuntimeStatus.OWNERSHIP_LOST
+    )
+    assert registry.get(cid) is None
 
 
 def test_runtime_fork_is_explicitly_unsupported(docker_app):

--- a/tests/agent_server/test_event_router.py
+++ b/tests/agent_server/test_event_router.py
@@ -10,8 +10,12 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from openhands.agent_server.dependencies import get_event_service
+from openhands.agent_server.dependencies import (
+    get_event_history_service,
+    get_event_service,
+)
 from openhands.agent_server.event_router import (
+    event_history_router,
     event_router,
     normalize_datetime_to_server_timezone,
 )
@@ -65,6 +69,7 @@ def test_normalize_datetime_fixed_offset_timezone():
 def client():
     """Create a test client for the FastAPI app without authentication."""
     app = FastAPI()
+    app.include_router(event_history_router, prefix="/api")
     app.include_router(event_router, prefix="/api")
     return TestClient(app)
 
@@ -363,7 +368,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test search events with naive datetime (no timezone)."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -400,7 +407,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test search events with timezone-aware datetime."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -437,7 +446,9 @@ class TestSearchEventsEndpoint:
         """Test search events with both timestamp filters using
         timezone-aware datetimes."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -474,7 +485,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test count events with timezone-aware datetime."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the count_events method to return a sample result
@@ -507,7 +520,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test count events with source filter."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the count_events method to return a sample result
@@ -541,7 +556,9 @@ class TestSearchEventsEndpoint:
         """Test that different timezone representations of the same moment
         normalize consistently."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -596,7 +613,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test search events with source filter."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -631,7 +650,9 @@ class TestSearchEventsEndpoint:
     ):
         """Test search events with multiple filters including source."""
         # Override the dependency to return our mock
-        client.app.dependency_overrides[get_event_service] = lambda: mock_event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: mock_event_service
+        )
 
         try:
             # Mock the search_events method to return a sample result
@@ -717,7 +738,9 @@ class TestSearchEventsEndpoint:
         conversation._state = state
         event_service._conversation = conversation
 
-        client.app.dependency_overrides[get_event_service] = lambda: event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: event_service
+        )
 
         try:
             # Test filtering by source="user" - should return 2 events
@@ -790,7 +813,9 @@ class TestSearchEventsEndpoint:
         conversation._state = state
         event_service._conversation = conversation
 
-        client.app.dependency_overrides[get_event_service] = lambda: event_service
+        client.app.dependency_overrides[get_event_history_service] = (
+            lambda: event_service
+        )
 
         try:
             # Test filtering by body="hello" (case-insensitive) - should return 2 events


### PR DESCRIPTION
HUMAN:
Rerun formatting/lint and focused tests after replacing undefined `BASE_STATE` with `base_state.json`.

AGENT:

## Why
Conversation history is durable control-plane data and must remain readable after runtime ownership disappears, without accidentally reprovisioning execution infrastructure. This is the #4995 layer stacked on #4999.

## Summary
- add a read-only `EventHistoryService` backed directly by retained host event storage
- serve search, count, single-event, and batch reads without contacting a runtime
- preserve filtering, ordering, pagination, and existing TypeScript method signatures
- document archive retention and permanent deletion semantics

## How to Test
- focused Python suites (308 passed, 1 skipped)
- TypeScript suites (331 passed)
- Ruff format/lint and Pyright
- Agent Server OpenAPI quality check
- TypeScript build, Prettier, and ESLint

Closes #4995

_This pull request was created by an AI agent (OpenHands) on behalf of the user._