### PR TITLE
fix(sdk): isolate subagent definitions per conversation

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -76,7 +76,6 @@ from openhands.sdk.workspace import LocalWorkspace
 
 if TYPE_CHECKING:
     from openhands.sdk.mcp.config import MCPServer
-    from openhands.sdk.subagent.schema import AgentDefinition
 
 
 _AUTOMATION_TAG_KEYS = ("automationtrigger", "automationid", "automationrunid")
@@ -559,41 +558,6 @@ def _compose_webhook_conversation_info_sync(
     stored: StoredConversation, state: ConversationState
 ) -> ConversationInfo:
     return _compose_conversation_info_sync(stored, state)
-
-
-def _register_agent_definitions(
-    agent_defs: list["AgentDefinition"],
-    *,
-    context: str,
-) -> None:
-    """Register agent definitions into the subagent registry.
-
-    Used both when creating new conversations (definitions forwarded from the
-    client) and when resuming persisted ones (definitions stored in meta.json).
-    """
-    from openhands.sdk.subagent.registry import (
-        agent_definition_to_factory,
-        register_agent_if_absent,
-    )
-
-    registered = 0
-    for agent_def in agent_defs:
-        try:
-            factory = agent_definition_to_factory(agent_def)
-            register_agent_if_absent(
-                name=agent_def.name,
-                factory_func=factory,
-                description=agent_def,
-            )
-            registered += 1
-        except Exception as e:
-            logger.warning(
-                f"Failed to register agent definition "
-                f"'{agent_def.name}' ({context}): {e}"
-            )
-    logger.debug(
-        f"Registered {registered}/{len(agent_defs)} agent definition(s) ({context})"
-    )
 
 
 def _state_signature(base_state_path: str) -> tuple[int, int] | None:
@@ -1102,11 +1066,6 @@ class ConversationService:
                     )
         if stored.client_tools:
             register_client_tools(stored.client_tools)
-        if stored.agent_definitions:
-            _register_agent_definitions(
-                stored.agent_definitions,
-                context=f"resuming conversation {stored.id}",
-            )
 
     def _get_conversation_lock(self, conversation_id: UUID) -> asyncio.Lock:
         lock = self._conversation_locks.get(conversation_id)
@@ -1694,13 +1653,6 @@ class ConversationService:
                 request.agent = request.agent.model_copy(
                     update={"tools": [*request.agent.tools, *new_tools]}
                 )
-
-        # Register subagent definitions forwarded from the client
-        if request.agent_definitions:
-            _register_agent_definitions(
-                request.agent_definitions,
-                context=f"conversation {conversation_id}",
-            )
 
         # Plugin loading is now handled lazily by LocalConversation.
         # Just pass the plugin specs through to StoredConversation.

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1111,6 +1111,7 @@ class EventService:
             observability_tags=self.stored.observability_tags,
             observability_span_name=self.stored.observability_span_name,
             mcp_tool_provider=self.mcp_tool_provider,
+            agent_definitions=self.stored.agent_definitions,
         )
 
         conversation.set_confirmation_policy(self.stored.confirmation_policy)

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -107,6 +107,10 @@ from openhands.sdk.subagent import (
     register_file_agents,
     register_plugin_agents,
 )
+from openhands.sdk.subagent.registry import (
+    ConversationAgentRegistry,
+    agent_definition_to_factory,
+)
 from openhands.sdk.tool import ToolDefinition
 from openhands.sdk.tool.builtins import InvokeSkillTool
 from openhands.sdk.tool.client_tool import ClientToolSpec
@@ -238,6 +242,7 @@ class LocalConversation(BaseConversation):
         file_store: FileStore | None = None,
         mcp_tool_provider: MCPToolProvider | None = None,
         profile_store_dir: str | Path | None = None,
+        agent_definitions: list[AgentDefinition] | None = None,
         **_: object,
     ):
         """Initialize the conversation.
@@ -298,6 +303,9 @@ class LocalConversation(BaseConversation):
                 for state and EventLog storage.
             profile_store_dir: Optional directory containing saved LLM profiles.
                 Defaults to ``~/.openhands/profiles``.
+            agent_definitions: Subagent definitions forwarded from a parent or
+                server. Persisted for resume; None keeps the saved definitions,
+                while an explicit list replaces them. Factories are rebuilt lazily.
         """
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially
@@ -385,6 +393,12 @@ class LocalConversation(BaseConversation):
             cipher=cipher,
             tags=tags,
         )
+        self._agent_registry = ConversationAgentRegistry()
+        self._state._agent_registry = self._agent_registry
+        with self._state:
+            if agent_definitions is not None:
+                self._state.agent_definitions = list(agent_definitions)
+            self._agent_definitions = list(self._state.agent_definitions)
         # base_state.json is the source of truth for the agent. On resume with
         # ``agent=None`` the state holds the persisted agent; adopt it here so
         # ``self.agent`` and ``self._state.agent`` are the same object.
@@ -852,6 +866,10 @@ class LocalConversation(BaseConversation):
                 visualizer=type(self._visualizer) if self._visualizer else None,
                 delete_on_close=self.delete_on_close,
                 tags=tags,
+                agent_definitions=[
+                    *self._agent_definitions,
+                    *self._agent_registry.get_registered_agent_definitions(),
+                ],
             )
 
             # Branch slice copies path_to_root(event) (root-first, re-rootable);
@@ -1230,6 +1248,7 @@ class LocalConversation(BaseConversation):
             register_plugin_agents(
                 agents=all_plugin_agents,
                 work_dir=self.workspace.working_dir,
+                registry=self._agent_registry,
             )
 
         # Combine explicit hook_config with plugin hooks
@@ -1475,6 +1494,7 @@ class LocalConversation(BaseConversation):
                 register_plugin_agents(
                     agents=plugin.agents,
                     work_dir=self.workspace.working_dir,
+                    registry=self._agent_registry,
                 )
             if plugin.hooks and not plugin.hooks.is_empty():
                 self._merge_runtime_plugin_hooks(plugin.hooks)
@@ -1500,8 +1520,7 @@ class LocalConversation(BaseConversation):
         """Discover and register file-based agents into the agent registry.
 
         Agents are loaded from Markdown definition files and registered via
-        `register_agent_if_absent`, so they never overwrite agents that were
-        already registered programmatically or by plugins.
+        the conversation registry, below programmatic and plugin priority.
 
         Registration order (highest to lowest priority):
           1. Programmatic `register_agent()` calls (already in the registry)
@@ -1513,7 +1532,28 @@ class LocalConversation(BaseConversation):
                 then `~/.openhands/agents/*.md`)
         """
         # register project-level and then user-level file-based agents
-        register_file_agents(self.workspace.working_dir)
+        register_file_agents(
+            self.workspace.working_dir,
+            registry=self._agent_registry,
+        )
+
+    def _register_agent_definitions(self) -> None:
+        """Restore forwarded definitions without rejecting valid peers."""
+        for agent_def in self._agent_definitions:
+            try:
+                factory = agent_definition_to_factory(
+                    agent_def, work_dir=self.workspace.working_dir
+                )
+                self._agent_registry.register_if_absent(
+                    agent_def.name, factory, agent_def
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to register agent definition '%s'",
+                    agent_def.name,
+                    exc_info=True,
+                )
+        self._agent_definitions.clear()
 
     def _ensure_agent_ready(self) -> None:
         """Ensure the agent is fully initialized with plugins and agents loaded.
@@ -1521,10 +1561,11 @@ class LocalConversation(BaseConversation):
         Performs one-time lazy initialization on the first `send_message()`
         or `run()` call.  The steps executed (in order) are:
 
-        1. Load plugins (merges skills, MCP config, and hooks).
-        2. Register file-based agents into the agent registry.
-        3. Initialize the agent with complete plugin config and hooks.
-        4. Register LLMs in the LLM registry.
+        1. Restore forwarded subagent definitions into the conversation registry.
+        2. Load plugins (merges skills, MCP config, and hooks).
+        3. Register file-based agents into the agent registry.
+        4. Initialize the agent with complete plugin config and hooks.
+        5. Register LLMs in the LLM registry.
 
         This preserves the design principle that constructors should not perform
         I/O or error-prone operations, while eliminating double initialization.
@@ -1544,6 +1585,8 @@ class LocalConversation(BaseConversation):
             # Re-check after acquiring lock in case another thread initialized
             if self._agent_ready:
                 return
+
+            self._register_agent_definitions()
 
             # Load plugins first (merges skills, MCP config, hooks)
             self._ensure_plugins_loaded()

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -16,6 +16,7 @@ from websockets.exceptions import ConnectionClosed
 
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.base import BaseConversation, ConversationStateProtocol
+from openhands.sdk.subagent.registry import ConversationAgentRegistry
 
 
 if TYPE_CHECKING:
@@ -813,13 +814,13 @@ class RemoteConversation(BaseConversation):
 
         if should_create:
             # Import here to avoid circular imports
-            from openhands.sdk.subagent.registry import get_registered_agent_definitions
             from openhands.sdk.tool.registry import get_tool_module_qualnames
 
             tool_qualnames = get_tool_module_qualnames()
             logger.debug(f"Sending tool_module_qualnames to server: {tool_qualnames}")
 
-            agent_defs = get_registered_agent_definitions()
+            # Workspace files and plugins are discovered on the server.
+            agent_defs = ConversationAgentRegistry().get_registered_agent_definitions()
             serialized_defs = [d.model_dump(mode="json") for d in agent_defs]
             logger.debug(f"Sending {len(serialized_defs)} agent_definitions to server")
 

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager
 from enum import Enum
 from pathlib import Path
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import Field, PrivateAttr
 
@@ -37,12 +37,16 @@ from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
     NeverConfirm,
 )
+from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.utils.models import OpenHandsModel
 from openhands.sdk.workspace.base import BaseWorkspace
 
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from openhands.sdk.subagent.registry import ConversationAgentRegistry
 
 
 class ConversationExecutionStatus(str, Enum):
@@ -80,6 +84,7 @@ class ConversationExecutionStatus(str, Enum):
 
 
 class ConversationState(OpenHandsModel):
+    _agent_registry: "ConversationAgentRegistry | None" = PrivateAttr(default=None)
     # ===== Public, validated fields =====
     id: ConversationID = Field(description="Unique conversation ID")
 
@@ -91,6 +96,11 @@ class ConversationState(OpenHandsModel):
             "check agent configuration to handle e.g., tool changes, "
             "LLM changes, etc."
         ),
+    )
+    agent_definitions: list[AgentDefinition] = Field(
+        default_factory=list,
+        description="Forwarded subagent definitions used to rebuild the "
+        "conversation registry on resume.",
     )
     workspace: BaseWorkspace = Field(
         ...,

--- a/openhands-sdk/openhands/sdk/subagent/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/subagent/AGENTS.md
@@ -59,34 +59,39 @@ loading must:
 
 ## Invariant 2: resolution / precedence (“who wins”)
 
-### Core rule: first registration wins
+### Core rule: process base plus conversation overlay
 
-Once an agent name is registered in the global registry (`_agent_factories`), later
-sources must not overwrite it.
+Explicit programmatic agents and built-ins live in the process registry.
+Plugin and project/user file agents live in each `LocalConversation`'s
+`ConversationAgentRegistry`, so same-name definitions in different conversations
+do not collide. The scoped registry keeps the highest-priority source; first
+registration wins within the same priority. This also handles forwarded
+definitions and plugins loaded after project files.
 
 This is enforced by using:
 
 - `register_agent(...)` (raises on duplicates; used for programmatic registration)
-- `register_agent_if_absent(...)` (skips duplicates; used for plugins, file agents, builtins)
+- `register_agent_if_absent(...)` (process-level first wins; used for built-ins)
+- `ConversationAgentRegistry.register_if_absent(...)` (scoped source priority)
 
 ### Effective precedence order
 
-`LocalConversation._ensure_agent_ready()` establishes this order for agents loaded
-as part of conversation initialization:
+The resolver enforces this order, independent of arrival order:
 
-1. Existing registry entries, including explicit `register_agent(...)` calls
-2. Plugin-provided agents (`Plugin.agents` → `register_plugin_agents`)
+1. Explicit process-level `register_agent(...)` calls
+2. Conversation plugin agents (`Plugin.agents` → `register_plugin_agents`)
 3. Project file-based agents
    - `{project}/.agents/agents/*.md` then `{project}/.openhands/agents/*.md`
 4. User file-based agents
    - `~/.agents/agents/*.md` then `~/.openhands/agents/*.md`
 
-Built-ins are discovered and registered separately by `openhands-tools` through
-`register_builtins_agents()`. Because all non-programmatic sources use
-`register_agent_if_absent(...)`, whichever source registers a name first keeps it.
-Call built-in registration after higher-priority sources if built-ins should act as
-fallbacks. The agent-server registers built-ins during tool-router import, before
-per-conversation file discovery.
+5. Process-level built-ins registered by `openhands-tools`
+
+Task/Delegate resolution uses the parent conversation's resolver. Remote clients
+forward shared programmatic/built-in definitions; workspace files and plugins
+are discovered on the server, not by reading server paths on the client.
+Forwarded definitions are restored lazily into the server conversation overlay;
+they are never registered into the server process registry.
 
 ### Deduplication rules inside file-based loading
 
@@ -94,7 +99,7 @@ File-based loading has *two* layers of “first wins” deduplication:
 
 1. **Within a level** (`load_project_agents` / `load_user_agents`):
    - `.agents/agents` wins over `.openhands/agents` for the same agent name.
-2. **Across levels** (`register_file_agents`):
+2. **Across levels** (`discover_agents`, used by `register_file_agents`):
    - project wins over user for the same agent name.
 
 If you change these rules, update the unit tests in `tests/sdk/subagent/`.

--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -27,15 +27,12 @@ from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from threading import RLock
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, NoReturn
 
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.logger import get_logger
-from openhands.sdk.subagent.load import (
-    load_project_agents,
-    load_user_agents,
-)
-from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.subagent.load import discover_agents
+from openhands.sdk.subagent.schema import AgentDefinition, AgentDefinitionLevel
 from openhands.sdk.utils.deprecation import warn_deprecated
 
 
@@ -45,12 +42,97 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_AGENT_PRIORITY: dict[AgentDefinitionLevel | None, int] = {
+    None: 0,
+    "programmatic": 0,
+    "plugin": 1,
+    "project": 2,
+    "user": 3,
+    "builtin": 4,
+}
+
 
 class AgentFactory(NamedTuple):
     """Container for an agent factory function and its definition."""
 
     factory_func: Callable[["LLM"], "Agent"]
     definition: AgentDefinition
+
+
+class ConversationAgentRegistry:
+    """Conversation-owned agent factories layered over global registrations.
+
+    Explicit programmatic registrations remain process-wide. File and plugin
+    definitions live in this overlay, so conversations may safely use the same
+    name with different definitions. Built-ins remain the final fallback.
+    """
+
+    def __init__(self) -> None:
+        self._factories: dict[str, AgentFactory] = {}
+        self._lock = RLock()
+
+    def register_if_absent(
+        self,
+        name: str,
+        factory_func: Callable[["LLM"], "Agent"],
+        description: str | AgentDefinition,
+    ) -> bool:
+        """Keep the highest-priority definition; first wins within a priority."""
+        candidate = _resolve_agent_definition(name, description)
+        with self._lock:
+            existing = self._factories.get(name)
+            if existing is not None and (
+                _AGENT_PRIORITY[existing.definition.level]
+                <= _AGENT_PRIORITY[candidate.level]
+            ):
+                return False
+            self._factories[name] = AgentFactory(factory_func, candidate)
+            return True
+
+    def get_agent_factory(self, name: str | None) -> AgentFactory:
+        factory_name = _canonical_agent_name(name)
+        with _registry_lock:
+            global_factory = _agent_factories.get(factory_name)
+        with self._lock:
+            scoped_factory = self._factories.get(factory_name)
+
+        if global_factory is not None and global_factory.definition.level in (
+            None,
+            "programmatic",
+        ):
+            return global_factory
+        if scoped_factory is not None:
+            return scoped_factory
+        if global_factory is not None and global_factory.definition.level == "builtin":
+            return global_factory
+        _raise_unknown_agent(
+            name, {d.name for d in self.get_registered_agent_definitions()}
+        )
+
+    def get_registered_agent_definitions(self) -> list[AgentDefinition]:
+        with _registry_lock:
+            global_factories = list(_agent_factories.values())
+        with self._lock:
+            scoped_factories = list(self._factories.values())
+
+        definitions: list[AgentDefinition] = []
+        seen: set[str] = set()
+        for factory in [
+            *(
+                f
+                for f in global_factories
+                if f.definition.level in (None, "programmatic")
+            ),
+            *scoped_factories,
+            *(f for f in global_factories if f.definition.level == "builtin"),
+        ]:
+            if factory.definition.name not in seen:
+                seen.add(factory.definition.name)
+                definitions.append(factory.definition)
+        return definitions
+
+    def get_factory_info(self) -> str:
+        return _format_factory_info(self.get_registered_agent_definitions())
 
 
 # Global registry for user-registered agent factories
@@ -111,6 +193,8 @@ def register_agent(
         ValueError: If an agent with the same name already exists.
     """
     definition = _resolve_agent_definition(name, description)
+    if definition.level is None:
+        definition = definition.model_copy(update={"level": "programmatic"})
 
     with _registry_lock:
         if name in _agent_factories:
@@ -141,6 +225,8 @@ def register_agent_if_absent(
         that name already existed.
     """
     definition = _resolve_agent_definition(name, description)
+    if definition.level is None:
+        definition = definition.model_copy(update={"level": "programmatic"})
 
     with _registry_lock:
         if name in _agent_factories:
@@ -285,7 +371,10 @@ def agent_definition_to_factory(
     return _factory
 
 
-def register_file_agents(work_dir: str | Path) -> list[str]:
+def register_file_agents(
+    work_dir: str | Path,
+    registry: ConversationAgentRegistry | None = None,
+) -> list[str]:
     """Load and register file-based agents from project-level `.agents/agents` and
     `.openhands/agents`, and user-level `~/.agents/agents` and `~/.openhands/agents`
     directories.
@@ -298,27 +387,11 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
     Returns:
         List of agent names that were actually registered.
     """
-    project_agents = load_project_agents(work_dir)
-    user_agents = load_user_agents()
-
-    # Deduplicate: project wins over user
-    seen_names: set[str] = set()
-    deduplicated: list[AgentDefinition] = []
-
-    for agent_def in project_agents:
-        if agent_def.name not in seen_names:
-            seen_names.add(agent_def.name)
-            deduplicated.append(agent_def)
-
-    for agent_def in user_agents:
-        if agent_def.name not in seen_names:
-            seen_names.add(agent_def.name)
-            deduplicated.append(agent_def)
-
+    register = registry.register_if_absent if registry else register_agent_if_absent
     registered: list[str] = []
-    for agent_def in deduplicated:
+    for agent_def in discover_agents(work_dir):
         factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
-        was_registered = register_agent_if_absent(
+        was_registered = register(
             name=agent_def.name,
             factory_func=factory,
             description=agent_def,
@@ -336,6 +409,7 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
 def register_plugin_agents(
     agents: list[AgentDefinition],
     work_dir: str | Path | None = None,
+    registry: ConversationAgentRegistry | None = None,
 ) -> list[str]:
     """Register plugin-provided agent definitions into the delegate registry.
 
@@ -348,14 +422,18 @@ def register_plugin_agents(
         agents: Agent definitions collected from loaded plugins.
         work_dir: Project directory for resolving skill names in agent
             definitions. If None, only user-level skills are searched.
+        registry: Conversation registry, or None for process-wide registration.
 
     Returns:
         List of agent names that were actually registered.
     """
+    register = registry.register_if_absent if registry else register_agent_if_absent
     registered: list[str] = []
     for agent_def in agents:
+        if agent_def.level is None:
+            agent_def = agent_def.model_copy(update={"level": "plugin"})
         factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
-        was_registered = register_agent_if_absent(
+        was_registered = register(
             name=agent_def.name,
             factory_func=factory,
             description=agent_def,
@@ -367,20 +445,8 @@ def register_plugin_agents(
     return registered
 
 
-def get_agent_factory(name: str | None) -> AgentFactory:
-    """
-    Get a registered agent factory by name.
-
-    Args:
-        name: Name of the agent factory to retrieve. If None, empty, or "default",
-            the default agent factory is returned.
-
-    Returns:
-        AgentFactory: The factory function and definition
-
-    Raises:
-        ValueError: If no agent factory with the given name is found
-    """
+def _canonical_agent_name(name: str | None) -> str:
+    """Normalize default and deprecated agent names for both registries."""
     # Map old names to new names for backward compatibility
     _DEPRECATED_NAMES = {
         "default": "general-purpose",
@@ -397,40 +463,48 @@ def get_agent_factory(name: str | None) -> AgentFactory:
             removed_in="2.0.0",
             details=f"Use '{new_name}' instead.",
         )
-        factory_name = new_name
-    else:
-        factory_name = "general-purpose" if not name else name
+        return new_name
+    return "general-purpose" if not name else name
+
+
+def _raise_unknown_agent(name: str | None, available: set[str]) -> NoReturn:
+    available_list = ", ".join(sorted(available)) if available else "none registered"
+    raise ValueError(
+        f"Unknown agent '{name}'. Available types: {available_list}. "
+        "Use register_agent() to add custom agent types."
+    )
+
+
+def get_agent_factory(name: str | None) -> AgentFactory:
+    """Get a factory from the process-wide registry."""
+    factory_name = _canonical_agent_name(name)
 
     with _registry_lock:
         factory = _agent_factories.get(factory_name)
-        available = sorted(_agent_factories.keys())
+        available = set(_agent_factories)
 
     if factory is None:
-        available_list = ", ".join(available) if available else "none registered"
-        raise ValueError(
-            f"Unknown agent '{name}'. Available types: {available_list}. "
-            "Use register_agent() to add custom agent types."
-        )
+        _raise_unknown_agent(name, available)
 
     return factory
 
 
-def get_factory_info() -> str:
-    """Get formatted information about available agent factories."""
-    with _registry_lock:
-        user_factories = dict(_agent_factories)
-
-    if not user_factories:
+def _format_factory_info(definitions: list[AgentDefinition]) -> str:
+    if not definitions:
         return "- No user-registered agents yet. Call register_agent(...) to add custom agents."  # noqa: E501
 
-    def get_agent_info(name, factory):
-        defn = factory.definition
+    def get_agent_info(defn: AgentDefinition) -> str:
         tools = f" (tools: {', '.join(defn.tools)})" if defn.tools else ""
-        return f"- **{name}**: {defn.description}{tools}"
+        return f"- **{defn.name}**: {defn.description}{tools}"
 
     return "\n".join(
-        get_agent_info(name, f) for name, f in sorted(user_factories.items())
+        get_agent_info(d) for d in sorted(definitions, key=lambda d: d.name)
     )
+
+
+def get_factory_info() -> str:
+    """Get formatted information about available process-wide factories."""
+    return _format_factory_info(get_registered_agent_definitions())
 
 
 def get_registered_agent_definitions() -> list[AgentDefinition]:

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -12,7 +12,6 @@ from openhands.sdk.conversation.state import (
     ConversationState,
 )
 from openhands.sdk.logger import get_logger
-from openhands.sdk.subagent import get_agent_factory
 from openhands.sdk.tool.tool import ToolExecutor
 from openhands.tools.delegate.definition import DelegateObservation
 
@@ -172,8 +171,9 @@ class DelegateExecutor(ToolExecutor):
             resolved_agent_types = [
                 self._resolve_agent_type(action, i) for i in range(len(action.ids))
             ]
+            registry = parent_conversation._agent_registry
             factories = [
-                get_agent_factory(name=agent_type)
+                registry.get_agent_factory(agent_type)
                 for agent_type in resolved_agent_types
             ]
 
@@ -220,6 +220,7 @@ class DelegateExecutor(ToolExecutor):
                     "visualizer": sub_visualizer,
                     "hook_config": factory.definition.hooks,
                     "persistence_dir": subagents_persistence_dir,
+                    "agent_definitions": registry.get_registered_agent_definitions(),
                 }
 
                 if factory.definition.max_iteration_per_run is not None:

--- a/openhands-tools/openhands/tools/task/definition.py
+++ b/openhands-tools/openhands/tools/task/definition.py
@@ -233,9 +233,16 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
         """
         from openhands.tools.task.impl import TaskExecutor, TaskManager
 
-        agent_types_info = get_factory_info()
-
-        registered = {d.name for d in get_registered_agent_definitions()}
+        registry = conv_state._agent_registry
+        agent_types_info = (
+            registry.get_factory_info() if registry else get_factory_info()
+        )
+        definitions = (
+            registry.get_registered_agent_definitions()
+            if registry
+            else get_registered_agent_definitions()
+        )
+        registered = {d.name for d in definitions}
         task_tool_examples = "\n".join(
             ex for name, ex in TASK_TOOL_EXAMPLES.items() if name in registered
         )

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -34,7 +34,7 @@ from openhands.sdk.hooks.config import HookConfig
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import detached_delegate_context
 from openhands.sdk.security import ConfirmationPolicyBase
-from openhands.sdk.subagent.registry import AgentFactory, get_agent_factory
+from openhands.sdk.subagent.registry import AgentFactory
 
 
 if TYPE_CHECKING:
@@ -209,7 +209,9 @@ class TaskManager:
                     f"Available tasks: {', '.join(sorted(self._tasks))}"
                 )
 
-            factory = get_agent_factory(subagent_type)
+            factory = self.parent_conversation._agent_registry.get_agent_factory(
+                subagent_type
+            )
             worker_agent = self._get_sub_agent_from_factory(factory)
             conversation_id = self._tasks[resume].conversation_id
             with detached_delegate_context() as link:
@@ -224,6 +226,9 @@ class TaskManager:
                         task_id=resume, subagent_type=subagent_type, link=link
                     ),
                     observability_tags=["delegate"],
+                    agent_definitions=(
+                        self.parent_conversation._agent_registry.get_registered_agent_definitions()
+                    ),
                 )
 
             self._set_confirmation_policy(
@@ -251,7 +256,9 @@ class TaskManager:
         1. ``factory.definition.max_iteration_per_run`` (from the agent definition)
         2. The parent conversation's ``max_iteration_per_run``
         """
-        factory = get_agent_factory(subagent_type)
+        factory = self.parent_conversation._agent_registry.get_agent_factory(
+            subagent_type
+        )
         worker_agent = self._get_sub_agent_from_factory(factory)
 
         effective_max_iter = (
@@ -327,6 +334,9 @@ class TaskManager:
                     task_id=task_id, subagent_type=subagent_type, link=link
                 ),
                 observability_tags=["delegate"],
+                agent_definitions=(
+                    parent._agent_registry.get_registered_agent_definitions()
+                ),
             )
 
     def _delegate_observability_metadata(
@@ -355,7 +365,9 @@ class TaskManager:
         Raises:
             ValueError: If the subagent type is invalid.
         """
-        factory = get_agent_factory(subagent_type)
+        factory = self.parent_conversation._agent_registry.get_agent_factory(
+            subagent_type
+        )
         return self._get_sub_agent_from_factory(factory)
 
     def _get_sub_agent_from_factory(self, factory: "AgentFactory") -> Agent:

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -52,6 +52,7 @@ from openhands.sdk.io.memory import InMemoryFileStore
 from openhands.sdk.llm import MessageToolCall, TextContent
 from openhands.sdk.mcp.config import coerce_mcp_config
 from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.subagent.registry import get_agent_factory
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
@@ -68,6 +69,63 @@ from tests.agent_server.stress.scripts import (
 # EventService separately.
 def _sample_agent() -> Agent:
     return Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[])
+
+
+async def test_resume_restores_scoped_subagents_from_disk(
+    tmp_path: Path, sample_stored_conversation, monkeypatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    stored = sample_stored_conversation.model_copy(
+        update={
+            "workspace": LocalWorkspace(working_dir=str(tmp_path / "project")),
+            "agent_definitions": [
+                AgentDefinition(
+                    name="persisted-reviewer",
+                    description="stored plugin",
+                    system_prompt="Restored plugin prompt",
+                    level="plugin",
+                )
+            ],
+        }
+    )
+    service = EventService(
+        stored=stored, agent=_sample_agent(), conversations_dir=tmp_path / "state"
+    )
+    try:
+        await service.start()
+        await asyncio.to_thread(
+            service.get_conversation().send_message, "Before restart"
+        )
+        await service.save_meta()
+    finally:
+        await service.close()
+
+    resumed = EventService(
+        stored=stored.model_copy(update={"agent_definitions": []}),
+        conversations_dir=tmp_path / "state",
+    )
+    try:
+        await resumed.load_meta()
+        await resumed.start()
+        conversation = resumed.get_conversation()
+        await asyncio.to_thread(conversation.send_message, "After restart")
+        worker = conversation._agent_registry.get_agent_factory(
+            "persisted-reviewer"
+        ).factory_func(conversation.agent.llm)
+        assert worker.agent_context is not None
+        assert worker.agent_context.system_message_suffix == "Restored plugin prompt"
+        assert any(
+            isinstance(event, MessageEvent)
+            and any(
+                isinstance(content, TextContent) and content.text == "Before restart"
+                for content in event.llm_message.content
+            )
+            for event in conversation.state.events
+        )
+        with pytest.raises(ValueError, match="Unknown agent 'persisted-reviewer'"):
+            get_agent_factory("persisted-reviewer")
+    finally:
+        await resumed.close()
 
 
 @pytest.fixture

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -11,6 +11,7 @@ import textwrap
 import threading
 import time
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
@@ -1961,7 +1962,7 @@ def test_hook_config_sent_to_server(
 
 
 def test_subagent_definitions_forwarded_to_server(server_env, patched_llm):
-    """Agent definitions registered on the client survive the HTTP roundtrip.
+    """Agent definitions survive the HTTP roundtrip without leaking globally.
 
     This is a regression test for the bug where the server's delegate registry
     was empty because register_builtins_agents() only ran on the client.
@@ -1971,12 +1972,11 @@ def test_subagent_definitions_forwarded_to_server(server_env, patched_llm):
             ( or register_agent_if_absent(...))
         → get_registered_agent_definitions()
         → JSON payload in POST /api/conversations
-        → server start_conversation() deserializes & re-registers
+        → server LocalConversation's scoped registry
 
     Because client and server share a process in this test, we reset the
     global registry *after* building the payload, then POST directly to the
-    server. The server re-populates the registry from the HTTP payload (not
-    from any shared in-process state).
+    server. The server keeps the definitions on the created conversation.
     """
     _reset_registry_for_tests()
 
@@ -2029,14 +2029,73 @@ def test_subagent_definitions_forwarded_to_server(server_env, patched_llm):
         resp = client.post("/api/conversations", json=payload, timeout=10.0)
         resp.raise_for_status()
 
-    # The server should have re-registered both agents from the HTTP payload
+    # Conversation-specific definitions must not leak back into the process registry.
     info = get_factory_info()
-    assert "test_bash" in info
-    assert "Command execution specialist" in info
-    assert "test_reviewer" in info
-    assert "Code review specialist" in info
+    assert "test_bash" not in info
+    assert "test_reviewer" not in info
+
+    event_services = server_env["conversation_service"]._event_services
+    assert event_services is not None
+    conversation = event_services[UUID(resp.json()["id"])].get_conversation()
+    conversation.send_message("Prepare the forwarded agents")
+    restored = conversation._agent_registry.get_agent_factory(
+        "test_reviewer"
+    ).definition
+    assert restored.system_prompt == reviewer_def.system_prompt
+    assert restored.tools == reviewer_def.tools
 
     _reset_registry_for_tests()
+
+
+def test_server_conversations_isolate_same_name_subagents(server_env):
+    """Concurrent server conversations resolve their own same-name definition."""
+    agent = Agent(
+        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test")),
+        tools=[],
+    )
+    agent_payload = agent.model_dump(mode="json", context={"expose_secrets": True})
+
+    def create_conversation(project: str, description: str) -> UUID:
+        definition = AgentDefinition(
+            name="shared-reviewer",
+            description=description,
+            system_prompt=description,
+            level="project",
+        )
+        payload = {
+            "agent": agent_payload,
+            "workspace": {"working_dir": f"/tmp/workspace/{project}"},
+            "agent_definitions": [definition.model_dump(mode="json")],
+        }
+        with httpx.Client(base_url=server_env["host"]) as client:
+            response = client.post("/api/conversations", json=payload, timeout=10.0)
+            response.raise_for_status()
+            return UUID(response.json()["id"])
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(create_conversation, project, description)
+            for project, description in [
+                ("project-a", "definition-a"),
+                ("project-b", "definition-b"),
+            ]
+        ]
+        conversation_ids = [future.result() for future in futures]
+
+    event_services = server_env["conversation_service"]._event_services
+    assert event_services is not None
+    descriptions = []
+    for conversation_id in conversation_ids:
+        conversation = event_services[conversation_id].get_conversation()
+        conversation.send_message("Prepare the reviewer")
+        worker = conversation._agent_registry.get_agent_factory(
+            "shared-reviewer"
+        ).factory_func(conversation.agent.llm)
+        assert worker.agent_context is not None
+        descriptions.append(worker.agent_context.system_message_suffix)
+
+    assert descriptions == ["definition-a", "definition-b"]
+    assert "shared-reviewer" not in get_factory_info()
 
 
 def test_agent_final_response_endpoint(server_env, monkeypatch: pytest.MonkeyPatch):

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -2,6 +2,7 @@
 
 import time
 import uuid
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import httpx
@@ -27,6 +28,13 @@ from openhands.sdk.event.conversation_state import (
 from openhands.sdk.event.llm_completion_log import LLMCompletionLogEvent
 from openhands.sdk.llm import LLM, Message, Metrics, TextContent
 from openhands.sdk.security.confirmation_policy import AlwaysConfirm
+from openhands.sdk.subagent.registry import (
+    _reset_registry_for_tests,
+    agent_definition_to_factory,
+    register_agent,
+    register_file_agents,
+)
+from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.workspace import RemoteWorkspace
 
 
@@ -101,6 +109,43 @@ class TestRemoteConversation:
 
         mock_client_instance.request.side_effect = request_side_effect
         return mock_client_instance
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
+    def test_remote_payload_excludes_other_workspaces_and_client_path_files(
+        self, mock_ws_client, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        _reset_registry_for_tests()
+        for project in ("unrelated", "server-path"):
+            directory = tmp_path / project / ".agents" / "agents"
+            directory.mkdir(parents=True)
+            (directory / "reviewer.md").write_text(
+                f"---\nname: {project}\ndescription: private to {project}\n---\n"
+            )
+        register_file_agents(tmp_path / "unrelated")
+        definition = AgentDefinition(name="explicit", description="shared programmatic")
+        register_agent(
+            definition.name, agent_definition_to_factory(definition), definition
+        )
+        self.workspace = RemoteWorkspace(
+            host=self.host, working_dir=str(tmp_path / "server-path")
+        )
+        client = self.setup_mock_client()
+        conversation = RemoteConversation(
+            agent=self.agent, workspace=self.workspace, visualizer=None
+        )
+        try:
+            payload = next(
+                call.kwargs["json"]
+                for call in client.request.call_args_list
+                if call.args[:2] == ("POST", "/api/conversations")
+            )
+            assert [d["name"] for d in payload["agent_definitions"]] == ["explicit"]
+        finally:
+            conversation.close()
+            _reset_registry_for_tests()
 
     def create_mock_conversation_response(self, conversation_id: str | None = None):
         """Create mock conversation creation response."""

--- a/tests/sdk/conversation/test_subagent_registry_isolation.py
+++ b/tests/sdk/conversation/test_subagent_registry_isolation.py
@@ -1,0 +1,253 @@
+import json
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.persistence_const import BASE_STATE
+from openhands.sdk.io import InMemoryFileStore
+from openhands.sdk.plugin import PluginSource
+from openhands.sdk.subagent.registry import get_agent_factory
+from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.testing import TestLLM
+from openhands.tools.task.definition import TaskToolSet
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+
+def _write_agent(project: Path, description: str) -> None:
+    directory = project / ".agents" / "agents"
+    directory.mkdir(parents=True)
+    (directory / "shared.md").write_text(
+        "---\n"
+        "name: shared\n"
+        f"description: {description}\n"
+        "---\n\n"
+        f"Prompt for {description}.\n"
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_file_agents_are_isolated_per_conversation(
+    tmp_path: Path, reverse: bool
+) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    _write_agent(project_a, "definition-a")
+    _write_agent(project_b, "definition-b")
+    projects = [project_a, project_b]
+    if reverse:
+        projects.reverse()
+
+    conversations = [
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=project,
+            visualizer=None,
+        )
+        for project in projects
+    ]
+    try:
+        for conversation in conversations:
+            conversation.send_message("Prepare the conversation")
+
+        descriptions = {
+            Path(conversation.workspace.working_dir).name: (
+                conversation._agent_registry.get_agent_factory(
+                    "shared"
+                ).definition.description
+            )
+            for conversation in conversations
+        }
+        assert descriptions == {
+            "project-a": "definition-a",
+            "project-b": "definition-b",
+        }
+        for conversation in conversations:
+            description = descriptions[Path(conversation.workspace.working_dir).name]
+            task_tool = TaskToolSet.create(conversation._state)[0]
+            assert description in task_tool.description
+            worker = conversation._agent_registry.get_agent_factory(
+                "shared"
+            ).factory_func(conversation.agent.llm)
+            assert worker.agent_context is not None
+            assert (
+                worker.agent_context.system_message_suffix
+                == f"Prompt for {description}."
+            )
+    finally:
+        for conversation in conversations:
+            conversation.close()
+
+
+@pytest.mark.parametrize("initialize", [False, True])
+@pytest.mark.parametrize("custom_file_store", [False, True])
+def test_close_reopen_keeps_forwarded_definitions(
+    tmp_path: Path, initialize: bool, custom_file_store: bool
+) -> None:
+    file_store = InMemoryFileStore() if custom_file_store else None
+    persistence_dir = str(tmp_path / "conversations")
+    definition = AgentDefinition(
+        name="forwarded", description="resume-visible", system_prompt="Saved prompt"
+    )
+    with closing(
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=tmp_path,
+            persistence_dir=persistence_dir,
+            file_store=file_store,
+            agent_definitions=[definition],
+            visualizer=None,
+        )
+    ) as conversation:
+        conversation_id = conversation.id
+        if initialize:
+            conversation.send_message("Prepare original")
+            assert (
+                conversation._agent_registry.get_agent_factory("forwarded").definition
+                == definition
+            )
+            with pytest.raises(ValueError, match="Unknown agent 'forwarded'"):
+                get_agent_factory("forwarded")
+
+    with closing(
+        LocalConversation(
+            conversation_id=conversation_id,
+            agent=None,
+            workspace=tmp_path,
+            persistence_dir=persistence_dir,
+            file_store=file_store,
+            visualizer=None,
+        )
+    ) as resumed:
+        resumed.send_message("Prepare resumed")
+        assert "resume-visible" in TaskToolSet.create(resumed._state)[0].description
+        factory = resumed._agent_registry.get_agent_factory("forwarded")
+        assert factory.definition == definition
+        worker = factory.factory_func(resumed.agent.llm)
+        assert worker.agent_context is not None
+        assert worker.agent_context.system_message_suffix == "Saved prompt"
+        with pytest.raises(ValueError, match="Unknown agent 'forwarded'"):
+            get_agent_factory("forwarded")
+
+
+@pytest.mark.parametrize("mode", ["replace", "clear", "legacy"])
+def test_resume_forwarded_definition_updates(tmp_path: Path, mode: str) -> None:
+    file_store = InMemoryFileStore()
+    with closing(
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=tmp_path,
+            file_store=file_store,
+            agent_definitions=[AgentDefinition(name="forwarded", description="old")],
+            visualizer=None,
+        )
+    ) as conversation:
+        conversation_id = conversation.id
+
+    replacement = AgentDefinition(name="forwarded", description="replacement")
+    definitions = [replacement] if mode == "replace" else []
+    if mode == "legacy":
+        saved = json.loads(file_store.read(BASE_STATE))
+        del saved["agent_definitions"]
+        file_store.write(BASE_STATE, json.dumps(saved))
+
+    # Reopen again without arguments to verify the update itself was saved.
+    for forwarded in [None if mode == "legacy" else definitions, None]:
+        with closing(
+            LocalConversation(
+                agent=None,
+                conversation_id=conversation_id,
+                workspace=tmp_path,
+                file_store=file_store,
+                agent_definitions=forwarded,
+                visualizer=None,
+            )
+        ) as resumed:
+            resumed.send_message("Prepare resumed")
+            if mode == "replace":
+                assert (
+                    resumed._agent_registry.get_agent_factory("forwarded").definition
+                    == replacement
+                )
+            else:
+                with pytest.raises(ValueError, match="Unknown agent 'forwarded'"):
+                    resumed._agent_registry.get_agent_factory("forwarded")
+
+
+def test_plugin_overrides_forwarded_project_definition(tmp_path: Path) -> None:
+    plugin = tmp_path / "plugin"
+    manifest = plugin / ".plugin"
+    manifest.mkdir(parents=True)
+    (manifest / "plugin.json").write_text(json.dumps({"name": "review-plugin"}))
+    agents = plugin / "agents"
+    agents.mkdir()
+    (agents / "shared.md").write_text(
+        "---\nname: shared\ndescription: plugin winner\n---\nPlugin prompt.\n"
+    )
+    definition = AgentDefinition(
+        name="shared", description="project loser", level="project"
+    )
+    with closing(
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=tmp_path,
+            plugins=[PluginSource(source=str(plugin))],
+            agent_definitions=[definition],
+            visualizer=None,
+        )
+    ) as conversation:
+        conversation.send_message("Prepare the conversation")
+        assert "plugin winner" in TaskToolSet.create(conversation._state)[0].description
+        assert (
+            "project loser"
+            not in TaskToolSet.create(conversation._state)[0].description
+        )
+
+
+def test_bad_forwarded_definition_does_not_block_valid_agents(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with closing(
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=tmp_path,
+            agent_definitions=[
+                AgentDefinition(
+                    name="broken", description="bad", skills=["missing-skill"]
+                ),
+                AgentDefinition(
+                    name="valid", description="survives", system_prompt="Valid prompt"
+                ),
+            ],
+            visualizer=None,
+        )
+    ) as conversation:
+        assert "Failed to register" not in caplog.text
+        conversation.send_message("Prepare the conversation")
+        assert "Failed to register agent definition 'broken'" in caplog.text
+        assert "survives" in TaskToolSet.create(conversation._state)[0].description
+
+
+@pytest.mark.parametrize("initialize", [False, True])
+def test_fork_keeps_forwarded_definitions(tmp_path: Path, initialize: bool) -> None:
+    with closing(
+        LocalConversation(
+            agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
+            workspace=tmp_path,
+            agent_definitions=[
+                AgentDefinition(name="forwarded", description="fork-visible")
+            ],
+            visualizer=None,
+        )
+    ) as conversation:
+        if initialize:
+            conversation.send_message("Prepare parent")
+        with closing(conversation.fork()) as fork:
+            fork.send_message("Prepare fork")
+            assert "fork-visible" in TaskToolSet.create(fork._state)[0].description

--- a/tests/sdk/subagent/test_subagent_registry.py
+++ b/tests/sdk/subagent/test_subagent_registry.py
@@ -11,6 +11,7 @@ from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.mcp.config import MCPServer, dump_mcp_config
 from openhands.sdk.subagent.registry import (
+    ConversationAgentRegistry,
     _reset_registry_for_tests,
     agent_definition_to_factory,
     get_agent_factory,
@@ -20,7 +21,7 @@ from openhands.sdk.subagent.registry import (
     register_file_agents,
     register_plugin_agents,
 )
-from openhands.sdk.subagent.schema import AgentDefinition
+from openhands.sdk.subagent.schema import AgentDefinition, AgentDefinitionLevel
 
 
 def setup_function() -> None:
@@ -46,6 +47,86 @@ def _create_skill_file(skills_dir: Path, name: str, content: str) -> None:
     skill_file.write_text(
         f"---\nname: {name}\ntriggers:\n  - {name}\n---\n\n{content}\n"
     )
+
+
+def test_conversation_registry_ignores_legacy_global_file_agents() -> None:
+    def factory(llm: LLM) -> Agent:
+        return cast(Agent, MagicMock())
+
+    register_agent_if_absent(
+        "other-project",
+        factory,
+        AgentDefinition(name="other-project", description="leaked", level="project"),
+    )
+
+    registry = ConversationAgentRegistry()
+    with pytest.raises(ValueError, match="Unknown agent 'other-project'"):
+        registry.get_agent_factory("other-project")
+    assert registry.get_registered_agent_definitions() == []
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_scoped_priority_is_independent_of_registration_order(reverse: bool) -> None:
+    registry = ConversationAgentRegistry()
+    levels: list[AgentDefinitionLevel] = [
+        "programmatic",
+        "plugin",
+        "project",
+        "user",
+        "builtin",
+    ]
+    for start in range(len(levels)):
+        name = f"agent-{start}"
+        candidates = levels[start:]
+        if reverse:
+            candidates = list(reversed(candidates))
+        for level in candidates:
+            definition = AgentDefinition(name=name, description=level, level=level)
+            registry.register_if_absent(
+                name, agent_definition_to_factory(definition), definition
+            )
+        duplicate = AgentDefinition(
+            name=name, description="duplicate", level=levels[start]
+        )
+        assert not registry.register_if_absent(
+            name, agent_definition_to_factory(duplicate), duplicate
+        )
+
+    definitions = registry.get_registered_agent_definitions()
+    assert len(definitions) == len(levels)
+    for definition in definitions:
+        assert definition == registry.get_agent_factory(definition.name).definition
+        assert definition.description == levels[int(definition.name.split("-")[1])]
+
+
+def test_scoped_catalog_and_lookup_agree_with_global_precedence() -> None:
+    registry = ConversationAgentRegistry()
+    for level in ("programmatic", "builtin"):
+        definition = AgentDefinition(name=level, description=level, level=level)
+        register_agent(level, agent_definition_to_factory(definition), definition)
+        local = AgentDefinition(name=level, description="local", level="project")
+        registry.register_if_absent(level, agent_definition_to_factory(local), local)
+
+    fallback = AgentDefinition(
+        name="general-purpose", description="fallback", level="builtin"
+    )
+    register_agent(fallback.name, agent_definition_to_factory(fallback), fallback)
+    assert registry.get_agent_factory(None).definition == fallback
+    assert registry.get_agent_factory("").definition == fallback
+    assert registry.get_agent_factory("default").definition == fallback
+
+    definitions = registry.get_registered_agent_definitions()
+    assert {d.name: d.description for d in definitions} == {
+        "programmatic": "programmatic",
+        "builtin": "local",
+        "general-purpose": "fallback",
+    }
+    for definition in definitions:
+        assert registry.get_agent_factory(definition.name).definition == definition
+    with pytest.raises(
+        ValueError, match="Available types: builtin, general-purpose, programmatic"
+    ):
+        registry.get_agent_factory("missing")
 
 
 def test_register_file_agents_project_priority(tmp_path: Path) -> None:

--- a/tests/tools/delegate/test_delegation.py
+++ b/tests/tools/delegate/test_delegation.py
@@ -7,13 +7,17 @@ from unittest.mock import MagicMock, patch
 
 from pydantic import SecretStr
 
+from openhands.sdk import Agent
 from openhands.sdk.agent.utils import fix_malformed_tool_arguments
 from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
 from openhands.sdk.llm import LLM, TextContent
 from openhands.sdk.subagent.registry import (
+    ConversationAgentRegistry,
     _reset_registry_for_tests,
+    agent_definition_to_factory,
     register_agent,
 )
 from openhands.sdk.subagent.schema import AgentDefinition
@@ -23,6 +27,43 @@ from openhands.tools.delegate import (
 )
 from openhands.tools.delegate.definition import DelegateAction
 from openhands.tools.preset import register_builtins_agents
+from openhands.tools.task.definition import TaskToolSet
+
+
+def test_delegate_uses_scoped_factory_and_forwards_catalog(tmp_path: Path):
+    parent = LocalConversation(
+        agent=Agent(llm=LLM(model="test/model", api_key=SecretStr("test")), tools=[]),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    executor = DelegateExecutor()
+    definition = AgentDefinition(
+        name="delegate-reviewer",
+        description="parent plugin reviewer",
+        system_prompt="Parent plugin prompt",
+        level="plugin",
+    )
+    parent._agent_registry.register_if_absent(
+        definition.name, agent_definition_to_factory(definition), definition
+    )
+    try:
+        result = executor(
+            DelegateAction(
+                command="spawn", ids=["review"], agent_types=[definition.name]
+            ),
+            parent,
+        )
+        assert not result.is_error
+        child = executor._sub_agents["review"]
+        assert child.agent.agent_context is not None
+        assert (
+            child.agent.agent_context.system_message_suffix == definition.system_prompt
+        )
+        child.send_message("Prepare child")
+        assert definition.description in TaskToolSet.create(child._state)[0].description
+    finally:
+        executor.close()
+        parent.close()
 
 
 def create_test_executor_and_parent():
@@ -34,6 +75,7 @@ def create_test_executor_and_parent():
     )
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = llm
     parent_conversation.agent.cli_mode = True
@@ -258,6 +300,7 @@ def test_spawn_disables_streaming_for_sub_agents():
     register_builtins_agents()
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.agent.cli_mode = True
@@ -294,6 +337,7 @@ def test_spawn_gives_sub_agents_independent_metrics():
     )
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"
@@ -332,6 +376,7 @@ def test_delegate_merges_metrics_into_parent():
     parent_stats.usage_to_metrics["agent"] = parent_llm.metrics
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"
@@ -411,6 +456,7 @@ def test_repeated_delegation_does_not_double_count():
     parent_stats.usage_to_metrics["agent"] = parent_llm.metrics
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"
@@ -529,6 +575,7 @@ def test_spawn_passes_hook_config_to_sub_conversation():
     )
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"
@@ -564,6 +611,7 @@ def test_spawn_inherits_persistence_dir_from_parent():
     )
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"
@@ -596,6 +644,7 @@ def test_spawn_no_persistence_when_parent_has_none():
     )
 
     parent_conversation = MagicMock()
+    parent_conversation._agent_registry = ConversationAgentRegistry()
     parent_conversation.id = uuid.uuid4()
     parent_conversation.agent.llm = parent_llm
     parent_conversation.state.workspace.working_dir = "/tmp"

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -12,15 +12,55 @@ from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
 from openhands.sdk.subagent.registry import (
     _reset_registry_for_tests,
+    agent_definition_to_factory,
     register_agent,
 )
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.tools.preset import register_builtins_agents
+from openhands.tools.task.definition import TaskToolSet
 from openhands.tools.task.manager import (
     Task,
     TaskManager,
     TaskStatus,
 )
+
+
+def test_task_child_and_resume_keep_parent_catalog(tmp_path: Path) -> None:
+    manager, parent = _manager_with_parent(tmp_path, persistence_dir=tmp_path / "state")
+    definition = AgentDefinition(
+        name="scoped-reviewer",
+        description="parent plugin reviewer",
+        system_prompt="Use the parent's plugin",
+        level="plugin",
+    )
+    parent._agent_registry.register_if_absent(
+        definition.name, agent_definition_to_factory(definition), definition
+    )
+    try:
+        task = manager._create_task(subagent_type=definition.name, description=None)
+        child = task.conversation
+        assert child is not None
+        assert child.agent.agent_context is not None
+        assert (
+            child.agent.agent_context.system_message_suffix == definition.system_prompt
+        )
+        child.send_message("Remember this task")
+        assert definition.description in TaskToolSet.create(child._state)[0].description
+        conversation_id = child.id
+        manager._evict_task(task)
+
+        resumed = manager._resume_task(task.id, definition.name)
+        assert resumed.conversation is not None
+        assert resumed.conversation.id == conversation_id
+        resumed.conversation.send_message("Continue the task")
+        assert (
+            definition.description
+            in TaskToolSet.create(resumed.conversation._state)[0].description
+        )
+        assert len(resumed.conversation.state.events) > 1
+    finally:
+        manager.close()
+        parent.close()
 
 
 def _make_llm() -> LLM:

--- a/tests/tools/task/test_task_tool_set.py
+++ b/tests/tools/task/test_task_tool_set.py
@@ -348,7 +348,7 @@ class TestTaskToolExamples:
     def teardown_method(self):
         _reset_registry_for_tests()
 
-    def test_matching_agent_example_included(self, tmp_path):
+    def test_matching_agent_example_included(self, mock_conversation_state):
         """When a registered agent name matches a TASK_TOOL_EXAMPLES key,
         its example appears in the tool description."""
         # Pick one key from the examples dict
@@ -363,13 +363,13 @@ class TestTaskToolExamples:
         )
 
         tools = TaskToolSet.create(
-            conv_state=None,  # type: ignore[arg-type]
+            conv_state=mock_conversation_state,
         )
         assert len(tools) == 1
         description = tools[0].description
         assert example_text.strip() in description
 
-    def test_no_matching_agent_example_excluded(self, tmp_path):
+    def test_no_matching_agent_example_excluded(self, mock_conversation_state):
         """When no registered agent name matches any TASK_TOOL_EXAMPLES key,
         no example text appears in the tool description."""
         # Register an agent whose name does NOT match any example key
@@ -380,14 +380,14 @@ class TestTaskToolExamples:
         )
 
         tools = TaskToolSet.create(
-            conv_state=None,  # type: ignore[arg-type]
+            conv_state=mock_conversation_state,
         )
         assert len(tools) == 1
         description = tools[0].description
         for name, example_text in TASK_TOOL_EXAMPLES.items():
             assert example_text.strip() not in description
 
-    def test_only_registered_examples_included(self, tmp_path):
+    def test_only_registered_examples_included(self, mock_conversation_state):
         """Only examples for registered agents appear; others are excluded."""
         keys = list(TASK_TOOL_EXAMPLES.keys())
         if len(keys) < 2:
@@ -403,7 +403,7 @@ class TestTaskToolExamples:
         )
 
         tools = TaskToolSet.create(
-            conv_state=None,  # type: ignore[arg-type]
+            conv_state=mock_conversation_state,
         )
         description = tools[0].description
         assert TASK_TOOL_EXAMPLES[included_name].strip() in description


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->
<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

- Recreated and confirmed the bug locally using the below script
- Reviewed the code for fixing the bug
- Ensured the code handles edge cases
- Made sure the test coverage is good and there are test cases for identified edge cases
- Confirmed the bug was resolved

<details>
<summary>Reproduction script</summary>

Save as `/tmp/repro_4661_conversations.py`:

```python
import os
import tempfile
from contextlib import ExitStack, closing
from pathlib import Path
from unittest.mock import patch

os.environ["LOG_LEVEL"] = "ERROR"
os.environ["OPENHANDS_SUPPRESS_BANNER"] = "1"

from openhands.sdk import Agent
from openhands.sdk.conversation.impl.local_conversation import LocalConversation
from openhands.sdk.subagent.registry import _reset_registry_for_tests, get_agent_factory
from openhands.sdk.testing import TestLLM


def write_agent(project, description, prompt):
    directory = project / ".agents" / "agents"
    directory.mkdir(parents=True)
    (directory / "shared-repro-agent.md").write_text(
        f"---\nname: shared-repro-agent\ndescription: {description}\n---\n\n{prompt}\n"
    )


print("Issue #4661: conversation isolation")
failures = 0

with tempfile.TemporaryDirectory() as raw:
    root = Path(raw)
    projects = [root / "project-a", root / "project-b"]
    write_agent(projects[0], "definition-from-A", "PROMPT_A")
    write_agent(projects[1], "definition-from-B", "PROMPT_B")
    with patch.object(Path, "home", return_value=root / "home"):
        for order in [projects, projects[::-1]]:
            _reset_registry_for_tests()
            print("\nOrder: " + " -> ".join(p.name for p in order))
            print(f"{'Project':<12} {'Expected':<10} {'Actual':<10} Result")
            print("-" * 40)
            with ExitStack() as stack:
                conversations = [
                    stack.enter_context(
                        closing(
                            LocalConversation(
                                agent=Agent(llm=TestLLM.from_messages([]), tools=[]),
                                workspace=p,
                                visualizer=None,
                            )
                        )
                    )
                    for p in order
                ]
                for conversation in conversations:
                    conversation.send_message("Prepare conversation")
                for project, conversation in zip(order, conversations):
                    # The baseline uses the global lookup; the fix owns a resolver.
                    registry = getattr(conversation, "_agent_registry", None)
                    factory = (
                        registry.get_agent_factory if registry else get_agent_factory
                    )("shared-repro-agent")
                    worker = factory.factory_func(conversation.agent.llm)
                    prompt = worker.agent_context.system_message_suffix
                    expected = "PROMPT_A" if project == projects[0] else "PROMPT_B"
                    correct = prompt == expected
                    failures += not correct
                    print(
                        f"{project.name:<12} {expected:<10} {prompt:<10} "
                        f"{'PASS' if correct else 'FAIL'}"
                    )
                try:
                    get_agent_factory("shared-repro-agent")
                    failures += 1
                    print("Global isolation: FAIL (project agent leaked)")
                except ValueError:
                    print("Global isolation: PASS (no leak)")
            _reset_registry_for_tests()

print(
    "\nResult: "
    + (f"FAIL ({failures} checks failed)" if failures else "PASS (all 6 checks passed)")
)
```

Run from the repository root:

```bash
uv run --offline python /tmp/repro_4661_conversations.py
```

Before the fix (routine SDK logs suppressed by the script):

```text
Issue #4661: conversation isolation

Order: project-a -> project-b
Project      Expected   Actual     Result
----------------------------------------
project-a    PROMPT_A   PROMPT_A   PASS
project-b    PROMPT_B   PROMPT_A   FAIL
Global isolation: FAIL (project agent leaked)

Order: project-b -> project-a
Project      Expected   Actual     Result
----------------------------------------
project-b    PROMPT_B   PROMPT_B   PASS
project-a    PROMPT_A   PROMPT_B   FAIL
Global isolation: FAIL (project agent leaked)

Result: FAIL (4 checks failed)
```

After the fix (routine SDK logs suppressed by the script):

```text
Issue #4661: conversation isolation

Order: project-a -> project-b
Project      Expected   Actual     Result
----------------------------------------
project-a    PROMPT_A   PROMPT_A   PASS
project-b    PROMPT_B   PROMPT_B   PASS
Global isolation: PASS (no leak)

Order: project-b -> project-a
Project      Expected   Actual     Result
----------------------------------------
project-b    PROMPT_B   PROMPT_B   PASS
project-a    PROMPT_A   PROMPT_A   PASS
Global isolation: PASS (no leak)

Result: PASS (all 6 checks passed)
```

</details>

---

AGENT:

## Why

File and plugin subagent definitions were registered globally, allowing conversations in different workspaces to resolve the same name to another conversation’s definition. Remote creation could also forward definitions from unrelated workspaces.

## Summary

- Resolve file and plugin subagents through a conversation-owned registry, preserving programmatic > plugin > project > user > built-in precedence.
- Use the scoped registry for Task/Delegate lookup, child conversations, and remote/server handoff.
- Persist forwarded definitions for local resume and cover isolation, precedence, and restoration.

## Issue Number

Fixes #4661

## How to Test

Run the local isolation/persistence tests and the live-server regression tests:

```bash
uv run --offline pytest -q tests/sdk/conversation/test_subagent_registry_isolation.py

uv run --offline pytest -q tests/cross/test_remote_conversation_live_server.py \
  -k 'subagent_definitions_forwarded or isolate_same_name_subagents'
```

**Results:** 13 local tests and 2 live-server tests passed.

The live-server tests create conversations through HTTP and verify that same-name subagents remain isolated and forwarded definitions resolve correctly. Local tests cover precedence, persistence, and forks.

## Video/Screenshots

No UI changes. Live-server execution results and reproduction details are included above.

## Design Doc

Not included.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Explicit programmatic registrations and built-ins remain process-wide. Existing global registration APIs remain available. The subagent AGENTS.md update documents the changed ownership and precedence rules.
