### PR TITLE
fix(skills): exclude installed resources from generic context discovery

### DIFF
--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -877,9 +877,22 @@ def load_skills_from_dir(
     # Note: Third-party files (AGENTS.md, etc.) are loaded separately by
     # load_project_skills() to ensure they're loaded even when this directory
     # doesn't exist.
-    skill_md_files = find_skill_md_directories(skill_dir)
+    # Installed packages are loaded separately with registry enable/disable state.
+    # Import lazily because installed.py imports Skill from this module.
+    from openhands.sdk.skills.installed import get_installed_skills_dir
+
+    installed_dir = get_installed_skills_dir().resolve()
+    skill_md_files = [
+        path
+        for path in find_skill_md_directories(skill_dir)
+        if not path.resolve().is_relative_to(installed_dir)
+    ]
     skill_md_dirs = {skill_md.parent for skill_md in skill_md_files}
-    regular_md_files = find_regular_md_files(skill_dir, skill_md_dirs)
+    regular_md_files = [
+        path
+        for path in find_regular_md_files(skill_dir, skill_md_dirs)
+        if not path.resolve().is_relative_to(installed_dir)
+    ]
 
     # Load SKILL.md files (auto-detected and validated in Skill.load)
     # Wrap each load in try/except to ensure one bad skill doesn't break all loading

--- a/tests/sdk/skills/test_load_user_skills.py
+++ b/tests/sdk/skills/test_load_user_skills.py
@@ -395,3 +395,41 @@ def test_load_user_skills_disabled_installed_skill_excluded(tmp_path, monkeypatc
         assert "disabled-skill" not in skill_names
     finally:
         skill.USER_SKILLS_DIRS = original_dirs
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_installed_skill_resources_do_not_leak_into_user_skills(
+    tmp_path, monkeypatch, enabled
+):
+    skills_dir = tmp_path / "skills"
+    installed_dir = skills_dir / "installed"
+    source = tmp_path / "resource-skill"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        "---\nname: resource-skill\ndescription: Resource skill\n---\nInstructions."
+    )
+    for directory in ("commands", "references"):
+        (source / directory).mkdir()
+        (source / directory / "notes.md").write_text("Private resource instructions.")
+    install_skill(str(source), installed_dir=installed_dir)
+    if not enabled:
+        disable_skill("resource-skill", installed_dir=installed_dir)
+
+    (skills_dir / "legacy").mkdir()
+    (skills_dir / "legacy" / "notes.md").write_text("Legacy instructions.")
+    direct = skills_dir / "direct-skill"
+    direct.mkdir()
+    (direct / "SKILL.md").write_text(
+        "---\nname: direct-skill\ndescription: Direct skill\n---\nInstructions."
+    )
+    (direct / "reference.md").write_text("Direct resource instructions.")
+    monkeypatch.setattr(skill, "USER_SKILLS_DIRS", [skills_dir])
+    monkeypatch.setattr(installed, "DEFAULT_INSTALLED_SKILLS_DIR", installed_dir)
+
+    loaded = load_user_skills()
+    expected = {"legacy/notes", "direct-skill"}
+    if enabled:
+        expected.add("resource-skill")
+    assert {entry.name for entry in loaded} == expected
+    assert len(loaded) == len(expected)
+    assert (installed_dir / "resource-skill" / "references" / "notes.md").is_file()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Managed installed packages sit inside the generic user-skills scan root. Their command/reference markdown is loaded as legacy permanent context even when the package is disabled. The separate installed-skills loader correctly handles the callable skill but cannot undo those leaked entries.

## Summary

- Exclude files resolving inside the actual managed installation directory from both generic SKILL.md and loose-markdown discovery. Keep the installed loader responsible for registry state.
- Preserve recursive legacy markdown discovery elsewhere, user precedence, and package resource files. No changes to Helm, deployment, registry format, or public function signatures.
- Add enabled/disabled regression cases using real installation and filesystem APIs. Only path configuration is redirected with monkeypatch; no installer or loader behavior is mocked.

## Issue Number

Fixes #5021

## How to Test

```bash
uv run pytest tests/sdk/skills/test_load_user_skills.py tests/sdk/skills/test_installed_skills.py tests/sdk/skills/test_skill_utils.py
```

**Validation actually performed:** imported this checkout through `PYTHONPATH="$PWD/openhands-sdk"` with the existing runtime dependencies. Before the fix, a self-contained install → load → disable → load reproduction produced:

```text
enabled: ['example', 'installed/example/references/notes']
disabled: ['installed/example/references/notes']
```

After the fix, executed the exact self-contained Python reproduction in #5021:

```text
enabled: ['example']
disabled: []
```

Also executed both new regression test bodies directly using Python (without pytest collection), covering supporting commands and references, resource retention, direct-child packages, and recursive legacy skills. Both passed. Additional real-filesystem checks passed for user-over-installed precedence, disabled override preservation, scanning the managed root directly, an unrelated directory named `installed`, and a symlink alias of the user skills root. `git diff --check` passed.

**Limitations:** pytest and Ruff are not installed in this environment. The full pytest suite, lint, and agent/benchmark evaluations were not run. Direct execution of test bodies is not claimed as a pytest run. This remains a draft pending CI and maintainer review, particularly because the fix changes initial prompt content.

## Type

- [x] Bug fix

## Notes

No live deployment or persisted installation was modified. Delivery to Agent Canvas requires an image containing the SDK fix; existing transcript content is not erased by updating discovery.

_This PR was created by an AI agent (OpenHands) on behalf of the user._
