### PR TITLE
ci: accept the existing search limit schema repair

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -47,7 +47,12 @@ Policies enforced:
      replacing ``MCPNoneAuthCredential-Input`` with the structurally identical
      ``MCPNoneAuthCredential`` is a component-name repair, not a union removal.
 
-6) No in-place contract breakage
+6) Publishing the existing pagination limit is allowed
+   - Four search endpoints already rejected limits above 100 at runtime. Their
+     historical schemas used the unsupported ``lte: 100`` keyword. Replacing it
+     with ``maximum: 100`` documents that existing bound.
+
+7) No in-place contract breakage
    - Breaking REST contract changes that are not removals of previously-deprecated
      operations/properties, additive oneOf expansions, or additive response property
      type widenings fail the check. REST clients need 5 minor releases of runway, so
@@ -678,6 +683,43 @@ def _is_accepted_vscode_base_url_default_removal(change: dict) -> bool:
     )
 
 
+_SEARCH_LIMIT_SCHEMA_REPAIR_PATHS = frozenset(
+    {
+        "/api/conversations/search",
+        "/api/conversations/{conversation_id}/events/search",
+        "/api/bash/bash_events/search",
+        "/api/file/search_subdirs",
+    }
+)
+
+
+def _is_search_limit_schema_repair(change: dict, prev_schema: dict) -> bool:
+    """Accept the known pagination ``lte: 100`` to ``maximum: 100`` repair."""
+    path = change.get("path", "")
+    if (
+        change.get("id") != "request-parameter-max-set"
+        or path not in _SEARCH_LIMIT_SCHEMA_REPAIR_PATHS
+        or str(change.get("operation", "")).lower() != "get"
+        or change.get("text")
+        != "for the `query` request parameter `limit`, the max was set to `100.00`"
+    ):
+        return False
+
+    operation = prev_schema.get("paths", {}).get(path, {}).get("get", {})
+    if change.get("operationId") != operation.get("operationId"):
+        return False
+
+    for parameter in operation.get("parameters", []):
+        if parameter.get("in") == "query" and parameter.get("name") == "limit":
+            schema = parameter.get("schema", {})
+            return (
+                schema.get("type") == "integer"
+                and schema.get("lte") == 100
+                and "maximum" not in schema
+            )
+    return False
+
+
 def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
     """Return True for the accepted /api/cloud-proxy removal from PR #3326."""
     path = str(operation.get("path", ""))
@@ -1099,6 +1141,16 @@ def main() -> int:
             for change in other_breaking_changes
             if not _is_accepted_vscode_base_url_default_removal(change)
         ]
+        search_limit_schema_repairs = [
+            change
+            for change in other_breaking_changes
+            if _is_search_limit_schema_repair(change, prev_schema)
+        ]
+        other_breaking_changes = [
+            change
+            for change in other_breaking_changes
+            if not _is_search_limit_schema_repair(change, prev_schema)
+        ]
 
         removal_errors = _validate_removed_operations(
             removed_operations,
@@ -1130,6 +1182,15 @@ def main() -> int:
                 "The parameter stays optional; only the server-side fallback "
                 "changed, so requests that omit it keep working."
             )
+
+        if search_limit_schema_repairs:
+            print(
+                f"\n::notice title={PYPI_DISTRIBUTION} REST API::"
+                "Published the existing search limit of 100 by correcting "
+                "legacy lte metadata to maximum."
+            )
+            for item in search_limit_schema_repairs:
+                print(f"  - GET {item['path']}: {item['text']}")
 
         if additive_response_oneof:
             print(
@@ -1211,7 +1272,7 @@ def main() -> int:
                 "GET /api/vscode/url base_url default removal, additive response "
                 "oneOf expansions, and/or additive response property type widenings."
                 " It may also include wire-compatible repairs of historically "
-                "opaque MCP/settings schemas."
+                "opaque MCP/settings schemas or the existing search limit of 100."
             )
         else:
             return 1

--- a/tests/cross/conftest.py
+++ b/tests/cross/conftest.py
@@ -34,3 +34,29 @@ def nonfncall_raw_logs(llm_fixtures_dir):
             with open(log_file) as f:
                 logs.append(json.load(f))
     return logs
+
+
+@pytest.fixture
+def run_rest_api_breakage_check(monkeypatch):
+    """Run the check's exit policy with supplied schemas and oasdiff output."""
+
+    def run(module, previous_schema, current_schema, changes):
+        monkeypatch.setattr(
+            module, "_read_version_from_pyproject", lambda _path: "1.47.0"
+        )
+        monkeypatch.setattr(
+            module, "_get_baseline_version", lambda _distribution, _current: "1.47.0"
+        )
+        monkeypatch.setattr(
+            module, "_find_sdk_deprecated_fastapi_routes", lambda _root: []
+        )
+        monkeypatch.setattr(module, "_generate_current_openapi", lambda: current_schema)
+        monkeypatch.setattr(
+            module, "_generate_openapi_for_git_ref", lambda _ref: previous_schema
+        )
+        monkeypatch.setattr(
+            module, "_run_oasdiff_breakage_check", lambda _prev, _cur: (changes, 0)
+        )
+        return module.main()
+
+    return run

--- a/tests/cross/test_check_agent_server_rest_api_breakage.py
+++ b/tests/cross/test_check_agent_server_rest_api_breakage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -1185,6 +1186,152 @@ def test_main_passes_for_mcp_contract_schema_repairs(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "Typed historically opaque MCP/settings schemas" in captured.out
+
+
+def _search_limit_repair_case(
+    path: str = "/api/conversations/search",
+    operation_id: str = "search_conversations_api_conversations_search_get",
+) -> tuple[dict, dict, dict]:
+    previous = _schema_with_operation(
+        path,
+        "get",
+        {
+            "operationId": operation_id,
+            "parameters": [
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "schema": {"type": "integer", "lte": 100, "exclusiveMinimum": 0},
+                }
+            ],
+            "responses": {"200": {"description": "Page"}},
+        },
+    )
+    current = deepcopy(previous)
+    current["paths"][path]["get"]["parameters"][0]["schema"] = {
+        "type": "integer",
+        "maximum": 100,
+        "exclusiveMinimum": 0,
+    }
+    change = {
+        "id": "request-parameter-max-set",
+        "text": (
+            "for the `query` request parameter `limit`, the max was set to `100.00`"
+        ),
+        "operation": "GET",
+        "operationId": operation_id,
+        "path": path,
+    }
+    return previous, current, change
+
+
+@pytest.mark.parametrize(
+    "path, operation_id",
+    [
+        (
+            "/api/conversations/search",
+            "search_conversations_api_conversations_search_get",
+        ),
+        (
+            "/api/conversations/{conversation_id}/events/search",
+            "search_conversation_events_api_conversations__conversation_id__events_search_get",
+        ),
+        (
+            "/api/bash/bash_events/search",
+            "search_bash_events_api_bash_bash_events_search_get",
+        ),
+        ("/api/file/search_subdirs", "search_subdirs_api_file_search_subdirs_get"),
+    ],
+)
+def test_main_accepts_search_limit_schema_repair(
+    run_rest_api_breakage_check, capsys, path, operation_id
+):
+    previous, current, change = _search_limit_repair_case(path, operation_id)
+
+    assert run_rest_api_breakage_check(_prod, previous, current, [change]) == 0
+    output = capsys.readouterr().out
+    assert "Published the existing search limit of 100" in output
+    assert f"GET {path}" in output
+
+
+@pytest.mark.parametrize(
+    "change_updates, baseline_limit_schema",
+    [
+        pytest.param({"path": "/api/other/search"}, None, id="other-endpoint"),
+        pytest.param({"operation": "POST"}, None, id="other-method"),
+        pytest.param({"operationId": "another_search"}, None, id="other-operation"),
+        pytest.param(
+            {
+                "text": (
+                    "for the `query` request parameter `offset`, "
+                    "the max was set to `100.00`"
+                )
+            },
+            None,
+            id="other-parameter",
+        ),
+        pytest.param(
+            {
+                "text": (
+                    "for the `header` request parameter `limit`, "
+                    "the max was set to `100.00`"
+                )
+            },
+            None,
+            id="other-location",
+        ),
+        pytest.param(
+            {
+                "text": (
+                    "for the `query` request parameter `limit`, "
+                    "the max was set to `50.00`"
+                )
+            },
+            None,
+            id="smaller-limit",
+        ),
+        pytest.param(
+            {"id": "request-parameter-max-decreased"}, None, id="future-tightening"
+        ),
+        pytest.param({}, {"type": "integer"}, id="no-legacy-typo"),
+        pytest.param({}, {"type": "integer", "lte": 200}, id="different-legacy-limit"),
+        pytest.param(
+            {},
+            {"type": "integer", "lte": 100, "maximum": 200},
+            id="previously-published-maximum",
+        ),
+    ],
+)
+def test_main_rejects_other_search_limit_changes(
+    run_rest_api_breakage_check, change_updates, baseline_limit_schema
+):
+    previous, current, change = _search_limit_repair_case()
+    change.update(change_updates)
+    if baseline_limit_schema is not None:
+        previous["paths"]["/api/conversations/search"]["get"]["parameters"][0][
+            "schema"
+        ] = baseline_limit_schema
+
+    assert run_rest_api_breakage_check(_prod, previous, current, [change]) == 1
+
+
+def test_search_limit_schema_repair_does_not_hide_other_breakages(
+    run_rest_api_breakage_check, capsys
+):
+    previous, current, repair = _search_limit_repair_case()
+    breaking_change = {
+        **repair,
+        "id": "request-parameter-became-required",
+        "text": "the query parameter `page_id` became required",
+    }
+
+    assert (
+        run_rest_api_breakage_check(_prod, previous, current, [repair, breaking_change])
+        == 1
+    )
+    output = capsys.readouterr().out
+    assert "Published the existing search limit of 100" in output
+    assert "page_id" in output
 
 
 def test_main_fails_when_additive_oneof_mixed_with_real_breakage(monkeypatch, capsys):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
Allow only the four known GET search operations to publish maximum 100 when their baseline limit schema contains the legacy lte 100 typo. Keep other parameter restrictions and mixed breaking changes blocking.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

PR #4991 corrects `Query(lte=100)` to `Query(le=100)` on four paginated search endpoints. The handlers already rejected limits above 100 with assertions; publishing `maximum: 100` documents that existing bound and lets invalid requests return HTTP 422.

oasdiff 1.19.1 reports this schema repair as `request-parameter-max-set` warnings. Although `oasdiff --fail-on ERR` exits 0, the REST compatibility wrapper rejects the unrecognized changes and exits 1. This targeted exception allows the repair while preserving checks for other restrictions.

## Summary

- Accept only the `limit` query parameter gaining `maximum: 100` on GET conversation search, conversation event search, bash event search, and subdirectory search.
- Require the baseline operation ID to match and its integer query parameter to contain `lte: 100` with no existing `maximum`.
- Emit a notice for accepted repairs and test that other endpoints, methods, parameters, bounds, missing legacy metadata, future tightening, and mixed unrelated breakages still fail.

## Issue Number

Related to #5041. This PR supplies the compatibility-check prerequisite; the endpoint fix is in the companion PR.

## How to Test

Focused tests run locally on this PR's head, `641eb55b`:

```bash
uv run --no-sync python -m pytest -q -o addopts='' \
  tests/cross/test_check_agent_server_rest_api_breakage.py
# 53 passed
```

The [upstream cross-tests job](https://github.com/OpenHands/software-agent-sdk/actions/runs/34781539522/job/103789339840) also passed: **501 passed, 1 skipped**, including accepted repairs, rejected variants, and mixed-breakage coverage.

A separate local comparison generated real OpenAPI schemas from released `v1.47.0` and PR #4991 at `d390bed7`, then ran the original checker and this PR's checker against the same schemas with **oasdiff 1.19.1**:

| Source under review | Checker | Exit |
| --- | --- | --- |
| #4991 at `d390bed7` | Original | 1 |
| #4991 at `d390bed7` | This PR at `641eb55b` | 0 |

The successful comparison emitted the repair notice for exactly the four search endpoints. This evidence predates #4991's subsequent merge from main.

<details>
<summary>Reproduce the real-schema comparison</summary>

In an isolated checkout of #4991 at `d390bed7545c65fdeba2683e6697e75fc9550ec0`, run `make build`, make the `v1.47.0` tag and this PR's commit available locally, and put oasdiff 1.19.1 on PATH. Run the command below first with the original checker, then after replacing only `.github/scripts/check_agent_server_rest_api_breakage.py` with this PR's version. It pins the published baseline and fails if baseline generation is unavailable, so a skipped comparison cannot count as success.

```bash
uv run --no-sync python - <<'PY'
import importlib.util
import sys
from pathlib import Path

path = Path('.github/scripts/check_agent_server_rest_api_breakage.py')
spec = importlib.util.spec_from_file_location('compat', path)
assert spec and spec.loader
module = importlib.util.module_from_spec(spec)
sys.modules[spec.name] = module
spec.loader.exec_module(module)
module._get_baseline_version = lambda distribution, current: '1.47.0'
generate_baseline = module._generate_openapi_for_git_ref

def required_baseline(ref):
    schema = generate_baseline(ref)
    if schema is None:
        raise RuntimeError('Baseline generation failed: ' + ref)
    return schema

module._generate_openapi_for_git_ref = required_baseline
raise SystemExit(module.main())
PY
```

Expected result: exit 1 with four `request-parameter-max-set` reports using the original checker, and exit 0 with the following notice using this PR:

```text
Published the existing search limit of 100 by correcting legacy lte metadata to maximum.
```

</details>

## Video/Screenshots

Not applicable; checker exit codes and reproduction instructions are provided above.

## Design Doc

The exception's scope and rationale are documented above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Merge this checker prerequisite before #4991, then update that branch to include it. This PR does not change endpoint behavior.

The exception requires historical `lte: 100` metadata and the absence of a published maximum. Once the release baseline publishes the corrected maximum, it no longer qualifies; later tightening continues to fail.
