### PR TITLE
fix(secret): resolve this server's own LookupSecret URLs in-process

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -49,6 +49,7 @@ from openhands.agent_server.init_router import (
     require_initialized,
 )
 from openhands.agent_server.llm_router import llm_router
+from openhands.agent_server.local_secret_resolver import local_secret_resolution
 from openhands.agent_server.mcp_router import mcp_router
 from openhands.agent_server.middleware import CORSDispatcher
 from openhands.agent_server.openai.router import (
@@ -153,12 +154,18 @@ def _cleanup_stale_tmux_sessions() -> None:
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
     tmux_tmpdir, tmux_tmpdir_was_defaulted = _ensure_server_tmux_tmpdir()
+    secret_resolution: local_secret_resolution | None = None
     try:
         # Clean up stale tmux sessions from previous server runs
         _cleanup_stale_tmux_sessions()
 
         config: Config = api.state.config
         deferred = config.deferred_init
+
+        # Answer our own LookupSecret URLs in-process; a loopback fetch made
+        # from the event loop cannot be served by the loop blocked on it.
+        secret_resolution = local_secret_resolution(config)
+        secret_resolution.__enter__()
 
         # Deferred pods boot with telemetry disabled and are rebuilt by
         # InitService, so they emit `server_started` there instead.
@@ -281,6 +288,8 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
     finally:
         # Outer finally so a startup failure cannot leak the drain task, and
         # after `async with service` so terminal events are still accepted.
+        if secret_resolution is not None:
+            secret_resolution.__exit__(None, None, None)
         emit_server_stopped()
         await shutdown_telemetry_sink()
 

--- a/openhands-agent-server/openhands/agent_server/local_secret_resolver.py
+++ b/openhands-agent-server/openhands/agent_server/local_secret_resolver.py
@@ -1,0 +1,69 @@
+"""Serve this server's own ``LookupSecret`` URLs without a loopback request.
+
+``LookupSecret`` resolves lazily over HTTP so raw values never transit an SDK
+client. When the client and the server are the same process, that round trip
+buys nothing and costs correctness: a resolution on the event loop blocks the
+very loop that would answer it, so it stalls until the client times out.
+Resolving those URLs against the local store keeps the laziness and drops the
+round trip.
+"""
+
+from urllib.parse import urlsplit
+
+from openhands.agent_server.config import Config
+from openhands.agent_server.persistence import get_secrets_store
+from openhands.sdk.logger import get_logger
+from openhands.sdk.secret import (
+    register_local_secret_resolver,
+    unregister_local_secret_resolver,
+)
+
+
+logger = get_logger(__name__)
+
+_SECRET_PATH_PREFIX = "/api/settings/secrets/"
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+
+def _secret_name_if_local(url: str) -> str | None:
+    """Return the secret name when ``url`` is one this process serves itself."""
+    parsed = urlsplit(url)
+    if parsed.hostname not in _LOOPBACK_HOSTS:
+        return None
+    if not parsed.path.startswith(_SECRET_PATH_PREFIX):
+        return None
+    name = parsed.path[len(_SECRET_PATH_PREFIX) :]
+    # Only a bare name; anything deeper is a different route.
+    if not name or "/" in name:
+        return None
+    return name
+
+
+def build_local_secret_resolver(config: Config):
+    """Build a resolver that answers this server's own secret URLs."""
+
+    def resolve(url: str) -> str | None:
+        name = _secret_name_if_local(url)
+        if name is None:
+            return None
+        value = get_secrets_store(config).get_secret(name)
+        if value is None:
+            # Fall through to HTTP so the caller still sees the server's 404.
+            return None
+        logger.debug("Resolved secret '%s' in-process", name)
+        return value
+
+    return resolve
+
+
+class local_secret_resolution:
+    """Context manager registering the in-process resolver for a server."""
+
+    def __init__(self, config: Config) -> None:
+        self._resolver = build_local_secret_resolver(config)
+
+    def __enter__(self) -> None:
+        register_local_secret_resolver(self._resolver)
+
+    def __exit__(self, *exc_info) -> None:
+        unregister_local_secret_resolver(self._resolver)

--- a/openhands-sdk/openhands/sdk/secret/__init__.py
+++ b/openhands-sdk/openhands/sdk/secret/__init__.py
@@ -4,16 +4,22 @@ This module provides classes and types for managing secrets in OpenHands.
 """
 
 from openhands.sdk.secret.secrets import (
+    LocalSecretResolver,
     LookupSecret,
     SecretSource,
     SecretValue,
     StaticSecret,
+    register_local_secret_resolver,
+    unregister_local_secret_resolver,
 )
 
 
 __all__ = [
+    "LocalSecretResolver",
     "SecretSource",
     "StaticSecret",
     "LookupSecret",
     "SecretValue",
+    "register_local_secret_resolver",
+    "unregister_local_secret_resolver",
 ]

--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -2,6 +2,7 @@
 
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from urllib.parse import urljoin, urlsplit
 
 import httpx
@@ -30,6 +31,50 @@ def _resolve_lookup_secret_url(url: str) -> str:
 
     base_url = os.getenv(_INTERNAL_SERVER_URL_ENV, _DEFAULT_INTERNAL_SERVER_URL)
     return urljoin(f"{base_url.rstrip('/')}/", url)
+
+
+LocalSecretResolver = Callable[[str], str | None]
+
+_local_secret_resolvers: list[LocalSecretResolver] = []
+
+
+def register_local_secret_resolver(resolver: LocalSecretResolver) -> None:
+    """Register an in-process resolver for ``LookupSecret`` URLs.
+
+    A process that both serves and consumes ``LookupSecret`` URLs — an
+    agent-server running an in-process conversation, say — cannot fetch them
+    over HTTP from its own event loop: the request can only be answered by the
+    loop that is blocked waiting for it, so it stalls until the client times
+    out. Registering a resolver lets such a process answer its own URLs
+    directly and skip the round trip.
+
+    The resolver receives the fully-resolved URL and returns the secret value,
+    or ``None`` when it does not serve that URL, in which case resolution falls
+    through to the next resolver and finally to HTTP.
+    """
+    if resolver not in _local_secret_resolvers:
+        _local_secret_resolvers.append(resolver)
+
+
+def unregister_local_secret_resolver(resolver: LocalSecretResolver) -> None:
+    """Remove a resolver registered with ``register_local_secret_resolver``."""
+    if resolver in _local_secret_resolvers:
+        _local_secret_resolvers.remove(resolver)
+
+
+def _resolve_secret_locally(url: str) -> str | None:
+    """Return a locally-served value for ``url``, or ``None`` if there is none."""
+    for resolver in list(_local_secret_resolvers):
+        try:
+            value = resolver(url)
+        except Exception:
+            logger.warning(
+                "Local secret resolver raised; falling back to HTTP", exc_info=True
+            )
+            continue
+        if value is not None:
+            return value
+    return None
 
 
 class SecretSource(DiscriminatedUnionMixin, ABC):
@@ -77,6 +122,9 @@ class LookupSecret(SecretSource):
         return _resolve_lookup_secret_url(url)
 
     def get_value(self) -> str:
+        local_value = _resolve_secret_locally(self.url)
+        if local_value is not None:
+            return local_value
         response = httpx.get(self.url, headers=self.headers, timeout=30.0)
         response.raise_for_status()
         return response.text

--- a/tests/agent_server/test_local_secret_resolver.py
+++ b/tests/agent_server/test_local_secret_resolver.py
@@ -1,0 +1,28 @@
+"""Tests for in-process resolution of this server's own LookupSecret URLs."""
+
+from openhands.agent_server.local_secret_resolver import _secret_name_if_local
+
+
+def test_matches_loopback_secret_url():
+    assert (
+        _secret_name_if_local("http://127.0.0.1:8000/api/settings/secrets/TOKEN")
+        == "TOKEN"
+    )
+    assert (
+        _secret_name_if_local("http://localhost:18000/api/settings/secrets/TOKEN")
+        == "TOKEN"
+    )
+
+
+def test_ignores_remote_host():
+    assert (
+        _secret_name_if_local("https://remote.example/api/settings/secrets/T") is None
+    )
+
+
+def test_ignores_other_routes_and_malformed_names():
+    assert _secret_name_if_local("http://127.0.0.1:8000/api/settings") is None
+    assert _secret_name_if_local("http://127.0.0.1:8000/api/settings/secrets/") is None
+    assert (
+        _secret_name_if_local("http://127.0.0.1:8000/api/settings/secrets/a/b") is None
+    )

--- a/tests/sdk/conversation/test_secret_source.py
+++ b/tests/sdk/conversation/test_secret_source.py
@@ -302,3 +302,78 @@ def test_lookup_secret_get_value_resolves_relative_url(monkeypatch):
         headers={},
         timeout=30.0,
     )
+
+
+@pytest.fixture
+def local_resolvers_cleared():
+    """Keep the process-wide resolver registry isolated per test."""
+    from openhands.sdk.secret import secrets as secrets_module
+
+    original = list(secrets_module._local_secret_resolvers)
+    secrets_module._local_secret_resolvers.clear()
+    yield secrets_module._local_secret_resolvers
+    secrets_module._local_secret_resolvers[:] = original
+
+
+def test_local_resolver_short_circuits_http(local_resolvers_cleared):
+    """A matching resolver answers without any HTTP request.
+
+    This is the deadlock guard: resolving over loopback from the event loop
+    blocks the loop that would serve the request.
+    """
+    from openhands.sdk.secret import register_local_secret_resolver
+
+    secret = LookupSecret(url="http://127.0.0.1:8000/api/settings/secrets/TOKEN")
+    register_local_secret_resolver(
+        lambda url: "resolved-locally" if url.endswith("/TOKEN") else None
+    )
+
+    with patch("httpx.get", side_effect=AssertionError("HTTP must not be used")):
+        assert secret.get_value() == "resolved-locally"
+
+
+def test_local_resolver_declining_falls_back_to_http(local_resolvers_cleared):
+    """A resolver returning None leaves the URL to HTTP."""
+    from openhands.sdk.secret import register_local_secret_resolver
+
+    secret = LookupSecret(url="https://remote.example/api/settings/secrets/TOKEN")
+    register_local_secret_resolver(lambda url: None)
+
+    response = Mock(text="from-http")
+    response.raise_for_status = Mock()
+    with patch("httpx.get", return_value=response) as http_get:
+        assert secret.get_value() == "from-http"
+    http_get.assert_called_once()
+
+
+def test_local_resolver_raising_falls_back_to_http(local_resolvers_cleared):
+    """A broken resolver must not take secret resolution down with it."""
+    from openhands.sdk.secret import register_local_secret_resolver
+
+    def boom(url: str) -> str | None:
+        raise RuntimeError("resolver is broken")
+
+    secret = LookupSecret(url="https://remote.example/api/settings/secrets/TOKEN")
+    register_local_secret_resolver(boom)
+
+    response = Mock(text="from-http")
+    response.raise_for_status = Mock()
+    with patch("httpx.get", return_value=response):
+        assert secret.get_value() == "from-http"
+
+
+def test_unregister_local_secret_resolver(local_resolvers_cleared):
+    from openhands.sdk.secret import (
+        register_local_secret_resolver,
+        unregister_local_secret_resolver,
+    )
+
+    def resolver(url: str) -> str | None:
+        return "resolved-locally"
+
+    register_local_secret_resolver(resolver)
+    register_local_secret_resolver(resolver)
+    assert len(local_resolvers_cleared) == 1
+
+    unregister_local_secret_resolver(resolver)
+    assert local_resolvers_cleared == []


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

This one took down my self-hosted agent-server three times before I understood it. Four
secrets on a conversation, each resolution blocking the loop for 30s, so the liveness
probe killed the pod, the restart reloaded the same conversations, and it went round
again. Happy to reshape the interface if you'd rather it looked different — the part I
care about is that the process stops making HTTP calls to itself.

---

AGENT:

## Why

`LookupSecret.get_value()` performs a synchronous, blocking `httpx.get()`. When the URL points back at the process making the call, the event loop that would serve the request is the one blocked waiting for it. Nothing answers, and it stalls for the full 30s timeout.

While that is in flight the server answers nothing at all — `alive()` is `async def` and runs on the blocked loop. Registered secrets resolve serially, so four of them freeze the server for about two minutes. On the deployment where this surfaced that was long enough for the liveness probe to kill the container; the restart reloaded the same conversations and the cycle repeated.

`local_conversation.py` already documents this failure mode and wraps two call sites in `asyncio.to_thread` because of it. That treats callers rather than the cause: `get_value()` is a public `SecretSource` method, and any synchronous call reached from the loop reproduces the deadlock.

## Summary

- Add `register_local_secret_resolver()` / `unregister_local_secret_resolver()` to `openhands.sdk.secret`. `LookupSecret.get_value()` consults registered resolvers before falling back to HTTP; a resolver returning `None` declines and the request proceeds unchanged. `openhands.sdk` cannot import `openhands.agent_server` (`check-import-rules`), so this is an extension point the server opts into, not a special case in the SDK.
- Register a resolver for the agent-server's own loopback secret route in the API lifespan. It matches only loopback hosts and the exact `/api/settings/secrets/<name>` shape, and falls through to HTTP when its store does not hold the name so the caller still sees the server's 404.
- Additive only: no signature changes, no behavior change for remote or non-loopback URLs, no change to the agent loop or the registry format.

## Issue Number

Fixes #5025

## How to Test

```bash
make build
uv run pytest tests/sdk/conversation tests/sdk/mcp tests/agent_server
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/secret/secrets.py \
  openhands-sdk/openhands/sdk/secret/__init__.py \
  openhands-agent-server/openhands/agent_server/api.py \
  openhands-agent-server/openhands/agent_server/local_secret_resolver.py \
  tests/sdk/conversation/test_secret_source.py \
  tests/agent_server/test_local_secret_resolver.py
```

**End-to-end evidence.** The reproduction from #5025 runs a real `uvicorn` server and resolves a `LookupSecret` pointing at that same process, once from a worker thread and once inline on the loop. On `main`:

```text
off-loop  : 's3cr3t' in 0.00s
on-loop   : ReadTimeout after 30.00s
/alive served during the on-loop call: 0
```

With this branch and a resolver registered, plus a second `LookupSecret` whose URL the resolver declines so it still goes over HTTP:

```text
on-loop, resolver registered : 's3cr3t' in 0.00s
unmatched URL -> HTTP        : 's3cr3t' in 0.01s
```

30.00s and a wedged server become 0.00s, and the HTTP path is untouched for URLs the process does not serve.

**Test suites**, on this branch:

```text
uv run pytest tests/sdk/conversation  ->   814 passed
uv run pytest tests/sdk/mcp           ->   134 passed
uv run pytest tests/agent_server      ->  2109 passed
```

**Pre-commit**, on all six changed files:

```text
Ruff format .......... Passed      Ruff lint ............................ Passed
PEP8 (pycodestyle) ... Passed      Type check with pyright .............. Passed
Forbid dynamic attribute access in SDK .................................. Passed
Check import dependency rules ........................................... Passed
Check Tool subclass registration ........................................ Passed
```

`Check import dependency rules` passing is the one worth calling out: the SDK gains the extension point without importing the agent-server.

Environment: Python 3.13.15, branched from `c37007429be8b4465a83487dc1fd0914df0ea734`.

## Video/Screenshots

Not applicable — no UI surface. The before/after console output above is the observable behavior change.

## Design Doc

Not included. The change is additive and small, but it does introduce a public extension point, so if you would rather see a design page before reviewing the code, say so and I will add one under `.pr/`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The guarantee `LookupSecret` exists for — "raw values **never** transit through the SDK client", per `RemoteWorkspace.get_secrets()` — is unaffected. When client and server are the same process the value is already in that process's memory; only the loopback hop is removed. Lazy resolution is preserved.
- The resolver registry is process-global, matching how these URLs are resolved. Registration is scoped to the API lifespan and unregistered in the outer `finally`.
- A resolver that raises is logged and skipped so one bad resolver cannot take secret resolution down; covered by a test.
- Loopback matching is host-based (`127.0.0.1`, `localhost`, `::1`). Two agent-servers on one host with different stores would both match a loopback URL; if you would prefer matching on the server's own advertised base URL instead, that is a small change and I am happy to make it.
- Separate, not addressed here: `httpx.ReadTimeout` is logged through the generic `Unexpected error` branch in `secret_registry.py` rather than `Transient error`, because it derives from `httpx.TransportError → HTTPError → Exception` rather than `OSError`/`TimeoutError`. Happy to fold in a one-line fix if you want it here rather than separately.
