### PR TITLE
fix(skills): exclude installed resources from generic context discovery

### DIFF
--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -877,9 +877,22 @@ def load_skills_from_dir(
     # Note: Third-party files (AGENTS.md, etc.) are loaded separately by
     # load_project_skills() to ensure they're loaded even when this directory
     # doesn't exist.
-    skill_md_files = find_skill_md_directories(skill_dir)
+    # Installed packages are loaded separately with registry enable/disable state.
+    # Import lazily because installed.py imports Skill from this module.
+    from openhands.sdk.skills.installed import get_installed_skills_dir
+
+    installed_dir = get_installed_skills_dir().resolve()
+    skill_md_files = [
+        path
+        for path in find_skill_md_directories(skill_dir)
+        if not path.resolve().is_relative_to(installed_dir)
+    ]
     skill_md_dirs = {skill_md.parent for skill_md in skill_md_files}
-    regular_md_files = find_regular_md_files(skill_dir, skill_md_dirs)
+    regular_md_files = [
+        path
+        for path in find_regular_md_files(skill_dir, skill_md_dirs)
+        if not path.resolve().is_relative_to(installed_dir)
+    ]
 
     # Load SKILL.md files (auto-detected and validated in Skill.load)
     # Wrap each load in try/except to ensure one bad skill doesn't break all loading

--- a/tests/sdk/skills/test_load_user_skills.py
+++ b/tests/sdk/skills/test_load_user_skills.py
@@ -395,3 +395,41 @@ def test_load_user_skills_disabled_installed_skill_excluded(tmp_path, monkeypatc
         assert "disabled-skill" not in skill_names
     finally:
         skill.USER_SKILLS_DIRS = original_dirs
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_installed_skill_resources_do_not_leak_into_user_skills(
+    tmp_path, monkeypatch, enabled
+):
+    skills_dir = tmp_path / "skills"
+    installed_dir = skills_dir / "installed"
+    source = tmp_path / "resource-skill"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        "---\nname: resource-skill\ndescription: Resource skill\n---\nInstructions."
+    )
+    for directory in ("commands", "references"):
+        (source / directory).mkdir()
+        (source / directory / "notes.md").write_text("Private resource instructions.")
+    install_skill(str(source), installed_dir=installed_dir)
+    if not enabled:
+        disable_skill("resource-skill", installed_dir=installed_dir)
+
+    (skills_dir / "legacy").mkdir()
+    (skills_dir / "legacy" / "notes.md").write_text("Legacy instructions.")
+    direct = skills_dir / "direct-skill"
+    direct.mkdir()
+    (direct / "SKILL.md").write_text(
+        "---\nname: direct-skill\ndescription: Direct skill\n---\nInstructions."
+    )
+    (direct / "reference.md").write_text("Direct resource instructions.")
+    monkeypatch.setattr(skill, "USER_SKILLS_DIRS", [skills_dir])
+    monkeypatch.setattr(installed, "DEFAULT_INSTALLED_SKILLS_DIR", installed_dir)
+
+    loaded = load_user_skills()
+    expected = {"legacy/notes", "direct-skill"}
+    if enabled:
+        expected.add("resource-skill")
+    assert {entry.name for entry in loaded} == expected
+    assert len(loaded) == len(expected)
+    assert (installed_dir / "resource-skill" / "references" / "notes.md").is_file()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Ran into this on my self-hosted Agent Canvas deployment (image 1.18.0). One installed
skill was quietly adding six entries to every conversation — three command shims plus
three reference documents, injected in full whether or not I invoked the skill.
Disabling the skill dropped the callable entry but left the documents behind, which is
what pushed me to look at discovery instead of my own configuration.

---

AGENT:

## Why

Managed installed packages sit inside the generic user-skills scan root. `find_skill_md_directories()` only recognizes direct-child package roots, while `find_regular_md_files()` recurses, so the extra `installed/` level lets a package's `commands/` and `references/` markdown escape the package exclusion. Carrying no `triggers` frontmatter, those files are classified as permanent repository context and injected into `REPO_CONTEXT` on every conversation. The installed-skills loader owns the callable entry, so disabling the package leaves the leaked documents behind.

This defeats progressive disclosure, and the cost is paid on every conversation. On the deployment where this surfaced, one package contributed six always-on entries — three near-identical command shims plus three reference documents in full.

## Summary

- Filter both discovery passes in `load_skills_from_dir()` against the managed installation directory, leaving enable/disable state to the installed-skills loader.
- Preserve recursive legacy markdown discovery elsewhere, direct-child AgentSkills resources, and user-over-installed precedence. No change to public function signatures, registry format, or the agent loop.
- Add enabled/disabled regression cases driven through the real installation and filesystem APIs; only path configuration is redirected with `monkeypatch`.

## Issue Number

Fixes #5023

## How to Test

```bash
make build
uv run pytest tests/sdk/skills tests/sdk/context
uv run pre-commit run --files openhands-sdk/openhands/sdk/skills/skill.py tests/sdk/skills/test_load_user_skills.py
```

**End-to-end evidence.** The self-contained reproduction from #5023 (real `install_skill` / `disable_skill` / `load_user_skills`, real filesystem, no mocks), run against this checkout with the patch stashed and unstashed:

```text
===== BEFORE (stash patch) =====
enabled: ['example', 'installed/example/references/notes']
disabled: ['installed/example/references/notes']
===== AFTER (patched) =====
enabled: ['example']
disabled: []
```

**Test suites**, on this branch:

```text
uv run pytest tests/sdk/skills   ->  364 passed, 0 failed, 2 skipped
uv run pytest tests/sdk/context  ->  440 passed
```

**Pre-commit**, on both changed files:

```text
Ruff format .......... Passed      Ruff lint ............................ Passed
PEP8 (pycodestyle) ... Passed      Type check with pyright .............. Passed
Forbid dynamic attribute access in SDK .................................. Passed
Check import dependency rules ........................................... Passed
Check Tool subclass registration ........................................ Passed
```

Environment: Python 3.13.15, branched from `c37007429be8b4465a83487dc1fd0914df0ea734`.

## Video/Screenshots

Not applicable — no UI surface. The before/after console output above is the observable behavior change.

## Design Doc

Skipped per CONTRIBUTING: this is a small bug fix with no public API change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Behavior change to initial prompt content: packages that were leaking supporting documents will stop contributing them, so `REPO_CONTEXT` shrinks for affected deployments. That is the intent of the fix, but it does alter prompts, so it deserves a deliberate look.
- The import of `get_installed_skills_dir` is lazy because `installed.py` imports `Skill` from `skill.py`.
- Scope: this filters the managed installation directory. A package nested at depth under some *other* scan root would still be swept; that is a separate, broader change and is deliberately not attempted here.
- Supersedes #5022, opened in error from an automation account.
