### PR TITLE
fix: preserve repository identity in linked-issue checks

### DIFF
--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -21,8 +21,11 @@ HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
 HUMAN_HEADING_RE = re.compile(r"(?im)^\s*HUMAN:\s*$")
 AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
-ISSUE_REF_RE = re.compile(r"(?i)\b(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+#(\d+)")
-BARE_ISSUE_REF_RE = re.compile(r"(?<!\w)#(\d+)")
+ISSUE_REFERENCE = r"(?:(?P<repo>[A-Za-z0-9-]+/[A-Za-z0-9_.-]+))?#(?P<number>\d+)"
+ISSUE_REF_RE = re.compile(
+    r"(?i)\b(?:fix|clos|resolv)(?:e?(?:s|d)?|ing)?\s+" + ISSUE_REFERENCE
+)
+BARE_ISSUE_REF_RE = re.compile(r"(?<![\w/#.-])" + ISSUE_REFERENCE)
 READY_FOR_DEV_LABEL = "ready-for-dev"
 # Issues created before the `ready-for-dev` rollout are grandfathered: the
 # issue-readiness workflow only labels issues on `issues` events, so long-open
@@ -82,23 +85,19 @@ def extract_human_note(body: str) -> str:
     return visible_text(body[human_match.end() : agent_match.start()])
 
 
-def extract_linked_issue_numbers(body: str) -> list[int]:
-    numbers: list[int] = []
-    seen: set[int] = set()
-    for match in ISSUE_REF_RE.finditer(body):
-        number = int(match.group(1))
-        if number not in seen:
-            numbers.append(number)
-            seen.add(number)
-
-    sections = extract_sections(body)
-    issue_section = sections.get("Issue Number", "")
-    for match in BARE_ISSUE_REF_RE.finditer(issue_section):
-        number = int(match.group(1))
-        if number not in seen:
-            numbers.append(number)
-            seen.add(number)
-    return numbers
+def extract_linked_issues(body: str, repo: str = "") -> list[tuple[str, int]]:
+    """Resolve local and qualified references without losing repository identity."""
+    references: dict[tuple[str, int], None] = {}
+    searchable = without_fenced_code_blocks(HTML_COMMENT_RE.sub("", body))
+    issue_section = extract_sections(searchable).get("Issue Number", "")
+    for pattern, text in (
+        (ISSUE_REF_RE, searchable),
+        (BARE_ISSUE_REF_RE, issue_section),
+    ):
+        for match in pattern.finditer(text):
+            key = ((match.group("repo") or repo).lower(), int(match.group("number")))
+            references[key] = None
+    return list(references)
 
 
 def fetch_issue_details(
@@ -124,8 +123,8 @@ def fetch_issue_details(
 def validate_linked_issue_ready(
     body: str, repo: str | None = None, token: str | None = None
 ) -> list[str]:
-    numbers = extract_linked_issue_numbers(body)
-    if not numbers:
+    references = extract_linked_issues(body, repo or "")
+    if not references:
         return [
             "Link an issue in the `## Issue Number` section (e.g. `Fixes #123`). "
             "Newly opened issues must carry the `ready-for-dev` label."
@@ -133,28 +132,28 @@ def validate_linked_issue_ready(
     if not repo or not token:
         return []
 
-    checked: list[int] = []
-    not_ready_new: list[int] = []
-    for number in numbers:
+    missing: list[str] = []
+    not_ready_new: list[str] = []
+    for issue_repo, number in references:
+        reference = f"{issue_repo}#{number}"
         try:
-            labels, created_at = fetch_issue_details(repo, number, token)
+            labels, created_at = fetch_issue_details(issue_repo, number, token)
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
+                missing.append(reference)
                 continue
             raise
-        checked.append(number)
         if READY_FOR_DEV_LABEL in (label.lower() for label in labels):
             continue
         if created_at[:10] < READY_FOR_DEV_ROLLOUT_ISO:
             # Predates the rollout; grandfathered to avoid retroactive blocking.
             continue
-        not_ready_new.append(number)
+        not_ready_new.append(reference)
 
-    if not checked:
-        refs = ", ".join(f"#{number}" for number in numbers)
-        return [f"Referenced issue(s) {refs} could not be found in this repository."]
+    if missing:
+        return [f"Referenced issue(s) {', '.join(missing)} could not be found."]
     if not_ready_new:
-        refs = ", ".join(f"#{number}" for number in not_ready_new)
+        refs = ", ".join(not_ready_new)
         return [
             f"Linked issue(s) ({refs}) carry neither `ready-for-dev` nor a "
             "pre-rollout creation date. Newly referenced issues must meet the "

--- a/.github/scripts/refresh_linked_pr_checks.py
+++ b/.github/scripts/refresh_linked_pr_checks.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from check_pr_description import extract_linked_issue_numbers
+from check_pr_description import extract_linked_issues
 
 
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -26,7 +26,9 @@ query($owner: String!, $name: String!, $num: Int!) {
           ... on CrossReferencedEvent {
             source {
               __typename
-              ... on PullRequest { number headRefOid state }
+              ... on PullRequest {
+                number headRefOid state repository { nameWithOwner }
+              }
             }
           }
         }
@@ -68,6 +70,12 @@ query($owner: String!, $name: String!, $num: Int!) {
         if source.get("__typename") != "PullRequest":
             continue
         if source.get("state") != "OPEN":
+            continue
+        if (
+            source.get("repository", {}).get("nameWithOwner", "").lower()
+            != repo.lower()
+        ):
+            # The workflow token can refresh checks only in this repository.
             continue
         prs.append(source)
     return prs
@@ -150,7 +158,9 @@ def main() -> int:
         )
         if body_result.returncode != 0:
             continue
-        if issue_number not in extract_linked_issue_numbers(body_result.stdout):
+        if (repo.lower(), issue_number) not in extract_linked_issues(
+            body_result.stdout, repo
+        ):
             # Cross-referenced but not treated as a linked issue by the gate;
             # nothing to refresh.
             continue

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -25,7 +25,7 @@ _prod = _load("check_pr_description", "check_pr_description.py")
 validate_pr_body = _prod.validate_pr_body
 body_from_event = _prod.body_from_event
 extract_human_note = _prod.extract_human_note
-extract_linked_issue_numbers = _prod.extract_linked_issue_numbers
+extract_linked_issues = _prod.extract_linked_issues
 validate_linked_issue_ready = _prod.validate_linked_issue_ready
 fetch_issue_details = _prod.fetch_issue_details
 
@@ -163,7 +163,7 @@ def test_body_from_event_reads_pull_request_body(tmp_path: Path):
     assert repo == "org/repo"
 
 
-def test_extract_linked_issue_numbers_keyword_and_bare_ref():
+def test_extract_linked_issues_keyword_and_bare_ref():
     body = (
         "Fixes #12\n"
         "Closes #12 again\n"
@@ -171,28 +171,28 @@ def test_extract_linked_issue_numbers_keyword_and_bare_ref():
         "## Issue Number\n"
         "Issue: #56, see also #12\n"
     )
-    assert extract_linked_issue_numbers(body) == [12, 34, 56]
+    assert extract_linked_issues(body) == [("", 12), ("", 34), ("", 56)]
 
 
-def test_extract_linked_issue_numbers_only_bare_ref_in_issue_section():
+def test_extract_linked_issues_only_bare_ref_in_issue_section():
     body = "## Summary\n\nSome work.\n\n## Issue Number\n\n#7\n"
-    assert extract_linked_issue_numbers(body) == [7]
+    assert extract_linked_issues(body) == [("", 7)]
 
 
-def test_extract_linked_issue_numbers_no_bare_ref_outside_issue_section():
+def test_extract_linked_issues_no_bare_ref_outside_issue_section():
     # A bare `#42` in the Summary must not be treated as a linked issue.
     body = "## Summary\n\nSee #42 for background.\n\n## Issue Number\n\nN/A\n"
-    assert extract_linked_issue_numbers(body) == []
+    assert extract_linked_issues(body) == []
 
 
-def test_extract_linked_issue_numbers_keyword_inside_word_is_ignored():
+def test_extract_linked_issues_keyword_inside_word_is_ignored():
     # "fix"/"clos"/"resolv" must not match inside larger words (e.g. "crucifixes").
     body = (
         "## Summary\n\n"
         "crucifixes #12, encloses #34, transfixes #56.\n\n"
         "## Issue Number\n\nN/A\n"
     )
-    assert extract_linked_issue_numbers(body) == []
+    assert extract_linked_issues(body) == []
 
 
 def test_validate_linked_issue_ready_requires_a_number():
@@ -281,3 +281,66 @@ def test_validate_linked_issue_ready_returns_error_when_all_issues_not_found(
     monkeypatch.setattr(_prod, "fetch_issue_details", _missing)
     errors = validate_linked_issue_ready("Fixes #12\n", "org/repo", "token")
     assert errors and "could not be found" in errors[0]
+
+
+def test_qualified_references_preserve_repository_and_deduplicate():
+    body = (
+        "Fixes #12 and closes Other/Project#12\n"
+        "## Issue Number\norg/repo#12, other/project#12, Other/Project#34\n"
+    )
+    assert extract_linked_issues(body, "org/repo") == [
+        ("org/repo", 12),
+        ("other/project", 12),
+        ("other/project", 34),
+    ]
+
+
+def test_reference_examples_do_not_count_as_linked_issues():
+    body = "<!-- Fixes other/repo#12 -->\n```\nFixes #34\n```\n"
+    assert extract_linked_issues(body, "org/repo") == []
+
+
+def test_qualified_readiness_checks_the_named_repository(monkeypatch):
+    calls = []
+
+    def details(repo, number, token):
+        calls.append((repo, number))
+        return ["ready-for-dev"], "2026-09-13T00:00:00Z"
+
+    monkeypatch.setattr(_prod, "fetch_issue_details", details)
+    assert (
+        validate_linked_issue_ready(
+            "Fixes OpenHands/OpenHands#17236", "OpenHands/software-agent-sdk", "token"
+        )
+        == []
+    )
+    assert calls == [("openhands/openhands", 17236)]
+
+
+def test_unready_foreign_issue_is_not_masked_by_ready_local_number(monkeypatch):
+    def details(repo, number, token):
+        return (["ready-for-dev"] if repo == "org/repo" else []), "2026-09-13"
+
+    monkeypatch.setattr(_prod, "fetch_issue_details", details)
+    errors = validate_linked_issue_ready(
+        "## Issue Number\n#12, other/repo#12", "org/repo", "token"
+    )
+    assert "other/repo#12" in errors[0]
+
+
+def test_missing_foreign_issue_is_not_masked_by_ready_local_number(monkeypatch):
+    import urllib.error
+    from http.client import HTTPMessage
+
+    def details(repo, number, token):
+        if repo == "other/repo":
+            raise urllib.error.HTTPError(
+                "https://api.github.com", 404, "Not Found", HTTPMessage(), None
+            )
+        return ["ready-for-dev"], "2026-09-13"
+
+    monkeypatch.setattr(_prod, "fetch_issue_details", details)
+    errors = validate_linked_issue_ready(
+        "Fixes #12 and closes other/repo#12", "org/repo", "token"
+    )
+    assert "other/repo#12" in errors[0] and "could not be found" in errors[0]

--- a/tests/cross/test_refresh_linked_pr_checks.py
+++ b/tests/cross/test_refresh_linked_pr_checks.py
@@ -148,3 +148,38 @@ def test_rerun_pr_description_check_lists_runs_with_get(monkeypatch):
         "-X",
         "POST",
     ]
+
+
+def test_foreign_reference_does_not_refresh_same_number_local_issue(
+    monkeypatch, tmp_path
+):
+    _write_event(monkeypatch, _event(), tmp_path)
+    monkeypatch.setattr(
+        _prod,
+        "_linked_open_prs",
+        lambda repo, num: [{"number": 7, "headRefOid": "abc"}],
+    )
+    monkeypatch.setattr(
+        _prod, "_run", lambda args: _FakeProc("## Issue Number\nother/repo#12")
+    )
+    monkeypatch.setattr(
+        _prod, "_rerun_pr_description_check", _fail_on_call("wrong issue")
+    )
+    assert _prod.main() == 0
+
+
+def test_linked_pr_query_does_not_refresh_foreign_pr_number(monkeypatch):
+    nodes = [
+        {
+            "source": {
+                "__typename": "PullRequest",
+                "number": 7,
+                "headRefOid": "abc",
+                "state": "OPEN",
+                "repository": {"nameWithOwner": repo},
+            }
+        }
+        for repo in ("other/repo", "Org/Repo")
+    ]
+    monkeypatch.setattr(_prod, "_run", lambda args: _FakeProc(json.dumps(nodes)))
+    assert _prod._linked_open_prs("org/repo", 12) == [nodes[1]["source"]]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

This seems simple enough and low stakes.

---

AGENT:

## Why

SDK #4931 links the ready OpenHands/OpenHands issue 17236, but the description gate drops the repository name and reports no linked issue. Same-number foreign references can also trigger the wrong local readiness refresh.

## Summary

Preserve repository identity in the existing issue parser and reuse it in validation and linked-PR refresh. Deduplicate by repository and number, ignore commented/fenced examples, and report missing or unready references without falling back to local numbers. Refresh only local PRs, within the existing workflow token's scope.

## Issue Number

Fixes #5027.

## How to Test

`uv run pytest tests/cross/test_check_pr_description.py tests/cross/test_refresh_linked_pr_checks.py -q` — 33 passed. Ruff lint and formatting checks pass.

Live check: fetched SDK PR 4931's current body, ran the modified description checker with its real repository and authenticated GitHub access. The referenced OpenHands/OpenHands issue 17236 passed readiness; only the pre-existing empty HUMAN note remained. No issue or PR state was bypassed.

## Type

- [x] Bug fix

## Notes

Targets main independently. Merge before re-running SDK #4931's description gate, which executes trusted base-branch code. Foreign issue label events cannot automatically re-run this repository's workflow; editing the PR description or manually re-running the check refreshes it. This only changes internal workflow helpers; all callers are updated.



<!-- AGENT_SERVER_IMAGES_START -->
---
<details>
<summary><b>🐳 Agent Server images for this PR</b> — GHCR package, pull/run commands, and all pushed tags (click to expand)</summary>

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python-slim | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a4e28eb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a4e28eb-python \
  ghcr.io/openhands/agent-server:a4e28eb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a4e28eb-golang-amd64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-golang-amd64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-golang-amd64
ghcr.io/openhands/agent-server:a4e28eb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a4e28eb-golang-arm64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-golang-arm64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-golang-arm64
ghcr.io/openhands/agent-server:a4e28eb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a4e28eb-java-amd64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-java-amd64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-java-amd64
ghcr.io/openhands/agent-server:a4e28eb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a4e28eb-java-arm64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-java-arm64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-java-arm64
ghcr.io/openhands/agent-server:a4e28eb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a4e28eb-python-amd64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python-amd64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python-amd64
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a4e28eb-python-arm64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python-arm64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python-arm64
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a4e28eb-python-slim-amd64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python-slim-amd64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python-slim-amd64
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-amd64
ghcr.io/openhands/agent-server:a4e28eb-python-slim-arm64
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python-slim-arm64
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python-slim-arm64
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim-arm64
ghcr.io/openhands/agent-server:a4e28eb-golang
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-golang
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-golang
ghcr.io/openhands/agent-server:a4e28eb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a4e28eb-java
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-java
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-java
ghcr.io/openhands/agent-server:a4e28eb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a4e28eb-python-slim
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python-slim
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python-slim
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-slim
ghcr.io/openhands/agent-server:a4e28eb-python
ghcr.io/openhands/agent-server:a4e28ebb765af60f247641afac9fd477bfc7ce8f-python
ghcr.io/openhands/agent-server:fix-cross-repo-issue-readiness-python
ghcr.io/openhands/agent-server:a4e28eb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a4e28eb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a4e28eb-python-amd64`) are also available if needed
</details>
<!-- AGENT_SERVER_IMAGES_END -->

## Recorded evidence

The same live SDK #4931 body fails linked-issue recognition on the baseline and passes that recognition on this change. The independent HUMAN-note error remains, so both overall commands correctly exit 1. [Report and artifacts](https://github.com/OpenHands/software-agent-sdk/blob/d26e500e1d0ae95c3af354bb816c53746dc4d55e/.pr/readiness-evidence.md). Links are pinned to the artifact commit so review cleanup cannot invalidate them.
