### PR TITLE
feat(ts-client): normalize conversation lifecycle

### DIFF
--- a/clients/typescript/src/__tests__/conversation-lifecycle.test.ts
+++ b/clients/typescript/src/__tests__/conversation-lifecycle.test.ts
@@ -1,0 +1,129 @@
+import {
+  normalizeCloudConversationLifecycle,
+  normalizeConversationLifecycle,
+} from '../models/conversation-lifecycle';
+import { ConversationExecutionStatus } from '../types/base';
+
+describe('normalizeConversationLifecycle', () => {
+  it('maps explicit archived Agent Server lifecycle fields directly', () => {
+    expect(
+      normalizeConversationLifecycle({
+        archived_at: '2026-09-12T15:00:00Z',
+        runtime_status: 'missing',
+        execution_status: ConversationExecutionStatus.PAUSED,
+        can_resume: true,
+      })
+    ).toEqual({
+      isArchived: true,
+      archivedAt: '2026-09-12T15:00:00Z',
+      runtimeStatus: 'missing',
+      executionStatus: ConversationExecutionStatus.PAUSED,
+      canResume: true,
+    });
+  });
+
+  it('keeps missing runtimes independent from explicit unarchived state', () => {
+    expect(
+      normalizeConversationLifecycle({
+        archived_at: null,
+        runtime_status: 'missing',
+        execution_status: ConversationExecutionStatus.ERROR,
+        can_resume: false,
+      })
+    ).toEqual({
+      isArchived: false,
+      archivedAt: null,
+      runtimeStatus: 'missing',
+      executionStatus: ConversationExecutionStatus.ERROR,
+      canResume: false,
+    });
+  });
+});
+
+describe('normalizeCloudConversationLifecycle', () => {
+  it('prefers an explicit archive timestamp over the sandbox status', () => {
+    expect(
+      normalizeCloudConversationLifecycle({
+        archived_at: '2026-09-12T15:00:00Z',
+        sandbox_status: 'RUNNING',
+        execution_status: ConversationExecutionStatus.FINISHED,
+      })
+    ).toEqual({
+      isArchived: true,
+      archivedAt: '2026-09-12T15:00:00Z',
+      runtimeStatus: 'available',
+      executionStatus: ConversationExecutionStatus.FINISHED,
+      canResume: false,
+    });
+  });
+
+  it('prefers explicit unarchived metadata over a missing sandbox', () => {
+    expect(
+      normalizeCloudConversationLifecycle({
+        archived_at: null,
+        sandbox_status: 'MISSING',
+        execution_status: ConversationExecutionStatus.ERROR,
+        can_resume: true,
+      })
+    ).toEqual({
+      isArchived: false,
+      archivedAt: null,
+      runtimeStatus: 'missing',
+      executionStatus: ConversationExecutionStatus.ERROR,
+      canResume: true,
+    });
+  });
+
+  it('temporarily infers archive state from a legacy missing sandbox', () => {
+    expect(
+      normalizeCloudConversationLifecycle({
+        sandbox_status: 'MISSING',
+        execution_status: ConversationExecutionStatus.PAUSED,
+      })
+    ).toEqual({
+      isArchived: true,
+      archivedAt: null,
+      runtimeStatus: 'missing',
+      executionStatus: ConversationExecutionStatus.PAUSED,
+      canResume: false,
+    });
+  });
+
+  it.each([
+    ['RUNNING', 'available'],
+    ['PAUSED', 'available'],
+    ['STARTING', 'starting'],
+    ['ERROR', 'error'],
+    [null, 'missing'],
+  ] as const)(
+    'maps Cloud sandbox status %s to runtime status %s',
+    (sandboxStatus, runtimeStatus) => {
+      expect(
+        normalizeCloudConversationLifecycle({
+          archived_at: null,
+          sandbox_status: sandboxStatus,
+          execution_status: null,
+        })
+      ).toMatchObject({
+        runtimeStatus,
+        executionStatus: null,
+      });
+    }
+  );
+
+  it('uses explicit resumability for unarchived conversations', () => {
+    expect(
+      normalizeCloudConversationLifecycle({
+        archived_at: null,
+        sandbox_status: 'ERROR',
+        execution_status: ConversationExecutionStatus.ERROR,
+        can_resume: false,
+      })
+    ).toMatchObject({
+      isArchived: false,
+      runtimeStatus: 'error',
+      executionStatus: ConversationExecutionStatus.ERROR,
+      canResume: false,
+    });
+  });
+});

--- a/clients/typescript/src/client/cloud-client.ts
+++ b/clients/typescript/src/client/cloud-client.ts
@@ -20,6 +20,7 @@ import type {
   SaveProfileRequest,
   SettingsSchema,
 } from '../models/api';
+import type { ConversationRuntimeStatus } from '../models/conversation';
 
 export interface CloudProxyOptions {
   /** Agent-server or ingress host exposing `/api/cloud-proxy`. */
@@ -218,7 +219,10 @@ export interface CloudAppConversation {
   metrics: unknown;
   created_at: string;
   updated_at: string;
+  archived_at?: string | null;
   execution_status: string | null;
+  runtime_status?: ConversationRuntimeStatus | null;
+  can_resume?: boolean | null;
   sandbox_status?: string | null;
   conversation_url: string | null;
   session_api_key: string | null;

--- a/clients/typescript/src/clients.ts
+++ b/clients/typescript/src/clients.ts
@@ -26,6 +26,15 @@ export {
   startDeviceFlow,
 } from './client/device-flow-client';
 export {
+  normalizeCloudConversationLifecycle,
+  normalizeConversationLifecycle,
+} from './models/conversation-lifecycle';
+export type {
+  ConversationLifecycle,
+  ConversationLifecycleFields,
+  LegacyCloudConversationLifecycleFields,
+} from './models/conversation-lifecycle';
+export {
   AGENT_SERVER_VERSION_ERROR_CODE,
   AgentServerFeatureRequirements,
   AgentServerVersionError,

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -252,6 +252,17 @@ export type {
 export { deriveSwitchPlan } from './profiles/derive-switch-plan';
 export type { SwitchPlan } from './profiles/derive-switch-plan';
 
+// Conversation lifecycle
+export {
+  normalizeCloudConversationLifecycle,
+  normalizeConversationLifecycle,
+} from './models/conversation-lifecycle';
+export type {
+  ConversationLifecycle,
+  ConversationLifecycleFields,
+  LegacyCloudConversationLifecycleFields,
+} from './models/conversation-lifecycle';
+
 // Conversation models
 export type {
   ConversationInfo,

--- a/clients/typescript/src/models/conversation-lifecycle.ts
+++ b/clients/typescript/src/models/conversation-lifecycle.ts
@@ -1,0 +1,90 @@
+import { ConversationExecutionStatus } from '../types/base';
+import type { ConversationRuntimeStatus } from './conversation';
+
+export interface ConversationLifecycle {
+  isArchived: boolean;
+  archivedAt: string | null;
+  runtimeStatus: ConversationRuntimeStatus;
+  executionStatus: ConversationExecutionStatus | null;
+  canResume: boolean;
+}
+
+export interface ConversationLifecycleFields {
+  archived_at: string | null;
+  runtime_status: ConversationRuntimeStatus;
+  execution_status: ConversationExecutionStatus;
+  can_resume: boolean;
+}
+
+export interface LegacyCloudConversationLifecycleFields {
+  archived_at?: string | null;
+  runtime_status?: ConversationRuntimeStatus | null;
+  execution_status?: string | null;
+  can_resume?: boolean | null;
+  sandbox_status?: string | null;
+}
+
+export function normalizeConversationLifecycle(
+  conversation: ConversationLifecycleFields
+): ConversationLifecycle {
+  return {
+    isArchived: conversation.archived_at !== null,
+    archivedAt: conversation.archived_at,
+    runtimeStatus: conversation.runtime_status,
+    executionStatus: conversation.execution_status,
+    canResume: conversation.can_resume,
+  };
+}
+
+export function normalizeCloudConversationLifecycle(
+  conversation: LegacyCloudConversationLifecycleFields
+): ConversationLifecycle {
+  const archivedAt = conversation.archived_at ?? null;
+  const isArchived =
+    conversation.archived_at !== undefined
+      ? archivedAt !== null
+      : inferLegacyCloudArchiveState(conversation.sandbox_status);
+
+  return {
+    isArchived,
+    archivedAt,
+    runtimeStatus: conversation.runtime_status ?? cloudRuntimeStatus(conversation.sandbox_status),
+    executionStatus: cloudExecutionStatus(conversation.execution_status),
+    canResume: conversation.can_resume ?? (!isArchived && conversation.sandbox_status === 'PAUSED'),
+  };
+}
+
+/**
+ * @deprecated Replaced by explicit Cloud `archived_at`. Remove when every
+ * supported Cloud deployment returns that field. See the linked removal issue.
+ */
+function inferLegacyCloudArchiveState(sandboxStatus: string | null | undefined): boolean {
+  return sandboxStatus === 'MISSING';
+}
+
+function cloudRuntimeStatus(sandboxStatus: string | null | undefined): ConversationRuntimeStatus {
+  switch (sandboxStatus) {
+    case 'RUNNING':
+    case 'PAUSED':
+      return 'available';
+    case 'STARTING':
+      return 'starting';
+    case 'ERROR':
+      return 'error';
+    case 'MISSING':
+    case null:
+    case undefined:
+    default:
+      return 'missing';
+  }
+}
+
+function cloudExecutionStatus(
+  executionStatus: string | null | undefined
+): ConversationExecutionStatus | null {
+  return Object.values(ConversationExecutionStatus).includes(
+    executionStatus as ConversationExecutionStatus
+  )
+    ? (executionStatus as ConversationExecutionStatus)
+    : null;
+}


### PR DESCRIPTION
HUMAN:
Implement #4996 as the final stacked lifecycle compatibility layer, preserving backward compatibility and avoiding generated-client churn.

AGENT:

## Why
Agent Server and legacy Cloud expose different conversation lifecycle representations. Product code needs one stable TypeScript boundary that preserves canonical lifecycle semantics while containing temporary legacy inference in one clearly deprecated adapter.

## Summary
- add a canonical adapter for Agent Server lifecycle fields
- add a legacy Cloud adapter that prefers explicit `archived_at`, `runtime_status`, and `can_resume` metadata before compatibility inference
- retain the deprecated `sandbox_status === "MISSING"` archive fallback without fabricating an archive timestamp
- export normalized lifecycle APIs from both public TypeScript entrypoints
- keep generated files untouched

The canonical adapter maps the explicit Agent Server contract directly. The legacy Cloud adapter provides compatibility for older Cloud payloads while ensuring explicit metadata always takes precedence. When legacy state indicates archival but no timestamp exists, `isArchived` is true and `archivedAt` remains `null`; no timestamp is fabricated.

Follow-up removal issue created for the deprecated fallback.

## How to Test
- `npm run lint`
- `npm run build`
- `env -u AGENT_SERVER_URL npm run test:coverage -- --runInBand` — 342 tests passed
- `npm run format:check`
- `npm run check:public-type-budget`

Closes #4996

_This pull request was created by an AI agent (OpenHands) on behalf of the user._